### PR TITLE
Fix MEM-7: Transmit key_index instead of private_key

### DIFF
--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -39,6 +39,20 @@ if (SEAL_KEY_SERVERS.length === 0) {
     console.error("[sidecar] WARNING: SEAL_KEY_SERVERS env var is empty — SEAL encrypt/decrypt will fail");
 }
 
+// Server Sui Private Keys for Walrus uploads
+const SERVER_SUI_PRIVATE_KEYS = (process.env.SERVER_SUI_PRIVATE_KEYS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+if (SERVER_SUI_PRIVATE_KEYS.length === 0 && process.env.SERVER_SUI_PRIVATE_KEY) {
+    SERVER_SUI_PRIVATE_KEYS.push(process.env.SERVER_SUI_PRIVATE_KEY.trim());
+}
+
+if (SERVER_SUI_PRIVATE_KEYS.length === 0) {
+    console.error("[sidecar] WARNING: SERVER_SUI_PRIVATE_KEYS env var is empty — Walrus uploads will fail");
+}
+
 // Walrus package ID (for on-chain Move calls: metadata, blob type queries)
 const WALRUS_PACKAGE_ID = process.env.WALRUS_PACKAGE_ID || (
     SUI_NETWORK === "testnet"
@@ -536,18 +550,22 @@ app.post("/walrus/upload", async (req, res) => {
     try {
         const {
             data,
-            privateKey,
+            keyIndex,
             owner,
             namespace,
             packageId,
             epochs: rawEpochs = DEFAULT_WALRUS_EPOCHS,
         } = req.body;
-
         // LOW-17: Cap epochs at 5 to prevent accidental large storage purchases
         const epochs = Math.min(Number(rawEpochs) || DEFAULT_WALRUS_EPOCHS, 5);
 
-        if (!data || !privateKey) {
-            return res.status(400).json({ error: "Missing required fields: data, privateKey" });
+        if (!data || keyIndex === undefined) {
+            return res.status(400).json({ error: "Missing required fields: data, keyIndex" });
+        }
+
+        const privateKey = SERVER_SUI_PRIVATE_KEYS[keyIndex];
+        if (!privateKey) {
+            return res.status(400).json({ error: `Invalid keyIndex: ${keyIndex}` });
         }
 
         // LOW-16: Validate packageId resembles a Sui address to prevent injection

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -166,16 +166,8 @@ pub async fn remember(
     let encrypted = encrypted_result?;
 
     // Step 2: Upload encrypted blob → Walrus (via sidecar)
-    let sui_key = state
-        .key_pool
-        .next()
-        .map(|s| s.to_string())
-        .ok_or_else(|| {
-            AppError::Internal(
-                "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)"
-                    .into(),
-            )
-        })?;
+    let key_index = state.key_pool.next_index()
+        .ok_or_else(|| AppError::Internal("No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into()))?;
     let upload_result = walrus::upload_blob(
         &state.http_client,
         &state.config.sidecar_url,
@@ -183,7 +175,7 @@ pub async fn remember(
         &encrypted,
         50,
         owner,
-        &sui_key,
+        key_index,
         namespace,
         &state.config.package_id,
     )
@@ -385,16 +377,8 @@ pub async fn remember_manual(
     rate_limit::check_storage_quota(&state, owner, encrypted_bytes.len() as i64).await?;
 
     // Upload encrypted bytes to Walrus via sidecar (pool key pays gas)
-    let sui_key = state
-        .key_pool
-        .next()
-        .map(|s| s.to_string())
-        .ok_or_else(|| {
-            AppError::Internal(
-                "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)"
-                    .into(),
-            )
-        })?;
+    let key_index = state.key_pool.next_index()
+        .ok_or_else(|| AppError::Internal("No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into()))?;
 
     let upload = walrus::upload_blob(
         &state.http_client,
@@ -403,7 +387,7 @@ pub async fn remember_manual(
         &encrypted_bytes,
         50,
         owner,
-        &sui_key,
+        key_index,
         namespace,
         &state.config.package_id,
     )
@@ -548,12 +532,11 @@ pub async fn analyze(
         let fact_text = fact_text.clone();
         // Pick the next key in round-robin order at task construction time.
         // Convert to owned String *before* async move so we don't borrow-then-move `state`.
-        let sui_key: Result<String, AppError> = state.key_pool.next()
-            .map(|s| s.to_string())
+        let key_index: Result<usize, AppError> = state.key_pool.next_index()
             .ok_or_else(|| AppError::Internal("No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into()));
         let namespace = namespace.clone();
         async move {
-            let sui_key = sui_key?;
+            let key_index = key_index?;
             // Embed + SEAL encrypt concurrently (independent operations)
             let embed_fut = generate_embedding(&state.http_client, &state.config, &fact_text);
             let encrypt_fut = seal::seal_encrypt(
@@ -569,7 +552,7 @@ pub async fn analyze(
             let upload_result = walrus::upload_blob(
                 &state.http_client, &state.config.sidecar_url,
                 state.config.sidecar_secret.as_deref(),
-                &encrypted, 50, &owner, &sui_key, &namespace, &state.config.package_id,
+                &encrypted, 50, &owner, key_index, &namespace, &state.config.package_id,
             ).await?;
 
             // Store in Vector DB with namespace

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -41,12 +41,21 @@ impl KeyPool {
     }
 
     /// Returns the next key in round-robin order, or `None` if the pool is empty.
+    #[allow(dead_code)]
     pub fn next(&self) -> Option<&str> {
         if self.keys.is_empty() {
             return None;
         }
         let idx = self.counter.fetch_add(1, Ordering::Relaxed) % self.keys.len();
         Some(&self.keys[idx])
+    }
+
+    /// Returns the pool index for the next key in round-robin order.
+    pub fn next_index(&self) -> Option<usize> {
+        if self.keys.is_empty() {
+            return None;
+        }
+        Some(self.counter.fetch_add(1, Ordering::Relaxed) % self.keys.len())
     }
 
     #[allow(dead_code)]

--- a/services/server/src/walrus.rs
+++ b/services/server/src/walrus.rs
@@ -39,7 +39,7 @@ struct QueryBlobsResponse {
 #[serde(rename_all = "camelCase")]
 struct WalrusUploadRequest {
     data: String,
-    private_key: String,
+    key_index: usize,
     owner: String,
     namespace: String,
     package_id: String,
@@ -68,7 +68,7 @@ pub async fn upload_blob(
     data: &[u8],
     epochs: u64,
     owner_address: &str,
-    sui_private_key: &str,
+    key_index: usize,
     namespace: &str,
     package_id: &str,
 ) -> Result<UploadResult, AppError> {
@@ -79,7 +79,7 @@ pub async fn upload_blob(
         .post(&url)
         .json(&WalrusUploadRequest {
             data: data_b64,
-            private_key: sui_private_key.to_string(),
+            key_index,
             owner: owner_address.to_string(),
             namespace: namespace.to_string(),
             package_id: package_id.to_string(),


### PR DESCRIPTION
Fixes MEM-7: Stops transmitting raw private keys between the rust server and typescript sidecar. Keys are now mapped via `key_index` over the wire, and resolved locally in the sidecar.