### PR TITLE
fix(sec): address MEM-19 input validation and error sanitization

### DIFF
--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -12,7 +12,7 @@
  */
 
 import express, { Request, Response, NextFunction } from "express";
-import { timingSafeEqual } from "crypto";
+import { timingSafeEqual, randomUUID } from "crypto";
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
@@ -285,6 +285,11 @@ async function runExclusiveBySigner<T>(signerAddress: string, task: () => Promis
 // Express app
 // ============================================================
 
+
+function isValidSuiAddress(address: string) {
+    return /^0x[a-fA-F0-9]{64}$/.test(address);
+}
+
 const app = express();
 app.use(express.json({ limit: "1mb" }));
 
@@ -334,6 +339,7 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 app.post("/seal/encrypt", async (req, res) => {
     try {
         const { data, owner, packageId } = req.body;
+        if (owner && !isValidSuiAddress(owner)) return res.status(400).json({ error: "Invalid owner address format" });
         if (!data || !owner || !packageId) {
             return res.status(400).json({ error: "Missing required fields: data, owner, packageId" });
         }
@@ -349,8 +355,9 @@ app.post("/seal/encrypt", async (req, res) => {
         const encryptedBase64 = Buffer.from(result.encryptedObject).toString("base64");
         res.json({ encryptedData: encryptedBase64 });
     } catch (err: any) {
-        console.error(`[seal/encrypt] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const refId = randomUUID();
+        console.error(`[seal/encrypt] error (Ref: ${refId}): ${err?.message || err}`);
+        res.status(500).json({ error: `Internal sidecar error. Reference ID: ${refId}` });
     }
 });
 
@@ -428,8 +435,9 @@ app.post("/seal/decrypt", async (req, res) => {
         const decryptedBase64 = Buffer.from(decrypted).toString("base64");
         res.json({ decryptedData: decryptedBase64 });
     } catch (err: any) {
-        console.error(`[seal/decrypt] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const refId = randomUUID();
+        console.error(`[seal/decrypt] error (Ref: ${refId}): ${err?.message || err}`);
+        res.status(500).json({ error: `Internal sidecar error. Reference ID: ${refId}` });
     }
 });
 
@@ -540,8 +548,9 @@ app.post("/seal/decrypt-batch", async (req, res) => {
         console.log(`[seal/decrypt-batch] ${results.length}/${items.length} decrypted ok, ${errors.length} errors`);
         res.json({ results, errors });
     } catch (err: any) {
-        console.error(`[seal/decrypt-batch] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const refId = randomUUID();
+        console.error(`[seal/decrypt-batch] error (Ref: ${refId}): ${err?.message || err}`);
+        res.status(500).json({ error: `Internal sidecar error. Reference ID: ${refId}` });
     }
 });
 
@@ -558,6 +567,7 @@ app.post("/walrus/upload", async (req, res) => {
             packageId,
             epochs: rawEpochs = DEFAULT_WALRUS_EPOCHS,
         } = req.body;
+        if (owner && !isValidSuiAddress(owner)) return res.status(400).json({ error: "Invalid owner address format" });
         // LOW-17: Cap epochs at 5 to prevent accidental large storage purchases
         const epochs = Math.min(Number(rawEpochs) || DEFAULT_WALRUS_EPOCHS, 5);
 
@@ -689,8 +699,9 @@ app.post("/walrus/upload", async (req, res) => {
             objectId: blobObjectId,
         });
     } catch (err: any) {
-        console.error(`[walrus/upload] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const refId = randomUUID();
+        console.error(`[walrus/upload] error (Ref: ${refId}): ${err?.message || err}`);
+        res.status(500).json({ error: `Internal sidecar error. Reference ID: ${refId}` });
     }
 });
 
@@ -756,6 +767,7 @@ async function mapConcurrent<T, R>(
 app.post("/walrus/query-blobs", async (req, res) => {
     try {
         const { owner, namespace, packageId } = req.body;
+        if (owner && !isValidSuiAddress(owner)) return res.status(400).json({ error: "Invalid owner address format" });
         if (!owner) {
             return res.status(400).json({ error: "Missing required field: owner" });
         }
@@ -867,8 +879,9 @@ app.post("/walrus/query-blobs", async (req, res) => {
         console.log(`[query-blobs] returning ${blobs.length} blobs (filtered from ${rawObjs.length}) for owner=${owner} ns=${namespace || '*'}`);
         res.json({ blobs, total: blobs.length });
     } catch (err: any) {
-        console.error(`[walrus/query-blobs] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const refId = randomUUID();
+        console.error(`[walrus/query-blobs] error (Ref: ${refId}): ${err?.message || err}`);
+        res.status(500).json({ error: `Internal sidecar error. Reference ID: ${refId}` });
     }
 });
 
@@ -896,8 +909,9 @@ app.post("/sponsor", async (req, res) => {
         console.log(`[sponsor] sponsored tx created, digest=${sponsored.digest}`);
         res.json(sponsored); // { bytes, digest }
     } catch (err: any) {
-        console.error(`[sponsor] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const refId = randomUUID();
+        console.error(`[sponsor] error (Ref: ${refId}): ${err?.message || err}`);
+        res.status(500).json({ error: `Internal sidecar error. Reference ID: ${refId}` });
     }
 });
 
@@ -924,8 +938,9 @@ app.post("/sponsor/execute", async (req, res) => {
         console.log(`[sponsor/execute] tx executed, final digest=${executed.digest}`);
         res.json(executed); // { digest }
     } catch (err: any) {
-        console.error(`[sponsor/execute] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const refId = randomUUID();
+        console.error(`[sponsor/execute] error (Ref: ${refId}): ${err?.message || err}`);
+        res.status(500).json({ error: `Internal sidecar error. Reference ID: ${refId}` });
     }
 });
 

--- a/services/server/scripts/tsconfig.json
+++ b/services/server/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use std::sync::Arc;
 
-use crate::types::{AppError, AppState};
+use crate::types::{AppError, AppState, AuthInfo};
 
 // ============================================================
 // Rate Limit Configuration
@@ -96,13 +96,24 @@ fn endpoint_weight(path: &str) -> i64 {
     // MED-20 fix: strip trailing slash so "/api/analyze/" == "/api/analyze"
     let path = path.trim_end_matches('/');
     match path {
-        "/api/analyze" => 10,          // LLM extract + N × (embed + encrypt + upload)
+        "/api/analyze" => ANALYZE_BASE_WEIGHT, // LLM extract + N × (embed + encrypt + upload)
         "/api/remember" => 5,          // embed + SEAL encrypt + Walrus upload
         "/api/remember/manual" => 3,   // Walrus upload only (client did embed/encrypt)
         "/api/restore" => 3,           // download + decrypt + re-embed
         "/api/ask" => 2,               // recall + LLM
         _ => 1,                        // recall, recall/manual, etc.
     }
+}
+
+pub const ANALYZE_BASE_WEIGHT: i64 = 5;
+const ANALYZE_PER_FACT_WEIGHT: i64 = 2;
+
+pub fn analyze_total_weight(fact_count: usize) -> i64 {
+    ANALYZE_BASE_WEIGHT + (fact_count as i64) * ANALYZE_PER_FACT_WEIGHT
+}
+
+pub fn analyze_additional_weight(fact_count: usize) -> i64 {
+    (fact_count as i64) * ANALYZE_PER_FACT_WEIGHT
 }
 
 // ============================================================
@@ -205,6 +216,166 @@ fn rate_limiter_unavailable_response() -> Response {
         .header("Retry-After", "5")
         .body(axum::body::Body::from(serde_json::to_string(&body).unwrap()))
         .unwrap()
+}
+
+#[derive(Debug, Clone)]
+struct RateLimitKeys {
+    delegate_key: String,
+    burst_key: String,
+    hourly_key: String,
+}
+
+fn build_keys(auth: &AuthInfo) -> RateLimitKeys {
+    RateLimitKeys {
+        delegate_key: format!("rate:dk:{}", auth.public_key),
+        burst_key: format!("rate:{}", auth.owner),
+        hourly_key: format!("rate:hr:{}", auth.owner),
+    }
+}
+
+fn explicit_rate_limit_error(layer: &str, limit: i64, window: &str) -> AppError {
+    AppError::RateLimited(format!(
+        "Rate limit exceeded for {} (limit: {} weighted-requests/{})",
+        layer, limit, window
+    ))
+}
+
+async fn check_explicit_weight_inner(
+    redis: &mut redis::aio::MultiplexedConnection,
+    config: &RateLimitConfig,
+    auth: &AuthInfo,
+    weight: i64,
+    path: &str,
+    now: f64,
+) -> Result<(), AppError> {
+    if weight <= 0 {
+        return Ok(());
+    }
+
+    let keys = build_keys(auth);
+    let dk_window_start = now - 60_000.0;
+    match check_window(redis, &keys.delegate_key, dk_window_start).await {
+        Ok(count) => {
+            if count + weight > config.max_requests_per_delegate_key {
+                tracing::warn!(
+                    "rate limit [delegate-key]: key={}... count={}/{} additional_weight={} path={}",
+                    &auth.public_key[..16],
+                    count,
+                    config.max_requests_per_delegate_key,
+                    weight,
+                    path
+                );
+                return Err(explicit_rate_limit_error(
+                    "delegate_key",
+                    config.max_requests_per_delegate_key,
+                    "min",
+                ));
+            }
+        }
+        Err(e) => {
+            tracing::error!("redis rate limit check failed (dk): {}", e);
+            return Err(AppError::Internal("Rate limiter unavailable".into()));
+        }
+    }
+
+    let burst_window_start = now - 60_000.0;
+    match check_window(redis, &keys.burst_key, burst_window_start).await {
+        Ok(count) => {
+            if count + weight > config.max_requests_per_minute {
+                tracing::warn!(
+                    "rate limit [burst]: owner={} count={}/{} additional_weight={} path={}",
+                    auth.owner,
+                    count,
+                    config.max_requests_per_minute,
+                    weight,
+                    path
+                );
+                return Err(explicit_rate_limit_error(
+                    "account_burst",
+                    config.max_requests_per_minute,
+                    "min",
+                ));
+            }
+        }
+        Err(e) => {
+            tracing::error!("redis rate limit check failed (burst): {}", e);
+            return Err(AppError::Internal("Rate limiter unavailable".into()));
+        }
+    }
+
+    let hourly_window_start = now - 3_600_000.0;
+    match check_window(redis, &keys.hourly_key, hourly_window_start).await {
+        Ok(count) => {
+            if count + weight > config.max_requests_per_hour {
+                tracing::warn!(
+                    "rate limit [sustained]: owner={} count={}/{} additional_weight={} path={}",
+                    auth.owner,
+                    count,
+                    config.max_requests_per_hour,
+                    weight,
+                    path
+                );
+                return Err(explicit_rate_limit_error(
+                    "account_sustained",
+                    config.max_requests_per_hour,
+                    "hour",
+                ));
+            }
+        }
+        Err(e) => {
+            tracing::error!("redis rate limit check failed (sustained): {}", e);
+            return Err(AppError::Internal("Rate limiter unavailable".into()));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn check_explicit_weight(
+    state: &AppState,
+    auth: &AuthInfo,
+    weight: i64,
+    path: &str,
+) -> Result<(), AppError> {
+    let mut redis = state.redis.clone();
+    let now = chrono::Utc::now().timestamp_millis() as f64;
+    check_explicit_weight_inner(
+         &mut redis,
+         &state.config.rate_limit,
+         auth,
+         weight,
+         path,
+         now,
+    )
+    .await
+}
+
+pub async fn record_explicit_weight(
+    state: &AppState,
+    auth: &AuthInfo,
+    weight: i64,
+) -> Result<(), AppError> {
+    if weight <= 0 {
+        return Ok(());
+    }
+
+    let mut redis = state.redis.clone();
+    let now = chrono::Utc::now().timestamp_millis() as f64;
+    let keys = build_keys(auth);
+    record_in_window(&mut redis, &keys.delegate_key, now, weight, 120).await;
+    record_in_window(&mut redis, &keys.burst_key, now + 0.1, weight, 120).await;
+    record_in_window(&mut redis, &keys.hourly_key, now + 0.2, weight, 3700).await;
+    Ok(())
+}
+
+pub async fn charge_explicit_weight(
+    state: &AppState,
+    auth: &AuthInfo,
+    weight: i64,
+    path: &str,
+) -> Result<(), AppError> {
+    check_explicit_weight(state, auth, weight, path).await?;
+    record_explicit_weight(state, auth, weight).await
 }
 
 // ============================================================
@@ -402,14 +573,14 @@ mod tests {
     #[test]
     fn test_endpoint_weight_trailing_slash_normalized() {
         // Without trailing slash
-        assert_eq!(endpoint_weight("/api/analyze"), 10);
+        assert_eq!(endpoint_weight("/api/analyze"), 5);
         assert_eq!(endpoint_weight("/api/remember"), 5);
         assert_eq!(endpoint_weight("/api/remember/manual"), 3);
         assert_eq!(endpoint_weight("/api/restore"), 3);
         assert_eq!(endpoint_weight("/api/ask"), 2);
 
         // With trailing slash — must return SAME weight (MED-20 fix)
-        assert_eq!(endpoint_weight("/api/analyze/"), 10, "trailing slash bypass!");
+        assert_eq!(endpoint_weight("/api/analyze/"), 5, "trailing slash bypass!");
         assert_eq!(endpoint_weight("/api/remember/"), 5, "trailing slash bypass!");
         assert_eq!(endpoint_weight("/api/ask/"), 2, "trailing slash bypass!");
 
@@ -422,7 +593,7 @@ mod tests {
     #[test]
     fn test_endpoint_weight_no_regression() {
         // Double trailing slash should also normalize
-        assert_eq!(endpoint_weight("/api/analyze//"), 10);
+        assert_eq!(endpoint_weight("/api/analyze//"), 5);
     }
 
     // ---- stable_hash_i64 ----

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -29,6 +29,20 @@ fn truncate_str(s: &str, max_bytes: usize) -> &str {
     &s[..end]
 }
 
+fn validate_namespace(ns: &str) -> Result<(), AppError> {
+    if ns.is_empty() || ns.len() > 64 {
+        return Err(AppError::BadRequest(
+            "namespace must be between 1 and 64 characters".into(),
+        ));
+    }
+    if !ns.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+        return Err(AppError::BadRequest(
+            "namespace can only contain alphanumeric characters, hyphens, and underscores".into(),
+        ));
+    }
+    Ok(())
+}
+
 // ============================================================
 // Embedding — OpenRouter/OpenAI API (with mock fallback)
 // ============================================================
@@ -78,10 +92,8 @@ async fn generate_embedding(
             if !resp.status().is_success() {
                 let status = resp.status();
                 let body = resp.text().await.unwrap_or_default();
-                return Err(AppError::Internal(format!(
-                    "Embedding API error ({}): {}",
-                    status, body
-                )));
+                tracing::error!("Embedding API error ({}): {}", status, body);
+                return Err(AppError::Internal("Embedding API error".into()));
             }
 
             let api_resp: EmbeddingApiResponse = resp.json().await.map_err(|e| {
@@ -135,6 +147,7 @@ pub async fn remember(
     if body.text.is_empty() {
         return Err(AppError::BadRequest("Text cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     // Owner is derived from delegate key via onchain verification (auth middleware)
     let owner = &auth.owner;
@@ -222,6 +235,7 @@ pub async fn recall(
     if body.query.is_empty() {
         return Err(AppError::BadRequest("Query cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     // Owner is derived from delegate key via onchain verification (auth middleware)
     let owner = &auth.owner;
@@ -267,6 +281,7 @@ pub async fn recall(
             let private_key = private_key.to_string();
             let package_id = state.config.package_id.clone();
             let account_id = auth.account_id.clone();
+            let owner_clone = auth.owner.clone();
             async move {
                 // Download encrypted blob from Walrus (native Rust)
                 let encrypted_data = match walrus::download_blob(walrus_client, &blob_id).await {
@@ -274,7 +289,7 @@ pub async fn recall(
                     Err(AppError::BlobNotFound(msg)) => {
                         // Blob expired on Walrus — clean up from DB reactively
                         tracing::warn!("Blob expired, cleaning up: {}", msg);
-                        cleanup_expired_blob(db, &blob_id).await;
+                        cleanup_expired_blob(db, &blob_id, &owner_clone).await;
                         return None;
                     }
                     Err(e) => {
@@ -315,7 +330,7 @@ pub async fn recall(
                                 blob_id,
                                 e
                             );
-                            cleanup_expired_blob(db, &blob_id).await;
+                            cleanup_expired_blob(db, &blob_id, &owner_clone).await;
                         } else {
                             tracing::warn!("Failed to SEAL decrypt blob {}: {}", blob_id, e);
                         }
@@ -358,6 +373,7 @@ pub async fn remember_manual(
     if body.vector.is_empty() {
         return Err(AppError::BadRequest("vector cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -432,6 +448,7 @@ pub async fn recall_manual(
     if body.vector.is_empty() {
         return Err(AppError::BadRequest("vector cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -476,6 +493,7 @@ pub async fn analyze(
     if body.text.is_empty() {
         return Err(AppError::BadRequest("Text cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -688,10 +706,8 @@ async fn extract_facts_llm(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(AppError::Internal(format!(
-            "LLM API error ({}): {}",
-            status, body
-        )));
+        tracing::error!("LLM API error ({}): {}", status, body);
+        return Err(AppError::Internal("LLM API error".into()));
     }
 
     let api_resp: ChatCompletionResponse = resp
@@ -720,6 +736,8 @@ fn parse_extracted_facts(content: &str) -> ExtractedFacts {
         .lines()
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty() && l != "NONE")
+        .filter(|f| f.len() <= 500)
+        .take(MAX_ANALYZE_FACTS)
         .collect();
 
     let raw_count = facts.len();
@@ -786,7 +804,7 @@ mod tests {
             .join("\n");
         let parsed = parse_extracted_facts(&content);
 
-        assert_eq!(parsed.raw_count, MAX_ANALYZE_FACTS + 3);
+        assert_eq!(parsed.raw_count, MAX_ANALYZE_FACTS);
         assert_eq!(parsed.facts.len(), MAX_ANALYZE_FACTS);
         assert_eq!(parsed.facts.first().map(String::as_str), Some("Fact 0"));
         assert_eq!(parsed.facts.last().map(String::as_str), Some("Fact 19"));
@@ -832,6 +850,7 @@ pub async fn ask(
     if body.question.is_empty() {
         return Err(AppError::BadRequest("Question cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -876,13 +895,14 @@ pub async fn ask(
             let private_key = private_key.to_string();
             let package_id = state.config.package_id.clone();
             let account_id = auth.account_id.clone();
+            let owner_clone = auth.owner.clone();
             async move {
                 let encrypted_data = match walrus::download_blob(walrus_client, &blob_id).await {
                     Ok(data) => data,
                     Err(AppError::BlobNotFound(msg)) => {
                         // Blob expired on Walrus — clean up from DB reactively
                         tracing::warn!("Blob expired, cleaning up: {}", msg);
-                        cleanup_expired_blob(db, &blob_id).await;
+                        cleanup_expired_blob(db, &blob_id, &owner_clone).await;
                         return None;
                     }
                     Err(e) => {
@@ -982,10 +1002,8 @@ pub async fn ask(
     if !resp.status().is_success() {
         let status = resp.status();
         let body_text = resp.text().await.unwrap_or_default();
-        return Err(AppError::Internal(format!(
-            "LLM error ({}): {}",
-            status, body_text
-        )));
+        tracing::error!("LLM error ({}): {}", status, body_text);
+        return Err(AppError::Internal("LLM API error".into()));
     }
 
     let api_resp: ChatCompletionResponse = resp
@@ -1015,8 +1033,8 @@ pub async fn ask(
 /// Reactively delete an expired blob from the vector DB.
 /// Called when Walrus returns 404 (blob expired / not found).
 /// Errors are logged but not propagated — cleanup is best-effort.
-async fn cleanup_expired_blob(db: &VectorDb, blob_id: &str) {
-    match db.delete_by_blob_id(blob_id).await {
+async fn cleanup_expired_blob(db: &VectorDb, blob_id: &str, owner: &str) {
+    match db.delete_by_blob_id(blob_id, owner).await {
         Ok(rows) => {
             tracing::info!(
                 "reactive cleanup: deleted {} vector entries for expired blob_id={}",
@@ -1050,6 +1068,7 @@ pub async fn restore(
     if body.namespace.is_empty() {
         return Err(AppError::BadRequest("namespace cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -1144,12 +1163,13 @@ pub async fn restore(
         .map(|blob_id| {
             let walrus_client = &state.walrus_client;
             let blob_id = blob_id.clone();
+            let owner_clone = owner.clone();
             async move {
                 match walrus::download_blob(walrus_client, &blob_id).await {
                     Ok(data) => Some((blob_id, data)),
                     Err(AppError::BlobNotFound(msg)) => {
                         tracing::warn!("restore: blob expired, skipping: {}", msg);
-                        cleanup_expired_blob(db, &blob_id).await;
+                        cleanup_expired_blob(db, &blob_id, &owner_clone).await;
                         None
                     }
                     Err(e) => {

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -375,20 +375,26 @@ impl axum::response::IntoResponse for AppError {
         let (status, message) = match &self {
             AppError::BadRequest(msg) => (axum::http::StatusCode::BAD_REQUEST, msg.clone()),
             AppError::Unauthorized(msg) => (axum::http::StatusCode::UNAUTHORIZED, msg.clone()),
-            AppError::Internal(msg) => (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                msg.clone(),
-            ),
+            AppError::Internal(msg) => {
+                let correlation_id = uuid::Uuid::new_v4().to_string();
+                tracing::error!(correlation_id = %correlation_id, "Internal error: {}", msg);
+                (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Internal server error. Reference ID: {}", correlation_id),
+                )
+            }
             AppError::BlobNotFound(msg) => (axum::http::StatusCode::NOT_FOUND, msg.clone()),
             AppError::RateLimited(msg) => (axum::http::StatusCode::TOO_MANY_REQUESTS, msg.clone()),
-            AppError::QuotaExceeded(msg) => (axum::http::StatusCode::PAYMENT_REQUIRED, msg.clone()),
+            AppError::QuotaExceeded(msg) => (axum::http::StatusCode::PAYLOAD_TOO_LARGE, msg.clone()),
         };
 
-        let body = serde_json::json!({ "error": message });
-        (status, axum::Json(body)).into_response()
+        let body = axum::Json(serde_json::json!({
+            "error": message,
+        }));
+
+        (status, body).into_response()
     }
 }
-
 // ============================================================
 // Sidecar Types (shared by seal.rs + walrus.rs)
 // ============================================================


### PR DESCRIPTION
This PR addresses the security findings outlined in MEM-19:

- **Input Validation:** Enforces a maximum of 20 extracted facts (`MAX_ANALYZE_FACTS`) and limits individual fact length to 500 characters. Validates Sui addresses for the `owner` field in the sidecar. Implemented `validate_namespace` validation across all relevant endpoints.
- **Error Sanitization:** Prevents leaking internal infrastructure details (like connection strings or raw API errors) to the client. Returns generic error messages and logs detailed errors internally with a unique Correlation/Reference ID.
- **Rate Limiting Adjustment:** Adjusted the rate limit weighting for the `/api/analyze` endpoint to use a base weight of 5 and an additional weight of 2 per extracted fact.