### PR TITLE
Refactor: Extract magic numbers to shared constants

### DIFF
--- a/packages/openclaw-memory-memwal/src/capture.ts
+++ b/packages/openclaw-memory-memwal/src/capture.ts
@@ -6,12 +6,7 @@
  * Based on patterns from LanceDB's shouldCapture() implementation.
  */
 
-// ============================================================================
-// Constants
-// ============================================================================
-
-const MIN_CAPTURE_LENGTH = 30;
-const MAX_EMOJI_COUNT = 3;
+import { MIN_CAPTURE_LENGTH, MAX_EMOJI_COUNT } from "./constants.js";
 
 /** Filler patterns — exact-match trivial responses. */
 const FILLER_PATTERN = /^(ok|okay|sure|thanks|thank you|thx|yes|yep|yeah|no|nope|nah|got it|hmm|hm|ah|oh|lol|haha|nice|cool|great|right|alright|fine|k|kk)\s*[.!?]*$/i;

--- a/packages/openclaw-memory-memwal/src/constants.ts
+++ b/packages/openclaw-memory-memwal/src/constants.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared numeric constants used across the plugin.
+ *
+ * Centralised here to avoid magic numbers scattered in business logic.
+ * Each constant documents its purpose and which modules consume it.
+ */
+
+// ============================================================================
+// Capture filtering (capture.ts)
+// ============================================================================
+
+/** Minimum character length for a message to be considered capturable. */
+export const MIN_CAPTURE_LENGTH = 30;
+
+/** Messages with more emoji than this are treated as reactions, not facts. */
+export const MAX_EMOJI_COUNT = 3;
+
+// ============================================================================
+// Text extraction (format.ts)
+// ============================================================================
+
+/** Messages shorter than this (after tag stripping) are dropped as trivial. */
+export const MIN_EXTRACTED_TEXT_LENGTH = 10;
+
+// ============================================================================
+// Recall hook (hooks/recall.ts)
+// ============================================================================
+
+/** Prompts shorter than this skip the recall round-trip entirely. */
+export const MIN_PROMPT_LENGTH = 10;
+
+// ============================================================================
+// Store tool (tools/store.ts)
+// ============================================================================
+
+/** Minimum trimmed length for text submitted to memory_store. */
+export const MIN_STORE_TEXT_LENGTH = 3;
+
+/** Max extracted facts shown in the store confirmation preview. */
+export const MAX_FACT_PREVIEW_COUNT = 3;
+
+/** Max characters of raw text shown as fallback preview. */
+export const MAX_TEXT_PREVIEW_LENGTH = 100;
+
+// ============================================================================
+// Search tool (tools/search.ts)
+// ============================================================================
+
+/** Default result limit for memory_search when caller omits `limit`. */
+export const DEFAULT_SEARCH_LIMIT = 5;
+
+// ============================================================================
+// Retry (format.ts → withRetry)
+// ============================================================================
+
+/** Default number of retry attempts (1 = 2 total tries). */
+export const DEFAULT_RETRY_COUNT = 1;
+
+/** Default delay in ms between retry attempts. */
+export const DEFAULT_RETRY_DELAY_MS = 2000;

--- a/packages/openclaw-memory-memwal/src/format.ts
+++ b/packages/openclaw-memory-memwal/src/format.ts
@@ -3,6 +3,12 @@
  * Shared by hooks, tools, and CLI.
  */
 
+import {
+  MIN_EXTRACTED_TEXT_LENGTH,
+  DEFAULT_RETRY_COUNT,
+  DEFAULT_RETRY_DELAY_MS,
+} from "./constants.js";
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -104,7 +110,7 @@ export function extractMessageTexts(
     // Strip our injected memory tags to prevent feedback loops, then drop
     // anything that's empty or trivially short after stripping
     text = stripMemoryTags(text).trim();
-    if (text.length > 10) {
+    if (text.length > MIN_EXTRACTED_TEXT_LENGTH) {
       texts.push(text);
     }
   }
@@ -130,8 +136,8 @@ export function toolError(message: string, err: unknown) {
  */
 export async function withRetry<T>(
   fn: () => Promise<T>,
-  retries: number = 1,
-  delayMs: number = 2000,
+  retries: number = DEFAULT_RETRY_COUNT,
+  delayMs: number = DEFAULT_RETRY_DELAY_MS,
 ): Promise<T> {
   try {
     return await fn();

--- a/packages/openclaw-memory-memwal/src/hooks/recall.ts
+++ b/packages/openclaw-memory-memwal/src/hooks/recall.ts
@@ -11,8 +11,7 @@ import { resolveAgent } from "../config.js";
 import { looksLikeInjection } from "../capture.js";
 import { formatMemoriesForPrompt } from "../format.js";
 import type { PluginConfig } from "../types.js";
-
-const MIN_PROMPT_LENGTH = 10;
+import { MIN_PROMPT_LENGTH } from "../constants.js";
 
 /** Register the before_prompt_build hook for auto-recall. */
 export function registerRecallHook(api: any, client: MemWal, config: PluginConfig): void {

--- a/packages/openclaw-memory-memwal/src/tools/search.ts
+++ b/packages/openclaw-memory-memwal/src/tools/search.ts
@@ -12,6 +12,7 @@ import { Type } from "@sinclair/typebox";
 import { looksLikeInjection } from "../capture.js";
 import { escapeForPrompt, toolError } from "../format.js";
 import type { PluginConfig } from "../types.js";
+import { DEFAULT_SEARCH_LIMIT } from "../constants.js";
 
 /** Register the memory_search agent tool. */
 export function registerSearchTool(api: any, client: MemWal, config: PluginConfig): void {
@@ -35,7 +36,7 @@ export function registerSearchTool(api: any, client: MemWal, config: PluginConfi
         ),
       }),
       async execute(_id: string, params: any) {
-        const { query, limit = 5, namespace } = params;
+        const { query, limit = DEFAULT_SEARCH_LIMIT, namespace } = params;
         // LLM may omit namespace (e.g. tools.allow set but hooks disabled) — fall back safely
         const ns = namespace || config.defaultNamespace;
 

--- a/packages/openclaw-memory-memwal/src/tools/store.ts
+++ b/packages/openclaw-memory-memwal/src/tools/store.ts
@@ -11,6 +11,7 @@ import { Type } from "@sinclair/typebox";
 import { looksLikeInjection } from "../capture.js";
 import { toolError } from "../format.js";
 import type { PluginConfig } from "../types.js";
+import { MIN_STORE_TEXT_LENGTH, MAX_FACT_PREVIEW_COUNT, MAX_TEXT_PREVIEW_LENGTH } from "../constants.js";
 
 /** Register the memory_store agent tool. */
 export function registerStoreTool(api: any, client: MemWal, config: PluginConfig): void {
@@ -52,7 +53,7 @@ export function registerStoreTool(api: any, client: MemWal, config: PluginConfig
           };
         }
 
-        if (!text || text.trim().length < 3) {
+        if (!text || text.trim().length < MIN_STORE_TEXT_LENGTH) {
           return {
             content: [
               {
@@ -71,8 +72,8 @@ export function registerStoreTool(api: any, client: MemWal, config: PluginConfig
           // Show first 3 extracted facts as confirmation, or raw text truncation as fallback
           const preview = result.facts
             ?.map((f: any) => f.text)
-            .slice(0, 3)
-            .join("; ") ?? text.slice(0, 100);
+            .slice(0, MAX_FACT_PREVIEW_COUNT)
+            .join("; ") ?? text.slice(0, MAX_TEXT_PREVIEW_LENGTH);
 
           return {
             content: [


### PR DESCRIPTION
## Summary

### Why
Magic numbers are scattered across 5 source files in the openclaw-memory-memwal plugin, making it hard to find and tune thresholds (capture length, retry delays, search limits, etc.).

### What
- Add `src/constants.ts` with all numeric constants documented by purpose and consumer
- Update `capture.ts`, `format.ts`, `hooks/recall.ts`, `tools/search.ts`, `tools/store.ts` to import from constants

### Solution
Centralise all magic numbers into a single `constants.ts` file with JSDoc comments explaining each value. Each consuming module imports only what it needs. No behavior change — pure refactor.

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [x] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [x] I have tested this code locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed