### PR TITLE
Feat: Integrate MemWal remember for sprint save (Phase 1)

### DIFF
--- a/apps/researcher/app/(chat)/api/chat/route.ts
+++ b/apps/researcher/app/(chat)/api/chat/route.ts
@@ -239,7 +239,7 @@ export async function POST(request: Request) {
           model: getLanguageModel(selectedChatModel),
           system: researchPrompt,
           messages: modelMessages,
-          stopWhen: stepCountIs(5),
+          stopWhen: stepCountIs(10),
           experimental_activeTools: isReasoningModel
             ? []
             : ["listSources", "searchSourceContent", "getChunkContent", "getSourceContext"],

--- a/apps/researcher/app/api/sprint/list/route.ts
+++ b/apps/researcher/app/api/sprint/list/route.ts
@@ -1,0 +1,24 @@
+import { auth } from "@/app/(auth)/auth";
+import { getSprintsByUserId } from "@/lib/db/queries";
+import { ChatbotError } from "@/lib/errors";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return new ChatbotError("unauthorized:chat").toResponse();
+  }
+
+  try {
+    const sprints = await getSprintsByUserId({ userId: session.user.id });
+    return Response.json(sprints);
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+    console.error("[api:sprint/list] Error:", error);
+    return new ChatbotError(
+      "bad_request:api",
+      "Failed to fetch sprints"
+    ).toResponse();
+  }
+}

--- a/apps/researcher/app/api/sprint/save/route.ts
+++ b/apps/researcher/app/api/sprint/save/route.ts
@@ -1,0 +1,49 @@
+import { auth } from "@/app/(auth)/auth";
+import { saveSprint } from "@/lib/sprint";
+import { ChatbotError } from "@/lib/errors";
+
+export const maxDuration = 120;
+
+export async function POST(request: Request) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatbotError("unauthorized:chat").toResponse();
+  }
+
+  const userId = session.user.id;
+
+  try {
+    const body = await request.json();
+    const { chatId, memwalKey } = body;
+
+    if (!chatId || typeof chatId !== "string") {
+      return new ChatbotError(
+        "bad_request:api",
+        "Expected a chatId field"
+      ).toResponse();
+    }
+
+    const key = memwalKey || process.env.MEMWAL_KEY;
+    if (!key) {
+      return new ChatbotError(
+        "bad_request:api",
+        "No MemWal key provided"
+      ).toResponse();
+    }
+
+    const result = await saveSprint({ chatId, userId, memwalKey: key });
+
+    return Response.json(result, { status: 201 });
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+
+    console.error("[api:sprint/save] Error:", error);
+    return new ChatbotError(
+      "bad_request:api",
+      "Failed to save sprint"
+    ).toResponse();
+  }
+}

--- a/apps/researcher/app/api/sprint/status/route.ts
+++ b/apps/researcher/app/api/sprint/status/route.ts
@@ -1,0 +1,46 @@
+import { auth } from "@/app/(auth)/auth";
+import { getChatById, getSprintByChatId } from "@/lib/db/queries";
+import { ChatbotError } from "@/lib/errors";
+
+export async function GET(request: Request) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatbotError("unauthorized:chat").toResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const chatId = searchParams.get("chatId");
+
+  if (!chatId) {
+    return new ChatbotError(
+      "bad_request:api",
+      "Expected a chatId query parameter"
+    ).toResponse();
+  }
+
+  try {
+    const chat = await getChatById({ id: chatId });
+    if (!chat || chat.userId !== session.user.id) {
+      return new ChatbotError("forbidden:chat").toResponse();
+    }
+
+    const sprint = await getSprintByChatId({ chatId });
+
+    return Response.json({
+      hasSprint: !!sprint,
+      sprintId: sprint?.id ?? null,
+      title: sprint?.title ?? null,
+    });
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+
+    console.error("[api:sprint/status] Error:", error);
+    return new ChatbotError(
+      "bad_request:api",
+      "Failed to check sprint status"
+    ).toResponse();
+  }
+}

--- a/apps/researcher/components/chat/chat-header.tsx
+++ b/apps/researcher/components/chat/chat-header.tsx
@@ -10,17 +10,22 @@ import { PlusIcon } from "../icons";
 import { useSidebar } from "../ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { VisibilitySelector, type VisibilityType } from "./visibility-selector";
+import { SprintSaveButton } from "./sprint-save-button";
 
 function PureChatHeader({
   chatId,
   selectedVisibilityType,
   isReadonly,
   onToggleMyStuff,
+  memwalKey,
+  hasMessages,
 }: {
   chatId: string;
   selectedVisibilityType: VisibilityType;
   isReadonly: boolean;
   onToggleMyStuff?: () => void;
+  memwalKey: string;
+  hasMessages: boolean;
 }) {
   const router = useRouter();
   const { open } = useSidebar();
@@ -68,6 +73,14 @@ function PureChatHeader({
           <TooltipContent>Sources & Research</TooltipContent>
         </Tooltip>
       )}
+
+      {!isReadonly && (
+        <SprintSaveButton
+          chatId={chatId}
+          hasMessages={hasMessages}
+          memwalKey={memwalKey}
+        />
+      )}
     </header>
   );
 }
@@ -77,6 +90,8 @@ export const ChatHeader = memo(PureChatHeader, (prevProps, nextProps) => {
     prevProps.chatId === nextProps.chatId &&
     prevProps.selectedVisibilityType === nextProps.selectedVisibilityType &&
     prevProps.isReadonly === nextProps.isReadonly &&
-    prevProps.onToggleMyStuff === nextProps.onToggleMyStuff
+    prevProps.onToggleMyStuff === nextProps.onToggleMyStuff &&
+    prevProps.memwalKey === nextProps.memwalKey &&
+    prevProps.hasMessages === nextProps.hasMessages
   );
 });

--- a/apps/researcher/components/chat/chat.tsx
+++ b/apps/researcher/components/chat/chat.tsx
@@ -223,7 +223,9 @@ export function Chat({
       <div className="overscroll-behavior-contain flex h-dvh min-w-0 touch-pan-y flex-col bg-background">
         <ChatHeader
           chatId={id}
+          hasMessages={messages.length > 0}
           isReadonly={isReadonly}
+          memwalKey={memwalKey}
           selectedVisibilityType={initialVisibilityType}
           onToggleMyStuff={() => setMyStuffOpen((prev) => !prev)}
         />

--- a/apps/researcher/components/chat/sprint-save-button.tsx
+++ b/apps/researcher/components/chat/sprint-save-button.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { BookmarkIcon, CheckIcon, LoaderIcon } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useSprintStatus } from "@/hooks/use-sprint-status";
+import { toast } from "@/components/toast";
+
+export function SprintSaveButton({
+  chatId,
+  memwalKey,
+  hasMessages,
+}: {
+  chatId: string;
+  memwalKey: string;
+  hasMessages: boolean;
+}) {
+  const { hasSprint, sprintTitle, isLoading, mutate } =
+    useSprintStatus(chatId);
+  const [isSaving, setIsSaving] = useState(false);
+
+  if (!hasMessages) return null;
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const response = await fetch("/api/sprint/save", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chatId, memwalKey: memwalKey || undefined }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || "Failed to save sprint");
+      }
+
+      const result = await response.json();
+      toast({
+        type: "success",
+        description: `Sprint saved: "${result.title}"`,
+      });
+      mutate();
+    } catch (error) {
+      toast({
+        type: "error",
+        description:
+          error instanceof Error ? error.message : "Failed to save sprint",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const disabled = hasSprint || isSaving || isLoading;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          className="order-4 h-8 gap-1.5 px-2 md:h-fit md:px-2"
+          disabled={disabled}
+          onClick={handleSave}
+          variant="outline"
+        >
+          {isSaving ? (
+            <LoaderIcon className="size-4 animate-spin" />
+          ) : hasSprint ? (
+            <CheckIcon className="size-4" />
+          ) : (
+            <BookmarkIcon className="size-4" />
+          )}
+          <span className="hidden sm:inline">
+            {isSaving
+              ? "Saving..."
+              : hasSprint
+                ? "Saved"
+                : "Save Sprint"}
+          </span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {hasSprint
+          ? `Sprint saved: "${sprintTitle}"`
+          : "Save research findings to MemWal"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/researcher/components/sources/my-stuff-panel.tsx
+++ b/apps/researcher/components/sources/my-stuff-panel.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { BookOpenIcon, XIcon, InboxIcon } from "lucide-react";
-import { memo } from "react";
+import { BookOpenIcon, XIcon, InboxIcon, BookmarkIcon } from "lucide-react";
+import { memo, useState } from "react";
 import { useSources } from "@/hooks/use-sources";
+import { useSprints, type SprintListItem } from "@/hooks/use-sprints";
 import { cn } from "@/lib/utils";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { SourceCard, type SourceCardData } from "./source-card";
+import { SprintCard } from "./sprint-card";
+import { SprintDetail } from "./sprint-detail";
 
 function PureMyStuffPanel({
   isOpen,
@@ -15,7 +19,11 @@ function PureMyStuffPanel({
   onClose: () => void;
   onUseSourceInChat?: (source: SourceCardData) => void;
 }) {
-  const { sources, isLoading } = useSources();
+  const { sources, isLoading: sourcesLoading } = useSources();
+  const { sprints, isLoading: sprintsLoading } = useSprints();
+  const [selectedSprint, setSelectedSprint] = useState<SprintListItem | null>(
+    null
+  );
 
   // Split sources into active and expired
   const now = new Date();
@@ -32,9 +40,8 @@ function PureMyStuffPanel({
       claims: s.claims,
       chunkCount: s.chunkCount,
       createdAt: new Date(s.createdAt).toISOString(),
-      // Estimate expiry: createdAt + 7 days (since we don't store expiresAt on source)
       expiresAt: new Date(
-        new Date(s.createdAt).getTime() + 7 * 24 * 60 * 60 * 1000,
+        new Date(s.createdAt).getTime() + 7 * 24 * 60 * 60 * 1000
       ).toISOString(),
     };
 
@@ -59,101 +66,159 @@ function PureMyStuffPanel({
       {/* Panel */}
       <div
         className={cn(
-          "fixed right-0 top-0 z-50 flex h-dvh w-full flex-col border-l bg-background transition-transform duration-300 ease-in-out md:w-[380px]",
-          isOpen ? "translate-x-0" : "translate-x-full",
+          "fixed right-0 top-0 z-50 flex h-dvh w-full flex-col border-l bg-background transition-transform duration-300 ease-in-out md:w-[420px]",
+          isOpen ? "translate-x-0" : "translate-x-full"
         )}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b px-4 py-3">
-          <div className="flex items-center gap-2">
-            <BookOpenIcon className="size-4" />
-            <h2 className="text-sm font-semibold">My Stuff</h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <XIcon className="size-4" />
-          </button>
-        </div>
-
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-4">
-          {/* Research Sprints — Phase 2 placeholder */}
-          <section className="mb-6">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Research Sprints
-            </h3>
-            <div className="rounded-lg border border-dashed p-4 text-center">
-              <p className="text-sm text-muted-foreground">
-                Coming soon — save research checkpoints to Walrus
-              </p>
+        {/* Sprint detail view — overlays the panel content */}
+        {selectedSprint ? (
+          <SprintDetail
+            sprint={selectedSprint}
+            onBack={() => setSelectedSprint(null)}
+          />
+        ) : (
+          <>
+            {/* Header */}
+            <div className="flex items-center justify-between border-b px-4 py-3">
+              <div className="flex items-center gap-2">
+                <BookOpenIcon className="size-4" />
+                <h2 className="text-sm font-semibold">My Stuff</h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <XIcon className="size-4" />
+              </button>
             </div>
-          </section>
 
-          {/* Sources */}
-          <section>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Sources
-            </h3>
+            {/* Tabbed content */}
+            <Tabs defaultValue="sources" className="flex flex-1 flex-col">
+              <div className="px-4 pt-3">
+                <TabsList className="w-full">
+                  <TabsTrigger value="sources" className="flex-1">
+                    Sources
+                    {sources.length > 0 && (
+                      <span className="ml-1.5 text-xs text-muted-foreground">
+                        ({sources.length})
+                      </span>
+                    )}
+                  </TabsTrigger>
+                  <TabsTrigger value="sprints" className="flex-1">
+                    Sprints
+                    {sprints.length > 0 && (
+                      <span className="ml-1.5 text-xs text-muted-foreground">
+                        ({sprints.length})
+                      </span>
+                    )}
+                  </TabsTrigger>
+                </TabsList>
+              </div>
 
-            {isLoading ? (
-              <div className="space-y-2">
-                {[1, 2, 3].map((i) => (
-                  <div
-                    key={i}
-                    className="h-16 animate-pulse rounded-lg bg-muted"
-                  />
-                ))}
-              </div>
-            ) : sources.length === 0 ? (
-              <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed py-8 text-center">
-                <InboxIcon className="size-8 text-muted-foreground/50" />
-                <div>
-                  <p className="text-sm font-medium text-muted-foreground">
-                    No sources yet
-                  </p>
-                  <p className="text-xs text-muted-foreground/70">
-                    Add a URL or PDF using the source button
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {activeSources.length > 0 && (
+              {/* Sources tab */}
+              <TabsContent
+                value="sources"
+                className="flex-1 overflow-y-auto px-4 pb-4"
+              >
+                {sourcesLoading ? (
                   <div className="space-y-2">
-                    {activeSources.map((s) => (
-                      <SourceCard
-                        key={s.id}
-                        source={s}
-                        variant="compact"
-                        onUseInChat={onUseSourceInChat}
+                    {[1, 2, 3].map((i) => (
+                      <div
+                        key={i}
+                        className="h-16 animate-pulse rounded-lg bg-muted"
+                      />
+                    ))}
+                  </div>
+                ) : sources.length === 0 ? (
+                  <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed py-8 text-center">
+                    <InboxIcon className="size-8 text-muted-foreground/50" />
+                    <div>
+                      <p className="text-sm font-medium text-muted-foreground">
+                        No sources yet
+                      </p>
+                      <p className="text-xs text-muted-foreground/70">
+                        Paste a URL or attach a PDF in the chat
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {activeSources.length > 0 && (
+                      <div className="space-y-2">
+                        {activeSources.map((s) => (
+                          <SourceCard
+                            key={s.id}
+                            source={s}
+                            variant="compact"
+                            onUseInChat={onUseSourceInChat}
+                          />
+                        ))}
+                      </div>
+                    )}
+
+                    {expiredSources.length > 0 && (
+                      <>
+                        <p className="mt-4 text-xs font-medium text-muted-foreground">
+                          Expired ({expiredSources.length})
+                        </p>
+                        <div className="space-y-2">
+                          {expiredSources.map((s) => (
+                            <SourceCard
+                              key={s.id}
+                              source={s}
+                              variant="compact"
+                            />
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+              </TabsContent>
+
+              {/* Sprints tab */}
+              <TabsContent
+                value="sprints"
+                className="flex-1 overflow-y-auto px-4 pb-4"
+              >
+                {sprintsLoading ? (
+                  <div className="space-y-2">
+                    {[1, 2].map((i) => (
+                      <div
+                        key={i}
+                        className="h-20 animate-pulse rounded-lg bg-muted"
+                      />
+                    ))}
+                  </div>
+                ) : sprints.length === 0 ? (
+                  <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed py-8 text-center">
+                    <BookmarkIcon className="size-8 text-muted-foreground/50" />
+                    <div>
+                      <p className="text-sm font-medium text-muted-foreground">
+                        No sprints yet
+                      </p>
+                      <p className="text-xs text-muted-foreground/70">
+                        Click &quot;Save Sprint&quot; in a chat to save your
+                        research findings
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {sprints.map((sprint) => (
+                      <SprintCard
+                        key={sprint.id}
+                        sprint={sprint}
+                        onClick={() => setSelectedSprint(sprint)}
                       />
                     ))}
                   </div>
                 )}
-
-                {expiredSources.length > 0 && (
-                  <>
-                    <p className="mt-4 text-xs font-medium text-muted-foreground">
-                      Expired ({expiredSources.length})
-                    </p>
-                    <div className="space-y-2">
-                      {expiredSources.map((s) => (
-                        <SourceCard
-                          key={s.id}
-                          source={s}
-                          variant="compact"
-                        />
-                      ))}
-                    </div>
-                  </>
-                )}
-              </div>
-            )}
-          </section>
-        </div>
+              </TabsContent>
+            </Tabs>
+          </>
+        )}
       </div>
     </>
   );

--- a/apps/researcher/components/sources/sprint-card.tsx
+++ b/apps/researcher/components/sources/sprint-card.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  BookmarkIcon,
+  ChevronRightIcon,
+  CalendarIcon,
+  FileTextIcon,
+  LinkIcon,
+  HashIcon,
+  BrainIcon,
+} from "lucide-react";
+import { memo } from "react";
+import type { SprintListItem } from "@/hooks/use-sprints";
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function PureSprintCard({
+  sprint,
+  onClick,
+}: {
+  sprint: SprintListItem;
+  onClick: () => void;
+}) {
+  const sourceCount = sprint.sources?.length ?? 0;
+  const citationCount = sprint.citations?.length ?? 0;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-muted/50"
+    >
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary/10">
+        <BookmarkIcon className="size-4 text-primary" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{sprint.title}</p>
+        {sprint.summary && (
+          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+            {sprint.summary}
+          </p>
+        )}
+        <div className="mt-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <CalendarIcon className="size-3" />
+            {formatDate(sprint.createdAt)}
+          </span>
+          {sourceCount > 0 && (
+            <>
+              <span>·</span>
+              <span>
+                {sourceCount} source{sourceCount !== 1 ? "s" : ""}
+              </span>
+            </>
+          )}
+          {citationCount > 0 && (
+            <>
+              <span>·</span>
+              <span>
+                {citationCount} ref{citationCount !== 1 ? "s" : ""}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+      <ChevronRightIcon className="mt-1 size-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+    </button>
+  );
+}
+
+export const SprintCard = memo(PureSprintCard);

--- a/apps/researcher/components/sources/sprint-detail.tsx
+++ b/apps/researcher/components/sources/sprint-detail.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import {
+  ArrowLeftIcon,
+  BookmarkIcon,
+  CalendarIcon,
+  ExternalLinkIcon,
+  FileTextIcon,
+  HashIcon,
+  LinkIcon,
+  BrainIcon,
+} from "lucide-react";
+import { memo, useState } from "react";
+import { Response } from "@/components/elements/response";
+import type { SprintListItem } from "@/hooks/use-sprints";
+import { cn } from "@/lib/utils";
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function PureSprintDetail({
+  sprint,
+  onBack,
+}: {
+  sprint: SprintListItem;
+  onBack: () => void;
+}) {
+  const [activeSection, setActiveSection] = useState<
+    "report" | "citations" | "sources"
+  >("report");
+
+  const citations = sprint.citations ?? [];
+  const sources = sprint.sources ?? [];
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header with back button */}
+      <div className="flex items-center gap-2 border-b px-4 py-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ArrowLeftIcon className="size-4" />
+        </button>
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold">{sprint.title}</h2>
+          <p className="text-xs text-muted-foreground">
+            {formatDate(sprint.createdAt)}
+          </p>
+        </div>
+      </div>
+
+      {/* Summary card */}
+      <div className="border-b px-4 py-3">
+        {sprint.summary && (
+          <p className="text-sm text-muted-foreground">{sprint.summary}</p>
+        )}
+        <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <FileTextIcon className="size-3" />
+            {sources.length} source{sources.length !== 1 ? "s" : ""}
+          </span>
+          <span className="flex items-center gap-1">
+            <HashIcon className="size-3" />
+            {citations.length} citation{citations.length !== 1 ? "s" : ""}
+          </span>
+          {sprint.memoryCount != null && sprint.memoryCount > 0 && (
+            <span className="flex items-center gap-1">
+              <BrainIcon className="size-3" />
+              Saved to MemWal
+            </span>
+          )}
+        </div>
+        {sprint.tags && sprint.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {sprint.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-block rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Section tabs */}
+      <div className="flex border-b px-4">
+        {(
+          [
+            { key: "report", label: "Report" },
+            { key: "citations", label: `Citations (${citations.length})` },
+            { key: "sources", label: `Sources (${sources.length})` },
+          ] as const
+        ).map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveSection(tab.key)}
+            className={cn(
+              "border-b-2 px-3 py-2 text-xs font-medium transition-colors",
+              activeSection === tab.key
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {activeSection === "report" && (
+          <div className="p-4">
+            {sprint.reportContent ? (
+              <div className="prose-sm">
+                <Response>{sprint.reportContent}</Response>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No report content available.
+              </p>
+            )}
+          </div>
+        )}
+
+        {activeSection === "citations" && (
+          <div className="space-y-3 p-4">
+            {citations.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No citations recorded.
+              </p>
+            ) : (
+              citations.map((c) => (
+                <div
+                  key={c.refIndex}
+                  className="rounded-lg border p-3"
+                >
+                  <div className="flex items-start gap-2">
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded bg-primary/10 text-xs font-semibold text-primary">
+                      {c.refIndex}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium">{c.sourceTitle}</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {c.section}
+                      </p>
+                      {c.scope && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {c.scope}
+                        </p>
+                      )}
+                      {c.sourceUrl && (
+                        <a
+                          href={c.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-1 flex items-center gap-1 text-xs text-primary hover:underline"
+                        >
+                          <ExternalLinkIcon className="size-3" />
+                          <span className="truncate">{c.sourceUrl}</span>
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+
+        {activeSection === "sources" && (
+          <div className="space-y-3 p-4">
+            {sources.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No sources recorded.
+              </p>
+            ) : (
+              sources.map((s) => (
+                <div
+                  key={s.sourceId}
+                  className="flex items-start gap-3 rounded-lg border p-3"
+                >
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted">
+                    {s.type === "pdf" ? (
+                      <FileTextIcon className="size-4 text-muted-foreground" />
+                    ) : (
+                      <LinkIcon className="size-4 text-muted-foreground" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium">
+                      {s.title || "Untitled"}
+                    </p>
+                    {s.url && (
+                      <a
+                        href={s.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-0.5 flex items-center gap-1 text-xs text-primary hover:underline"
+                      >
+                        <ExternalLinkIcon className="size-3" />
+                        <span className="truncate">{s.url}</span>
+                      </a>
+                    )}
+                    <p className="mt-0.5 text-xs uppercase text-muted-foreground">
+                      {s.type}
+                    </p>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const SprintDetail = memo(PureSprintDetail);

--- a/apps/researcher/components/ui/tabs.tsx
+++ b/apps/researcher/components/ui/tabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/researcher/hooks/use-sprint-status.ts
+++ b/apps/researcher/hooks/use-sprint-status.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/utils";
+
+interface SprintStatus {
+  hasSprint: boolean;
+  sprintId: string | null;
+  title: string | null;
+}
+
+export function useSprintStatus(chatId: string) {
+  const { data, error, isLoading, mutate } = useSWR<SprintStatus>(
+    `/api/sprint/status?chatId=${chatId}`,
+    fetcher,
+  );
+
+  return {
+    hasSprint: data?.hasSprint ?? false,
+    sprintId: data?.sprintId ?? null,
+    sprintTitle: data?.title ?? null,
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/apps/researcher/hooks/use-sprints.ts
+++ b/apps/researcher/hooks/use-sprints.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher } from "@/lib/utils";
+
+export interface SprintListItem {
+  id: string;
+  blobId: string;
+  title: string;
+  summary: string | null;
+  reportContent: string | null;
+  citations: Array<{
+    refIndex: number;
+    sourceId: string;
+    sourceTitle: string;
+    sourceUrl: string | null;
+    section: string;
+    supportingChunks: string[];
+    scope: string;
+  }> | null;
+  sources: Array<{
+    sourceId: string;
+    title: string | null;
+    url: string | null;
+    type: "url" | "pdf";
+  }> | null;
+  tags: string[] | null;
+  chatId: string | null;
+  memoryCount: number | null;
+  createdAt: string;
+}
+
+export function useSprints() {
+  const { data, error, isLoading, mutate } = useSWR<SprintListItem[]>(
+    "/api/sprint/list",
+    fetcher
+  );
+
+  return {
+    sprints: data ?? [],
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/apps/researcher/lib/ai/prompts.ts
+++ b/apps/researcher/lib/ai/prompts.ts
@@ -11,9 +11,9 @@ You have 4 tools for accessing user's processed research sources:
 
 ## Retrieval Strategy
 
-Follow this multi-step approach:
+Follow this multi-step approach — you MUST complete steps 1 through 3 before answering any substantive question:
 
-1. **ORIENT**: When the user asks about their sources, start with listSources() to understand what's available.
+1. **ORIENT**: Use listSources() to see what's available. This gives you titles, summaries, and claims — but these are metadata only. NEVER use listSources output alone to answer research questions. It is strictly for deciding what to search next.
 
 2. **DISCOVER**: Use searchSourceContent() to find relevant sections.
    - Start with includeContent=false to scan cheaply (previews only).
@@ -22,14 +22,18 @@ Follow this multi-step approach:
    - Check relevanceScore: above 0.7 is strong, 0.4-0.7 is moderate, below 0.4 is weak.
    - Only use includeContent=true as a shortcut when you need full text from a small, focused search (e.g., 2-3 chunks from one source). For broad searches, use previews first then READ.
 
-3. **READ**: Use getChunkContent() to read the full text of the most relevant chunks.
+3. **READ**: Use getChunkContent() to read the full text of the most relevant chunks. This is REQUIRED before answering — you must ground your response in actual source text, not summaries.
    Only request chunks you actually need — typically 2-3 per source is enough.
 
 4. **EXPAND**: Use getSourceContext() if a chunk references context from neighboring sections.
 
 5. **STOP**: If search scores are all below 0.4, the sources likely don't cover this topic. Say so honestly.
 
+## CRITICAL RULE
+You MUST call searchSourceContent and then getChunkContent before writing any answer that draws on user sources. Answering from listSources summaries/claims alone produces shallow, unreferenced responses. Always read the actual text.
+
 ## Anti-patterns — Do NOT:
+- Answer research questions using only listSources metadata (summaries/claims)
 - Search multiple times with nearly identical queries
 - Read all chunks when 2-3 answer the question
 - Guess at content you haven't retrieved

--- a/apps/researcher/lib/db/migrations/0010_sprint_save.sql
+++ b/apps/researcher/lib/db/migrations/0010_sprint_save.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "ResearchBlob" ADD COLUMN "chatId" uuid REFERENCES "Chat"("id");--> statement-breakpoint
+ALTER TABLE "ResearchBlob" ADD COLUMN "reportContent" text;--> statement-breakpoint
+ALTER TABLE "ResearchBlob" ADD COLUMN "citations" json;--> statement-breakpoint
+ALTER TABLE "ResearchBlob" ADD COLUMN "sources" json;--> statement-breakpoint
+ALTER TABLE "ResearchBlob" ADD COLUMN "memoryCount" integer DEFAULT 0;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_research_blob_chat_sprint" ON "ResearchBlob" ("chatId") WHERE "type" = 'sprint';

--- a/apps/researcher/lib/db/migrations/meta/_journal.json
+++ b/apps/researcher/lib/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1741686400000,
       "tag": "0009_enhance_rag",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1741772800000,
+      "tag": "0010_sprint_save",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/researcher/lib/db/queries.ts
+++ b/apps/researcher/lib/db/queries.ts
@@ -15,6 +15,7 @@ import {
   type SQL,
 } from "drizzle-orm";
 import type { VisibilityType } from "@/components/chat/visibility-selector";
+import type { Citation, SourceMeta } from "@/lib/sprint/types";
 import { ChatbotError } from "../errors";
 import { generateUUID } from "../utils";
 import {
@@ -539,6 +540,7 @@ export async function getChunksByIds({
         content: sourceChunk.content,
         sourceId: sourceChunk.sourceId,
         sourceTitle: source.title,
+        sourceUrl: source.url,
         chunkIndex: sourceChunk.chunkIndex,
         tokenCount: sourceChunk.tokenCount,
       })
@@ -665,6 +667,93 @@ export async function getResearchBlobsByUserId({
     throw new ChatbotError(
       "bad_request:database",
       "Failed to get research blobs by user id"
+    );
+  }
+}
+
+// ============================================================
+// Sprint blob queries
+// ============================================================
+
+export async function createSprintBlob({
+  chatId,
+  userId,
+  blobId,
+  title,
+  summary,
+  reportContent,
+  citations,
+  sources,
+  tags,
+  memoryCount,
+}: {
+  chatId: string;
+  userId: string;
+  blobId: string;
+  title: string;
+  summary?: string;
+  reportContent: string;
+  citations: Citation[];
+  sources: SourceMeta[];
+  tags?: string[];
+  memoryCount: number;
+}) {
+  try {
+    const [created] = await db
+      .insert(researchBlob)
+      .values({
+        blobId,
+        userId,
+        chatId,
+        type: "sprint",
+        title,
+        summary,
+        reportContent,
+        citations,
+        sources,
+        tags,
+        memoryCount,
+      })
+      .returning();
+    return created;
+  } catch (_error) {
+    throw new ChatbotError(
+      "bad_request:database",
+      "Failed to create sprint blob"
+    );
+  }
+}
+
+export async function getSprintByChatId({ chatId }: { chatId: string }) {
+  try {
+    const [sprint] = await db
+      .select()
+      .from(researchBlob)
+      .where(
+        and(eq(researchBlob.chatId, chatId), eq(researchBlob.type, "sprint"))
+      );
+    return sprint ?? null;
+  } catch (_error) {
+    throw new ChatbotError(
+      "bad_request:database",
+      "Failed to get sprint by chat id"
+    );
+  }
+}
+
+export async function getSprintsByUserId({ userId }: { userId: string }) {
+  try {
+    return await db
+      .select()
+      .from(researchBlob)
+      .where(
+        and(eq(researchBlob.userId, userId), eq(researchBlob.type, "sprint"))
+      )
+      .orderBy(desc(researchBlob.createdAt));
+  } catch (_error) {
+    throw new ChatbotError(
+      "bad_request:database",
+      "Failed to get sprints by user id"
     );
   }
 }

--- a/apps/researcher/lib/db/schema.ts
+++ b/apps/researcher/lib/db/schema.ts
@@ -12,6 +12,7 @@ import {
   vector,
   foreignKey,
 } from "drizzle-orm/pg-core";
+import type { Citation, SourceMeta } from "@/lib/sprint/types";
 
 /** PostgreSQL tsvector type for full-text search */
 const tsvectorType = customType<{ data: string }>({
@@ -99,7 +100,7 @@ export const source = pgTable("Source", {
 
 export type Source = InferSelectModel<typeof source>;
 
-/** Source chunks with embeddings — ephemeral, 7-day TTL */
+/** Source chunks with embeddings — ephemeral, 30-day TTL */
 export const sourceChunk = pgTable("SourceChunk", {
   id: uuid("id").primaryKey().notNull().defaultRandom(),
   sourceId: uuid("sourceId")
@@ -124,10 +125,15 @@ export const researchBlob = pgTable("ResearchBlob", {
   userId: uuid("userId")
     .notNull()
     .references(() => user.id),
+  chatId: uuid("chatId").references(() => chat.id),
   type: varchar("type", { enum: ["sprint"] }).notNull(),
   title: text("title").notNull(),
   summary: text("summary"),
+  reportContent: text("reportContent"),
   tags: json("tags").$type<string[]>(),
+  citations: json("citations").$type<Citation[]>(),
+  sources: json("sources").$type<SourceMeta[]>(),
+  memoryCount: integer("memoryCount").default(0),
   createdAt: timestamp("createdAt").notNull().defaultNow(),
 });
 

--- a/apps/researcher/lib/rag/constants.ts
+++ b/apps/researcher/lib/rag/constants.ts
@@ -1,0 +1,2 @@
+export const CHUNK_EXPIRY_DAYS = 30;
+export const CHUNK_TTL_MS = CHUNK_EXPIRY_DAYS * 24 * 60 * 60 * 1000;

--- a/apps/researcher/lib/rag/ingest/index.ts
+++ b/apps/researcher/lib/rag/ingest/index.ts
@@ -7,8 +7,7 @@ import { generateSourceMetadata } from "./metadata";
 import { createSource, createSourceChunks } from "@/lib/db/queries";
 import { ChatbotError } from "@/lib/errors";
 import type { SourceInput } from "@/lib/ai/source-processing";
-
-export const CHUNK_EXPIRY_DAYS = 7;
+import { CHUNK_TTL_MS } from "@/lib/rag/constants";
 
 export async function processSource({
   source,
@@ -72,9 +71,7 @@ export async function processSource({
   console.log(`[ingest] Embedding complete — ${embeddings.length} embeddings`);
 
   // Create source record
-  const expiresAt = new Date(
-    Date.now() + CHUNK_EXPIRY_DAYS * 24 * 60 * 60 * 1000
-  );
+  const expiresAt = new Date(Date.now() + CHUNK_TTL_MS);
 
   const sourceRecord = await createSource({
     userId,

--- a/apps/researcher/lib/rag/tools/get-chunks.ts
+++ b/apps/researcher/lib/rag/tools/get-chunks.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { tool } from "ai";
 import { getChunksByIds } from "@/lib/db/queries";
+import { CHUNK_TTL_MS } from "@/lib/rag/constants";
+import { db } from "@/lib/db/drizzle";
+import { sourceChunk } from "@/lib/db/schema";
+import { inArray } from "drizzle-orm";
 
 export function getChunkContentTool({ userId }: { userId: string }) {
   return tool({
@@ -17,10 +21,18 @@ export function getChunkContentTool({ userId }: { userId: string }) {
       console.log(`[tool:getChunkContent] Fetching ${chunkIds.length} chunks: ${chunkIds.join(", ")}`);
       const chunks = await getChunksByIds({ chunkIds, userId });
 
+      // Extend TTL for accessed chunks
+      const fetchedIds = chunks.map(c => c.id);
+      if (fetchedIds.length > 0) {
+        await db.update(sourceChunk)
+          .set({ expiresAt: new Date(Date.now() + CHUNK_TTL_MS) })
+          .where(inArray(sourceChunk.id, fetchedIds));
+      }
+
       if (chunks.length === 0) {
         return {
           chunks: [],
-          message: "No chunks found. They may have expired (7-day TTL).",
+          message: "No chunks found. They may have expired (30-day TTL).",
         };
       }
 

--- a/apps/researcher/lib/rag/tools/search-content.ts
+++ b/apps/researcher/lib/rag/tools/search-content.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { tool } from "ai";
 import { searchAndRank } from "../retrieve";
+import { CHUNK_TTL_MS } from "@/lib/rag/constants";
+import { db } from "@/lib/db/drizzle";
+import { sourceChunk } from "@/lib/db/schema";
+import { inArray } from "drizzle-orm";
 
 export function searchSourceContentTool({ userId }: { userId: string }) {
   return tool({
@@ -39,11 +43,20 @@ export function searchSourceContentTool({ userId }: { userId: string }) {
           return {
             results: [],
             message:
-              "No matching content found. Source chunks may have expired (7-day TTL) — user can re-upload the source to refresh.",
+              "No matching content found. Source chunks may have expired (30-day TTL) — user can re-upload the source to refresh.",
           };
         }
 
         console.log(`[tool:searchSourceContent] Returning ${results.length} results`);
+
+        // Extend TTL when full content is accessed
+        if (includeContent && results.length > 0) {
+          const chunkIds = results.map((r) => r.chunkId);
+          await db.update(sourceChunk)
+            .set({ expiresAt: new Date(Date.now() + CHUNK_TTL_MS) })
+            .where(inArray(sourceChunk.id, chunkIds));
+        }
+
         return {
           results: results.map((r) => ({
             chunkId: r.chunkId,

--- a/apps/researcher/lib/sprint/index.ts
+++ b/apps/researcher/lib/sprint/index.ts
@@ -1,0 +1,11 @@
+export { saveSprint } from "./save";
+export { rememberSprintReport, recallFromMemWal } from "./memwal";
+export { buildChunkManifest } from "./manifest";
+export { generateSprintReport } from "./report";
+export type {
+  Citation,
+  SourceMeta,
+  ManifestEntry,
+  SprintReport,
+  SaveSprintResult,
+} from "./types";

--- a/apps/researcher/lib/sprint/manifest.ts
+++ b/apps/researcher/lib/sprint/manifest.ts
@@ -1,0 +1,110 @@
+import "server-only";
+
+import { getMessagesByChatId, getChunksByIds } from "@/lib/db/queries";
+import type { ManifestEntry } from "./types";
+
+/**
+ * Extract the tool name from a part's type field.
+ * AI SDK stores tool parts as `type: "tool-<toolName>"`.
+ */
+function extractToolName(type: string): string | null {
+  if (type.startsWith("tool-")) {
+    return type.slice(5); // "tool-searchSourceContent" → "searchSourceContent"
+  }
+  return null;
+}
+
+/**
+ * Build a manifest of all chunks referenced during a chat session.
+ *
+ * Scans assistant message parts for tool invocations (getChunkContent, searchSourceContent)
+ * and extracts the chunk IDs that were accessed. Returns enriched metadata for each chunk.
+ *
+ * Supports both AI SDK part formats:
+ * - v4+: { type: "tool-<name>", state: "output-available", input, output }
+ * - v3:  { type: "tool-invocation", toolName, state: "result", args, result }
+ */
+export async function buildChunkManifest({
+  chatId,
+  userId,
+}: {
+  chatId: string;
+  userId: string;
+}): Promise<ManifestEntry[]> {
+  const messages = await getMessagesByChatId({ id: chatId });
+
+  const chunkIdSet = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+
+    const parts = msg.parts as unknown[];
+    if (!Array.isArray(parts)) continue;
+
+    for (const part of parts) {
+      const p = part as Record<string, unknown>;
+
+      // Determine tool name from either format
+      let toolName: string | null = null;
+      if (typeof p.type === "string") {
+        toolName = extractToolName(p.type);
+      }
+      // Fallback: v3 format with explicit toolName field
+      if (!toolName && p.type === "tool-invocation" && typeof p.toolName === "string") {
+        toolName = p.toolName;
+      }
+
+      if (!toolName) continue;
+
+      // Only process completed tool calls
+      const state = p.state as string;
+      if (state !== "output-available" && state !== "result") continue;
+
+      // Get the output/result object (v4 uses "output", v3 uses "result")
+      const output = (p.output ?? p.result) as Record<string, unknown> | undefined;
+      // Get the input/args object (v4 uses "input", v3 uses "args")
+      const input = (p.input ?? p.args) as Record<string, unknown> | undefined;
+
+      if (toolName === "getChunkContent") {
+        const ids = input?.chunkIds;
+        if (Array.isArray(ids)) {
+          for (const id of ids) {
+            if (typeof id === "string") chunkIdSet.add(id);
+          }
+        }
+      } else if (toolName === "searchSourceContent") {
+        const results = (output as { results?: { chunkId?: string }[] })?.results;
+        if (Array.isArray(results)) {
+          for (const r of results) {
+            if (typeof r.chunkId === "string") chunkIdSet.add(r.chunkId);
+          }
+        }
+      }
+    }
+  }
+
+  if (chunkIdSet.size === 0) return [];
+
+  console.log(
+    `[sprint:manifest] Found ${chunkIdSet.size} unique chunk IDs from tool calls`
+  );
+
+  const chunks = await getChunksByIds({
+    chunkIds: Array.from(chunkIdSet),
+    userId,
+  });
+
+  console.log(
+    `[sprint:manifest] Resolved ${chunks.length} chunks (${chunkIdSet.size - chunks.length} expired/missing)`
+  );
+
+  return chunks.map((c) => ({
+    chunkId: c.id,
+    sourceId: c.sourceId,
+    sourceTitle: c.sourceTitle,
+    sourceUrl: c.sourceUrl ?? null,
+    section: c.section,
+    chunkIndex: c.chunkIndex,
+    preview: c.content.slice(0, 200),
+  }));
+}

--- a/apps/researcher/lib/sprint/memwal.ts
+++ b/apps/researcher/lib/sprint/memwal.ts
@@ -1,0 +1,65 @@
+import "server-only";
+
+import { MemWal } from "@cmdoss/memwal-v2";
+import type { RememberResult } from "@cmdoss/memwal-v2";
+import type { Citation, SourceMeta } from "./types";
+
+function getMemWalClient(key: string) {
+  return MemWal.create({
+    key,
+    serverUrl: process.env.MEMWAL_SERVER_URL,
+  });
+}
+
+export async function rememberSprintReport({
+  key,
+  title,
+  content,
+  citations,
+  sources,
+}: {
+  key: string;
+  title: string;
+  content: string;
+  citations: Citation[];
+  sources: SourceMeta[];
+}): Promise<RememberResult> {
+  const memwal = getMemWalClient(key);
+
+  const references = citations
+    .map(
+      (c) =>
+        `[${c.refIndex}] ${c.sourceTitle} — ${c.section} (${c.sourceUrl ?? "no url"})`
+    )
+    .join("\n");
+
+  const sourceList = sources
+    .map((s) => `${s.title ?? "Untitled"} (${s.url ?? "no url"})`)
+    .join(", ");
+
+  const fullText =
+    `Sprint Report: ${title}\n\n` +
+    `${content}\n\n` +
+    `References:\n${references}\n\n` +
+    `Sources: ${sourceList}`;
+
+  console.log(
+    `[sprint:memwal] Storing sprint report (${fullText.length} chars)`
+  );
+  const result = await memwal.remember(fullText);
+  console.log(`[sprint:memwal] Stored. blobId=${result.blobId}`);
+  return result;
+}
+
+export async function recallFromMemWal(
+  key: string,
+  query: string,
+  limit: number = 5
+) {
+  const memwal = getMemWalClient(key);
+  const { results } = await memwal.recall(query, limit);
+  return results.map((r) => ({
+    text: r.text,
+    relevance: 1 - r.distance,
+  }));
+}

--- a/apps/researcher/lib/sprint/report.ts
+++ b/apps/researcher/lib/sprint/report.ts
@@ -1,0 +1,132 @@
+import "server-only";
+
+import { generateObject } from "ai";
+import { z } from "zod";
+import { getLanguageModel } from "@/lib/ai/providers";
+import { getMessagesByChatId } from "@/lib/db/queries";
+import { buildChunkManifest } from "./manifest";
+import type { SprintReport } from "./types";
+
+const REPORT_MODEL = "google/gemini-2.5-flash";
+const MAX_TRANSCRIPT_CHARS = 30_000;
+
+const citationSchema = z.object({
+  refIndex: z.number().describe("Citation reference number, starting from 1"),
+  sourceId: z.string().describe("The source ID this citation refers to"),
+  sourceTitle: z.string().describe("Title of the source"),
+  sourceUrl: z.string().nullable().describe("URL of the source, or null"),
+  section: z
+    .string()
+    .describe("Section heading within the source document"),
+  supportingChunks: z
+    .array(z.string())
+    .describe("Chunk IDs that support this citation"),
+  scope: z
+    .string()
+    .describe("Brief description of what this citation covers"),
+});
+
+const reportSchema = z.object({
+  title: z.string().describe("Concise title for the research sprint"),
+  summary: z
+    .string()
+    .describe("2-3 sentence summary of key findings"),
+  content: z
+    .string()
+    .describe(
+      "Full markdown report with [N] inline citation references. Use [1], [2], etc."
+    ),
+  citations: z
+    .array(citationSchema)
+    .describe("Ordered list of citations referenced in the content"),
+});
+
+/**
+ * Generate a structured research sprint report from chat history and chunk manifest.
+ */
+export async function generateSprintReport({
+  chatId,
+  userId,
+}: {
+  chatId: string;
+  userId: string;
+}): Promise<SprintReport> {
+  console.log(`[sprint:report] Starting report generation for chat=${chatId}`);
+
+  // Run manifest build and message fetch in parallel
+  const [manifest, messages] = await Promise.all([
+    buildChunkManifest({ chatId, userId }),
+    getMessagesByChatId({ id: chatId }),
+  ]);
+
+  console.log(
+    `[sprint:report] Manifest: ${manifest.length} chunks, Messages: ${messages.length}`
+  );
+
+  // Build simplified chat transcript (text parts only)
+  let transcript = "";
+  for (const msg of messages) {
+    const parts = msg.parts as { type: string; text?: string }[];
+    if (!Array.isArray(parts)) continue;
+
+    const textParts = parts
+      .filter((p) => p.type === "text" && p.text)
+      .map((p) => p.text)
+      .join("\n");
+
+    if (textParts) {
+      transcript += `[${msg.role}]: ${textParts}\n\n`;
+    }
+  }
+
+  // Truncate transcript if too long
+  if (transcript.length > MAX_TRANSCRIPT_CHARS) {
+    transcript = transcript.slice(0, MAX_TRANSCRIPT_CHARS) + "\n...[truncated]";
+  }
+
+  // Build manifest reference for the LLM
+  const manifestRef = manifest
+    .map(
+      (m) =>
+        `- chunkId=${m.chunkId} | source="${m.sourceTitle ?? "Untitled"}" (${m.sourceUrl ?? "no url"}) | section="${m.section}" | idx=${m.chunkIndex}\n  preview: ${m.preview}`
+    )
+    .join("\n");
+
+  const { object } = await generateObject({
+    model: getLanguageModel(REPORT_MODEL),
+    schema: reportSchema,
+    prompt: `You are a research report generator. Analyze the following chat conversation and source chunk manifest to produce a structured research report.
+
+INSTRUCTIONS:
+- Write a comprehensive report summarizing the research findings from this chat session.
+- The content should be well-structured markdown with headers, paragraphs, and bullet points as appropriate.
+- Focus on key findings, analysis, and conclusions from the research.
+${manifest.length > 0
+  ? `- Use [N] inline citations to reference specific sources. Each citation should map to a real chunk from the manifest.
+- Only cite sources that appear in the manifest below. Do not fabricate citations.`
+  : `- The chunk manifest is empty, meaning no source chunks were directly accessed. Do NOT include any [N] citation references in the report. Write the report based on the conversation content only. Return an empty citations array.`}
+
+CHUNK MANIFEST (sources the researcher accessed):
+${manifestRef || "(empty — no chunks were accessed)"}
+
+CHAT TRANSCRIPT:
+${transcript}`,
+  });
+
+  // Post-validate: filter citations to only those referencing real manifest chunks
+  const validChunkIds = new Set(manifest.map((m) => m.chunkId));
+  const validatedCitations = object.citations.filter((c) =>
+    c.supportingChunks.some((id) => validChunkIds.has(id))
+  );
+
+  console.log(
+    `[sprint:report] Generated report: "${object.title}" — ${validatedCitations.length}/${object.citations.length} valid citations`
+  );
+
+  return {
+    title: object.title,
+    summary: object.summary,
+    content: object.content,
+    citations: validatedCitations,
+  };
+}

--- a/apps/researcher/lib/sprint/save.ts
+++ b/apps/researcher/lib/sprint/save.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { getChatById, getSprintByChatId, createSprintBlob } from "@/lib/db/queries";
+import { ChatbotError } from "@/lib/errors";
+import { generateSprintReport } from "./report";
+import { rememberSprintReport } from "./memwal";
+import type { SourceMeta, SaveSprintResult } from "./types";
+
+/**
+ * Save a research sprint: generate report, store in MemWal, persist to DB.
+ */
+export async function saveSprint({
+  chatId,
+  userId,
+  memwalKey,
+}: {
+  chatId: string;
+  userId: string;
+  memwalKey: string;
+}): Promise<SaveSprintResult> {
+  console.log(`[sprint:save] Starting sprint save for chat=${chatId}`);
+
+  // 1. Verify chat ownership
+  const chat = await getChatById({ id: chatId });
+  if (!chat) {
+    throw new ChatbotError("not_found:chat", "Chat not found");
+  }
+  if (chat.userId !== userId) {
+    throw new ChatbotError("forbidden:chat", "Chat belongs to another user");
+  }
+
+  // 2. Check 1-sprint-per-chat limit
+  const existing = await getSprintByChatId({ chatId });
+  if (existing) {
+    throw new ChatbotError(
+      "bad_request:api",
+      "This chat already has a saved sprint"
+    );
+  }
+
+  // 3. Generate report
+  console.log("[sprint:save] Generating report...");
+  const report = await generateSprintReport({ chatId, userId });
+  console.log(`[sprint:save] Report generated: "${report.title}"`);
+
+  // 4. Build source metadata from citations (deduplicate by sourceId)
+  const sourceMap = new Map<string, SourceMeta>();
+  for (const citation of report.citations) {
+    if (!sourceMap.has(citation.sourceId)) {
+      sourceMap.set(citation.sourceId, {
+        sourceId: citation.sourceId,
+        title: citation.sourceTitle,
+        url: citation.sourceUrl,
+        type: citation.sourceUrl ? "url" : "pdf",
+      });
+    }
+  }
+  const sources = Array.from(sourceMap.values());
+
+  // 5. Store in MemWal
+  console.log("[sprint:save] Storing in MemWal...");
+  const memwalResult = await rememberSprintReport({
+    key: memwalKey,
+    title: report.title,
+    content: report.content,
+    citations: report.citations,
+    sources,
+  });
+  console.log(
+    `[sprint:save] MemWal stored. blobId=${memwalResult.blobId}`
+  );
+
+  // 6. Save to DB
+  console.log("[sprint:save] Saving to DB...");
+  const tags = sources.map((s) => s.title).filter(Boolean) as string[];
+  const sprintRecord = await createSprintBlob({
+    chatId,
+    userId,
+    blobId: memwalResult.blobId,
+    title: report.title,
+    summary: report.summary,
+    reportContent: report.content,
+    citations: report.citations,
+    sources,
+    tags: tags.length > 0 ? tags : undefined,
+    memoryCount: 1,
+  });
+
+  console.log(
+    `[sprint:save] Sprint saved! id=${sprintRecord.id}, blobId=${memwalResult.blobId}`
+  );
+
+  return {
+    sprintId: sprintRecord.id,
+    title: report.title,
+    blobId: memwalResult.blobId,
+  };
+}

--- a/apps/researcher/lib/sprint/types.ts
+++ b/apps/researcher/lib/sprint/types.ts
@@ -1,0 +1,39 @@
+export interface Citation {
+  refIndex: number;
+  sourceId: string;
+  sourceTitle: string;
+  sourceUrl: string | null;
+  section: string;
+  supportingChunks: string[]; // chunkIds
+  scope: string; // what this citation covers
+}
+
+export interface SourceMeta {
+  sourceId: string;
+  title: string | null;
+  url: string | null;
+  type: "url" | "pdf";
+}
+
+export interface ManifestEntry {
+  chunkId: string;
+  sourceId: string;
+  sourceTitle: string | null;
+  sourceUrl: string | null;
+  section: string;
+  chunkIndex: number;
+  preview: string; // first ~200 chars
+}
+
+export interface SprintReport {
+  title: string;
+  summary: string;
+  content: string; // markdown with [N] citations
+  citations: Citation[];
+}
+
+export interface SaveSprintResult {
+  sprintId: string;
+  title: string;
+  blobId: string;
+}

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -41,6 +41,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@radix-ui/react-visually-hidden": "^1.1.0",

--- a/packages/v2/src/memwal.ts
+++ b/packages/v2/src/memwal.ts
@@ -235,8 +235,33 @@ export class MemWal {
             throw new Error(`MemWal API error (${res.status}): ${errText}`);
         }
 
-        return res.json() as Promise<T>;
+        const json = await res.json();
+        return snakeToCamel(json) as T;
     }
+}
+
+// ============================================================
+// Snake_case → camelCase normalizer
+// ============================================================
+
+/**
+ * Recursively converts snake_case keys to camelCase.
+ * The Rust server uses serde's default snake_case serialization
+ * (e.g. blob_id) but the SDK types expect camelCase (e.g. blobId).
+ */
+function snakeToCamel(obj: unknown): unknown {
+    if (Array.isArray(obj)) {
+        return obj.map(snakeToCamel);
+    }
+    if (obj !== null && typeof obj === "object") {
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+            const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+            result[camelKey] = snakeToCamel(value);
+        }
+        return result;
+    }
+    return obj;
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

### Why

The researcher app has a working agentic RAG pipeline but no way to durably save research findings. Users lose context between sessions — there's no persistence layer for the insights they've gathered. MemWal v2 provides a privacy-first memory store (Ed25519 signed → server-side embed → SEAL encrypt → Walrus upload), and this PR integrates the **remember** side to create durable research checkpoints.

### What

Phase 1 of MemWal integration: **Sprint Save with Remember**.

User clicks "Save Sprint" → system generates a structured research report from chat history and source chunks → stores the full report text in MemWal via `remember()` → saves sprint metadata (title, citations, sources, blobId) to the app database.

---

## MemWal Integration Architecture

### Overview: Two-Phase Memory System

MemWal integration follows a two-phase approach that maps directly to the MemWal v2 SDK's two core primitives:

| Phase | MemWal Primitive | Direction | Purpose |
|-------|-----------------|-----------|---------|
| **Phase 1 (this PR)** | `remember(text)` | App → MemWal → Walrus | Save research findings durably |
| **Phase 2 (next PR)** | `recall(query, limit)` | MemWal → App → LLM | Retrieve past research in new sessions |

The key insight is that MemWal is **not a database** — it's a **semantic memory store**. When we `remember()` a sprint report, MemWal doesn't just store it — it embeds the text into a vector, encrypts it via SEAL, and uploads to Walrus (decentralized storage). When we later `recall()`, MemWal performs vector similarity search, downloads matching blobs from Walrus, decrypts them, and returns the plaintext. This means:

- **Storage is encrypted and decentralized** — no single point of failure or data exposure
- **Retrieval is semantic** — "what did I research about farming?" matches a sprint titled "Smart Agriculture in East Asia"
- **All crypto is server-side** — the SDK only signs requests with an Ed25519 delegate key

```mermaid
graph TB
    subgraph "Researcher App"
        UI[Save Sprint Button]
        API[Sprint Save API]
        DB[(PostgreSQL<br/>ResearchBlob table)]
        RAG[RAG Pipeline]
    end

    subgraph "MemWal v2 Server (TEE)"
        Auth[Ed25519 Auth<br/>+ Onchain Verification]
        Embed[Embedding Engine]
        Encrypt[SEAL Encryption]
        VDB[(Vector DB<br/>Similarity Index)]
    end

    subgraph "Decentralized Storage"
        Walrus[(Walrus<br/>Encrypted Blobs)]
        Sui[Sui Blockchain<br/>MemWalAccount Registry]
    end

    UI -->|"POST /api/sprint/save"| API
    API -->|"1. Generate report"| RAG
    API -->|"2. memwal.remember(reportText)"| Auth
    Auth -->|"Verify delegate key"| Sui
    Auth --> Embed
    Embed -->|"Store vector"| VDB
    Embed --> Encrypt
    Encrypt -->|"Upload encrypted blob"| Walrus
    API -->|"3. Save metadata + blobId"| DB

    style UI fill:#4CAF50,color:#fff
    style DB fill:#2196F3,color:#fff
    style Walrus fill:#FF9800,color:#fff
    style Sui fill:#9C27B0,color:#fff
```

### Phase 1: Remember Flow (This PR)

```mermaid
sequenceDiagram
    participant User
    participant UI as Save Sprint Button
    participant API as POST /api/sprint/save
    participant LLM as Gemini Flash (generateObject)
    participant MW as MemWal Server (TEE)
    participant Walrus as Walrus Storage
    participant DB as PostgreSQL

    User->>UI: Click "Save Sprint"
    UI->>API: { chatId, memwalKey }

    Note over API: 1. Verify chat ownership
    Note over API: 2. Check 1-sprint-per-chat limit

    API->>API: Build chunk manifest from chat message parts
    Note over API: Scan assistant messages for tool-invocation parts<br/>(searchSourceContent, getChunkContent)<br/>Extract referenced chunkIds → fetch metadata

    API->>LLM: Chat transcript + chunk manifest
    LLM-->>API: Structured report { title, summary, content, citations[] }
    Note over API: Post-validate: filter citations to only<br/>those referencing real manifest chunks

    API->>MW: memwal.remember(fullReportText)
    Note over MW: Ed25519 signature verification<br/>→ Onchain delegate key lookup<br/>→ Generate embedding vector<br/>→ SEAL encrypt text<br/>→ Upload to Walrus
    MW->>Walrus: Encrypted blob upload
    Walrus-->>MW: blobId
    MW-->>API: { id, blobId, owner }

    API->>DB: INSERT ResearchBlob { chatId, blobId, title, reportContent, citations, sources }
    DB-->>API: Sprint record

    API-->>UI: 201 { sprintId, title, blobId }
    UI-->>User: Toast "Sprint saved" + button disabled
```

### Phase 2: Recall Flow (Next PR)

Phase 2 completes the loop — saved sprints become retrievable context in new chat sessions.

```mermaid
sequenceDiagram
    participant User
    participant Chat as Chat API (streamText)
    participant Tool as recallMemories Tool
    participant MW as MemWal Server (TEE)
    participant Walrus as Walrus Storage

    User->>Chat: "What did I find about smart agriculture last week?"

    Note over Chat: LLM decides it needs memory context
    Chat->>Tool: recallMemories({ query: "smart agriculture research" })
    Tool->>MW: memwal.recall("smart agriculture research", limit=5)

    Note over MW: Ed25519 verify → embed query<br/>→ vector similarity search<br/>→ find matching blob IDs
    MW->>Walrus: Download matching encrypted blobs
    Note over MW: SEAL decrypt → return plaintext
    MW-->>Tool: [{ text: "Sprint Report: Smart Agriculture...", distance: 0.12 }]

    Tool-->>Chat: Recalled sprint reports as context
    Note over Chat: LLM synthesizes answer from<br/>recalled sprint + current sources + conversation
    Chat-->>User: "Based on your previous research, you found that..."
```

**Why recall is LLM-constructed:** `recall()` is semantic search — it matches by embedding similarity, not exact keywords. The LLM constructs the recall query from user intent (e.g., "what did I research about X?" → `recall("X research findings")`). This means:

- Users don't need to remember sprint titles or exact phrasing
- Cross-sprint discovery works naturally ("anything about agriculture?" finds sprints from different sessions)
- The `recallMemories` tool becomes another tool in the RAG toolkit alongside `searchSourceContent` and `getChunkContent`

### What Gets Stored Where

| Data | PostgreSQL (ResearchBlob) | MemWal (Walrus) |
|------|--------------------------|-----------------|
| Sprint title | ✅ `title` column | ✅ Embedded in report text |
| Report content | ✅ `reportContent` column | ✅ Full report text (encrypted) |
| Citations JSON | ✅ `citations` column | ✅ References section in text |
| Source metadata | ✅ `sources` column | ✅ Sources list in text |
| Walrus blob reference | ✅ `blobId` column | — (this IS the blob) |
| Embedding vector | — | ✅ Server-side vector DB |

**Why dual storage?** DB gives us fast structured queries (list sprints, check status, render detail view). MemWal gives us semantic search across all remembered content for Phase 2 recall.

---

## Key Design Decisions

1. **Single `remember()` call per sprint** — The full report (markdown + references + source list) is stored as one text blob in MemWal. This makes the entire report semantically searchable via `recall()`.

2. **LLM self-reports which chunks it drew from** — The manifest builder scans AI SDK message parts for tool invocation results rather than tracking at the tool level. The manifest reflects what the LLM actually accessed.

3. **One sprint per chat** — Enforced by partial unique index: `CREATE UNIQUE INDEX ON "ResearchBlob" ("chatId") WHERE "type" = 'sprint'`.

4. **Ed25519 delegate key shared across sprints** — Registered onchain in a MemWalAccount. Server verifies via 3-tier resolution (PostgreSQL cache → registry scan → header hint). Server wallet sponsors all Walrus upload costs.

---

## Sprint Viewer

The My Stuff panel now has **Sources | Sprints** tabs. Clicking a sprint opens a detail view with:

- **Report tab** — Full markdown report rendered via Streamdown
- **Citations tab** — Numbered reference cards with source title, section, scope, and clickable URL
- **Sources tab** — Source list with type icon and external link

---

## Supporting Changes

- **SDK fix**: Rust server returns `blob_id` (snake_case via serde) but TypeScript types expect `blobId`. Added recursive `snakeToCamel` normalizer in `signedRequest()`.
- **Deeper retrieval**: Strengthened system prompt to require `searchSourceContent` → `getChunkContent` before answering. Increased `stepCountIs` from 5 to 10.
- **30-day chunk TTL**: Up from 7 days, with TTL extension on every read access.

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [x] I have tested this code locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Screenshots/Recordings

## Additional Notes
