### PR TITLE
fix: enforce --frozen-lockfile in all CI workflows and Dockerfiles

### DIFF
--- a/.github/workflows/deploy-app-walrus.yml
+++ b/.github/workflows/deploy-app-walrus.yml
@@ -30,7 +30,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Validate ws-resources.json exists
         run: |

--- a/.github/workflows/release-oc-memwal.yml
+++ b/.github/workflows/release-oc-memwal.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build SDK (dependency)
         run: pnpm build:sdk

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Typecheck
         run: pnpm --filter @mysten-incubation/memwal typecheck

--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -18,7 +18,7 @@ COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/app/package.json      ./apps/app/
 
 # Install all workspace deps
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 # Build SDK first (apps/app depends on @mysten-incubation/memwal via workspace:*)
 COPY packages/sdk/ ./packages/sdk/

--- a/apps/researcher/Dockerfile
+++ b/apps/researcher/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 COPY apps/researcher/package.json ./
 
 # Install deps — @mysten-incubation/memwal is now on npm, no local SDK needed
-RUN bun install
+RUN bun install --frozen-lockfile
 
 # ── Stage 2: Build ─────────────────────────────────────────
 FROM oven/bun:1 AS builder

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -24,7 +24,7 @@
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/provider": "^3.0.3",
         "@ai-sdk/react": "3.0.39",
-        "@mysten-incubation/memwal": "^0.0.1-dev.0",
+        "@mysten-incubation/memwal": "0.0.1",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-python": "^6.1.6",
         "@codemirror/state": "^6.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,8 +702,8 @@ importers:
         specifier: ^13.7.0
         version: 13.12.0(react@19.0.1)
       '@mysten-incubation/memwal':
-        specifier: workspace:*
-        version: link:../../packages/sdk
+        specifier: 0.0.1
+        version: 0.0.1(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)
       '@noble/ed25519':
         specifier: ^2.2.3
         version: 2.3.0
@@ -972,6 +972,25 @@ importers:
       mintlify:
         specifier: ^4
         version: 4.2.441(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@24.12.0)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(typescript@5.9.3)
+
+  packages/openclaw-memory-memwal:
+    dependencies:
+      '@mysten-incubation/memwal':
+        specifier: ^0.0.1
+        version: 0.0.1(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
   packages/sdk:
     dependencies:
@@ -3045,6 +3064,26 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
+  '@mysten-incubation/memwal@0.0.1':
+    resolution: {integrity: sha512-kRAFFJBdk3D9XvGHZdPOrnz2x4C7dwCRf0xTaeLFAVTgVwfpk3GmOnJZ1O+pAQyrAhweAzBXNXBWutShnPWgJg==}
+    peerDependencies:
+      '@mysten/seal': '>=1.1.0'
+      '@mysten/sui': '>=2.5.0'
+      '@mysten/walrus': '>=1.0.3'
+      ai: '>=4.0.0'
+      zod: ^3.23.0
+    peerDependenciesMeta:
+      '@mysten/seal':
+        optional: true
+      '@mysten/sui':
+        optional: true
+      '@mysten/walrus':
+        optional: true
+      ai:
+        optional: true
+      zod:
+        optional: true
+
   '@mysten/bcs@1.2.0':
     resolution: {integrity: sha512-LuKonrGdGW7dq/EM6U2L9/as7dFwnhZnsnINzB/vu08Xfrj0qzWwpLOiXagAa5yZOPLK7anRZydMonczFkUPzA==}
 
@@ -4457,6 +4496,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sinclair/typebox@0.34.48':
+    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
@@ -13486,6 +13528,17 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
+  '@mysten-incubation/memwal@0.0.1(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@noble/ed25519': 2.3.0
+      '@noble/hashes': 2.0.1
+    optionalDependencies:
+      '@mysten/seal': 1.1.1(@mysten/sui@2.8.0(typescript@5.9.3))
+      '@mysten/sui': 2.8.0(typescript@5.9.3)
+      '@mysten/walrus': 1.0.4(@mysten/sui@2.8.0(typescript@5.9.3))
+      ai: 6.0.37(zod@3.25.76)
+      zod: 3.25.76
+
   '@mysten/bcs@1.2.0':
     dependencies:
       bs58: 6.0.0
@@ -16528,6 +16581,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sinclair/typebox@0.34.48': {}
+
   '@sindresorhus/is@5.6.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
@@ -16909,7 +16964,7 @@ snapshots:
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.15
 
   '@types/d3-array@3.2.2': {}
 
@@ -16958,7 +17013,7 @@ snapshots:
 
   '@types/es-aggregate-error@1.0.6':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.15
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -17088,7 +17143,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.15
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
@@ -18646,7 +18701,7 @@ snapshots:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.19
-      '@types/node': 20.19.37
+      '@types/node': 22.19.15
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -22163,7 +22218,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.15
       long: 5.3.2
 
   proxy-addr@2.0.7:


### PR DESCRIPTION
- deploy-app-walrus.yml: --no-frozen-lockfile → --frozen-lockfile
- release-oc-memwal.yml: --no-frozen-lockfile → --frozen-lockfile
- release-sdk.yml: --no-frozen-lockfile → --frozen-lockfile
- apps/app/Dockerfile: pnpm install → pnpm install --frozen-lockfile
- apps/researcher/Dockerfile: bun install → bun install --frozen-lockfile
- apps/researcher/package.json: pin @mysten-incubation/memwal to exact 0.0.1

Prevents supply chain attacks like axios@1.14.1 compromise (axios/axios#10604) from being silently pulled into CI builds.