### PR TITLE
fix(server): use UTF-8 safe truncation in log preview strings

### DIFF
--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -9,6 +9,19 @@ use crate::walrus;
 use crate::types::*;
 use crate::db::VectorDb;
 
+/// Truncate a string to at most `max_bytes` bytes without splitting a UTF-8
+/// character.  Falls back to the nearest char boundary when `max_bytes` lands
+/// inside a multi-byte sequence (e.g. emoji).
+fn truncate_str(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
 
 // ============================================================
 // Embedding — OpenRouter/OpenAI API (with mock fallback)
@@ -119,7 +132,7 @@ pub async fn remember(
     let owner = &auth.owner;
     let text = &body.text;
     let namespace = &body.namespace;
-    tracing::info!("remember: text=\"{}...\" owner={} ns={}", &text[..text.len().min(50)], owner, namespace);
+    tracing::info!("remember: text=\"{}...\" owner={} ns={}", truncate_str(text, 50), owner, namespace);
 
     // Step 1: Embed text + SEAL encrypt concurrently (they're independent)
     let embed_fut = generate_embedding(&state.http_client, &state.config, text);
@@ -178,7 +191,7 @@ pub async fn recall(
     // Owner is derived from delegate key via onchain verification (auth middleware)
     let owner = &auth.owner;
     let namespace = &body.namespace;
-    tracing::info!("recall: query=\"{}...\" owner={} ns={}", &body.query[..body.query.len().min(50)], owner, namespace);
+    tracing::info!("recall: query=\"{}...\" owner={} ns={}", truncate_str(&body.query, 50), owner, namespace);
 
     // Use delegate key from SDK for SEAL decryption (falls back to server key)
     let private_key = auth.delegate_key.as_deref()
@@ -368,7 +381,7 @@ pub async fn analyze(
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
-    tracing::info!("analyze: text=\"{}...\" owner={} ns={}", &body.text[..body.text.len().min(50)], owner, namespace);
+    tracing::info!("analyze: text=\"{}...\" owner={} ns={}", truncate_str(&body.text, 50), owner, namespace);
 
     // Step 1: Extract facts using LLM
     let facts = extract_facts_llm(&state.http_client, &state.config, &body.text).await?;
@@ -590,7 +603,7 @@ pub async fn ask(
     let owner = &auth.owner;
     let namespace = &body.namespace;
     let limit = body.limit.unwrap_or(5);
-    tracing::info!("ask: question=\"{}...\" owner={} ns={}", &body.question[..body.question.len().min(50)], owner, namespace);
+    tracing::info!("ask: question=\"{}...\" owner={} ns={}", truncate_str(&body.question, 50), owner, namespace);
 
     // Step 1: Recall relevant memories
     let query_vector = generate_embedding(&state.http_client, &state.config, &body.question).await?;


### PR DESCRIPTION
## Summary

When testing the app by adding some notes with emojis came across this issue.

Byte-level slicing via `&text[..text.len().min(50)]` in the 4 main API handlers (`remember`, `recall`, `analyze`, `ask`) panics when byte 50 lands inside a multi-byte UTF-8 character. This crashes the server for all connected users.

Any non-ASCII input longer than ~50 bytes triggers it — emoji (4 bytes each), CJK characters (3 bytes), accented Latin (2 bytes) etc.

---

## What this PR does

Adds a `truncate_str(s, max_bytes)` helper that backs up to the nearest `char_boundary` when the limit falls inside a multi-byte sequence. Replaces all 4 instances.

Only the log preview is truncated — the full user text is passed through untouched to the LLM, SEAL encrypt, Walrus upload, and DB insert pipeline.

---

## Affected endpoints

All 4 log-preview sites in `routes.rs`:

* `remember` (line 135)
* `recall` (line 194)
* `analyze` (line 384)
* `ask` (line 606)

All apps in the repo (noter, chatbot, researcher, playground) hit these endpoints — so all benefit from this fix.

---

## Test plan

* Sent multi-byte UTF-8 input via noter frontend — server panicked without fix
* Applied fix, same input — server truncated cleanly at char boundary, full flow completed (extract, encrypt, upload, store)
* Verified no other byte-slicing patterns in `db.rs`, `seal.rs`, `walrus.rs`, `auth.rs`, `sui.rs`
* Confirmed existing e2e tests (`tests/e2e_test.py`) still pass — they use ASCII-only input so were unaffected

<img width="1452" height="81" alt="Screenshot 2026-03-30 183353" src="https://github.com/user-attachments/assets/5fe20572-3f6d-4524-845e-af2a3a7e6d21" />
