### PR TITLE
feat: migrate SDK to @mysten-incubation + OIDC Trusted Publishing

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,6 +1,6 @@
 # Changesets
 
-This project uses [Changesets](https://github.com/changesets/changesets) to manage versioning and changelogs for `@mysten/memwal`.
+This project uses [Changesets](https://github.com/changesets/changesets) to manage versioning and changelogs for `@mysten-incubation/memwal`.
 
 ## How to add a changeset
 
@@ -11,7 +11,7 @@ pnpm changeset
 ```
 
 This will prompt you to:
-1. Select which packages have changed (`@mysten/memwal`)
+1. Select which packages have changed (`@mysten-incubation/memwal`)
 2. Choose the semver bump type (major / minor / patch)
 3. Write a summary of the change
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -36,8 +36,11 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for OIDC Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Typecheck
         run: pnpm --filter @mysten-incubation/memwal typecheck

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        run: pnpm --filter @mysten/memwal typecheck
+        run: pnpm --filter @mysten-incubation/memwal typecheck
 
       - name: Build SDK
         run: pnpm build:sdk
@@ -50,18 +50,16 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           BASE_VERSION=$(node -p "require('./packages/sdk/package.json').version")
-          npm view @mysten/memwal@$BASE_VERSION version 2>/dev/null \
+          npm view @mysten-incubation/memwal@$BASE_VERSION version 2>/dev/null \
             && echo "Version $BASE_VERSION already published, skipping" && exit 0
-          cd packages/sdk && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          cd packages/sdk && npm publish --provenance --access public
 
       # ── staging branch → release candidate (rc tag, auto-increment) ──
       - name: Publish staging release candidate
         if: github.ref == 'refs/heads/staging'
         run: |
           BASE_VERSION=$(node -p "require('./packages/sdk/package.json').version")
-          LATEST=$(npm view @mysten/memwal versions --json 2>/dev/null \
+          LATEST=$(npm view @mysten-incubation/memwal versions --json 2>/dev/null \
             | node -p "
                 const versions = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
                 const nums = (Array.isArray(versions) ? versions : [versions])
@@ -72,19 +70,17 @@ jobs:
               " || echo "-1")
           NEXT=$((LATEST + 1))
           NEW_VERSION="${BASE_VERSION}-rc.${NEXT}"
-          echo "Publishing @mysten/memwal@${NEW_VERSION}"
+          echo "Publishing @mysten-incubation/memwal@${NEW_VERSION}"
           cd packages/sdk
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag rc --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --tag rc --provenance --access public
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
         if: github.ref == 'refs/heads/dev'
         run: |
           BASE_VERSION=$(node -p "require('./packages/sdk/package.json').version")
-          LATEST=$(npm view @mysten/memwal versions --json 2>/dev/null \
+          LATEST=$(npm view @mysten-incubation/memwal versions --json 2>/dev/null \
             | node -p "
                 const versions = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
                 const nums = (Array.isArray(versions) ? versions : [versions])
@@ -95,9 +91,7 @@ jobs:
               " || echo "-1")
           NEXT=$((LATEST + 1))
           NEW_VERSION="${BASE_VERSION}-dev.${NEXT}"
-          echo "Publishing @mysten/memwal@${NEW_VERSION}"
+          echo "Publishing @mysten-incubation/memwal@${NEW_VERSION}"
           cd packages/sdk
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag dev --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --tag dev --provenance --access public

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -37,7 +37,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Typecheck
         run: pnpm --filter @mysten-incubation/memwal typecheck

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ retrieving them with semantic search.
 ## Install
 
 ```bash
-pnpm add @mysten/memwal
+pnpm add @mysten-incubation/memwal
 ```
 
 Peer dependencies (install as needed):
@@ -20,7 +20,7 @@ pnpm add @mysten/sui @mysten/seal @mysten/walrus ai zod
 ## Quick Start
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
   key: "your-delegate-key-hex",
@@ -77,9 +77,9 @@ For broader local setup guidance, see:
 
 | Entry | Description |
 |---|---|
-| `@mysten/memwal` | Default client (`MemWal`). The relayer handles embedding, encryption, Walrus upload/download, retrieval, and restore. |
-| `@mysten/memwal/manual` | Manual client flow (`MemWalManual`). You handle embedding calls and local SEAL operations. The relayer still handles upload relay, registration, search, and restore. |
-| `@mysten/memwal/ai` | Vercel AI SDK integration - wraps `MemWal` as middleware for use with `streamText`, `generateText`, etc. |
+| `@mysten-incubation/memwal` | Default client (`MemWal`). The relayer handles embedding, encryption, Walrus upload/download, retrieval, and restore. |
+| `@mysten-incubation/memwal/manual` | Manual client flow (`MemWalManual`). You handle embedding calls and local SEAL operations. The relayer still handles upload relay, registration, search, and restore. |
+| `@mysten-incubation/memwal/ai` | Vercel AI SDK integration - wraps `MemWal` as middleware for use with `streamText`, `generateText`, etc. |
 
 ## How It Works
 

--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -20,9 +20,9 @@ COPY apps/app/package.json      ./apps/app/
 # Install all workspace deps
 RUN pnpm install
 
-# Build SDK first (apps/app depends on @mysten/memwal via workspace:*)
+# Build SDK first (apps/app depends on @mysten-incubation/memwal via workspace:*)
 COPY packages/sdk/ ./packages/sdk/
-RUN pnpm --filter @mysten/memwal build
+RUN pnpm --filter @mysten-incubation/memwal build
 
 # Copy app source
 COPY apps/app/ ./apps/app/

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@mysten/dapp-kit": "^1.0.3",
     "@mysten/enoki": "^1.0.4",
-    "@mysten/memwal": "workspace:*",
+    "@mysten-incubation/memwal": "workspace:*",
     "@mysten/seal": "^1.1.0",
     "@mysten/sui": "^2.6.0",
     "@mysten/walrus": "^1.0.3",

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -10,8 +10,8 @@ import {
     useSuiClient,
 } from '@mysten/dapp-kit'
 import { useSponsoredTransaction } from '../hooks/useSponsoredTransaction'
-import { generateDelegateKey, addDelegateKey, removeDelegateKey } from '@mysten/memwal/account'
-import type { WalletSigner } from '@mysten/memwal/manual'
+import { generateDelegateKey, addDelegateKey, removeDelegateKey } from '@mysten-incubation/memwal/account'
+import type { WalletSigner } from '@mysten-incubation/memwal/manual'
 import { Link } from 'react-router-dom'
 import { Copy, Eye, EyeOff, Trash2, RefreshCw, Plus, LogOut } from 'lucide-react'
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -208,7 +208,7 @@ export default function Dashboard() {
     // SDK code snippets
     // ============================================================
 
-    const sdkSnippet = `import { MemWal } from "@mysten/memwal"
+    const sdkSnippet = `import { MemWal } from "@mysten-incubation/memwal"
 
 const memwal = MemWal.create({
   key: "${delegateKey?.slice(0, 8)}...${delegateKey?.slice(-8)}",
@@ -224,7 +224,7 @@ const result = await memwal.recall("food allergies")
 console.log(result.results[0].text)`
 
     const aiSnippet = `import { generateText } from "ai"
-import { withMemWal } from "@mysten/memwal/ai"
+import { withMemWal } from "@mysten-incubation/memwal/ai"
 import { openai } from "@ai-sdk/openai"
 
 const model = withMemWal(openai("gpt-4o"), {
@@ -606,10 +606,10 @@ const result = await generateText({
                         ))}
                     </div>
                     <SyntaxHighlighter language="bash" style={githubGist} className="demo-code-block install-command" customStyle={{ margin: 0, borderTopLeftRadius: 0, borderTopRightRadius: 0 }}>
-                        {pkgManager === 'npm' ? 'npm install @mysten/memwal' :
-                         pkgManager === 'pnpm' ? 'pnpm add @mysten/memwal' :
-                         pkgManager === 'yarn' ? 'yarn add @mysten/memwal' :
-                         'bun add @mysten/memwal'}
+                        {pkgManager === 'npm' ? 'npm install @mysten-incubation/memwal' :
+                         pkgManager === 'pnpm' ? 'pnpm add @mysten-incubation/memwal' :
+                         pkgManager === 'yarn' ? 'yarn add @mysten-incubation/memwal' :
+                         'bun add @mysten-incubation/memwal'}
                     </SyntaxHighlighter>
                 </div>
             </div>

--- a/apps/app/src/pages/Playground.tsx
+++ b/apps/app/src/pages/Playground.tsx
@@ -20,8 +20,8 @@ import {
     useSuiClient,
 } from '@mysten/dapp-kit'
 import { useSponsoredTransaction } from '../hooks/useSponsoredTransaction'
-import { MemWal } from '@mysten/memwal'
-import { MemWalManual } from '@mysten/memwal/manual'
+import { MemWal } from '@mysten-incubation/memwal'
+import { MemWalManual } from '@mysten-incubation/memwal/manual'
 import { useDelegateKey } from '../App'
 import { config } from '../config'
 import memwalLogo from '../assets/memwal-logo.svg'
@@ -459,7 +459,7 @@ export default function Playground() {
                     <p>
                         try each memwal SDK operation live. click{' '}
                         <strong>▶ run</strong> to execute against your server
-                        using <code>@mysten/memwal</code>.
+                        using <code>@mysten-incubation/memwal</code>.
                         {config.docsUrl && (
                             <> See the <a href={config.docsUrl} target="_blank" rel="noopener noreferrer" style={{ color: '#000', fontWeight: 600 }}>documentation</a> for full API reference.</>
                         )}
@@ -475,7 +475,7 @@ export default function Playground() {
                         key: <span className="demo-tag-value demo-tag-value--key">{keyPreview}</span>
                     </div>
                     <div className="demo-server-tag">
-                        SDK: <span className="demo-tag-value demo-tag-value--sdk">@mysten/memwal</span>
+                        SDK: <span className="demo-tag-value demo-tag-value--sdk">@mysten-incubation/memwal</span>
                     </div>
                     <div className="demo-server-tag" style={{ padding: 0, display: 'flex', alignItems: 'center' }}>
                         <span style={{ padding: '8px 0 8px 16px', whiteSpace: 'nowrap' }}>namespace:</span>
@@ -494,7 +494,7 @@ export default function Playground() {
                     number={1}
                     title="health check"
                     description="verify the memwal server is running"
-                    code={`import { MemWal } from "@mysten/memwal"
+                    code={`import { MemWal } from "@mysten-incubation/memwal"
 
 const memwal = MemWal.create({
   key: "${keyPreview}",
@@ -705,7 +705,7 @@ const result = await memwal.restore("${namespace || 'default'}")
 
                     <div className={askResult || askError || askPhase ? 'demo-code-block--spaced' : ''}>
                         <SyntaxHighlighter language="javascript" style={githubGist} className="demo-code-block" customStyle={{ margin: 0 }}>
-{`import { withMemWal } from "@mysten/memwal/ai"
+{`import { withMemWal } from "@mysten-incubation/memwal/ai"
 import { openai } from "@ai-sdk/openai"
 import { generateText } from "ai"
 
@@ -837,7 +837,7 @@ const { text } = await generateText({
 
                     <div className={fullRememberResult || fullRememberError || fullRememberPhase ? 'demo-code-block--spaced' : ''}>
                         <SyntaxHighlighter language="javascript" style={githubGist} className="demo-code-block" customStyle={{ margin: 0 }}>
-{`import { MemWalManual } from "@mysten/memwal/manual"
+{`import { MemWalManual } from "@mysten-incubation/memwal/manual"
 
 const memwal = MemWalManual.create({
   key: delegateKeyHex,

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -20,14 +20,14 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/chatbot/package.json ./apps/chatbot/
 
-# Install all workspace deps (resolves workspace:* for @mysten/memwal)
+# Install all workspace deps (resolves workspace:* for @mysten-incubation/memwal)
 RUN pnpm install --frozen-lockfile
 
 # ── Stage 2: Build SDK ─────────────────────────────────────
 FROM deps AS sdk-builder
 
 COPY packages/sdk/ ./packages/sdk/
-RUN pnpm --filter @mysten/memwal build
+RUN pnpm --filter @mysten-incubation/memwal build
 
 # ── Stage 3: Build Next.js App ─────────────────────────────
 FROM sdk-builder AS builder

--- a/apps/chatbot/lib/ai/providers.ts
+++ b/apps/chatbot/lib/ai/providers.ts
@@ -4,7 +4,7 @@ import {
   extractReasoningMiddleware,
   wrapLanguageModel,
 } from "ai";
-import { withMemWal } from "@mysten/memwal/ai";
+import { withMemWal } from "@mysten-incubation/memwal/ai";
 import { isTestEnvironment } from "../constants";
 
 const THINKING_SUFFIX_REGEX = /-thinking$/;

--- a/apps/chatbot/package.json
+++ b/apps/chatbot/package.json
@@ -22,7 +22,7 @@
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/provider": "^3.0.3",
     "@ai-sdk/react": "3.0.39",
-    "@mysten/memwal": "workspace:*",
+    "@mysten-incubation/memwal": "workspace:*",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-python": "^6.1.6",
     "@codemirror/state": "^6.5.0",

--- a/apps/noter/Dockerfile
+++ b/apps/noter/Dockerfile
@@ -20,12 +20,12 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/noter/package.json   ./apps/noter/
 
-# Install all workspace deps (resolves workspace:* for @mysten/memwal)
+# Install all workspace deps (resolves workspace:* for @mysten-incubation/memwal)
 RUN pnpm install --frozen-lockfile
 
-# Build SDK first (@mysten/memwal is the package name — matches sdk/package.json)
+# Build SDK first (@mysten-incubation/memwal is the package name — matches sdk/package.json)
 COPY packages/sdk/ ./packages/sdk/
-RUN pnpm --filter @mysten/memwal build
+RUN pnpm --filter @mysten-incubation/memwal build
 
 # ── Stage 2: Build Next.js App ─────────────────────────────
 FROM deps AS builder

--- a/apps/noter/app/api/chat/route.ts
+++ b/apps/noter/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { streamText, convertToModelMessages, stepCountIs } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
-import { withMemWal } from "@mysten/memwal/ai";
+import { withMemWal } from "@mysten-incubation/memwal/ai";
 import { DEFAULT_MODEL } from "@/shared/lib/ai/constant";
 import { createTools } from "@/shared/lib/ai/tools";
 import { db } from "@/shared/lib/db";

--- a/apps/noter/next.config.ts
+++ b/apps/noter/next.config.ts
@@ -11,7 +11,7 @@ const nextConfig: NextConfig = {
     ],
   },
   serverExternalPackages: [
-    "@mysten/memwal",
+    "@mysten-incubation/memwal",
     "@mysten/seal",
     "@mysten/walrus",
     "@mysten/sui",

--- a/apps/noter/package.json
+++ b/apps/noter/package.json
@@ -18,7 +18,7 @@
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/react": "3.0.39",
     "@base-ui/react": "^1.2.0",
-    "@mysten/memwal": "workspace:*",
+    "@mysten-incubation/memwal": "workspace:*",
     "@hookform/resolvers": "^5.2.2",
     "@lexical/code": "^0.41.0",
     "@lexical/link": "^0.41.0",

--- a/apps/noter/package/feature/note/lib/pdw-client.ts
+++ b/apps/noter/package/feature/note/lib/pdw-client.ts
@@ -6,7 +6,7 @@
  * Key can be set from env var OR at runtime via setMemWalKey().
  */
 
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 let _memwal: MemWal | null = null;
 let _runtimeKey: string | null = null;

--- a/apps/researcher/Dockerfile
+++ b/apps/researcher/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 
 COPY apps/researcher/package.json ./
 
-# Install deps — @mysten/memwal is now on npm, no local SDK needed
+# Install deps — @mysten-incubation/memwal is now on npm, no local SDK needed
 RUN bun install
 
 # ── Stage 2: Build ─────────────────────────────────────────

--- a/apps/researcher/lib/sprint/memwal.ts
+++ b/apps/researcher/lib/sprint/memwal.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
-import { MemWal } from "@mysten/memwal";
-import type { RememberResult } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
+import type { RememberResult } from "@mysten-incubation/memwal";
 import type { Citation, SourceMeta } from "./types";
 
 function getMemWalClient(key: string, accountId?: string) {

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -24,7 +24,7 @@
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/provider": "^3.0.3",
         "@ai-sdk/react": "3.0.39",
-        "@mysten/memwal": "0.0.1-dev.0",
+        "@mysten-incubation/memwal": "^0.0.1-dev.0",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-python": "^6.1.6",
         "@codemirror/state": "^6.5.0",

--- a/docs/contract/delegate-key-management.md
+++ b/docs/contract/delegate-key-management.md
@@ -17,7 +17,7 @@ Delegate keys are lightweight Ed25519 keys used for SDK authentication. They are
 Use the SDK's `generateDelegateKey()` helper to create a new Ed25519 keypair:
 
 ```ts
-import { generateDelegateKey } from "@mysten/memwal/account";
+import { generateDelegateKey } from "@mysten-incubation/memwal/account";
 
 const delegate = await generateDelegateKey();
 // delegate.privateKey — hex string, store securely
@@ -30,7 +30,7 @@ const delegate = await generateDelegateKey();
 Only the account owner can add delegate keys:
 
 ```ts
-import { addDelegateKey } from "@mysten/memwal/account";
+import { addDelegateKey } from "@mysten-incubation/memwal/account";
 
 await addDelegateKey({
   packageId: "0x...",
@@ -44,7 +44,7 @@ await addDelegateKey({
 ### 3. Use the private key in the SDK
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
   key: delegate.privateKey,
@@ -57,7 +57,7 @@ const memwal = MemWal.create({
 Removing a delegate key prevents future relayer access from that key:
 
 ```ts
-import { removeDelegateKey } from "@mysten/memwal/account";
+import { removeDelegateKey } from "@mysten-incubation/memwal/account";
 
 await removeDelegateKey({
   packageId: "0x...",

--- a/docs/examples/example-apps.md
+++ b/docs/examples/example-apps.md
@@ -15,9 +15,9 @@ pnpm dev:noter
 pnpm dev:researcher
 ```
 
-## [App](https://github.com/MystenLabs/MemWal/tree/main/apps/app)
+## [Playground](https://github.com/MystenLabs/MemWal/tree/main/apps/app)
 
-Onboarding app, account dashboard, playground, and interactive demo for MemWal.
+Dashboard, playground, and interactive demo for MemWal.
 
 ```ts
 const memwal = MemWal.create({
@@ -39,7 +39,7 @@ This app covers the full getting-started flow in one place. It signs users in, s
 AI chat app with persistent memory across sessions.
 
 ```ts
-import { withMemWal } from "@mysten/memwal/ai";
+import { withMemWal } from "@mysten-incubation/memwal/ai";
 
 const model = withMemWal(baseModel, {
   key,

--- a/docs/getting-started/choose-your-path.md
+++ b/docs/getting-started/choose-your-path.md
@@ -10,7 +10,7 @@ These paths aren't mutually exclusive. You can combine them — for example, use
 
 ## 1. Default SDK
 
-Use `@mysten/memwal` when you want the fastest working integration.
+Use `@mysten-incubation/memwal` when you want the fastest working integration.
 
 - relayer handles embedding, encryption, retrieval, and restore
 - best starting point for most teams
@@ -30,7 +30,7 @@ Go to: [Public Relayer](/relayer/public-relayer)
 
 ## 3. Manual Client Flow
 
-Use `@mysten/memwal/manual` when you want full client-side control over encryption and embeddings. Recommended for Web3-native users who want to minimize trust in the relayer — it never sees your plaintext data.
+Use `@mysten-incubation/memwal/manual` when you want full client-side control over encryption and embeddings. Recommended for Web3-native users who want to minimize trust in the relayer — it never sees your plaintext data.
 
 - client handles embeddings and SEAL encryption locally
 - relayer only sees encrypted payloads and vectors
@@ -39,7 +39,7 @@ Go to: [SDK Usage](/sdk/usage)
 
 ## 4. AI Middleware
 
-Use `@mysten/memwal/ai` when you already use the AI SDK and want recall plus auto-save behavior.
+Use `@mysten-incubation/memwal/ai` when you already use the AI SDK and want recall plus auto-save behavior.
 
 Go to: [AI Integration](/sdk/usage/with-memwal)
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -22,29 +22,29 @@ The fastest way to get MemWal running is through the TypeScript SDK.
     <Tabs>
       <Tab title="pnpm">
         ```bash
-        pnpm add @mysten/memwal
+        pnpm add @mysten-incubation/memwal
         ```
       </Tab>
       <Tab title="npm">
         ```bash
-        npm install @mysten/memwal
+        npm install @mysten-incubation/memwal
         ```
       </Tab>
       <Tab title="yarn">
         ```bash
-        yarn add @mysten/memwal
+        yarn add @mysten-incubation/memwal
         ```
       </Tab>
       <Tab title="bun">
         ```bash
-        bun add @mysten/memwal
+        bun add @mysten-incubation/memwal
         ```
       </Tab>
     </Tabs>
 
     **Optional packages**
 
-    For AI middleware with [Vercel AI SDK](https://sdk.vercel.ai/) (`@mysten/memwal/ai`):
+    For AI middleware with [Vercel AI SDK](https://sdk.vercel.ai/) (`@mysten-incubation/memwal/ai`):
 
     <Tabs>
       <Tab title="pnpm">
@@ -69,7 +69,7 @@ The fastest way to get MemWal running is through the TypeScript SDK.
       </Tab>
     </Tabs>
 
-    For the [manual client flow](/getting-started/choose-your-path) (`@mysten/memwal/manual`):
+    For the [manual client flow](/getting-started/choose-your-path) (`@mysten-incubation/memwal/manual`):
 
     <Tabs>
       <Tab title="pnpm">
@@ -101,7 +101,7 @@ The fastest way to get MemWal running is through the TypeScript SDK.
     Set up the SDK with your delegate key, account ID, and relayer URL:
 
     ```ts
-    import { MemWal } from "@mysten/memwal";
+    import { MemWal } from "@mysten-incubation/memwal";
 
     const memwal = MemWal.create({
       key: "<your-ed25519-private-key>",

--- a/docs/getting-started/what-is-memwal.md
+++ b/docs/getting-started/what-is-memwal.md
@@ -100,7 +100,7 @@ And many more — check out the example apps below to see MemWal in action.
 
 The repo ships with ready-to-run apps in the [`/apps`](https://github.com/CommandOSSLabs/memwal/tree/main/apps) directory:
 
-- **App** — dashboard demo for zkLogin, delegate-key setup, and account management
+- **Playground** — dashboard demo for MemWal
 - **Chatbot** — AI chat app with persistent memory across sessions
 - **Noter** — note-taking tool that stores knowledge as encrypted memory
 - **Researcher** — research assistant that builds and recalls a knowledge base

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -3,14 +3,15 @@ title: "Environment Variables"
 ---
 
 Use this page when you run your own relayer.
+For setup steps and deployment context, see [Self-Hosting](/relayer/self-hosting).
 
 ## Required
 
 | Variable | Notes |
 | --- | --- |
 | `DATABASE_URL` | PostgreSQL connection string. `pgvector` must already exist |
-| `MEMWAL_PACKAGE_ID` | Sui package ID |
-| `MEMWAL_REGISTRY_ID` | Onchain registry object ID |
+| `MEMWAL_PACKAGE_ID` | Sui package ID. See [Contract Overview](/contract/overview) |
+| `MEMWAL_REGISTRY_ID` | Onchain registry object ID. See [Contract Overview](/contract/overview) |
 | `SEAL_KEY_SERVERS` | Comma-separated SEAL key server object IDs used by the sidecar for encrypt and decrypt |
 
 ## Usually Required
@@ -43,13 +44,9 @@ These are not all enforced at boot, but most real deployments need them.
 ## Notes
 
 - If both `SERVER_SUI_PRIVATE_KEYS` and `SERVER_SUI_PRIVATE_KEY` are set, the key pool takes priority for uploads.
-- `OPENAI_API_KEY` and `OPENAI_API_BASE` are how a self-hosted relayer calls your embedding provider.
-- The relayer uses them for `remember`, `recall`, `analyze`, `ask`, and restore re-indexing.
-- `SEAL_KEY_SERVERS` is required for the sidecar SEAL encrypt and decrypt path.
-- `SUI_NETWORK` now drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.
-- The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet`, `2` on `mainnet`, unless the request explicitly passes `epochs`.
-- `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
-- For testnet, use `MEMWAL_PACKAGE_ID=0xcf6ad755a1cdff7217865c796778fabe5aa399cb0cf2eba986f4b582047229c6` and `MEMWAL_REGISTRY_ID=0xe80f2feec1c139616a86c9f71210152e2a7ca552b20841f2e192f99f75864437`.
+- `OPENAI_API_KEY` and `OPENAI_API_BASE` control the embedding and fact-extraction provider used by `remember`, `recall`, `analyze`, `ask`, and restore re-indexing.
 - Without `OPENAI_API_KEY`, the server can fall back to mock embeddings. That is useful for local testing, not for normal production behavior.
-- The Rust server starts the TypeScript sidecar automatically.
-- `/health` is the fastest way to confirm the relayer is up.
+- `SUI_NETWORK` drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.
+- The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.
+- `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
+- For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).

--- a/docs/relayer/public-relayer.md
+++ b/docs/relayer/public-relayer.md
@@ -14,7 +14,7 @@ The public relayer is a managed MemWal deployment for teams that want to get sta
 ## Minimal Config
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
   key: "<your-ed25519-private-key>",

--- a/docs/sdk/ai-integration.md
+++ b/docs/sdk/ai-integration.md
@@ -8,7 +8,7 @@ MemWal includes an AI SDK integration for applications that already use model mi
 
 ```ts
 import { generateText } from "ai";
-import { withMemWal } from "@mysten/memwal/ai";
+import { withMemWal } from "@mysten-incubation/memwal/ai";
 import { openai } from "@ai-sdk/openai";
 
 const model = withMemWal(openai("gpt-4o"), {

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -119,7 +119,7 @@ These exist on the `MemWal` class for advanced use cases:
 ## `MemWalManual`
 
 ```ts
-import { MemWalManual } from "@mysten/memwal/manual";
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
 ```
 
 See [MemWalManual usage](/sdk/usage/memwal-manual) for the full setup and flow details.
@@ -149,7 +149,7 @@ Whether this client uses a connected wallet signer (vs. raw keypair).
 ## `withMemWal`
 
 ```ts
-import { withMemWal } from "@mysten/memwal/ai";
+import { withMemWal } from "@mysten-incubation/memwal/ai";
 ```
 
 Wraps a Vercel AI SDK model with automatic memory recall and save.
@@ -183,7 +183,7 @@ import {
   addDelegateKey,
   removeDelegateKey,
   generateDelegateKey,
-} from "@mysten/memwal/account";
+} from "@mysten-incubation/memwal/account";
 ```
 
 | Function | Description |
@@ -196,7 +196,7 @@ import {
 ## Utility Functions
 
 ```ts
-import { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "@mysten/memwal";
+import { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "@mysten-incubation/memwal";
 ```
 
 | Function | Description |

--- a/docs/sdk/examples.md
+++ b/docs/sdk/examples.md
@@ -7,7 +7,7 @@ title: "Examples"
 The shortest working MemWal example using the default relayer-backed SDK.
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
   key: process.env.MEMWAL_PRIVATE_KEY!,

--- a/docs/sdk/overview.md
+++ b/docs/sdk/overview.md
@@ -4,7 +4,7 @@ title: "Overview"
 
 MemWal exposes three SDK surfaces.
 
-## `@mysten/memwal`
+## `@mysten-incubation/memwal`
 
 Use this first.
 
@@ -13,25 +13,25 @@ Use this first.
 - main methods: `remember`, `recall`, `analyze`, `restore`, `health`
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 ```
 
-## `@mysten/memwal/manual`
+## `@mysten-incubation/memwal/manual`
 
 Use this when the client must handle embeddings and local SEAL operations.
 
 - relayer still handles upload relay, registration, search, and restore
 
 ```ts
-import { MemWalManual } from "@mysten/memwal/manual";
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
 ```
 
-## `@mysten/memwal/ai`
+## `@mysten-incubation/memwal/ai`
 
 Use this when you already use the AI SDK.
 
 ```ts
-import { withMemWal } from "@mysten/memwal/ai";
+import { withMemWal } from "@mysten-incubation/memwal/ai";
 ```
 
 ## Namespace

--- a/docs/sdk/quick-start.md
+++ b/docs/sdk/quick-start.md
@@ -7,24 +7,24 @@ The MemWal SDK gives your app persistent, encrypted memory — store, recall, an
 
 | Entry point | Import | When to use |
 | --- | --- | --- |
-| `MemWal` | `@mysten/memwal` | **Recommended default** for most integrations — relayer handles embeddings, SEAL, and storage |
-| `MemWalManual` | `@mysten/memwal/manual` | You need client-managed embeddings and local SEAL operations |
-| `withMemWal` | `@mysten/memwal/ai` | You already use the Vercel AI SDK and want memory as middleware |
+| `MemWal` | `@mysten-incubation/memwal` | **Recommended default** for most integrations — relayer handles embeddings, SEAL, and storage |
+| `MemWalManual` | `@mysten-incubation/memwal/manual` | You need client-managed embeddings and local SEAL operations |
+| `withMemWal` | `@mysten-incubation/memwal/ai` | You already use the Vercel AI SDK and want memory as middleware |
 
 ## Installation
 
 <CodeGroup>
 
 ```bash npm
-npm install @mysten/memwal
+npm install @mysten-incubation/memwal
 ```
 
 ```bash pnpm
-pnpm add @mysten/memwal
+pnpm add @mysten-incubation/memwal
 ```
 
 ```bash yarn
-yarn add @mysten/memwal
+yarn add @mysten-incubation/memwal
 ```
 
 </CodeGroup>
@@ -79,7 +79,7 @@ yarn add ai zod
 ## First Memory
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
   key: "<your-ed25519-private-key>",

--- a/docs/sdk/usage.md
+++ b/docs/sdk/usage.md
@@ -7,9 +7,9 @@ MemWal exposes three entry points:
 
 | Entry point | Import | When to use |
 | --- | --- | --- |
-| `MemWal` | `@mysten/memwal` | **Recommended default** — relayer handles embeddings, SEAL, and storage |
-| `MemWalManual` | `@mysten/memwal/manual` | You need client-managed embeddings and local SEAL operations |
-| `withMemWal` | `@mysten/memwal/ai` | You already use the Vercel AI SDK and want memory as middleware |
+| `MemWal` | `@mysten-incubation/memwal` | **Recommended default** — relayer handles embeddings, SEAL, and storage |
+| `MemWalManual` | `@mysten-incubation/memwal/manual` | You need client-managed embeddings and local SEAL operations |
+| `withMemWal` | `@mysten-incubation/memwal/ai` | You already use the Vercel AI SDK and want memory as middleware |
 
 ## Namespace Rules
 

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -23,7 +23,7 @@ This is the recommended path for Web3-native users who want to minimize trust in
 ## Setup
 
 ```ts
-import { MemWalManual } from "@mysten/memwal/manual";
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
 
 const manual = MemWalManual.create({
   key: "<your-ed25519-private-key>",

--- a/docs/sdk/usage/memwal.md
+++ b/docs/sdk/usage/memwal.md
@@ -13,7 +13,7 @@ The recommended default client. The relayer handles embeddings, SEAL encryption,
 4. `recall` searches by Memory Space and returns decrypted matches
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
   key: "<your-ed25519-private-key>",

--- a/docs/sdk/usage/with-memwal.md
+++ b/docs/sdk/usage/with-memwal.md
@@ -7,7 +7,7 @@ Drop-in memory middleware for Vercel AI SDK apps.
 
 ```ts
 import { generateText } from "ai";
-import { withMemWal } from "@mysten/memwal/ai";
+import { withMemWal } from "@mysten-incubation/memwal/ai";
 import { openai } from "@ai-sdk/openai";
 
 const model = withMemWal(openai("gpt-4o"), {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:sdk": "pnpm --filter @mysten/memwal build",
-    "dev:sdk": "pnpm --filter @mysten/memwal dev",
+    "build:sdk": "pnpm --filter @mysten-incubation/memwal build",
+    "dev:sdk": "pnpm --filter @mysten-incubation/memwal dev",
     "dev:noter": "pnpm --filter noter dev",
     "dev:chatbot": "pnpm --filter chatbot dev",
     "dev:app": "pnpm --filter app dev",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,4 @@
-# @mysten/memwal
+# @mysten-incubation/memwal
 
 Privacy-first AI memory SDK for storing encrypted memories on Walrus and retrieving them with semantic search.
 
@@ -11,7 +11,7 @@ For full documentation, visit [docs.memwal.ai](https://docs.memwal.ai).
 ## Install
 
 ```bash
-pnpm add @mysten/memwal
+pnpm add @mysten-incubation/memwal
 ```
 
 Peer dependencies (install as needed):
@@ -23,7 +23,7 @@ pnpm add @mysten/sui @mysten/seal @mysten/walrus ai zod
 ## Quick Start
 
 ```ts
-import { MemWal } from "@mysten/memwal";
+import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
   key: "your-delegate-key-hex",
@@ -43,9 +43,9 @@ If you are self-hosting the relayer and do not have an account ID yet, see [Self
 
 | Entry | Description |
 |---|---|
-| `@mysten/memwal` | Default client (`MemWal`). The relayer handles embedding, encryption, Walrus upload/download, retrieval, and restore. |
-| `@mysten/memwal/manual` | Manual client flow (`MemWalManual`). You handle embedding calls and local SEAL operations. The relayer still handles upload relay, registration, search, and restore. |
-| `@mysten/memwal/ai` | Vercel AI SDK integration - wraps `MemWal` as middleware for use with `streamText`, `generateText`, etc. |
+| `@mysten-incubation/memwal` | Default client (`MemWal`). The relayer handles embedding, encryption, Walrus upload/download, retrieval, and restore. |
+| `@mysten-incubation/memwal/manual` | Manual client flow (`MemWalManual`). You handle embedding calls and local SEAL operations. The relayer still handles upload relay, registration, search, and restore. |
+| `@mysten-incubation/memwal/ai` | Vercel AI SDK integration - wraps `MemWal` as middleware for use with `streamText`, `generateText`, etc. |
 
 ## How It Works
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -78,7 +78,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/CommandOSSLabs/MemWal.git",
+        "url": "https://github.com/MystenLabs/MemWal.git",
         "directory": "packages/sdk"
     },
     "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@mysten/memwal",
-    "version": "0.0.2",
+    "name": "@mysten-incubation/memwal",
+    "version": "0.0.1",
     "description": "MemWal — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",
@@ -76,6 +76,11 @@
         "tee"
     ],
     "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/CommandOSSLabs/MemWal.git",
+        "directory": "packages/sdk"
+    },
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org/"

--- a/packages/sdk/src/account-entry.ts
+++ b/packages/sdk/src/account-entry.ts
@@ -1,12 +1,12 @@
 /**
- * @mysten/memwal/account
+ * @mysten-incubation/memwal/account
  *
  * Account management entry point — on-chain operations.
  * Requires @mysten/sui as a peer dependency.
  *
  * @example
  * ```typescript
- * import { createAccount, addDelegateKey, generateDelegateKey } from "@mysten/memwal/account"
+ * import { createAccount, addDelegateKey, generateDelegateKey } from "@mysten-incubation/memwal/account"
  * ```
  */
 

--- a/packages/sdk/src/account.ts
+++ b/packages/sdk/src/account.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { createAccount, addDelegateKey, generateDelegateKey } from "@mysten/memwal/account"
+ * import { createAccount, addDelegateKey, generateDelegateKey } from "@mysten-incubation/memwal/account"
  *
  * // Generate a delegate keypair
  * const delegate = await generateDelegateKey()

--- a/packages/sdk/src/ai/middleware.ts
+++ b/packages/sdk/src/ai/middleware.ts
@@ -6,7 +6,7 @@
  * @example
  * ```typescript
  * import { generateText } from "ai"
- * import { withMemWal } from "@mysten/memwal/ai"
+ * import { withMemWal } from "@mysten-incubation/memwal/ai"
  * import { openai } from "@ai-sdk/openai"
  *
  * const model = withMemWal(openai("gpt-4o"), {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @mysten/memwal
+ * @mysten-incubation/memwal
  *
  * Privacy-first AI memory SDK.
  * Ed25519 delegate key auth + server-side TEE processing.
@@ -7,8 +7,8 @@
  * This is the default entry point — MemWal client + types only.
  * Does NOT import account.js (which requires @mysten/sui).
  *
- * For account management, import from "@mysten/memwal/account".
- * For manual (client-side SEAL + Walrus), import from "@mysten/memwal/manual".
+ * For account management, import from "@mysten-incubation/memwal/account".
+ * For manual (client-side SEAL + Walrus), import from "@mysten-incubation/memwal/manual".
  */
 
 // Core client (server-mode: server handles SEAL + Walrus + embedding)

--- a/packages/sdk/src/manual-entry.ts
+++ b/packages/sdk/src/manual-entry.ts
@@ -1,11 +1,11 @@
 /**
- * @mysten/memwal/manual
+ * @mysten-incubation/memwal/manual
  *
  * Manual (client-side) mode entry point.
  * Requires: @mysten/seal, @mysten/walrus, @mysten/sui
  *
  * Usage:
- *   import { MemWalManual } from "@mysten/memwal/manual";
+ *   import { MemWalManual } from "@mysten-incubation/memwal/manual";
  */
 
 export { MemWalManual } from "./manual.js";

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -9,7 +9,7 @@
  *
  * @example
  * ```typescript
- * import { MemWalManual } from "@mysten/memwal"
+ * import { MemWalManual } from "@mysten-incubation/memwal"
  *
  * const memwal = MemWalManual.create({
  *     key: process.env.MEMWAL_DELEGATE_KEY!,      // Ed25519 delegate key

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -11,7 +11,7 @@
  *
  * @example
  * ```typescript
- * import { MemWal } from "@mysten/memwal"
+ * import { MemWal } from "@mysten-incubation/memwal"
  *
  * const memwal = MemWal.create({
  *     key: process.env.MEMWAL_PRIVATE_KEY,  // Ed25519 private key (hex)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,15 +23,15 @@ importers:
 
   apps/app:
     dependencies:
+      '@mysten-incubation/memwal':
+        specifier: workspace:*
+        version: link:../../packages/sdk
       '@mysten/dapp-kit':
         specifier: ^1.0.3
         version: 1.0.4(@mysten/sui@2.8.0(typescript@5.9.3))(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@9.0.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))
       '@mysten/enoki':
         specifier: ^1.0.4
         version: 1.0.4(@mysten/sui@2.8.0(typescript@5.9.3))(@types/react@19.2.14)(react@19.2.3)
-      '@mysten/memwal':
-        specifier: workspace:*
-        version: link:../../packages/sdk
       '@mysten/seal':
         specifier: ^1.1.0
         version: 1.1.1(@mysten/sui@2.8.0(typescript@5.9.3))
@@ -177,7 +177,7 @@ importers:
       '@icons-pack/react-simple-icons':
         specifier: ^13.7.0
         version: 13.12.0(react@19.0.1)
-      '@mysten/memwal':
+      '@mysten-incubation/memwal':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@opentelemetry/api':
@@ -499,7 +499,7 @@ importers:
       '@lexical/utils':
         specifier: ^0.41.0
         version: 0.41.0
-      '@mysten/memwal':
+      '@mysten-incubation/memwal':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@mysten/sui':
@@ -701,9 +701,9 @@ importers:
       '@icons-pack/react-simple-icons':
         specifier: ^13.7.0
         version: 13.12.0(react@19.0.1)
-      '@mysten/memwal':
-        specifier: 0.0.1-dev.0
-        version: 0.0.1-dev.0(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)
+      '@mysten-incubation/memwal':
+        specifier: workspace:*
+        version: link:../../packages/sdk
       '@noble/ed25519':
         specifier: ^2.2.3
         version: 2.3.0
@@ -3075,26 +3075,6 @@ packages:
 
   '@mysten/ledgerjs-hw-app-sui@0.7.1':
     resolution: {integrity: sha512-2KfPyTzdIeSq4auepS56T09rPE2dHz2VX3G9rFnYjayzynJtNd9tzKWPRpjpCEdBGjp8wg0kEzAeHSOwB0P/Kg==}
-
-  '@mysten/memwal@0.0.1-dev.0':
-    resolution: {integrity: sha512-WJ9uD7V0NKakYLiw2aphkJiTGFNxU3VbsdWncPyaVXtKmt1ySSlXmP7fiMY09JNwJsYmYAJiCb9M6ujiz7hejg==}
-    peerDependencies:
-      '@mysten/seal': '>=1.1.0'
-      '@mysten/sui': '>=2.5.0'
-      '@mysten/walrus': '>=1.0.3'
-      ai: '>=4.0.0'
-      zod: ^3.23.0
-    peerDependenciesMeta:
-      '@mysten/seal':
-        optional: true
-      '@mysten/sui':
-        optional: true
-      '@mysten/walrus':
-        optional: true
-      ai:
-        optional: true
-      zod:
-        optional: true
 
   '@mysten/seal@1.1.1':
     resolution: {integrity: sha512-OGxEDmEuXQAzxJKz3ap1dkRSf5fD/iKpz/J8+wZlPbeSok2fVt3KPaCZngjrvqqVRn5lmQomNpzXQCKo929A3w==}
@@ -13563,17 +13543,6 @@ snapshots:
 
   '@mysten/ledgerjs-hw-app-sui@0.7.1': {}
 
-  '@mysten/memwal@0.0.1-dev.0(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)':
-    dependencies:
-      '@noble/ed25519': 2.3.0
-      '@noble/hashes': 2.0.1
-    optionalDependencies:
-      '@mysten/seal': 1.1.1(@mysten/sui@2.8.0(typescript@5.9.3))
-      '@mysten/sui': 2.8.0(typescript@5.9.3)
-      '@mysten/walrus': 1.0.4(@mysten/sui@2.8.0(typescript@5.9.3))
-      ai: 6.0.37(zod@3.25.76)
-      zod: 3.25.76
-
   '@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3))':
     dependencies:
       '@mysten/bcs': 2.0.3
@@ -19016,7 +18985,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -19049,7 +19018,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19063,7 +19032,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Changes
### SDK Package Migration
- Renamed `@mysten/memwal` → `@mysten-incubation/memwal` across all source, config, and Dockerfiles
- Updated repository URL to `MystenLabs/MemWal`
### CI/CD — OIDC Trusted Publishing
- Upgraded npm CLI in CI for OIDC authentication support
- Added `--provenance` flag for supply-chain security
- Removed dependency on long-lived `NPM_TOKEN` secret
- Changed to `--no-frozen-lockfile` to handle workspace/npm version mismatches