### PR TITLE
Fix silent Walrus download failure in recallManual()

### DIFF
--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -296,7 +296,10 @@ export class MemWalManual {
         );
 
         if (downloadedBlobs.length === 0) {
-            return { results: [], total: 0 };
+            throw new Error(
+                `All ${searchResult.results.length} Walrus download(s) failed. ` +
+                `The vector search matched memories, but none could be retrieved from Walrus.`,
+            );
         }
 
         // Step 4: Create ONE SEAL SessionKey (one wallet popup), then decrypt all blobs


### PR DESCRIPTION
### Description

While testing `MemWalManual` against a local setup with testnet infra, noticed that `recallManual()` silently swallows complete Walrus download failures.

---

### Abstract

In `packages/sdk/src/manual.ts`, `recallManual()` catches individual Walrus download errors and filters them out. When all downloads fail, it returns:

```ts
{ results: [], total: 0 }
```

This is indistinguishable from a valid “no memories found” case.

```ts
const downloadTasks = searchResult.results.map(async (hit) => {
    try {
        const data = await this.walrusDownload(hit.blob_id);
        return { blob_id: hit.blob_id, data, distance: hit.distance };
    } catch (err) {
        console.error(`[MemWalManual] Walrus download failed for ${hit.blob_id}:`, err);
        return null;
    }
});
const downloadedBlobs = (await Promise.all(downloadTasks)).filter((d) => d !== null);

if (downloadedBlobs.length === 0) {
    return { results: [], total: 0 }; // indistinguishable from "no results"
}
```

This makes it impossible for the caller to distinguish between:

* No vector search matches
* Walrus being unreachable / all downloads failing

---

### Fix

If the vector search returns results but all Walrus downloads fail, throw a descriptive error:

```ts
if (downloadedBlobs.length === 0 && searchResult.results.length > 0) {
    throw new Error(
        `All ${searchResult.results.length} Walrus download(s) failed. ` +
        `The vector search matched memories, but none could be retrieved from Walrus.`,
    );
}
```

This preserves:

* Correct behavior for empty search results
* Explicit failure for infrastructure issues

---

### Changes

* Replace silent `{ results: [], total: 0 }` return with a thrown error when:

  * `searchResult.results.length > 0`
  * AND all downloads fail

---

### Test Plan

* `npx tsc --noEmit` passes
* Reproduction script:

  * Store via server mode
  * Recall via `MemWalManual` with a dead `walrusAggregatorUrl`
  * Confirms error is now surfaced instead of returning silent empty

Branch: https://github.com/MystenLabs/MemWal/commit/0a4c8434a9733d3daf22832850bad5e785466bae
