### PR TITLE
Feat: Add sprint recall and preparation flow (Phase 2)

### DIFF
--- a/apps/researcher/app/(chat)/api/chat/route.ts
+++ b/apps/researcher/app/(chat)/api/chat/route.ts
@@ -16,7 +16,8 @@ import { createResumableStreamContext } from "resumable-stream";
 import { auth, type UserType } from "@/app/(auth)/auth";
 import { entitlementsByUserType } from "@/lib/ai/entitlements";
 import { allowedModelIds } from "@/lib/ai/models";
-import { researchPrompt } from "@/lib/ai/prompts";
+import { researchPrompt, getSprintResumePrompt } from "@/lib/ai/prompts";
+import { buildSprintContext } from "@/lib/sprint/resume";
 import {
   extractUrlsFromText,
   type SourceInput,
@@ -112,6 +113,8 @@ export async function POST(request: Request) {
         messagesFromDb = await getMessagesByChatId({ id });
       }
     } else if (message?.role === "user") {
+      // Chat is created during sprint preparation for sprint chats,
+      // or here for fresh chats without sprints.
       await saveChat({
         id,
         userId: session.user.id,
@@ -146,7 +149,40 @@ export async function POST(request: Request) {
         !selectedChatModel.includes("non-reasoning"));
 
     const modelMessages = await convertToModelMessages(uiMessages);
-    const researchTools = getResearchTools({ userId: session.user.id });
+
+    // Resolve sprint context — pre-built during preparation and stored on chat record
+    const memwalKey = (requestBody as any).memwalKey || process.env.MEMWAL_KEY;
+    const resolvedSprintIds: string[] = chat?.sprintIds ?? [];
+    const prebuiltSprintContext: string | null = chat?.sprintContext ?? null;
+
+    console.log(`[sprint:context] resolvedSprintIds=${JSON.stringify(resolvedSprintIds)}, memwalKey=${memwalKey ? "present" : "missing"}, prebuiltContext=${prebuiltSprintContext ? `${prebuiltSprintContext.length} chars` : "none"}`);
+
+    let systemPrompt = researchPrompt;
+    if (prebuiltSprintContext) {
+      // Use pre-built context from sprint preparation (LLM-generated queries → MemWal recall)
+      systemPrompt = getSprintResumePrompt(prebuiltSprintContext);
+      console.log(`[sprint:context] Using pre-built sprint context: ${prebuiltSprintContext.length} chars`);
+      console.log(`[sprint:context] Final system prompt length=${systemPrompt.length} chars (base=${researchPrompt.length}, sprint addition=${systemPrompt.length - researchPrompt.length})`);
+    } else if (resolvedSprintIds.length > 0) {
+      // Fallback for chats created before sprint preparation existed — build lightweight metadata context
+      const { systemPromptBlock, sprintCount } = await buildSprintContext({
+        sprintIds: resolvedSprintIds,
+        userId: session.user.id,
+      });
+      console.log(`[sprint:context] Fallback: buildSprintContext returned ${sprintCount} sprints, block length=${systemPromptBlock.length} chars`);
+      if (systemPromptBlock) {
+        systemPrompt = getSprintResumePrompt(systemPromptBlock);
+        console.log(`[sprint:context] Final system prompt length=${systemPrompt.length} chars (base=${researchPrompt.length}, sprint addition=${systemPrompt.length - researchPrompt.length})`);
+      }
+    }
+
+    const hasRecallTool = resolvedSprintIds.length > 0 && !!memwalKey;
+    console.log(`[sprint:tools] recallSprint tool ${hasRecallTool ? "ENABLED" : "disabled"}`);
+
+    const researchTools = getResearchTools({
+      userId: session.user.id,
+      memwalKey: hasRecallTool ? memwalKey : undefined,
+    });
 
     const stream = createUIMessageStream({
       originalMessages: isToolApprovalFlow ? uiMessages : undefined,
@@ -235,14 +271,24 @@ export async function POST(request: Request) {
         }
 
         // --- Stream AI response ---
+        const baseTools = [
+          "listSources",
+          "searchSourceContent",
+          "getChunkContent",
+          "getSourceContext",
+        ] as const;
+
+        const activeToolNames =
+          resolvedSprintIds.length > 0 && memwalKey
+            ? ([...baseTools, "recallSprint"] as const)
+            : baseTools;
+
         const result = streamText({
           model: getLanguageModel(selectedChatModel),
-          system: researchPrompt,
+          system: systemPrompt,
           messages: modelMessages,
           stopWhen: stepCountIs(10),
-          experimental_activeTools: isReasoningModel
-            ? []
-            : ["listSources", "searchSourceContent", "getChunkContent", "getSourceContext"],
+          experimental_activeTools: isReasoningModel ? [] : [...activeToolNames],
           tools: researchTools,
           experimental_telemetry: {
             isEnabled: isProductionEnvironment,

--- a/apps/researcher/app/(chat)/chat/[id]/page.tsx
+++ b/apps/researcher/app/(chat)/chat/[id]/page.tsx
@@ -50,31 +50,18 @@ async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
   const cookieStore = await cookies();
   const chatModelFromCookie = cookieStore.get("chat-model");
 
-  if (!chatModelFromCookie) {
-    return (
-      <>
-        <Chat
-          autoResume={true}
-          id={chat.id}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialMessages={uiMessages}
-          initialVisibilityType={chat.visibility}
-          isReadonly={session?.user?.id !== chat.userId}
-        />
-        <DataStreamHandler />
-      </>
-    );
-  }
+  const chatModel = chatModelFromCookie?.value ?? DEFAULT_CHAT_MODEL;
 
   return (
     <>
       <Chat
         autoResume={true}
         id={chat.id}
-        initialChatModel={chatModelFromCookie.value}
+        initialChatModel={chatModel}
         initialMessages={uiMessages}
         initialVisibilityType={chat.visibility}
         isReadonly={session?.user?.id !== chat.userId}
+        initialSprintIds={chat.sprintIds ?? undefined}
       />
       <DataStreamHandler />
     </>

--- a/apps/researcher/app/(chat)/page.tsx
+++ b/apps/researcher/app/(chat)/page.tsx
@@ -17,30 +17,14 @@ async function NewChatPage() {
   const cookieStore = await cookies();
   const modelIdFromCookie = cookieStore.get("chat-model");
   const id = generateUUID();
-
-  if (!modelIdFromCookie) {
-    return (
-      <>
-        <Chat
-          autoResume={false}
-          id={id}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialMessages={[]}
-          initialVisibilityType="private"
-          isReadonly={false}
-          key={id}
-        />
-        <DataStreamHandler />
-      </>
-    );
-  }
+  const chatModel = modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
 
   return (
     <>
       <Chat
         autoResume={false}
         id={id}
-        initialChatModel={modelIdFromCookie.value}
+        initialChatModel={chatModel}
         initialMessages={[]}
         initialVisibilityType="private"
         isReadonly={false}

--- a/apps/researcher/app/api/sprint/prepare/route.ts
+++ b/apps/researcher/app/api/sprint/prepare/route.ts
@@ -1,0 +1,269 @@
+import { generateObject } from "ai";
+import { z } from "zod";
+import { auth } from "@/app/(auth)/auth";
+import { getLanguageModel } from "@/lib/ai/providers";
+import { getSprintsByIds, saveChat, updateChatSprintContext } from "@/lib/db/queries";
+import { recallFromMemWal } from "@/lib/sprint/memwal";
+import { ChatbotError } from "@/lib/errors";
+
+export const maxDuration = 60;
+
+const QUERY_MODEL = "google/gemini-2.5-flash";
+
+interface PrepareRequestBody {
+  chatId: string;
+  sprintIds: string[];
+  memwalKey?: string;
+  visibility?: "public" | "private";
+}
+
+function sseEvent(event: string, data: Record<string, unknown>): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+const recallQueriesSchema = z.object({
+  queries: z
+    .array(z.string())
+    .min(1)
+    .max(5)
+    .describe("Semantic search queries to retrieve the full sprint content from memory"),
+});
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return new ChatbotError("unauthorized:chat").toResponse();
+  }
+
+  let body: PrepareRequestBody;
+  try {
+    body = await request.json();
+    if (!body.chatId || !Array.isArray(body.sprintIds) || body.sprintIds.length === 0) {
+      return new ChatbotError("bad_request:api").toResponse();
+    }
+  } catch {
+    return new ChatbotError("bad_request:api").toResponse();
+  }
+
+  const { chatId, sprintIds, visibility = "private" } = body;
+  const memwalKey = body.memwalKey || process.env.MEMWAL_KEY;
+  const userId = session.user.id;
+
+  if (!memwalKey) {
+    return new ChatbotError("bad_request:api", "MemWal key is required for sprint preparation").toResponse();
+  }
+
+  console.log(`[sprint:prepare] memwalKey source=${body.memwalKey ? "client" : "env"}, key=${memwalKey.slice(0, 8)}...`);
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (event: string, data: Record<string, unknown>) => {
+        controller.enqueue(encoder.encode(sseEvent(event, data)));
+      };
+
+      try {
+        // Step 1: Validate sprint ownership
+        send("step", { step: "validate", status: "start", message: "Validating sprint access..." });
+        console.log(`[sprint:prepare] Validating ${sprintIds.length} sprints for user=${userId.slice(0, 8)}...`);
+
+        const ownedSprints = await getSprintsByIds({ sprintIds, userId });
+        if (ownedSprints.length === 0) {
+          console.log(`[sprint:prepare] No owned sprints found — aborting`);
+          send("error", { step: "validate", message: "No valid sprints found. You may not have access to the selected sprints." });
+          controller.close();
+          return;
+        }
+
+        console.log(`[sprint:prepare] Validated ${ownedSprints.length} sprints: ${ownedSprints.map(s => `"${s.title}"`).join(", ")}`);
+        send("step", {
+          step: "validate",
+          status: "done",
+          message: "Access confirmed",
+          detail: { sprintCount: ownedSprints.length },
+        });
+
+        // Step 2: Create chat record
+        send("step", { step: "create-chat", status: "start", message: "Creating session..." });
+
+        await saveChat({
+          id: chatId,
+          userId,
+          title: "New chat",
+          visibility,
+          sprintIds: ownedSprints.map((s) => s.id),
+        });
+
+        console.log(`[sprint:prepare] Chat created: ${chatId}`);
+        send("step", { step: "create-chat", status: "done", message: "Session created" });
+
+        // Step 3: Per-sprint — LLM query generation → MemWal recall → context assembly
+        send("step", { step: "build-context", status: "start", message: "Retrieving sprint research..." });
+
+        const sprintContextBlocks: string[] = [];
+
+        for (let i = 0; i < ownedSprints.length; i++) {
+          const sprint = ownedSprints[i];
+          const sourceNames = (sprint.sources ?? []).map((s) => s.title ?? "Untitled").join(", ");
+          const tagList = sprint.tags?.length ? sprint.tags.join(", ") : "";
+
+          // Phase A: Analyzing metadata
+          send("sprint", {
+            sprintIndex: i,
+            sprintId: sprint.id,
+            title: sprint.title,
+            status: "analyzing",
+            message: "Analyzing sprint metadata...",
+          });
+
+          console.log(`[sprint:prepare] Sprint[${i}] "${sprint.title}" — generating recall queries...`);
+          console.log(`[sprint:prepare]   summary=${sprint.summary?.length ?? 0} chars, sources=${(sprint.sources ?? []).length}, tags=[${tagList}]`);
+
+          // LLM generates semantic recall queries from metadata
+          const { object: queryResult } = await generateObject({
+            model: getLanguageModel(QUERY_MODEL),
+            schema: recallQueriesSchema,
+            prompt: `You are helping retrieve a research sprint report from semantic memory. Given the sprint metadata below, generate 3-5 diverse search queries that would retrieve the most comprehensive content from this sprint.
+
+The queries should:
+- Cover different aspects/topics of the sprint
+- Use specific terms and concepts from the summary and tags
+- Be phrased as semantic search queries (not questions)
+- Together, aim to retrieve the sprint's full findings
+
+Sprint metadata:
+- Title: ${sprint.title}
+- Summary: ${sprint.summary ?? "No summary available"}
+- Sources: ${sourceNames || "No sources listed"}
+- Tags: ${tagList || "No tags"}`,
+          });
+
+          console.log(`[sprint:prepare] Sprint[${i}] LLM generated ${queryResult.queries.length} queries: ${JSON.stringify(queryResult.queries)}`);
+
+          // Phase B: Recalling from memory
+          send("sprint", {
+            sprintIndex: i,
+            sprintId: sprint.id,
+            title: sprint.title,
+            status: "recalling",
+            message: `Searching memory (${queryResult.queries.length} queries)...`,
+          });
+
+          // Execute all recall queries and deduplicate
+          const seenTexts = new Set<string>();
+          const allResults: { text: string; relevance: number }[] = [];
+
+          for (const query of queryResult.queries) {
+            try {
+              console.log(`[sprint:prepare] Sprint[${i}] recall query="${query}"`);
+              const results = await recallFromMemWal(memwalKey, query, 5);
+              console.log(`[sprint:prepare] Sprint[${i}] recall returned ${results.length} results for "${query}"`);
+
+              for (const r of results) {
+                // Deduplicate by first 200 chars
+                const key = r.text.slice(0, 200);
+                if (!seenTexts.has(key)) {
+                  seenTexts.add(key);
+                  allResults.push(r);
+                }
+              }
+            } catch (err) {
+              console.warn(`[sprint:prepare] Sprint[${i}] recall failed for query="${query}":`, err);
+            }
+          }
+
+          // Sort by relevance, filter out weak matches (unrelated sprints)
+          allResults.sort((a, b) => b.relevance - a.relevance);
+
+          const MIN_RELEVANCE = 0.4;
+          const relevant = allResults.filter((r) => r.relevance >= MIN_RELEVANCE);
+          const filtered = allResults.length - relevant.length;
+
+          for (const [ri, r] of allResults.entries()) {
+            const kept = r.relevance >= MIN_RELEVANCE ? "KEPT" : "filtered";
+            console.log(`[sprint:prepare] Sprint[${i}] result[${ri}] relevance=${r.relevance.toFixed(3)} [${kept}], ${r.text.length} chars, preview="${r.text.slice(0, 80)}..."`);
+          }
+
+          const totalChars = relevant.reduce((sum, r) => sum + r.text.length, 0);
+          console.log(`[sprint:prepare] Sprint[${i}] "${sprint.title}" — ${allResults.length} unique results, ${relevant.length} kept (${filtered} filtered below ${MIN_RELEVANCE}), ${totalChars} chars total`);
+
+          // Assemble sprint context block
+          const recalledContent = relevant
+            .map((r) => r.text)
+            .join("\n\n---\n\n");
+
+          const block = [
+            `### ${sprint.title}`,
+            sprint.summary ? `**Summary:** ${sprint.summary}` : "",
+            sourceNames ? `**Sources:** ${sourceNames}` : "",
+            tagList ? `**Tags:** ${tagList}` : "",
+            "",
+            recalledContent
+              ? `**Retrieved Research Findings:**\n\n${recalledContent}`
+              : `*No findings retrieved from memory for this sprint.*`,
+          ]
+            .filter(Boolean)
+            .join("\n");
+
+          sprintContextBlocks.push(block);
+
+          send("sprint", {
+            sprintIndex: i,
+            sprintId: sprint.id,
+            title: sprint.title,
+            status: "done",
+            charCount: totalChars,
+            resultCount: relevant.length,
+            queryCount: queryResult.queries.length,
+          });
+        }
+
+        // Assemble full sprint context
+        const fullContext = [
+          "## Previous Research Sprints",
+          "",
+          "The user has selected the following previous research sprints as context for this conversation.",
+          "The findings below were retrieved from long-term research memory (MemWal).",
+          "",
+          ...sprintContextBlocks,
+        ].join("\n");
+
+        console.log(`[sprint:prepare] Full sprint context assembled: ${fullContext.length} chars`);
+
+        send("step", { step: "build-context", status: "done", message: "Research retrieved" });
+
+        // Step 4: Persist context to DB
+        send("step", { step: "save-context", status: "start", message: "Saving context..." });
+
+        await updateChatSprintContext({ chatId, sprintContext: fullContext });
+
+        console.log(`[sprint:prepare] Sprint context persisted to chat ${chatId}`);
+        send("step", { step: "save-context", status: "done", message: "Context saved" });
+
+        // Step 5: Ready
+        send("ready", {
+          chatId,
+          sprintCount: ownedSprints.length,
+          contextChars: fullContext.length,
+        });
+        console.log(`[sprint:prepare] Preparation complete for chat ${chatId}`);
+      } catch (err) {
+        console.error("[sprint:prepare] Pipeline error:", err);
+        send("error", {
+          step: "unknown",
+          message: err instanceof Error ? err.message : "Preparation failed",
+        });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/researcher/app/research/new/layout.tsx
+++ b/apps/researcher/app/research/new/layout.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/app/(auth)/auth";
+
+export default async function LauncherLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/api/auth/guest");
+  }
+
+  return <>{children}</>;
+}

--- a/apps/researcher/app/research/new/page.tsx
+++ b/apps/researcher/app/research/new/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/app/(auth)/auth";
+import { getSprintsByUserId } from "@/lib/db/queries";
+import { SessionLauncher } from "@/components/research/session-launcher";
+
+export default async function LauncherPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/api/auth/guest");
+  }
+
+  const sprints = await getSprintsByUserId({ userId: session.user.id });
+
+  if (sprints.length === 0) {
+    redirect("/");
+  }
+
+  const serializedSprints = sprints.map((s) => ({
+    id: s.id,
+    title: s.title,
+    summary: s.summary,
+    reportContent: s.reportContent,
+    citations: s.citations,
+    sources: s.sources,
+    tags: s.tags,
+    chatId: s.chatId,
+    blobId: s.blobId,
+    memoryCount: s.memoryCount,
+    createdAt: s.createdAt.toISOString(),
+  }));
+
+  return <SessionLauncher sprints={serializedSprints} />;
+}

--- a/apps/researcher/components/chat/chat-header.tsx
+++ b/apps/researcher/components/chat/chat-header.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { BookOpenIcon } from "lucide-react";
+import { BookOpenIcon, BrainIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { memo } from "react";
 import { useWindowSize } from "usehooks-ts";
 import { SidebarToggle } from "../sidebar/sidebar-toggle";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PlusIcon } from "../icons";
 import { useSidebar } from "../ui/sidebar";
@@ -19,6 +20,7 @@ function PureChatHeader({
   onToggleMyStuff,
   memwalKey,
   hasMessages,
+  sprintIds,
 }: {
   chatId: string;
   selectedVisibilityType: VisibilityType;
@@ -26,6 +28,7 @@ function PureChatHeader({
   onToggleMyStuff?: () => void;
   memwalKey: string;
   hasMessages: boolean;
+  sprintIds?: string[];
 }) {
   const router = useRouter();
   const { open } = useSidebar();
@@ -40,7 +43,7 @@ function PureChatHeader({
         <Button
           className="order-2 ml-auto h-8 px-2 md:order-1 md:ml-0 md:h-fit md:px-2"
           onClick={() => {
-            router.push("/");
+            router.push("/research/new");
             router.refresh();
           }}
           variant="outline"
@@ -56,6 +59,18 @@ function PureChatHeader({
           className="order-1 md:order-2"
           selectedVisibilityType={selectedVisibilityType}
         />
+      )}
+
+      {sprintIds && sprintIds.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge variant="secondary" className="order-2 gap-1 md:order-3">
+              <BrainIcon className="size-3" />
+              {sprintIds.length} sprint{sprintIds.length !== 1 ? "s" : ""}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>Sprint context active</TooltipContent>
+        </Tooltip>
       )}
 
       {onToggleMyStuff && (
@@ -92,6 +107,7 @@ export const ChatHeader = memo(PureChatHeader, (prevProps, nextProps) => {
     prevProps.isReadonly === nextProps.isReadonly &&
     prevProps.onToggleMyStuff === nextProps.onToggleMyStuff &&
     prevProps.memwalKey === nextProps.memwalKey &&
-    prevProps.hasMessages === nextProps.hasMessages
+    prevProps.hasMessages === nextProps.hasMessages &&
+    prevProps.sprintIds === nextProps.sprintIds
   );
 });

--- a/apps/researcher/components/chat/chat.tsx
+++ b/apps/researcher/components/chat/chat.tsx
@@ -38,6 +38,7 @@ export function Chat({
   initialVisibilityType,
   isReadonly,
   autoResume,
+  initialSprintIds,
 }: {
   id: string;
   initialMessages: ChatMessage[];
@@ -45,6 +46,7 @@ export function Chat({
   initialVisibilityType: VisibilityType;
   isReadonly: boolean;
   autoResume: boolean;
+  initialSprintIds?: string[];
 }) {
   const router = useRouter();
 
@@ -85,6 +87,7 @@ export function Chat({
   const currentModelIdRef = useRef(currentModelId);
   const useMemWalRef = useRef(useMemWal);
   const memwalKeyRef = useRef(memwalKey);
+  const sprintIdsRef = useRef(initialSprintIds);
 
   useEffect(() => {
     currentModelIdRef.current = currentModelId;
@@ -155,6 +158,7 @@ export function Chat({
             selectedVisibilityType: visibilityType,
             useMemWal: useMemWalRef.current,
             memwalKey: memwalKeyRef.current || undefined,
+            // sprintIds are now set during preparation — no longer sent per-message
             ...request.body,
           },
         };
@@ -200,6 +204,8 @@ export function Chat({
     }
   }, [query, sendMessage, hasAppendedQuery, id]);
 
+  // Sprint chats now go directly to /chat/{id} after preparation — no URL cleanup needed
+
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [myStuffOpen, setMyStuffOpen] = useState(false);
 
@@ -228,6 +234,7 @@ export function Chat({
           memwalKey={memwalKey}
           selectedVisibilityType={initialVisibilityType}
           onToggleMyStuff={() => setMyStuffOpen((prev) => !prev)}
+          sprintIds={initialSprintIds}
         />
 
         <Messages

--- a/apps/researcher/components/chat/sprint-save-button.tsx
+++ b/apps/researcher/components/chat/sprint-save-button.tsx
@@ -2,6 +2,7 @@
 
 import { BookmarkIcon, CheckIcon, LoaderIcon } from "lucide-react";
 import { useState } from "react";
+import { useSWRConfig } from "swr";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useSprintStatus } from "@/hooks/use-sprint-status";
@@ -16,6 +17,7 @@ export function SprintSaveButton({
   memwalKey: string;
   hasMessages: boolean;
 }) {
+  const { mutate: globalMutate } = useSWRConfig();
   const { hasSprint, sprintTitle, isLoading, mutate } =
     useSprintStatus(chatId);
   const [isSaving, setIsSaving] = useState(false);
@@ -42,6 +44,7 @@ export function SprintSaveButton({
         description: `Sprint saved: "${result.title}"`,
       });
       mutate();
+      globalMutate("/api/sprint/list");
     } catch (error) {
       toast({
         type: "error",

--- a/apps/researcher/components/research/session-launcher.tsx
+++ b/apps/researcher/components/research/session-launcher.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowLeftIcon, ArrowRightIcon, BrainIcon, SearchIcon, XIcon } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { SprintDetail } from "@/components/sources/sprint-detail";
+import { SprintPreparationScreen } from "./sprint-preparation-screen";
+import { SprintSelectCard } from "./sprint-select-card";
+import { useSprintPreparation } from "@/hooks/use-sprint-preparation";
+import type { SprintListItem } from "@/hooks/use-sprints";
+import { generateUUID } from "@/lib/utils";
+
+export function SessionLauncher({
+  sprints,
+}: {
+  sprints: SprintListItem[];
+}) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<"select" | "preparing">("select");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [previewId, setPreviewId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const preparation = useSprintPreparation();
+
+  const filteredSprints = useMemo(() => {
+    if (!searchQuery.trim()) return sprints;
+    const q = searchQuery.toLowerCase();
+    return sprints.filter(
+      (s) =>
+        s.title.toLowerCase().includes(q) ||
+        (s.summary?.toLowerCase().includes(q) ?? false) ||
+        (s.tags?.some((t) => t.toLowerCase().includes(q)) ?? false)
+    );
+  }, [sprints, searchQuery]);
+
+  const previewSprint = useMemo(
+    () => sprints.find((s) => s.id === previewId) ?? null,
+    [sprints, previewId]
+  );
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleStartChat = () => {
+    const chatId = generateUUID();
+    const sprintTitles = new Map(sprints.map((s) => [s.id, s.title]));
+    const memwalKey =
+      typeof window !== "undefined"
+        ? localStorage.getItem("memwalKey") || undefined
+        : undefined;
+
+    preparation.start({
+      chatId,
+      sprintIds: Array.from(selectedIds),
+      sprintTitles,
+      memwalKey,
+    });
+    setPhase("preparing");
+  };
+
+  const handleStartFresh = () => {
+    setSelectedIds(new Set());
+    setPreviewId(null);
+  };
+
+  const handleJustChat = () => {
+    router.push("/");
+  };
+
+  const handleBackFromPreparation = () => {
+    preparation.reset();
+    setPhase("select");
+  };
+
+  // Redirect on ready — only when actively in preparing phase
+  useEffect(() => {
+    if (phase === "preparing" && preparation.state.phase === "ready" && preparation.state.chatId) {
+      const timer = setTimeout(() => {
+        router.push(`/chat/${preparation.state.chatId}`);
+      }, 600);
+      return () => clearTimeout(timer);
+    }
+  }, [phase, preparation.state.phase, preparation.state.chatId, router]);
+
+  return (
+    <AnimatePresence mode="wait">
+      {phase === "preparing" ? (
+        <SprintPreparationScreen
+          key="preparing"
+          state={preparation.state}
+          onRetry={preparation.retry}
+          onBack={handleBackFromPreparation}
+        />
+      ) : (
+        <motion.div
+          key="select"
+          initial={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="flex h-dvh flex-col bg-background"
+        >
+          {/* Top bar */}
+          <header className="flex items-center justify-between border-b px-6 py-4">
+            <div className="flex items-center gap-3">
+              <Link
+                href="/"
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <ArrowLeftIcon className="size-4" />
+              </Link>
+              <BrainIcon className="size-5 text-primary" />
+              <h1 className="text-lg font-semibold">New Research Session</h1>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={handleJustChat}>
+                Just Chat
+                <ArrowRightIcon className="ml-1 size-3.5" />
+              </Button>
+            </div>
+          </header>
+
+          {/* Main content */}
+          <div className="flex min-h-0 flex-1">
+            {/* Left column — sprint selection */}
+            <div className="flex w-full flex-col border-r md:w-[400px] lg:w-[440px]">
+              {/* Search */}
+              <div className="border-b px-4 py-3">
+                <div className="relative">
+                  <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    type="text"
+                    placeholder="Search sprints..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="w-full rounded-md border bg-background py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                  {searchQuery && (
+                    <button
+                      type="button"
+                      onClick={() => setSearchQuery("")}
+                      className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    >
+                      <XIcon className="size-3.5" />
+                    </button>
+                  )}
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Select sprints to bring their context into your new session.
+                  {selectedIds.size > 0 && (
+                    <span className="ml-1 font-medium text-primary">
+                      {selectedIds.size} selected
+                    </span>
+                  )}
+                </p>
+              </div>
+
+              {/* Sprint list */}
+              <div className="flex-1 space-y-2 overflow-y-auto p-4">
+                {filteredSprints.length === 0 ? (
+                  <p className="py-8 text-center text-sm text-muted-foreground">
+                    {searchQuery ? "No sprints match your search." : "No sprints available."}
+                  </p>
+                ) : (
+                  filteredSprints.map((sprint) => (
+                    <SprintSelectCard
+                      key={sprint.id}
+                      sprint={sprint}
+                      isSelected={selectedIds.has(sprint.id)}
+                      isPreviewing={previewId === sprint.id}
+                      onToggleSelect={() => toggleSelect(sprint.id)}
+                      onPreview={() =>
+                        setPreviewId((prev) =>
+                          prev === sprint.id ? null : sprint.id
+                        )
+                      }
+                    />
+                  ))
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex gap-2 border-t px-4 py-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleStartFresh}
+                  disabled={selectedIds.size === 0}
+                  className="flex-1"
+                >
+                  Start Fresh
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleStartChat}
+                  disabled={selectedIds.size === 0}
+                  className="flex-1"
+                >
+                  Start Chat
+                  <ArrowRightIcon className="ml-1 size-3.5" />
+                </Button>
+              </div>
+            </div>
+
+            {/* Right column — preview */}
+            <div className="hidden flex-1 md:block">
+              {previewSprint ? (
+                <SprintDetail
+                  sprint={previewSprint}
+                  onBack={() => setPreviewId(null)}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <p className="text-sm text-muted-foreground">
+                    Click a sprint to preview its details
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/researcher/components/research/sprint-preparation-screen.tsx
+++ b/apps/researcher/components/research/sprint-preparation-screen.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  BrainIcon,
+  CheckCircleIcon,
+  LoaderIcon,
+  MinusIcon,
+  SearchIcon,
+  SparklesIcon,
+  XCircleIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Shimmer } from "@/components/ai-elements/shimmer";
+import type { PreparationState, SprintProgress } from "@/hooks/use-sprint-preparation";
+
+export function SprintPreparationScreen({
+  state,
+  onRetry,
+  onBack,
+}: {
+  state: PreparationState;
+  onRetry: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <motion.div
+      key="preparing"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="flex h-dvh flex-col items-center justify-center bg-background px-4"
+    >
+      <div className="w-full max-w-md space-y-8">
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+          className="flex flex-col items-center gap-3"
+        >
+          <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
+            <BrainIcon className="size-6 text-primary" />
+          </div>
+          <h2 className="text-lg font-semibold">
+            {state.phase === "ready"
+              ? "Session Ready"
+              : state.phase === "error"
+                ? "Preparation Failed"
+                : "Preparing Your Session"}
+          </h2>
+        </motion.div>
+
+        {/* Step list */}
+        <div className="space-y-3">
+          {state.steps.map((step, i) => (
+            <motion.div
+              key={step.id}
+              initial={{ opacity: 0, x: -10 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: 0.15 + i * 0.06 }}
+              className="flex items-start gap-3"
+            >
+              <StepIcon status={step.status} />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  {step.status === "active" ? (
+                    <Shimmer className="text-sm font-medium">
+                      {step.label}
+                    </Shimmer>
+                  ) : (
+                    <span
+                      className={`text-sm font-medium ${
+                        step.status === "done"
+                          ? "text-foreground"
+                          : step.status === "error"
+                            ? "text-destructive"
+                            : "text-muted-foreground"
+                      }`}
+                    >
+                      {step.label}
+                    </span>
+                  )}
+                </div>
+                {step.status === "error" && step.message && (
+                  <p className="mt-0.5 text-xs text-destructive">
+                    {step.message}
+                  </p>
+                )}
+
+                {/* Sprint sub-items under build-context */}
+                {step.id === "build-context" &&
+                  (step.status === "active" || step.status === "done") &&
+                  state.sprints.length > 0 && (
+                    <div className="mt-2 space-y-2 pl-1">
+                      {state.sprints.map((sprint, si) => (
+                        <SprintItem key={sprint.sprintId} sprint={sprint} index={si} />
+                      ))}
+                    </div>
+                  )}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Progress bar */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.3 }}
+        >
+          <Progress value={state.progress} className="h-2" />
+        </motion.div>
+
+        {/* Ready message */}
+        <AnimatePresence>
+          {state.phase === "ready" && (
+            <motion.p
+              initial={{ opacity: 0, y: 5 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="text-center text-sm text-muted-foreground"
+            >
+              Context ready — redirecting...
+            </motion.p>
+          )}
+        </AnimatePresence>
+
+        {/* Error actions */}
+        {state.phase === "error" && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="flex justify-center gap-3"
+          >
+            <Button variant="outline" size="sm" onClick={onBack}>
+              Go Back
+            </Button>
+            <Button size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          </motion.div>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function SprintItem({ sprint, index }: { sprint: SprintProgress; index: number }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.08 }}
+      className="space-y-0.5"
+    >
+      <div className="flex items-center gap-2">
+        <SprintIcon status={sprint.status} />
+        <span
+          className={`text-xs font-medium ${
+            sprint.status === "done" ? "text-foreground" : "text-muted-foreground"
+          }`}
+        >
+          {sprint.title}
+        </span>
+      </div>
+      {/* Sub-status message */}
+      {sprint.status === "analyzing" && (
+        <div className="flex items-center gap-1.5 pl-5">
+          <SparklesIcon className="size-2.5 text-amber-500" />
+          <span className="text-[11px] text-muted-foreground">Analyzing metadata...</span>
+        </div>
+      )}
+      {sprint.status === "recalling" && (
+        <div className="flex items-center gap-1.5 pl-5">
+          <SearchIcon className="size-2.5 text-blue-500" />
+          <span className="text-[11px] text-muted-foreground">{sprint.message ?? "Searching memory..."}</span>
+        </div>
+      )}
+      {sprint.status === "done" && sprint.resultCount !== undefined && (
+        <div className="pl-5">
+          <span className="text-[11px] text-muted-foreground">
+            {sprint.resultCount} findings retrieved
+            {sprint.charCount ? ` (${(sprint.charCount / 1000).toFixed(1)}k chars)` : ""}
+          </span>
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function StepIcon({ status }: { status: string }) {
+  switch (status) {
+    case "done":
+      return (
+        <motion.div
+          initial={{ scale: 0.8 }}
+          animate={{ scale: 1 }}
+          transition={{ type: "spring", stiffness: 300, damping: 20 }}
+        >
+          <CheckCircleIcon className="mt-0.5 size-4 text-green-500" />
+        </motion.div>
+      );
+    case "active":
+      return <LoaderIcon className="mt-0.5 size-4 animate-spin text-primary" />;
+    case "error":
+      return <XCircleIcon className="mt-0.5 size-4 text-destructive" />;
+    default:
+      return <MinusIcon className="mt-0.5 size-4 text-muted-foreground/40" />;
+  }
+}
+
+function SprintIcon({ status }: { status: string }) {
+  switch (status) {
+    case "done":
+      return (
+        <motion.div initial={{ scale: 0.8 }} animate={{ scale: 1 }}>
+          <CheckCircleIcon className="size-3 text-green-500" />
+        </motion.div>
+      );
+    case "analyzing":
+      return <SparklesIcon className="size-3 animate-pulse text-amber-500" />;
+    case "recalling":
+      return <LoaderIcon className="size-3 animate-spin text-blue-500" />;
+    default:
+      return <MinusIcon className="size-3 text-muted-foreground/40" />;
+  }
+}

--- a/apps/researcher/components/research/sprint-select-card.tsx
+++ b/apps/researcher/components/research/sprint-select-card.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { CheckIcon, FileTextIcon } from "lucide-react";
+import { memo } from "react";
+import type { SprintListItem } from "@/hooks/use-sprints";
+import { cn } from "@/lib/utils";
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function PureSprintSelectCard({
+  sprint,
+  isSelected,
+  isPreviewing,
+  onToggleSelect,
+  onPreview,
+}: {
+  sprint: SprintListItem;
+  isSelected: boolean;
+  isPreviewing: boolean;
+  onToggleSelect: () => void;
+  onPreview: () => void;
+}) {
+  const sourceCount = sprint.sources?.length ?? 0;
+
+  return (
+    <div
+      className={cn(
+        "group relative flex cursor-pointer gap-3 rounded-lg border p-3 transition-all",
+        isSelected
+          ? "border-primary/50 bg-primary/5"
+          : "border-border hover:border-muted-foreground/30",
+        isPreviewing && "ring-2 ring-primary/30"
+      )}
+      onClick={onPreview}
+    >
+      {/* Checkbox */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleSelect();
+        }}
+        className={cn(
+          "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded border transition-colors",
+          isSelected
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-muted-foreground/40 hover:border-primary"
+        )}
+      >
+        {isSelected && <CheckIcon className="size-3" />}
+      </button>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate text-sm font-medium">{sprint.title}</h3>
+        {sprint.summary && (
+          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+            {sprint.summary}
+          </p>
+        )}
+        <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
+          <span>{formatDate(sprint.createdAt)}</span>
+          {sourceCount > 0 && (
+            <span className="flex items-center gap-1">
+              <FileTextIcon className="size-3" />
+              {sourceCount}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const SprintSelectCard = memo(PureSprintSelectCard);

--- a/apps/researcher/components/sidebar/app-sidebar.tsx
+++ b/apps/researcher/components/sidebar/app-sidebar.tsx
@@ -99,7 +99,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                       className="h-8 p-1 md:h-fit md:p-2"
                       onClick={() => {
                         setOpenMobile(false);
-                        router.push("/");
+                        router.push("/research/new");
                         router.refresh();
                       }}
                       type="button"

--- a/apps/researcher/components/sources/sprint-detail.tsx
+++ b/apps/researcher/components/sources/sprint-detail.tsx
@@ -37,7 +37,12 @@ function PureSprintDetail({
   >("report");
 
   const citations = sprint.citations ?? [];
-  const sources = sprint.sources ?? [];
+
+  // Deduplicate sources by title (same source may have different IDs across sessions)
+  const rawSources = sprint.sources ?? [];
+  const sources = rawSources.filter((s, i, arr) =>
+    arr.findIndex((o) => (o.title ?? o.sourceId) === (s.title ?? s.sourceId)) === i
+  );
 
   return (
     <div className="flex h-full flex-col">
@@ -81,7 +86,7 @@ function PureSprintDetail({
         </div>
         {sprint.tags && sprint.tags.length > 0 && (
           <div className="mt-2 flex flex-wrap gap-1">
-            {sprint.tags.map((tag) => (
+            {[...new Set(sprint.tags)].map((tag) => (
               <span
                 key={tag}
                 className="inline-block rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"

--- a/apps/researcher/hooks/use-sprint-preparation.ts
+++ b/apps/researcher/hooks/use-sprint-preparation.ts
@@ -1,0 +1,257 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export type PrepStep = {
+  id: string;
+  label: string;
+  status: "pending" | "active" | "done" | "error";
+  message?: string;
+};
+
+export type SprintProgress = {
+  sprintId: string;
+  title: string;
+  status: "pending" | "analyzing" | "recalling" | "done";
+  message?: string;
+  charCount?: number;
+  resultCount?: number;
+};
+
+export type PreparationState = {
+  phase: "idle" | "preparing" | "ready" | "error";
+  steps: PrepStep[];
+  sprints: SprintProgress[];
+  chatId: string | null;
+  error: string | null;
+  progress: number;
+};
+
+const INITIAL_STEPS: PrepStep[] = [
+  { id: "validate", label: "Validating sprint access", status: "pending" },
+  { id: "create-chat", label: "Creating session", status: "pending" },
+  { id: "build-context", label: "Retrieving sprint research", status: "pending" },
+  { id: "save-context", label: "Saving context", status: "pending" },
+];
+
+function calcProgress(
+  steps: PrepStep[],
+  sprints: SprintProgress[],
+): number {
+  // Weight: validate(10) + create-chat(10) + sprints(65) + save-context(5) + ready(10)
+  let progress = 0;
+
+  for (const step of steps) {
+    if (step.id === "validate" && (step.status === "done" || step.status === "error"))
+      progress += 10;
+    if (step.id === "create-chat" && (step.status === "done" || step.status === "error"))
+      progress += 10;
+    if (step.id === "save-context" && (step.status === "done" || step.status === "error"))
+      progress += 5;
+  }
+
+  // Sprint progress — analyzing=30%, recalling=70%, done=100% of their share
+  if (sprints.length > 0) {
+    let sprintProgress = 0;
+    for (const s of sprints) {
+      if (s.status === "analyzing") sprintProgress += 0.3;
+      else if (s.status === "recalling") sprintProgress += 0.7;
+      else if (s.status === "done") sprintProgress += 1;
+    }
+    progress += Math.round((sprintProgress / sprints.length) * 65);
+  }
+
+  return Math.min(progress, 100);
+}
+
+interface StartParams {
+  chatId: string;
+  sprintIds: string[];
+  sprintTitles: Map<string, string>;
+  memwalKey?: string;
+  visibility?: "public" | "private";
+}
+
+export function useSprintPreparation() {
+  const [state, setState] = useState<PreparationState>({
+    phase: "idle",
+    steps: [],
+    sprints: [],
+    chatId: null,
+    error: null,
+    progress: 0,
+  });
+
+  const abortRef = useRef<AbortController | null>(null);
+  const lastParamsRef = useRef<StartParams | null>(null);
+
+  const start = useCallback(async (params: StartParams) => {
+    lastParamsRef.current = params;
+    abortRef.current?.abort();
+    const abort = new AbortController();
+    abortRef.current = abort;
+
+    const initialSprints: SprintProgress[] = params.sprintIds.map((id) => ({
+      sprintId: id,
+      title: params.sprintTitles.get(id) ?? "Sprint",
+      status: "pending" as const,
+    }));
+
+    setState({
+      phase: "preparing",
+      steps: INITIAL_STEPS.map((s) => ({ ...s })),
+      sprints: initialSprints,
+      chatId: params.chatId,
+      error: null,
+      progress: 0,
+    });
+
+    try {
+      const response = await fetch("/api/sprint/prepare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chatId: params.chatId,
+          sprintIds: params.sprintIds,
+          memwalKey: params.memwalKey,
+          visibility: params.visibility ?? "private",
+        }),
+        signal: abort.signal,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        setState((prev) => ({
+          ...prev,
+          phase: "error",
+          error: errorData.message ?? `Server error: ${response.status}`,
+        }));
+        return;
+      }
+
+      if (!response.body) {
+        setState((prev) => ({
+          ...prev,
+          phase: "error",
+          error: "No response stream",
+        }));
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
+
+        for (const part of parts) {
+          if (!part.trim()) continue;
+
+          let eventType = "message";
+          let dataStr = "";
+
+          for (const line of part.split("\n")) {
+            if (line.startsWith("event: ")) {
+              eventType = line.slice(7).trim();
+            } else if (line.startsWith("data: ")) {
+              dataStr = line.slice(6);
+            }
+          }
+
+          if (!dataStr) continue;
+
+          let data: Record<string, any>;
+          try {
+            data = JSON.parse(dataStr);
+          } catch {
+            continue;
+          }
+
+          setState((prev) => {
+            const next = { ...prev };
+            next.steps = [...prev.steps];
+            next.sprints = [...prev.sprints];
+
+            if (eventType === "step") {
+              const stepIdx = next.steps.findIndex((s) => s.id === data.step);
+              if (stepIdx !== -1) {
+                const step = { ...next.steps[stepIdx] };
+                if (data.status === "start") {
+                  step.status = "active";
+                  step.message = data.message;
+                } else if (data.status === "done") {
+                  step.status = "done";
+                  step.message = data.message;
+                } else if (data.status === "error") {
+                  step.status = "error";
+                  step.message = data.message;
+                }
+                next.steps[stepIdx] = step;
+              }
+            } else if (eventType === "sprint") {
+              const sprintIdx = next.sprints.findIndex(
+                (s) => s.sprintId === data.sprintId,
+              );
+              if (sprintIdx !== -1) {
+                const sprint = { ...next.sprints[sprintIdx] };
+                sprint.title = data.title ?? sprint.title;
+                sprint.status = data.status as SprintProgress["status"];
+                sprint.message = data.message;
+                if (data.charCount !== undefined) sprint.charCount = data.charCount;
+                if (data.resultCount !== undefined) sprint.resultCount = data.resultCount;
+                next.sprints[sprintIdx] = sprint;
+              }
+            } else if (eventType === "ready") {
+              next.phase = "ready";
+              next.chatId = data.chatId;
+              next.progress = 100;
+              return next;
+            } else if (eventType === "error") {
+              next.phase = "error";
+              next.error = data.message ?? "Preparation failed";
+              return next;
+            }
+
+            next.progress = calcProgress(next.steps, next.sprints);
+            return next;
+          });
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      setState((prev) => ({
+        ...prev,
+        phase: "error",
+        error: err instanceof Error ? err.message : "Connection failed",
+      }));
+    }
+  }, []);
+
+  const retry = useCallback(() => {
+    if (lastParamsRef.current) {
+      start(lastParamsRef.current);
+    }
+  }, [start]);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    lastParamsRef.current = null;
+    setState({
+      phase: "idle",
+      steps: [],
+      sprints: [],
+      chatId: null,
+      error: null,
+      progress: 0,
+    });
+  }, []);
+
+  return { state, start, retry, reset };
+}

--- a/apps/researcher/lib/ai/entitlements.ts
+++ b/apps/researcher/lib/ai/entitlements.ts
@@ -9,14 +9,14 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    * For users without an account
    */
   guest: {
-    maxMessagesPerHour: 10,
+    maxMessagesPerHour: 100,
   },
 
   /*
    * For users with an account
    */
   regular: {
-    maxMessagesPerHour: 10,
+    maxMessagesPerHour: 100,
   },
 
   /*

--- a/apps/researcher/lib/ai/prompts.ts
+++ b/apps/researcher/lib/ai/prompts.ts
@@ -27,10 +27,13 @@ Follow this multi-step approach — you MUST complete steps 1 through 3 before a
 
 4. **EXPAND**: Use getSourceContext() if a chunk references context from neighboring sections.
 
-5. **STOP**: If search scores are all below 0.4, the sources likely don't cover this topic. Say so honestly.
+5. **GAP**: If search scores are all below 0.4, the sources don't cover this topic. In this case:
+   - Still answer using your general knowledge — be helpful first
+   - Clearly note which parts come from the user's sources vs. your general knowledge
+   - Suggest the user can provide additional sources (URLs or PDFs) for more grounded, source-backed answers on this specific topic
 
 ## CRITICAL RULE
-You MUST call searchSourceContent and then getChunkContent before writing any answer that draws on user sources. Answering from listSources summaries/claims alone produces shallow, unreferenced responses. Always read the actual text.
+You MUST call searchSourceContent and then getChunkContent before writing any answer that draws on user sources. Answering from listSources summaries/claims alone produces shallow, unreferenced responses. Always read the actual text. However, if sources don't cover the topic, you should still engage with the question using your own knowledge — just be transparent about the source gap.
 
 ## Anti-patterns — Do NOT:
 - Answer research questions using only listSources metadata (summaries/claims)
@@ -38,6 +41,7 @@ You MUST call searchSourceContent and then getChunkContent before writing any an
 - Read all chunks when 2-3 answer the question
 - Guess at content you haven't retrieved
 - Ignore relevance scores — they tell you how good the match is
+- Refuse to answer or go silent just because sources don't cover a topic — use your knowledge and be transparent
 
 ## Automatic Source Processing
 When the user includes URLs or attaches PDFs, those sources are automatically processed and indexed before you respond. Use searchSourceContent to access the content.
@@ -48,6 +52,30 @@ When the user includes URLs or attaches PDFs, those sources are automatically pr
 - Keep responses concise and well-structured
 - Use markdown formatting for readability
 `;
+
+const recallSprintGuidance = `## Sprint Memory Recall
+
+You have access to a **recallSprint** tool that searches long-term research memory (MemWal) for detailed findings from previous sprints.
+
+The sprint metadata above (titles, summaries, source lists) is for orientation only — the full reports, data points, citations, and detailed findings are stored in MemWal.
+
+**ALWAYS use recallSprint when:**
+- The user asks ANY question related to previous sprint topics
+- You need specific findings, facts, quotes, or data from past research
+- You need to cross-reference findings across multiple sprints
+- You want to ground your answer in actual research content
+
+**Only skip recallSprint when:**
+- The user asks a general "what did I research?" question (summaries suffice for listing topics)
+- The user is starting a completely new topic unrelated to any sprint
+- The user explicitly says they don't need past research context
+
+**Strategy:** Use the sprint titles and summaries to construct targeted recallSprint queries. For example, if a sprint is titled "Global Green Energy Landscape", search for specific sub-topics like "solar panel efficiency trends" rather than the full title.
+`;
+
+export function getSprintResumePrompt(sprintContextBlock: string): string {
+  return researchPrompt + "\n\n" + sprintContextBlock + "\n\n" + recallSprintGuidance;
+}
 
 export const titlePrompt = `Generate a short chat title (2-5 words) summarizing the user's message.
 

--- a/apps/researcher/lib/db/migrations/0011_sprint_recall.sql
+++ b/apps/researcher/lib/db/migrations/0011_sprint_recall.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Chat" ADD COLUMN "sprintIds" json;

--- a/apps/researcher/lib/db/migrations/0012_sprint_context.sql
+++ b/apps/researcher/lib/db/migrations/0012_sprint_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Chat" ADD COLUMN "sprintContext" text;

--- a/apps/researcher/lib/db/migrations/meta/_journal.json
+++ b/apps/researcher/lib/db/migrations/meta/_journal.json
@@ -78,6 +78,20 @@
       "when": 1741772800000,
       "tag": "0010_sprint_save",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1741859200000,
+      "tag": "0011_sprint_recall",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1741945600000,
+      "tag": "0012_sprint_context",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/researcher/lib/db/queries.ts
+++ b/apps/researcher/lib/db/queries.ts
@@ -87,11 +87,13 @@ export async function saveChat({
   userId,
   title,
   visibility,
+  sprintIds,
 }: {
   id: string;
   userId: string;
   title: string;
   visibility: VisibilityType;
+  sprintIds?: string[];
 }) {
   try {
     return await db.insert(chat).values({
@@ -100,6 +102,7 @@ export async function saveChat({
       userId,
       title,
       visibility,
+      sprintIds: sprintIds ?? null,
     });
   } catch (_error) {
     throw new ChatbotError("bad_request:database", "Failed to save chat");
@@ -380,6 +383,26 @@ export async function updateChatVisibilityById({
     throw new ChatbotError(
       "bad_request:database",
       "Failed to update chat visibility by id"
+    );
+  }
+}
+
+export async function updateChatSprintContext({
+  chatId,
+  sprintContext,
+}: {
+  chatId: string;
+  sprintContext: string;
+}) {
+  try {
+    return await db
+      .update(chat)
+      .set({ sprintContext })
+      .where(eq(chat.id, chatId));
+  } catch (_error) {
+    throw new ChatbotError(
+      "bad_request:database",
+      "Failed to update chat sprint context"
     );
   }
 }
@@ -754,6 +777,34 @@ export async function getSprintsByUserId({ userId }: { userId: string }) {
     throw new ChatbotError(
       "bad_request:database",
       "Failed to get sprints by user id"
+    );
+  }
+}
+
+export async function getSprintsByIds({
+  sprintIds,
+  userId,
+}: {
+  sprintIds: string[];
+  userId: string;
+}) {
+  if (sprintIds.length === 0) return [];
+  try {
+    return await db
+      .select()
+      .from(researchBlob)
+      .where(
+        and(
+          inArray(researchBlob.id, sprintIds),
+          eq(researchBlob.userId, userId),
+          eq(researchBlob.type, "sprint")
+        )
+      )
+      .orderBy(desc(researchBlob.createdAt));
+  } catch (_error) {
+    throw new ChatbotError(
+      "bad_request:database",
+      "Failed to get sprints by ids"
     );
   }
 }

--- a/apps/researcher/lib/db/schema.ts
+++ b/apps/researcher/lib/db/schema.ts
@@ -43,6 +43,8 @@ export const chat = pgTable("Chat", {
   visibility: varchar("visibility", { enum: ["public", "private"] })
     .notNull()
     .default("private"),
+  sprintIds: json("sprintIds").$type<string[]>(),
+  sprintContext: text("sprintContext"),
 });
 
 export type Chat = InferSelectModel<typeof chat>;

--- a/apps/researcher/lib/rag/tools/index.ts
+++ b/apps/researcher/lib/rag/tools/index.ts
@@ -2,12 +2,38 @@ import { listSourcesTool } from "./list-sources";
 import { searchSourceContentTool } from "./search-content";
 import { getChunkContentTool } from "./get-chunks";
 import { getSourceContextTool } from "./get-context";
+import { recallSprintTool } from "./recall-sprint";
 
-export function getResearchTools({ userId }: { userId: string }) {
-  return {
+// Base tools always returned
+const BASE_TOOL_NAMES = [
+  "listSources",
+  "searchSourceContent",
+  "getChunkContent",
+  "getSourceContext",
+] as const;
+
+// All tool names including optional ones
+const ALL_TOOL_NAMES = [...BASE_TOOL_NAMES, "recallSprint"] as const;
+
+export type ResearchToolName = (typeof ALL_TOOL_NAMES)[number];
+
+export function getResearchTools({
+  userId,
+  memwalKey,
+}: {
+  userId: string;
+  memwalKey?: string;
+}) {
+  const tools: Record<string, any> = {
     listSources: listSourcesTool({ userId }),
     searchSourceContent: searchSourceContentTool({ userId }),
     getChunkContent: getChunkContentTool({ userId }),
     getSourceContext: getSourceContextTool({ userId }),
   };
+
+  if (memwalKey) {
+    tools.recallSprint = recallSprintTool({ memwalKey });
+  }
+
+  return tools;
 }

--- a/apps/researcher/lib/rag/tools/recall-sprint.ts
+++ b/apps/researcher/lib/rag/tools/recall-sprint.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { tool } from "ai";
+import { recallFromMemWal } from "@/lib/sprint/memwal";
+
+export function recallSprintTool({ memwalKey }: { memwalKey: string }) {
+  console.log(`[tool:recallSprint] Tool created with memwalKey=${memwalKey ? memwalKey.slice(0, 8) + "..." : "MISSING"}`);
+
+  return tool({
+    description:
+      "Search long-term research memory for relevant past findings, facts, and details from previous research sprints. Use this when you need deeper detail than what's in the sprint summaries, or to cross-reference across sprints.",
+    inputSchema: z.object({
+      query: z
+        .string()
+        .describe("Search query for research memories"),
+      limit: z
+        .number()
+        .min(1)
+        .max(10)
+        .default(5)
+        .describe("Maximum number of memory results to return"),
+    }),
+    execute: async ({ query, limit }) => {
+      console.log(
+        `[tool:recallSprint] >>> CALLED with query="${query}", limit=${limit}, memwalKey=${memwalKey.slice(0, 8)}...`
+      );
+      try {
+        const startTime = Date.now();
+        const results = await recallFromMemWal(memwalKey, query, limit);
+        const elapsed = Date.now() - startTime;
+
+        console.log(
+          `[tool:recallSprint] <<< MemWal returned ${results.length} results in ${elapsed}ms`
+        );
+
+        if (results.length === 0) {
+          console.log(`[tool:recallSprint] No matches found`);
+          return {
+            results: [],
+            message: "No matching memories found for this query.",
+          };
+        }
+
+        // Log each result's relevance and text preview
+        for (const [i, r] of results.entries()) {
+          console.log(
+            `[tool:recallSprint] Result[${i}] relevance=${r.relevance.toFixed(3)} text="${r.text.slice(0, 120)}..."`
+          );
+        }
+
+        return {
+          results: results.map((r) => ({
+            text: r.text,
+            relevance: Math.round(r.relevance * 100) / 100,
+          })),
+          total: results.length,
+        };
+      } catch (error) {
+        console.error("[tool:recallSprint] ERROR:", error);
+        return {
+          results: [],
+          message: `Memory recall failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        };
+      }
+    },
+  });
+}

--- a/apps/researcher/lib/sprint/index.ts
+++ b/apps/researcher/lib/sprint/index.ts
@@ -2,6 +2,7 @@ export { saveSprint } from "./save";
 export { rememberSprintReport, recallFromMemWal } from "./memwal";
 export { buildChunkManifest } from "./manifest";
 export { generateSprintReport } from "./report";
+export { buildSprintContext } from "./resume";
 export type {
   Citation,
   SourceMeta,

--- a/apps/researcher/lib/sprint/resume.ts
+++ b/apps/researcher/lib/sprint/resume.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import { getSprintsByIds } from "@/lib/db/queries";
+
+/**
+ * Builds a lightweight sprint briefing for the system prompt.
+ *
+ * Only metadata goes here (title, summary, source list, tags).
+ * The full report content lives in MemWal and is retrieved on-demand
+ * via the recallSprint tool.
+ */
+export async function buildSprintContext({
+  sprintIds,
+  userId,
+}: {
+  sprintIds: string[];
+  userId: string;
+}): Promise<{ systemPromptBlock: string; sprintCount: number }> {
+  if (sprintIds.length === 0) {
+    return { systemPromptBlock: "", sprintCount: 0 };
+  }
+
+  const sprints = await getSprintsByIds({ sprintIds, userId });
+
+  console.log(`[sprint:resume] Requested ${sprintIds.length} sprints, found ${sprints.length} owned by user`);
+
+  if (sprints.length === 0) {
+    console.log(`[sprint:resume] No owned sprints found — skipping context injection`);
+    return { systemPromptBlock: "", sprintCount: 0 };
+  }
+
+  const blocks = sprints.map((sprint) => {
+    const sourceNames = (sprint.sources ?? [])
+      .map((s) => s.title ?? "Untitled")
+      .join(", ");
+
+    const tagList = sprint.tags?.length ? sprint.tags.join(", ") : null;
+
+    console.log(`[sprint:resume] Sprint "${sprint.title}" — summary=${sprint.summary?.length ?? 0} chars, sources=${(sprint.sources ?? []).length}, tags=${sprint.tags?.length ?? 0}`);
+
+    return [
+      `### ${sprint.title}`,
+      sprint.summary ? `**Summary:** ${sprint.summary}` : "",
+      sourceNames ? `**Sources:** ${sourceNames}` : "",
+      tagList ? `**Tags:** ${tagList}` : "",
+      "",
+      `> Use **recallSprint** to retrieve detailed findings, data points, and citations from this sprint.`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  });
+
+  const systemPromptBlock = [
+    "## Previous Research Sprints",
+    "",
+    "The user has selected the following previous research sprints as context for this conversation.",
+    "These are **metadata briefings only** — the full reports and detailed findings are stored in long-term memory (MemWal).",
+    "You MUST use the **recallSprint** tool to retrieve specific content, quotes, data points, or citations from these sprints.",
+    "",
+    ...blocks,
+  ].join("\n");
+
+  return { systemPromptBlock, sprintCount: sprints.length };
+}

--- a/apps/researcher/lib/sprint/save.ts
+++ b/apps/researcher/lib/sprint/save.ts
@@ -43,7 +43,7 @@ export async function saveSprint({
   const report = await generateSprintReport({ chatId, userId });
   console.log(`[sprint:save] Report generated: "${report.title}"`);
 
-  // 4. Build source metadata from citations (deduplicate by sourceId)
+  // 4. Build source metadata from citations (deduplicate by sourceId, then by title)
   const sourceMap = new Map<string, SourceMeta>();
   for (const citation of report.citations) {
     if (!sourceMap.has(citation.sourceId)) {
@@ -55,7 +55,16 @@ export async function saveSprint({
       });
     }
   }
-  const sources = Array.from(sourceMap.values());
+  // Further deduplicate by title — same source may have different IDs across sessions
+  const seenTitles = new Set<string>();
+  const sources: SourceMeta[] = [];
+  for (const s of sourceMap.values()) {
+    const key = s.title?.toLowerCase() ?? s.sourceId;
+    if (!seenTitles.has(key)) {
+      seenTitles.add(key);
+      sources.push(s);
+    }
+  }
 
   // 5. Store in MemWal
   console.log("[sprint:save] Storing in MemWal...");
@@ -72,7 +81,7 @@ export async function saveSprint({
 
   // 6. Save to DB
   console.log("[sprint:save] Saving to DB...");
-  const tags = sources.map((s) => s.title).filter(Boolean) as string[];
+  const tags = [...new Set(sources.map((s) => s.title).filter(Boolean))] as string[];
   const sprintRecord = await createSprintBlob({
     chatId,
     userId,

--- a/apps/researcher/lib/types.ts
+++ b/apps/researcher/lib/types.ts
@@ -1,6 +1,5 @@
-import type { InferUITool, UIMessage } from "ai";
+import type { UIMessage } from "ai";
 import { z } from "zod";
-import type { getResearchTools } from "./rag/tools";
 
 export type DataPart = { type: "append-message"; message: string };
 
@@ -9,12 +8,6 @@ export const messageMetadataSchema = z.object({
 });
 
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
-
-type ResearchTools = ReturnType<typeof getResearchTools>;
-
-export type ChatTools = {
-  [K in keyof ResearchTools]: InferUITool<ResearchTools[K]>;
-};
 
 export type CustomUIDataTypes = {
   appendMessage: string;
@@ -27,8 +20,7 @@ export type CustomUIDataTypes = {
 
 export type ChatMessage = UIMessage<
   MessageMetadata,
-  CustomUIDataTypes,
-  ChatTools
+  CustomUIDataTypes
 >;
 
 export type Attachment = {

--- a/apps/researcher/lib/utils.ts
+++ b/apps/researcher/lib/utils.ts
@@ -9,7 +9,7 @@ import { formatISO } from 'date-fns';
 import { twMerge } from 'tailwind-merge';
 import type { DBMessage } from '@/lib/db/schema';
 import { ChatbotError, type ErrorCode } from './errors';
-import type { ChatMessage, ChatTools, CustomUIDataTypes } from './types';
+import type { ChatMessage, CustomUIDataTypes } from './types';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -91,7 +91,7 @@ export function convertToUIMessages(messages: DBMessage[]): ChatMessage[] {
   return messages.map((message) => ({
     id: message.id,
     role: message.role as 'user' | 'assistant' | 'system',
-    parts: message.parts as UIMessagePart<CustomUIDataTypes, ChatTools>[],
+    parts: message.parts as UIMessagePart<CustomUIDataTypes, any>[],
     metadata: {
       createdAt: formatISO(message.createdAt),
     },


### PR DESCRIPTION
## Summary

### Why

Phase 1 established the sprint save pipeline — users can save research findings to MemWal and view them in the My Stuff panel. However, there was no way to **resume** a sprint with full context. Users couldn't select previous sprints, recall their findings from long-term memory, or start a new chat session grounded in prior research.

This PR completes the remember/recall loop — the core value proposition of the MemWal integration.

### What

Full Phase 2 implementation: sprint recall tool, preparation pipeline, session launcher, and chat route integration.

**New capabilities:**
- Multi-sprint selection in a dedicated session launcher (`/research/new`)
- SSE preparation endpoint that builds context from MemWal recall before chat begins
- Animated processing screen showing per-sprint progress
- `recallSprint` tool for in-chat semantic search of long-term research memory
- Pre-built sprint context persisted to Chat record for fast access on every message
- Prompt updates enforcing recall usage and graceful handling of source gaps

**Bug fixes included:**
- Deduplicate sprint sources by title (cross-session source ID duplicates)
- Raise dev rate limit from 10 to 100 messages/hour
- Fix new chat button navigation to `/research/new`

### Solution

#### Architecture: LLM-Driven Recall via Preparation Endpoint

The original design injected raw `reportContent` from DB into the system prompt. The implemented architecture improves on this — MemWal is the single source of truth for research findings, and we use LLM-generated semantic queries to recall them.

```mermaid
sequenceDiagram
    participant User
    participant Launcher as Session Launcher
    participant Server as /api/sprint/prepare
    participant LLM as Gemini 2.5 Flash
    participant MemWal
    participant DB as PostgreSQL

    User->>Launcher: Select sprints → "Start Chat →"
    Launcher->>Server: POST (SSE stream)

    Server->>DB: Validate sprint ownership
    Server-->>Launcher: step:validate ✓
    Server->>DB: Create chat record with sprintIds
    Server-->>Launcher: step:create-chat ✓

    loop For each selected sprint
        Server->>DB: Read metadata (title, summary, sources, tags)
        Server-->>Launcher: sprint:analyzing

        Server->>LLM: generateObject(metadata → 3-5 recall queries)
        LLM-->>Server: Diverse semantic search queries

        loop For each query
            Server->>MemWal: recallFromMemWal(key, query, 5)
            MemWal-->>Server: Results with relevance scores
        end

        Note over Server: Deduplicate by text prefix<br/>Filter relevance ≥ 0.4
        Server-->>Launcher: sprint:done (resultCount, charCount)
    end

    Server->>DB: Persist assembled sprintContext to Chat
    Server-->>Launcher: step:save-context ✓
    Server-->>Launcher: ready (chatId, contextChars)
    Launcher->>Launcher: Redirect → /chat/{chatId}
```

#### Chat Flow: Pre-Built Context + Live Recall

Once preparation completes, the chat route reads the pre-built context from DB (fast) rather than hitting MemWal on every message. The `recallSprint` tool remains available for additional depth.

```mermaid
flowchart TB
    A[User sends message] --> B{Chat has sprintContext?}
    B -->|Yes| C[Read pre-built context from DB]
    B -->|No, but has sprintIds| D[Fallback: metadata-only context]
    B -->|No sprints| E[Standard research prompt]

    C --> F[System prompt = research + sprintContext + recallGuidance]
    D --> F
    E --> G[System prompt = research only]

    F --> H[Register 4 RAG tools + recallSprint]
    G --> I[Register 4 RAG tools only]

    H --> J[LLM responds with sprint context + recall capability]
    I --> K[LLM responds with source tools only]
```

#### Key Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Context source | MemWal recall (not DB reportContent) | MemWal is source of truth for findings; validates remember/recall loop |
| Query generation | LLM from sprint metadata | Diverse queries cover different aspects; better recall coverage than single query |
| Relevance threshold | 0.4 minimum | Filters unrelated sprints from shared MemWal key pool (e.g., Agriculture results when querying Energy) |
| Context persistence | `Chat.sprintContext` column | Build once during preparation, read on every message (fast) |
| Recall prompt | "ALWAYS use recallSprint" | LLM was under-utilizing recall when directed to use it only as fallback |
| Source gap handling | GAP step (was STOP) | AI answers from general knowledge and notes the gap, instead of refusing |

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [x] I have tested this code locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

### Manual E2E Verification

- [x] Session launcher → select sprints → processing screen → auto-redirect to chat
- [x] Per-sprint progress: analyzing → recalling → done with result/char counts
- [x] Chat loads with sprint badge in header
- [x] System prompt contains recalled findings from MemWal (`prebuiltContext` logged)
- [x] `recallSprint` tool available and functional in sprint-resumed chats
- [x] Error state → Retry works, Go Back preserves selections
- [x] "Just Chat" bypasses preparation entirely
- [x] Source deduplication in sprint detail view (existing data with duplicates)
- [x] New chat button navigates to `/research/new`
- [x] Rate limit raised — sustained testing without 429s

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Additional Notes

This PR completes the MemWal integration loop:
- **Phase 1** (PR #5): Chat → Save Sprint → `remember()` → Walrus
- **Phase 2** (this PR): Select Sprints → LLM queries → `recall()` → Chat with context

The `recallSprint` tool is conditionally registered only in sprint-resumed chats. Standard chats remain unchanged with 4 RAG tools only.