### PR TITLE
fix(server): log redis errors in rate limit record_in_window

### DIFF
--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -155,7 +155,9 @@ async fn record_in_window(
     }
     pipe.expire(key, ttl_seconds);
 
-    let _: Result<(), _> = pipe.query_async(redis).await;
+    if let Err(e) = pipe.query_async::<()>(redis).await {
+        tracing::warn!("rate limit: failed to record window for key {}: {}", key, e);
+    }
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

This is a very small fix.

When Redis goes flaky, the three `check_window` calls in `rate_limit_middleware` already log and fail open — this is intentional and visible in the logs:

```
ERROR rate_limit: redis rate limit check failed (dk): broken pipe, allowing
ERROR rate_limit: redis rate limit check failed (burst): broken pipe, allowing
ERROR rate_limit: redis rate limit check failed (sustained): broken pipe, allowing
```

However, the `record_in_window` calls that follow were silently dropping errors:

```
let _: Result<(), _> = pipe.query_async(redis).await;
```

Redis write failures were not logged, providing no signal when counters stopped being written. This made rate limiting effectively blind and difficult to diagnose under load.

---

## Fix

```
if let Err(e) = pipe.query_async::<()>(redis).await {
    tracing::warn!("rate limit: failed to record window for key {}: {}", key, e);
}
```

This brings the record path in line with the existing check path pattern. Fail-open behavior remains unchanged — requests are still allowed when Redis is unavailable.

---

## Verification

Tested locally by stopping Redis mid-flight with a live signed request:

* Before fix: 3 check ERROR logs, followed by no further indication
* After fix: 3 check ERROR logs followed by 3 record WARN logs

This provides full visibility into the degraded state.