### PR TITLE
Chore: Trigger noter deploy for lockfile sync

### DIFF
--- a/apps/noter/Dockerfile
+++ b/apps/noter/Dockerfile
@@ -1,5 +1,5 @@
 # ============================================================
-# MemWal Noter — Dockerfile
+# MemWal Noter — Dockerfile (v2 — Enoki build args)
 #
 # ⚠️  BUILD FROM MONOREPO ROOT:
 #     docker build -f apps/noter/Dockerfile -t memwal-noter .


### PR DESCRIPTION
Touches noter Dockerfile to trigger Railway watched path deploy. The lockfile fix from PR #86 was merged but Railway didn't pick it up because the watched paths weren't modified.