### PR TITLE
Fix: Remove openclaw peer dep, downgrade zod to v3

### DIFF
--- a/packages/openclaw-memory-memwal/package.json
+++ b/packages/openclaw-memory-memwal/package.json
@@ -34,19 +34,11 @@
   "dependencies": {
     "@mysten-incubation/memwal": "^0.0.1",
     "@sinclair/typebox": "0.34.48",
-    "zod": "^4.3.6"
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0"
-  },
-  "peerDependencies": {
-    "openclaw": ">=2026.3.11"
-  },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Summary

### Why
`openclaw plugins install @mysten-incubation/oc-memwal` fails because:
1. The `openclaw` peer dependency can't be resolved in the extensions directory
2. Zod v4 is not aligned with the rest of the monorepo (chatbot, researcher use v3)

### What
Remove the openclaw peer dependency and downgrade zod from v4 to v3.

### Solution
- Remove `peerDependencies` and `peerDependenciesMeta` — openclaw is the runtime host, not an npm dependency (Mem0 doesn't have it either)
- Downgrade `zod` from `^4.3.6` to `^3.23.0` — all zod usage is v3 compatible, no API changes

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [x] I have tested this code locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed