### PR TITLE
Fix: Disconnect Enoki wallet on noter logout

### DIFF
--- a/apps/noter/package/feature/auth/hook/use-auth.ts
+++ b/apps/noter/package/feature/auth/hook/use-auth.ts
@@ -6,6 +6,7 @@
 "use client";
 
 import { useCallback, useEffect } from "react";
+import { useDisconnectWallet } from "@mysten/dapp-kit";
 import { useAtom, useSetAtom } from "jotai";
 import {
   authAtom,
@@ -22,6 +23,9 @@ export function useAuth() {
   const setAuthenticated = useSetAtom(setAuthenticatedAtom);
   const clearAuth = useSetAtom(clearAuthAtom);
   const setLoading = useSetAtom(setLoadingAtom);
+
+  // Wallet disconnect (clears dapp-kit autoConnect state)
+  const { mutateAsync: disconnectWallet } = useDisconnectWallet();
 
   // tRPC mutations
   const connectEnokiMutation = trpc.auth.connectEnoki.useMutation();
@@ -118,18 +122,23 @@ export function useAuth() {
     [connectDelegateKeyMutation, setSession, setAuthenticated, setLoading]
   );
 
-  /** Logout — clear session and auth state. */
+  /** Logout — clear session, auth state, and disconnect wallet (prevents autoConnect). */
   const logout = useCallback(async () => {
     try {
       if (session?.sessionId) {
         await logoutMutation.mutateAsync({ sessionId: session.sessionId });
       }
-      clearAuth();
     } catch (error) {
       console.error("Logout failed:", error);
-      clearAuth();
     }
-  }, [session, logoutMutation, clearAuth]);
+    // Always disconnect wallet and clear auth, even if tRPC logout fails
+    try {
+      await disconnectWallet();
+    } catch {
+      // Wallet may already be disconnected
+    }
+    clearAuth();
+  }, [session, logoutMutation, disconnectWallet, clearAuth]);
 
   return {
     ...auth,


### PR DESCRIPTION
## Summary

### Why

After logging out of the noter app and returning to the login page, the user appears still logged in. The Enoki Google wallet session persists because `autoConnect` in dapp-kit restores it from localStorage.

### What

- Added `useDisconnectWallet` from `@mysten/dapp-kit` to the `useAuth` hook
- Call `disconnectWallet()` during logout to clear dapp-kit's stored wallet state

### Solution

The logout function now disconnects the wallet after clearing the app session, preventing `autoConnect` from restoring the Enoki wallet on the next page load. The disconnect call is wrapped in a separate try/catch so it doesn't block `clearAuth()` if the wallet is already disconnected (e.g. delegate key login path).

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [ ] I have tested this code locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

### Manual testing steps:

1. Login via Google (Enoki)
2. Click Logout
3. Verify you land on the login page with no auto-reconnect
4. Click "Sign in with Google" — should require fresh OAuth

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed