### PR TITLE
Fix: Pass NEXT_PUBLIC env vars as Docker build args for Enoki login

### DIFF
--- a/apps/noter/Dockerfile
+++ b/apps/noter/Dockerfile
@@ -37,8 +37,24 @@ WORKDIR /app/apps/noter
 # Next.js collects telemetry by default — disable it
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Dummy env var required for `next build` (real value injected at runtime)
+# Server-only env vars — dummies for build, real values at runtime
 ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
+
+# NEXT_PUBLIC_* vars are inlined into the client bundle at build time.
+# Railway passes env vars as Docker build args automatically.
+ARG NEXT_PUBLIC_ENOKI_API_KEY
+ARG NEXT_PUBLIC_GOOGLE_CLIENT_ID
+ARG NEXT_PUBLIC_SUI_NETWORK
+ARG NEXT_PUBLIC_MEMWAL_PACKAGE_ID
+ARG NEXT_PUBLIC_MEMWAL_REGISTRY_ID
+ARG NEXT_PUBLIC_MEMWAL_SERVER_URL
+
+ENV NEXT_PUBLIC_ENOKI_API_KEY=$NEXT_PUBLIC_ENOKI_API_KEY
+ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID
+ENV NEXT_PUBLIC_SUI_NETWORK=$NEXT_PUBLIC_SUI_NETWORK
+ENV NEXT_PUBLIC_MEMWAL_PACKAGE_ID=$NEXT_PUBLIC_MEMWAL_PACKAGE_ID
+ENV NEXT_PUBLIC_MEMWAL_REGISTRY_ID=$NEXT_PUBLIC_MEMWAL_REGISTRY_ID
+ENV NEXT_PUBLIC_MEMWAL_SERVER_URL=$NEXT_PUBLIC_MEMWAL_SERVER_URL
 
 RUN npx next build
 

--- a/apps/researcher/Dockerfile
+++ b/apps/researcher/Dockerfile
@@ -27,10 +27,25 @@ COPY apps/researcher/ .
 # Next.js collects telemetry by default — disable it
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Build needs these env vars at build time (set dummies for `next build`)
-# Real values are injected at runtime
+# Server-only env vars — dummies for build, real values at runtime
 ENV POSTGRES_URL="postgresql://dummy:dummy@localhost:5432/dummy"
 ENV AUTH_SECRET="build-time-placeholder"
+
+# NEXT_PUBLIC_* vars are inlined into the client bundle at build time.
+# Railway passes env vars as Docker build args automatically.
+ARG NEXT_PUBLIC_ENOKI_API_KEY
+ARG NEXT_PUBLIC_GOOGLE_CLIENT_ID
+ARG NEXT_PUBLIC_SUI_NETWORK
+ARG NEXT_PUBLIC_MEMWAL_PACKAGE_ID
+ARG NEXT_PUBLIC_MEMWAL_REGISTRY_ID
+ARG NEXT_PUBLIC_MEMWAL_SERVER_URL
+
+ENV NEXT_PUBLIC_ENOKI_API_KEY=$NEXT_PUBLIC_ENOKI_API_KEY
+ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID
+ENV NEXT_PUBLIC_SUI_NETWORK=$NEXT_PUBLIC_SUI_NETWORK
+ENV NEXT_PUBLIC_MEMWAL_PACKAGE_ID=$NEXT_PUBLIC_MEMWAL_PACKAGE_ID
+ENV NEXT_PUBLIC_MEMWAL_REGISTRY_ID=$NEXT_PUBLIC_MEMWAL_REGISTRY_ID
+ENV NEXT_PUBLIC_MEMWAL_SERVER_URL=$NEXT_PUBLIC_MEMWAL_SERVER_URL
 
 RUN bunx next build
 


### PR DESCRIPTION
## Summary

### Why

The Enoki (Google OAuth) login button does not appear on the deployed noter and researcher apps. `NEXT_PUBLIC_*` environment variables are inlined into the Next.js client bundle at build time, but the Dockerfiles did not declare them as `ARG`/`ENV`, so they were empty strings in the production build. The `EnokiLoginCard` component checks these values and returns `null` when they are missing.

### What

- Added `ARG` + `ENV` declarations for all `NEXT_PUBLIC_*` Enoki/Sui variables in both `apps/noter/Dockerfile` and `apps/researcher/Dockerfile`
- Railway automatically passes service environment variables as Docker build args, so no additional Railway configuration is needed beyond what is already set

### Solution

Added the following build args before `next build` in both Dockerfiles:

- `NEXT_PUBLIC_ENOKI_API_KEY`
- `NEXT_PUBLIC_GOOGLE_CLIENT_ID`
- `NEXT_PUBLIC_SUI_NETWORK`
- `NEXT_PUBLIC_MEMWAL_PACKAGE_ID`
- `NEXT_PUBLIC_MEMWAL_REGISTRY_ID`
- `NEXT_PUBLIC_MEMWAL_SERVER_URL`

Each `ARG` is mapped to a corresponding `ENV` so Next.js picks them up during `next build`.

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [ ] I have tested this code locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

### Manual testing steps:

1. Merge to dev and let Railway redeploy
2. Visit the deployed researcher/noter login page
3. Verify "Sign in with Google" button is visible
4. Open browser console and confirm no Enoki-related errors

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed