### PR TITLE
Fix: Add repository field for npm OIDC provenance

### DIFF
--- a/packages/openclaw-memory-memwal/package.json
+++ b/packages/openclaw-memory-memwal/package.json
@@ -4,6 +4,11 @@
   "type": "module",
   "description": "NemoClaw/OpenClaw memory plugin — encrypted, decentralized long-term memory via MemWal + Walrus",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MystenLabs/MemWal",
+    "directory": "packages/openclaw-memory-memwal"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

### Why
The CI release workflow fails with `E422: package.json "repository.url" is "", expected to match "https://github.com/MystenLabs/MemWal"`. npm OIDC provenance requires the `repository` field to match the GitHub repo.

### What
Add the `repository` field to `packages/openclaw-memory-memwal/package.json`.

### Solution
```json
"repository": {
  "type": "git",
  "url": "https://github.com/MystenLabs/MemWal",
  "directory": "packages/openclaw-memory-memwal"
}
```

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [x] I have tested this code locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed