### PR TITLE
docs: update managed relayer docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -24,13 +24,13 @@
     "links": [
       {
         "label": "GitHub",
-        "href": "https://github.com/CommandOSSLabs/memwal"
+        "href": "https://github.com/MystenLabs/MemWal"
       }
     ]
   },
   "footer": {
     "socials": {
-      "github": "https://github.com/CommandOSSLabs/memwal"
+      "github": "https://github.com/MystenLabs/MemWal"
     }
   },
   "navigation": {

--- a/docs/fundamentals/architecture/core-components.md
+++ b/docs/fundamentals/architecture/core-components.md
@@ -66,7 +66,7 @@ This means Web2 developers can integrate MemWal without touching wallets, signin
 Because the relayer handles encryption and plaintext data, you are placing trust in the relayer operator. This is a deliberate trade-off for developer experience. If you need full control over that trust boundary, you can [self-host](/relayer/self-hosting) your own relayer, or use the [manual client flow](/sdk/usage) to handle encryption and embedding entirely on the client side (recommended for Web3-native users). See [Trust & Security Model](/fundamentals/architecture/data-flow-security-model) for details.
 </Note>
 
-You can use the [public relayer](/relayer/public-relayer) to get started, [self-host](/relayer/self-hosting) your own, or use the manual client flow for full client-side control.
+You can use the [managed relayer](/relayer/public-relayer) to get started, [self-host](/relayer/self-hosting) your own, or use the manual client flow for full client-side control.
 
 ## MemWal Smart Contract
 

--- a/docs/fundamentals/architecture/data-flow-security-model.md
+++ b/docs/fundamentals/architecture/data-flow-security-model.md
@@ -33,11 +33,11 @@ You have options depending on your trust requirements:
 
 | Option | Trust level | What the relayer sees |
 |--------|------------|----------------------|
-| **Public relayer** | You trust the MemWal team | Plaintext content, embeddings, decrypted results |
+| **Managed relayer** | You trust Walrus Foundation | Plaintext content, embeddings, decrypted results |
 | **Self-hosted relayer** | You trust your own infra | Same as above, but under your control |
 | **Manual client flow** | Minimal trust | Only encrypted payloads and pre-computed vectors — never plaintext |
 
-- **Use the public relayer** — convenient for getting started and prototyping. You trust the MemWal team to operate it responsibly.
+- **Use the managed relayer** — convenient for getting started and prototyping. You trust Walrus Foundation to operate it responsibly.
 - **Self-host your own relayer** — you control the infrastructure, so the trust boundary is entirely yours. No third party sees your data.
 - **Manual client flow** — use `MemWalManual` to handle encryption and embedding entirely on the client side. The relayer only sees encrypted payloads and vectors, never plaintext. This is recommended for Web3-native users who want full control over their data and are comfortable managing keys, signing, and SEAL operations directly.
 

--- a/docs/getting-started/choose-your-path.md
+++ b/docs/getting-started/choose-your-path.md
@@ -5,7 +5,7 @@ title: "Choose Your Path"
 MemWal supports several integration modes depending on how much control you need. Pick the one that fits your use case.
 
 <Tip>
-These paths aren't mutually exclusive. You can combine them — for example, use the **Default SDK** with the **AI Middleware**, or start with the **Public Relayer** and move to **Self-Hosting** later. They all share the same backend and data layer.
+These paths aren't mutually exclusive. You can combine them - for example, use the **Default SDK** with the **AI Middleware**, or start with the **Managed Relayer** and move to **Self-Hosting** later. They all share the same backend and data layer.
 </Tip>
 
 ## 1. Default SDK
@@ -17,20 +17,24 @@ Use `@mysten-incubation/memwal` when you want the fastest working integration.
 
 Go to: [SDK Overview](/sdk/overview)
 
-## 2. Public Relayer
+## 2. Managed Relayer
 
-Use this when you want to evaluate MemWal without running the backend yourself.
+Use a hosted relayer, or deploy your own [self-hosted relayer](/relayer/self-hosting) with access to a wallet funded with WAL and SUI.
+
+<Note>
+Following endpoints are provided as public good by Walrus Foundation.
+</Note>
 
 | Network | Relayer URL |
-|---|---|
-| **Testnet** (staging) | `https://relayer.staging.memwal.ai` |
-| **Mainnet** (production) | `https://relayer.memwal.ai` |
+| --- | --- |
+| **Production** (mainnet) | `https://relayer.memwal.ai` |
+| **Staging** (testnet) | `https://relayer.staging.memwal.ai` |
 
-Go to: [Public Relayer](/relayer/public-relayer)
+Go to: [Managed Relayer](/relayer/public-relayer)
 
 ## 3. Manual Client Flow
 
-Use `@mysten-incubation/memwal/manual` when you want full client-side control over encryption and embeddings. Recommended for Web3-native users who want to minimize trust in the relayer — it never sees your plaintext data.
+Use `@mysten-incubation/memwal/manual` when you want full client-side control over encryption and embeddings. Recommended for Web3-native users who want to minimize trust in the relayer - it never sees your plaintext data.
 
 - client handles embeddings and SEAL encryption locally
 - relayer only sees encrypted payloads and vectors
@@ -45,6 +49,6 @@ Go to: [AI Integration](/sdk/usage/with-memwal)
 
 ## 5. Self-Host the Relayer
 
-Use this when you need full control over the trust boundary — your infrastructure, your credentials, no third party sees your data.
+Use this when you need full control over the trust boundary - your infrastructure, your credentials, no third party sees your data.
 
 Go to: [Self-Hosting](/relayer/self-hosting)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -7,11 +7,6 @@ The fastest way to get MemWal running is through the TypeScript SDK.
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) v18+ or [Bun](https://bun.sh/) v1+
-- A delegate key (Ed25519 private key in hex)
-- A MemWalAccount object ID on Sui
-- A relayer URL — use a [public relayer](/relayer/public-relayer) or your own [self-hosted relayer](/relayer/self-hosting)
-  - Production (mainnet): `https://relayer.memwal.ai`
-  - Staging (testnet): `https://relayer.staging.memwal.ai`
 
 ## Quick Start
 
@@ -96,6 +91,38 @@ The fastest way to get MemWal running is through the TypeScript SDK.
   </Step>
 
   <Step>
+    ### Generate your account ID and delegate key
+
+    Create a MemWal account ID and delegate private key for your SDK client using one of the hosted endpoints below.
+
+    <Note>
+    The following endpoints are provided as a public good by Walrus Foundation.
+    </Note>
+
+    | App | URL |
+    | --- | --- |
+    | **MemWal Playground** | [memwal.ai](https://memwal.ai) |
+    | **Walrus-hosted Playground** | [memwal.wal.app](https://memwal.wal.app) |
+
+    For the contract-based setup flow, see [Delegate Key Management](/contract/delegate-key-management) and [MemWal smart contract](/contract/overview).
+  </Step>
+
+  <Step>
+    ### Choose a relayer
+
+    Use a hosted relayer, or deploy your own [self-hosted relayer](/relayer/self-hosting) with access to a wallet funded with WAL and SUI:
+
+    <Note>
+    Following endpoints are provided as public good by Walrus Foundation.
+    </Note>
+
+    | Network | Relayer URL |
+    | --- | --- |
+    | **Production** (mainnet) | `https://relayer.memwal.ai` |
+    | **Staging** (testnet) | `https://relayer.staging.memwal.ai` |
+  </Step>
+
+  <Step>
     ### Configure the SDK
 
     Set up the SDK with your delegate key, account ID, and relayer URL:
@@ -110,14 +137,6 @@ The fastest way to get MemWal running is through the TypeScript SDK.
       namespace: "my-app",
     });
     ```
-
-    <Tip>
-    Use `https://relayer.memwal.ai` for production (mainnet) or `https://relayer.staging.memwal.ai` for staging (testnet). See [Public Relayer](/relayer/public-relayer) for details.
-    </Tip>
-
-    <Note>
-    If you are self-hosting and do not have `MEMWAL_ACCOUNT_ID` yet, see [Self-Hosting](/relayer/self-hosting) for the account-creation and delegate-key setup flow.
-    </Note>
   </Step>
 
   <Step>

--- a/docs/getting-started/what-is-memwal.md
+++ b/docs/getting-started/what-is-memwal.md
@@ -3,6 +3,10 @@ title: "What is MemWal?"
 description: "Persistent, verifiable memory for AI agents"
 ---
 
+<Note>
+MemWal is currently in beta and actively evolving. While fully usable today, we continue to refine the developer experience and operational guidance. We welcome feedback from early builders as we continue to improve the product.
+</Note>
+
 MemWal introduces a long-term, verifiable memory layer on Walrus, allowing agents to remember, share, and reuse information reliably.
 
 <CardGroup cols={2}>
@@ -98,7 +102,7 @@ And many more — check out the example apps below to see MemWal in action.
 
 ## Example Apps
 
-The repo ships with ready-to-run apps in the [`/apps`](https://github.com/CommandOSSLabs/memwal/tree/main/apps) directory:
+The repo ships with ready-to-run apps in the [`/apps`](https://github.com/MystenLabs/MemWal/tree/main/apps) directory:
 
 - **Playground** — dashboard demo for MemWal
 - **Chatbot** — AI chat app with persistent memory across sessions
@@ -120,7 +124,7 @@ See [Example Apps](/examples/example-apps) for short code examples from each app
     Quickstart, usage patterns, AI integration, and examples
   </Card>
   <Card title="Relayer" icon="tower-broadcast" href="/relayer/overview">
-    Public relayer, installation and setup, self-hosting
+    Managed relayer, installation and setup, self-hosting
   </Card>
   <Card title="Smart Contract" icon="scroll" href="/contract/overview">
     Onchain ownership model, delegate key management, permissions

--- a/docs/relayer/public-relayer.md
+++ b/docs/relayer/public-relayer.md
@@ -1,10 +1,10 @@
 ---
-title: "Public Relayer"
+title: "Managed Relayer"
 ---
 
-The public relayer is a managed MemWal deployment for teams that want to get started without running infrastructure. If a public relayer endpoint is available for your environment, it gives you the fastest path to integration.
+A managed relayer is a simpler experience for teams that want to get started without running infrastructure. If a managed relayer endpoint is available for your environment, it gives you the fastest path to integration.
 
-## Endpoints
+## Walrus Foundation hosted endpoints
 
 | Network | Relayer URL |
 |---|---|
@@ -26,9 +26,9 @@ const memwal = MemWal.create({
 
 ## What to Know
 
-- **Shared App ID** - all users of the public relayer share the same MemWal package ID. Your data is isolated by your own `owner + namespace` (Memory Space), but the underlying deployment is shared.
-- **Trust assumption** - the relayer sees plaintext during encryption and embedding. By using the public relayer, you're trusting the Mysten-hosted instance with that data. See [Trust & Security Model](/fundamentals/architecture/data-flow-security-model) for details.
-- **Availability** - the public relayer is a managed beta service. There are no SLA guarantees.
+- **Shared App ID** - all users of the managed relayer share the same MemWal package ID. Your data is isolated by your own `owner + namespace` (Memory Space), but the underlying deployment is shared.
+- **Trust assumption** - the relayer sees plaintext during encryption and embedding. By using the managed relayer, you're trusting the Walrus Foundation-hosted instance with that data. See [Trust & Security Model](/fundamentals/architecture/data-flow-security-model) for details.
+- **Availability** - the managed relayer is a managed beta service. There are no SLA guarantees.
 - **Storage costs** - the server wallet covers Walrus storage fees. Usage limits may apply during beta.
 
 If you need full control over the trust boundary or your own dedicated instance, see [Self-Hosting](/relayer/self-hosting).

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -4,7 +4,7 @@ title: "Self-Hosting"
 
 Self-hosting means running your own relayer — either pointing at an existing MemWal package ID or deploying an entirely new MemWal instance with your own contract, database, and server wallet.
 
-The public relayer provided by Mysten is a reference implementation. You can also build your own implementation that fits the same API surface with custom logic. This guide covers how to run the reference implementation as your own self-hosted relayer.
+The managed relayer provided by Walrus Foundation is a reference implementation. You can also build your own implementation that fits the same API surface with custom logic. This guide covers how to run the reference implementation as your own self-hosted relayer.
 
 ## When to Self-Host
 
@@ -13,7 +13,7 @@ The most common reasons are removing the trust assumption on a third-party relay
 - **Control the trust boundary** — a self-hosted relayer keeps plaintext, encryption, and embedding under your own control
 - **Run your own MemWal instance** — deploy your own contract with a separate package ID, SEAL encryption keys, and data isolation
 - **Choose your own embedding provider** — use your own OpenAI-compatible API and credentials
-- **Guarantee availability** — the public relayer is a beta service with no SLA
+- **Guarantee availability** — the managed relayer is a beta service with no SLA
 
 ## What Runs
 

--- a/docs/sdk/quick-start.md
+++ b/docs/sdk/quick-start.md
@@ -73,7 +73,7 @@ yarn add ai zod
 | --- | --- | --- | --- |
 | `key` | `string` | Yes | Ed25519 private key in hex |
 | `accountId` | `string` | Yes | MemWalAccount object ID on Sui |
-| `serverUrl` | `string` | No | Relayer URL — use `https://relayer.memwal.ai` (mainnet) or `https://relayer.staging.memwal.ai` (testnet) for the [public relayer](/relayer/public-relayer) |
+| `serverUrl` | `string` | No | Relayer URL — use `https://relayer.memwal.ai` (mainnet) or `https://relayer.staging.memwal.ai` (testnet) for the [managed relayer](/relayer/public-relayer) |
 | `namespace` | `string` | No | Default namespace — falls back to `"default"` |
 
 ## First Memory


### PR DESCRIPTION
## Summary
- add the beta admonition to the docs homepage
- simplify quick start prerequisites and add hosted setup/relayer guidance
- rename public relayer docs copy to managed relayer and update Walrus Foundation wording
- update docs GitHub links to the Mysten repo

## Notes
- docs-only changes
- excludes unrelated local changes such as pnpm-lock.yaml
