### PR TITLE
feat(server): add /api/embed route to expose embedding generation

### DIFF
--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -128,7 +128,7 @@ async fn main() {
         .route("/api/recall", post(routes::recall))
         .route("/api/remember/manual", post(routes::remember_manual))
         .route("/api/recall/manual", post(routes::recall_manual))
-
+        .route("/api/embed", post(routes::embed))
         .route("/api/analyze", post(routes::analyze))
         .route("/api/ask", post(routes::ask))
         .route("/api/restore", post(routes::restore))

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -599,6 +599,24 @@ async fn extract_facts_llm(
     Ok(facts)
 }
 
+
+/// POST /api/embed
+///
+/// Generate an embedding vector for text without storing it.
+/// Useful for the manual flow (rememberManual / recallManual) when the client
+/// wants a vector consistent with the server's embedding model.
+pub async fn embed(
+    State(state): State<Arc<AppState>>,
+    Extension(_auth): Extension<AuthInfo>,
+    Json(body): Json<EmbedRequest>,
+) -> Result<Json<EmbedResponse>, AppError> {
+    if body.text.is_empty() {
+        return Err(AppError::BadRequest("text cannot be empty".into()));
+    }
+    let vector = generate_embedding(&state.http_client, &state.config, &body.text).await?;
+    Ok(Json(EmbedResponse { vector }))
+}
+
 /// GET /health
 pub async fn health() -> Json<HealthResponse> {
     Json(HealthResponse {

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -190,6 +190,17 @@ pub struct RecallResult {
     pub distance: f64,
 }
 
+/// POST /api/embed
+#[derive(Debug, Deserialize)]
+pub struct EmbedRequest {
+    pub text: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmbedResponse {
+    pub vector: Vec<f32>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct SearchHit {
     pub blob_id: String,


### PR DESCRIPTION
## Summary

Adds a missing `/api/embed` endpoint to support the SDK’s `embed()` method, which is already exposed and documented.

This enables users—especially in manual flows (`rememberManual` / `recallManual`)—to generate embeddings consistent with the server’s model via the API.

---

## Description

The SDK exports an `embed()` method:

```js
await memwal.embed("some text") // → { vector: [...] }
```

However, the corresponding `/api/embed` route was not implemented on the server, resulting in 404 responses.

This PR adds the missing route and wires it to the existing internal `generate_embedding()` function.

---

## What this PR does

* Adds `routes::embed()` handler
* Uses existing `generate_embedding()` logic
* Defines request/response types in `types.rs`
* Registers `/api/embed` route in `main.rs`

---

## API

### Request

```json
{ "text": "I prefer dark mode" }
```

### Response

```json
{ "vector": [0.059, -0.043, ...] }
```

* Returns 400 on empty input
* Requires authentication (same as other `/api/*` routes)

---

## Verification

* HTTP 200 with correct vector dimensions on valid input
* HTTP 400 on empty input
