### PR TITLE
fix: Anthropic compatibility for memory injection middleware

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,7 +26,8 @@
     "scripts": {
         "build": "tsc",
         "dev": "tsc --watch",
-        "typecheck": "tsc --noEmit"
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "tsc"
     },
     "dependencies": {
         "@noble/ed25519": "^2.3.0",

--- a/packages/sdk/src/ai/middleware.test.ts
+++ b/packages/sdk/src/ai/middleware.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { findLastUserMessage, injectMemoryContext, formatMemories } from "./middleware.js";
+
+// ── findLastUserMessage ──────────────────────────────────────────────
+
+describe("findLastUserMessage", () => {
+    test("returns null for non-array prompt", () => {
+        expect(findLastUserMessage("not an array")).toBeNull();
+        expect(findLastUserMessage(null)).toBeNull();
+        expect(findLastUserMessage(undefined)).toBeNull();
+    });
+
+    test("returns string content from last user message", () => {
+        const prompt = [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: "Hi there!" },
+            { role: "user", content: "What is my name?" },
+        ];
+        expect(findLastUserMessage(prompt)).toBe("What is my name?");
+    });
+
+    test("returns joined text parts from array content", () => {
+        const prompt = [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "Hello" },
+                    { type: "text", text: "world" },
+                ],
+            },
+        ];
+        expect(findLastUserMessage(prompt)).toBe("Hello world");
+    });
+
+    test("returns null for empty array", () => {
+        expect(findLastUserMessage([])).toBeNull();
+    });
+
+    test("returns null when no user messages exist", () => {
+        const prompt = [
+            { role: "system", content: "You are helpful." },
+            { role: "assistant", content: "Hi!" },
+        ];
+        expect(findLastUserMessage(prompt)).toBeNull();
+    });
+});
+
+// ── injectMemoryContext ──────────────────────────────────────────────
+
+describe("injectMemoryContext", () => {
+    const memoryContext = "[Memory Context] User likes blue.";
+
+    test("returns prompt unchanged for non-array", () => {
+        expect(injectMemoryContext("not an array", memoryContext)).toBe("not an array");
+    });
+
+    test("appends to existing system message (Anthropic-safe)", () => {
+        const prompt = [
+            { role: "system", content: "You are Miso." },
+            { role: "user", content: "Hi" },
+        ];
+        const result = injectMemoryContext(prompt, memoryContext) as any[];
+
+        // Should still be exactly 2 messages — no extra system message
+        expect(result).toHaveLength(2);
+        expect(result[0].role).toBe("system");
+        expect(result[0].content).toBe("You are Miso.\n\n[Memory Context] User likes blue.");
+        expect(result[1].role).toBe("user");
+    });
+
+    test("does not mutate the original prompt array", () => {
+        const prompt = [
+            { role: "system", content: "Original." },
+            { role: "user", content: "Hi" },
+        ];
+        injectMemoryContext(prompt, memoryContext);
+        expect(prompt[0].content).toBe("Original.");
+    });
+
+    test("prepends system message when none exists", () => {
+        const prompt = [
+            { role: "user", content: "Hi" },
+        ];
+        const result = injectMemoryContext(prompt, memoryContext) as any[];
+
+        expect(result).toHaveLength(2);
+        expect(result[0].role).toBe("system");
+        expect(result[0].content).toBe(memoryContext);
+        expect(result[1].role).toBe("user");
+    });
+
+    test("handles system message with non-string content", () => {
+        const prompt = [
+            { role: "system", content: 123 },
+            { role: "user", content: "Hi" },
+        ];
+        const result = injectMemoryContext(prompt, memoryContext) as any[];
+
+        expect(result).toHaveLength(2);
+        expect(result[0].content).toBe(memoryContext);
+    });
+
+    test("works with multi-turn conversation", () => {
+        const prompt = [
+            { role: "system", content: "System prompt." },
+            { role: "user", content: "First message" },
+            { role: "assistant", content: "Response" },
+            { role: "user", content: "Second message" },
+        ];
+        const result = injectMemoryContext(prompt, memoryContext) as any[];
+
+        // Should be exactly 4 messages — memory appended to system, not inserted as new
+        expect(result).toHaveLength(4);
+        expect(result[0].role).toBe("system");
+        expect(result[0].content).toContain("System prompt.");
+        expect(result[0].content).toContain(memoryContext);
+        // No second system message
+        const systemCount = result.filter((m: any) => m.role === "system").length;
+        expect(systemCount).toBe(1);
+    });
+});
+
+// ── formatMemories ───────────────────────────────────────────────────
+
+describe("formatMemories", () => {
+    test("formats memories with relevance scores", () => {
+        const memories = [
+            { text: "User likes blue", distance: 0.3 },
+            { text: "User is an artist", distance: 0.5 },
+        ];
+        const result = formatMemories(memories as any);
+
+        expect(result).toContain("User likes blue (relevance: 0.70)");
+        expect(result).toContain("User is an artist (relevance: 0.50)");
+        expect(result).toContain("[Memory Context]");
+    });
+
+    test("returns header with empty list", () => {
+        const result = formatMemories([]);
+        expect(result).toContain("[Memory Context]");
+    });
+});

--- a/packages/sdk/src/ai/middleware.ts
+++ b/packages/sdk/src/ai/middleware.ts
@@ -154,10 +154,11 @@ export function withMemWal(
 }
 
 // ============================================================
-// Helpers
+// Helpers (exported for testing)
 // ============================================================
 
-function findLastUserMessage(
+/** @internal */
+export function findLastUserMessage(
     prompt: unknown
 ): string | null {
     if (!Array.isArray(prompt)) return null;
@@ -177,32 +178,34 @@ function findLastUserMessage(
     return null;
 }
 
-function formatMemories(memories: RecallMemory[]): string {
+/** @internal */
+export function formatMemories(memories: RecallMemory[]): string {
     const lines = memories.map(
         (m) => `- ${m.text} (relevance: ${(1 - m.distance).toFixed(2)})`
     );
     return `[Memory Context] The following are known facts about this user from their personal memory store. Use these facts to answer the user's question:\n${lines.join("\n")}`;
 }
 
-function injectMemoryContext(
+/** @internal */
+export function injectMemoryContext(
     prompt: unknown,
     memoryContext: string
 ): unknown {
     if (!Array.isArray(prompt)) return prompt;
 
-    // Insert memory as a separate system message right before the last user message
-    // This ensures the LLM sees it prominently, not buried in a long system prompt
-    const lastUserIndex = prompt.reduce(
-        (idx: number, m: any, i: number) => (m.role === "user" ? i : idx),
-        -1
-    );
+    // Append memory context to existing system message to avoid multiple system
+    // messages (Anthropic only allows one). If no system message exists, prepend one.
+    const systemIndex = prompt.findIndex((m: any) => m.role === "system");
 
-    if (lastUserIndex > 0) {
+    if (systemIndex >= 0) {
         const result = [...prompt];
-        result.splice(lastUserIndex, 0, {
-            role: "system" as const,
-            content: memoryContext,
-        });
+        const existing = result[systemIndex] as any;
+        result[systemIndex] = {
+            ...existing,
+            content: typeof existing.content === "string"
+                ? `${existing.content}\n\n${memoryContext}`
+                : memoryContext,
+        };
         return result;
     }
 

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -25,6 +25,7 @@
     "exclude": [
         "node_modules",
         "dist",
-        "examples"
+        "examples",
+        "src/**/*.test.ts"
     ]
 }


### PR DESCRIPTION
## Summary

- **Anthropic compatibility**: `injectMemoryContext` inserted memories as a separate `{ role: "system" }` message. When the consumer already passes a system prompt to `streamText`, this creates multiple system messages separated by user/assistant messages, which Anthropic rejects with `AI_UnsupportedFunctionalityError`. Fix: append memory context to the existing system message instead of inserting a new one.
- **Publish safety**: Added `prepublishOnly` script to ensure `tsc` runs before `npm publish`, preventing packages from being published without `dist/`.
- **Tests**: Added unit tests for `findLastUserMessage`, `injectMemoryContext`, and `formatMemories` using `bun:test`.

## Context

Discovered while integrating MemWal with [Sona](https://github.com/user/sona)'s Miso chat assistant, which uses `@ai-sdk/anthropic` + `streamText` with a system prompt. The middleware worked with OpenAI (which tolerates multiple system messages) but broke on Anthropic.

## Test plan

- [x] `bun test packages/sdk/src/ai/middleware.test.ts` — 13 tests pass
- [x] `bun run build` in `packages/sdk/` — clean compile
- [x] Verified end-to-end with `@ai-sdk/anthropic` + `streamText` + system prompt