### PR TITLE
fix(noter): implement server-side wallet signature verification

### DIFF
--- a/apps/noter/package/feature/auth/api/route.ts
+++ b/apps/noter/package/feature/auth/api/route.ts
@@ -5,6 +5,7 @@
 
 import { router, procedure } from "@/shared/lib/trpc/init";
 import { TRPCError } from "@trpc/server";
+import { verifyPersonalMessageSignature } from "@mysten/sui/verify";
 import { uuidv7 } from "uuidv7";
 import {
   initiateLoginInput,
@@ -247,9 +248,18 @@ export const authRouter = router({
       const { walletType, address, signature, message } = input;
 
       try {
-        // TODO: Verify signature on server-side
-        // For now, we trust the client signature
-        // In production, use @mysten/sui.js to verify the signature
+        // Verify the wallet signature before creating a session
+        const signerAddress = await verifyPersonalMessageSignature(
+          new TextEncoder().encode(message),
+          signature,
+        ).catch(() => {
+          throw new TRPCError({ code: "UNAUTHORIZED", message: "Invalid signature" });
+        });
+
+        if (signerAddress.toSuiAddress() !== address) {
+          throw new TRPCError({ code: "UNAUTHORIZED", message: "Signature does not match address" });
+        }
+
         // Create or update user via service
         const user = await authService.upsertWalletUser(ctx.db, {
           address,

--- a/apps/noter/package/feature/auth/lib/wallet-client.ts
+++ b/apps/noter/package/feature/auth/lib/wallet-client.ts
@@ -130,7 +130,7 @@ export async function signMessage(
 
     // Sign message using sui:signPersonalMessage feature
     const signFeature = wallet.features['sui:signPersonalMessage'] as {
-      signPersonalMessage: (params: { message: Uint8Array; account: any }) => Promise<{ signature: Uint8Array }>
+      signPersonalMessage: (params: { message: Uint8Array; account: any }) => Promise<{ signature: string | Uint8Array }>
     } | undefined;
 
     if (!signFeature) {
@@ -144,9 +144,10 @@ export async function signMessage(
       account: walletAccount,
     });
 
-
-    // Convert Uint8Array signature to base64
-    const signatureBase64 = Buffer.from(result.signature).toString("base64");
+    // Wallet standard returns signature as a base64 string; older versions return Uint8Array
+    const signatureBase64 = typeof result.signature === 'string'
+      ? result.signature
+      : Buffer.from(result.signature).toString("base64");
 
     return {
       signature: signatureBase64,


### PR DESCRIPTION
### Description

The connectWallet handler previously contained a TODO for server-side signature verification and trusted the client-provided signature.

While running the Noter application locally, I encountered consistent signature verification failures ("Unsupported signature scheme"), which led to identifying an encoding issue in the wallet client as well as the missing server-side verification.

This PR addresses both by implementing proper verification using @mysten/sui/verify and fixing the signature encoding bug in the client.

---

### Changes

#### `apps/noter/package/feature/auth/api/route.ts`

* Replace TODO with `verifyPersonalMessageSignature`
* Reject requests where the recovered signer address does not match the claimed address

#### `apps/noter/package/feature/auth/lib/wallet-client.ts`

* Fix signature encoding bug:

  * `signPersonalMessage` was typed as returning `Uint8Array`, but Slush returns the signature as a base64 string
  * `Buffer.from(str)` without an encoding argument treats the input as UTF-8, double-encoding the signature
  * The server then decodes invalid bytes (scheme byte `0x41` instead of `0x00`)
  * This causes `"Unsupported signature scheme"` on every call
* Added handling for both string and `Uint8Array` return types

---

### Test Plan

Tested locally with Noter against testnet using a Slush wallet:
* Valid signature + correct address → session created (200)
* Valid signature + tampered address → 401 "Signature does not match address"

<img width="2018" height="1145" alt="Screenshot 2026-03-26 192506" src="https://github.com/user-attachments/assets/04772999-b1a9-4c6e-9c6d-1defadcbdaf2" />