### PR TITLE
Prevent panic in generate_embedding on empty API response

### DIFF
--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -68,11 +68,11 @@ async fn generate_embedding(
                 AppError::Internal(format!("Failed to parse embedding response: {}", e))
             })?;
 
-            if api_resp.data.is_empty() {
-                return Err(AppError::Internal("Embedding API returned no data".into()));
-            }
-
-            let vector = api_resp.data.into_iter().next().unwrap().embedding;
+            let vector = api_resp.data
+                .into_iter()
+                .next()
+                .ok_or_else(|| AppError::Internal("Embedding API returned no data".into()))?
+                .embedding;
             Ok(vector)
         }
         None => {


### PR DESCRIPTION
## Description

  While going through the server codebase trying to run one of the applications, spotted this small precautionary fix.

  ## Abstract

  In `services/server/src/routes.rs`, `generate_embedding()` uses `.unwrap()` to extract the first embedding from the API response:

  ```rust
  if api_resp.data.is_empty() {
      return Err(AppError::Internal("Embedding API returned no data".into()));
  }
  let vector = api_resp.data.into_iter().next().unwrap().embedding;
  ```

  The .is_empty() guard and the .unwrap() are structurally decoupled; if the guard is ever moved or removed in a future refactor, .unwrap() panics and crashes the entire Axum server process.

  The fix collapses both into a single .ok_or_else() chain; same error message, same behavior, no panic path:

```rust
  let vector = api_resp.data
      .into_iter()
      .next()
      .ok_or_else(|| AppError::Internal("Embedding API returned no data".into()))?
      .embedding;
```
  **Changes**

  - Replace .unwrap() with idiomatic .ok_or_else()? in generate_embedding()

  **Test plan**

```bash
  cd services/server && cargo check
```

  Unit tests covering this fix (empty response, valid response, HTTP error, mock fallback) are in this branch commit 
  https://github.com/MystenLabs/MemWal/commit/856f50eb37a8e71aa9ceb63114b940f878168f13.
  Happy to include them or drop the mockito dep based on team preference.