### PR TITLE
docs: remove duplicate examples tab

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -49,17 +49,6 @@
         ]
       },
       {
-        "tab": "Examples",
-        "groups": [
-          {
-            "group": "Examples",
-            "pages": [
-              "examples/example-apps"
-            ]
-          }
-        ]
-      },
-      {
         "tab": "Fundamentals",
         "groups": [
           {


### PR DESCRIPTION
fixing duplicate examples tab in header