### PR TITLE
fix(security): HIGH-11 remove user_exists status to prevent account e…

### DIFF
--- a/apps/chatbot/app/(auth)/actions.ts
+++ b/apps/chatbot/app/(auth)/actions.ts
@@ -47,7 +47,6 @@ export type RegisterActionState = {
     | "in_progress"
     | "success"
     | "failed"
-    | "user_exists"
     | "invalid_data";
 };
 
@@ -63,8 +62,10 @@ export const register = async (
 
     const [user] = await getUser(validatedData.email);
 
+    // HIGH-11: Return generic failure — do not reveal whether the email is registered.
+    // Distinct "user_exists" status enables account enumeration.
     if (user) {
-      return { status: "user_exists" } as RegisterActionState;
+      return { status: "failed" };
     }
     await createUser(validatedData.email, validatedData.password);
     await signIn("credentials", {

--- a/apps/chatbot/app/(auth)/register/page.tsx
+++ b/apps/chatbot/app/(auth)/register/page.tsx
@@ -26,9 +26,7 @@ export default function Page() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: router and updateSession are stable refs
   useEffect(() => {
-    if (state.status === "user_exists") {
-      toast({ type: "error", description: "Account already exists!" });
-    } else if (state.status === "failed") {
+    if (state.status === "failed") {
       toast({ type: "error", description: "Failed to create account!" });
     } else if (state.status === "invalid_data") {
       toast({


### PR DESCRIPTION
## Summary

  - Removes the distinct `user_exists` status from `RegisterActionState` type
  - Registration with an already-registered email now returns `{ status: "failed" }` — identical to all other failure cases
  - Removes the `"Account already exists!"` toast that also leaked this information

## Security

Previously, an attacker could script registration attempts to build a map  of valid accounts by observing the distinct `user_exists` response status.   This enables targeted credential stuffing and phishing.

After this fix, all registration failure paths (`user exists`, DB error,  `signIn` error) return the same `{ status: "failed" }` — clients cannot  distinguish the cause.

 ## Files changed

  - `apps/chatbot/app/(auth)/actions.ts` — remove `user_exists` from type, return `failed` for existing user
  - `apps/chatbot/app/(auth)/register/page.tsx` — remove distinct `user_exists` toast branch