### PR TITLE
fix(sec): remove x-delegate-key from wire (ENG-1696 + ENG-1697)

### DIFF
--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -59,12 +59,44 @@ async function getEd() {
 // MemWal Client
 // ============================================================
 
+// ENG-1697: SEAL SessionKey cache layout. `bytes` holds the
+// base64(JSON(ExportedSessionKey)) envelope transmitted in the
+// `x-seal-session` header. `expiresAt` is an absolute epoch-millis
+// deadline with a safety margin applied so we refresh before the SEAL
+// key servers observe the session as expired.
+interface SessionCacheEntry {
+    bytes: string;
+    expiresAt: number;
+}
+
+interface ServerConfig {
+    packageId: string;
+    network: string;
+    suiRpcUrl: string;
+}
+
+const SEAL_SESSION_TTL_MIN = 5;
+// Refresh 30 seconds before SEAL's 5-minute TTL to avoid the window where
+// the client thinks the session is valid but a just-received request hits
+// a key server that sees it as expired.
+const SEAL_SESSION_SAFETY_MARGIN_MS = 30_000;
+
 export class MemWal {
     private privateKey: Uint8Array;
     private publicKey: Uint8Array | null = null;
     private serverUrl: string;
     private namespace: string;
     private accountId: string;
+
+    // ENG-1697 state — all internal, never surfaced to user code.
+    // The public API (`MemWal.create({ key, accountId })`) is unchanged.
+    private sessionCache: SessionCacheEntry | null = null;
+    private serverConfig: ServerConfig | null = null;
+    /** null = not probed yet; false = peer deps missing or probe failed. */
+    private sealSessionAvailable: boolean | null = null;
+    /** Single-flight guard so concurrent requests share one SessionKey build. */
+    private sessionBuildPromise: Promise<string | null> | null = null;
+    private sealFallbackWarned = false;
 
     private constructor(config: MemWalConfig) {
         this.privateKey = typeof config.key === "string" ? hexToBytes(config.key) : config.key;
@@ -97,6 +129,10 @@ export class MemWal {
         if (this.publicKey) {
             this.publicKey.fill(0);
         }
+        // ENG-1697: drop cached session material too — once destroyed the
+        // instance must not leak authorization tokens either.
+        this.sessionCache = null;
+        this.serverConfig = null;
     }
 
     // ============================================================
@@ -154,6 +190,10 @@ export class MemWal {
      * Remember (manual mode) — user handles SEAL encrypt, embedding,
      * and Walrus upload externally. Server only stores the vector ↔ blobId mapping.
      *
+     * Trust boundary (ENG-1696): the delegate private key is NOT transmitted on
+     * this request. Manual-mode handlers on the server never invoke SEAL
+     * decrypt, so the key stays client-side as the name implies.
+     *
      * @param opts.blobId - Walrus blob ID (user already uploaded encrypted data)
      * @param opts.vector - Embedding vector (user already generated, e.g. 1536-dim)
      * @returns RememberManualResult with id, blob_id, owner
@@ -169,17 +209,26 @@ export class MemWal {
      * ```
      */
     async rememberManual(opts: RememberManualOptions): Promise<RememberManualResult> {
-        return this.signedRequest<RememberManualResult>("POST", "/api/remember/manual", {
-            blob_id: opts.blobId,
-            vector: opts.vector,
-            namespace: opts.namespace ?? this.namespace,
-        });
+        return this.signedRequest<RememberManualResult>(
+            "POST",
+            "/api/remember/manual",
+            {
+                blob_id: opts.blobId,
+                vector: opts.vector,
+                namespace: opts.namespace ?? this.namespace,
+            },
+            { includeDelegateKey: false },
+        );
     }
 
     /**
      * Recall (manual mode) — user provides a pre-computed query vector.
      * Server returns matching blobIds + distances.
      * User then downloads from Walrus + SEAL decrypts on their own.
+     *
+     * Trust boundary (ENG-1696): the delegate private key is NOT transmitted on
+     * this request. Server returns blob IDs only; decryption happens entirely
+     * on the client.
      *
      * @param opts.vector - Pre-computed query embedding vector
      * @param opts.limit - Max results (default: 10)
@@ -202,11 +251,16 @@ export class MemWal {
      * ```
      */
     async recallManual(opts: RecallManualOptions): Promise<RecallManualResult> {
-        return this.signedRequest<RecallManualResult>("POST", "/api/recall/manual", {
-            vector: opts.vector,
-            limit: opts.limit ?? 10,
-            namespace: opts.namespace ?? this.namespace,
-        });
+        return this.signedRequest<RecallManualResult>(
+            "POST",
+            "/api/recall/manual",
+            {
+                vector: opts.vector,
+                limit: opts.limit ?? 10,
+                namespace: opts.namespace ?? this.namespace,
+            },
+            { includeDelegateKey: false },
+        );
     }
 
     /**
@@ -304,6 +358,169 @@ export class MemWal {
         return this.publicKey;
     }
 
+    // ============================================================
+    // ENG-1697: SEAL SessionKey discovery & build
+    //
+    // The SDK used to transmit the raw delegate private key in
+    // `x-delegate-key` on every request. That credential, once captured,
+    // lets an attacker retroactively decrypt every ciphertext the account
+    // ever produced (until the user rotates on-chain) and sign arbitrary
+    // Sui transactions from the delegate address.
+    //
+    // We now build a SEAL `SessionKey` on the client (ephemeral, scoped to
+    // a single `packageId`, 5-minute TTL, signed by the delegate key) and
+    // ship only the exported session bytes via `x-seal-session`. The raw
+    // private key never leaves the client.
+    //
+    // `packageId` is fetched from the server's public `/config` endpoint
+    // the first time it's needed so the user API (`new MemWal({ key,
+    // accountId })`) stays unchanged — past users upgrading to v0.4 do not
+    // have to touch their config.
+    //
+    // If the peer deps (`@mysten/seal`, `@mysten/sui`) are not installed,
+    // or `/config` is unreachable, we fall back to the legacy header and
+    // warn once. The server accepts both headers during the deprecation
+    // window so existing apps continue to work.
+    // ============================================================
+
+    private async fetchServerConfig(): Promise<ServerConfig> {
+        if (this.serverConfig) return this.serverConfig;
+        const res = await fetch(`${this.serverUrl}/config`, { method: "GET" });
+        if (!res.ok) {
+            throw new Error(`GET /config returned ${res.status}`);
+        }
+        const body = (await res.json()) as Partial<ServerConfig>;
+        if (!body.packageId || !body.network || !body.suiRpcUrl) {
+            throw new Error("GET /config response missing packageId / network / suiRpcUrl");
+        }
+        this.serverConfig = {
+            packageId: body.packageId,
+            network: body.network,
+            suiRpcUrl: body.suiRpcUrl,
+        };
+        return this.serverConfig;
+    }
+
+    private async buildSealSessionInner(): Promise<string | null> {
+        try {
+            const cfg = await this.fetchServerConfig();
+            // Dynamic imports: these are optional peer deps, so users on
+            // older setups without them still work via the legacy fallback.
+            // @mysten/sui renamed/moved `SuiClient` between minor versions:
+            //   - pre-2.6:  `SuiClient` in `@mysten/sui/client`
+            //   - 2.6+:     `SuiJsonRpcClient` in `@mysten/sui/jsonRpc`
+            // Probe both paths so the SDK works across the supported range.
+            const sealMod = (await import("@mysten/seal")) as any;
+            const ed25519Mod = (await import("@mysten/sui/keypairs/ed25519")) as any;
+            const SessionKey = sealMod.SessionKey;
+            const Ed25519Keypair = ed25519Mod.Ed25519Keypair;
+
+            let SuiClient: any = undefined;
+            try {
+                const mod = (await import("@mysten/sui/client")) as any;
+                SuiClient = mod.SuiClient;
+            } catch {
+                /* not present on this version */
+            }
+            if (typeof SuiClient !== "function") {
+                try {
+                    const mod = (await import("@mysten/sui/jsonRpc")) as any;
+                    SuiClient = mod.SuiJsonRpcClient ?? mod.SuiClient;
+                } catch {
+                    /* not present on this version either */
+                }
+            }
+            if (typeof SuiClient !== "function" || typeof Ed25519Keypair !== "function") {
+                throw new Error(
+                    "SuiClient/SuiJsonRpcClient or Ed25519Keypair not found in @mysten/sui. " +
+                    "Ensure @mysten/sui >=2.5.0 and @mysten/seal >=1.1.0 are installed."
+                );
+            }
+
+            const keypair = Ed25519Keypair.fromSecretKey(this.privateKey);
+            const suiClient = new SuiClient({ url: cfg.suiRpcUrl });
+
+            const session = await SessionKey.create({
+                address: keypair.getPublicKey().toSuiAddress(),
+                packageId: cfg.packageId,
+                ttlMin: SEAL_SESSION_TTL_MIN,
+                signer: keypair,
+                suiClient: suiClient as any,
+            });
+
+            // Eagerly sign the personal message so the exported envelope is
+            // fully self-contained. `SessionKey.create()` defers this signing
+            // until first use, which would break the migration: the sidecar
+            // imports without a signer and must be able to get a certificate
+            // from the exported state alone. Calling
+            // setPersonalMessageSignature() here populates the
+            // `personalMessageSignature` field in the subsequent export().
+            const personalMessage = session.getPersonalMessage();
+            const signResult = await keypair.signPersonalMessage(personalMessage);
+            await session.setPersonalMessageSignature(signResult.signature);
+
+            const exported = session.export();
+            // SEAL intentionally installs a throwing `toJSON` on the
+            // exported object to catch accidental serialization. The
+            // migration to `x-seal-session` IS the intended on-wire
+            // format, so we project the primitive fields into a fresh
+            // object before stringifying. The sidecar's
+            // `SessionKey.import()` expects this exact shape.
+            const jsonStr = JSON.stringify({
+                address: exported.address,
+                packageId: exported.packageId,
+                mvrName: exported.mvrName,
+                creationTimeMs: exported.creationTimeMs,
+                ttlMin: exported.ttlMin,
+                personalMessageSignature: exported.personalMessageSignature,
+                sessionKey: exported.sessionKey,
+            });
+            const bytes =
+                typeof btoa === "function"
+                    ? btoa(jsonStr)
+                    : Buffer.from(jsonStr, "utf8").toString("base64");
+
+            this.sessionCache = {
+                bytes,
+                expiresAt:
+                    Date.now() +
+                    SEAL_SESSION_TTL_MIN * 60_000 -
+                    SEAL_SESSION_SAFETY_MARGIN_MS,
+            };
+            this.sealSessionAvailable = true;
+            return bytes;
+        } catch (err) {
+            this.sealSessionAvailable = false;
+            if (!this.sealFallbackWarned) {
+                this.sealFallbackWarned = true;
+                // eslint-disable-next-line no-console
+                console.warn(
+                    "[memwal] Could not build SEAL SessionKey — falling back to " +
+                    "legacy x-delegate-key header. Install @mysten/seal + " +
+                    "@mysten/sui peer deps to enable the secure path. " +
+                    `Reason: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+            return null;
+        }
+    }
+
+    private async buildSealSession(): Promise<string | null> {
+        // Fast path: cached session still fresh.
+        if (this.sessionCache && Date.now() < this.sessionCache.expiresAt) {
+            return this.sessionCache.bytes;
+        }
+        // We already tried and failed once — don't keep probing.
+        if (this.sealSessionAvailable === false) return null;
+        // Single-flight: concurrent requests share one build.
+        if (this.sessionBuildPromise) return this.sessionBuildPromise;
+
+        this.sessionBuildPromise = this.buildSealSessionInner().finally(() => {
+            this.sessionBuildPromise = null;
+        });
+        return this.sessionBuildPromise;
+    }
+
     /**
      * Make a signed request to the server.
      *
@@ -319,11 +536,26 @@ export class MemWal {
      * an intermediary cannot swap the account hint without invalidating the
      * signature. Server-side verification in services/server/src/auth.rs must
      * use the matching message format.
+     *
+     * ENG-1696: Callers set `includeDelegateKey: false` on Manual-mode routes
+     * so the delegate private key is not transmitted. Manual-mode docstrings
+     * promise the key stays client-side; the server does not need it on those
+     * routes because Manual-mode handlers never invoke SEAL decrypt.
+     *
+     * ENG-1697: On Relayer-mode routes the SDK prefers a SEAL SessionKey
+     * built client-side (emitted via `x-seal-session`) over the legacy raw
+     * delegate private key (`x-delegate-key`). The SessionKey is ephemeral
+     * (5-min TTL, scoped to the server's `packageId`) so a wire capture has
+     * a bounded blast radius. If the SEAL peer deps are not installed or
+     * `/config` is unreachable the SDK warns once and falls back to the
+     * legacy header — the server accepts both during the deprecation
+     * window.
      */
     private async signedRequest<T>(
         method: string,
         path: string,
         body: object,
+        options: { includeDelegateKey?: boolean } = {},
     ): Promise<T> {
         const ed = await getEd();
 
@@ -344,17 +576,32 @@ export class MemWal {
 
         // Make HTTP request
         const url = `${this.serverUrl}${path}`;
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            "x-public-key": bytesToHex(publicKey),
+            "x-signature": bytesToHex(signature),
+            "x-timestamp": timestamp,
+            "x-nonce": nonce,           // MED-1: replay protection
+            "x-account-id": this.accountId,
+        };
+        // ENG-1696 / ENG-1697: attach a SEAL credential only on Relayer-
+        // mode routes where the server needs it for server-side SEAL
+        // decrypt. Manual-mode methods (rememberManual, recallManual) opt
+        // out and transmit no decrypt credential at all.
+        if (options.includeDelegateKey !== false) {
+            const sessionBytes = await this.buildSealSession();
+            if (sessionBytes) {
+                headers["x-seal-session"] = sessionBytes;
+            } else {
+                // Legacy fallback during the deprecation window. The
+                // server dual-accepts both headers until EOL; at that
+                // point users without SEAL peer deps must install them.
+                headers["x-delegate-key"] = bytesToHex(this.privateKey);
+            }
+        }
         const res = await fetch(url, {
             method,
-            headers: {
-                "Content-Type": "application/json",
-                "x-public-key": bytesToHex(publicKey),
-                "x-signature": bytesToHex(signature),
-                "x-timestamp": timestamp,
-                "x-nonce": nonce,           // MED-1: replay protection
-                "x-delegate-key": bytesToHex(this.privateKey),
-                "x-account-id": this.accountId,
-            },
+            headers,
             body: bodyStr,
         });
 

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -364,32 +364,76 @@ app.post("/seal/encrypt", async (req, res) => {
     }
 });
 
+/**
+ * ENG-1697: Resolve a SEAL SessionKey from the request headers.
+ *
+ * Preferred path: `x-seal-session` contains a base64-encoded
+ * `ExportedSessionKey` (built by the SDK on the client). We import it and
+ * skip touching any private-key material.
+ *
+ * Legacy path: `x-delegate-key` contains the raw delegate private key
+ * (hex or suiprivkey bech32). We reconstruct the keypair and build the
+ * SessionKey here — same behavior as before the migration. This path
+ * will be removed at EOL once all SDK clients emit `x-seal-session`.
+ *
+ * Returns `null` when neither header is present so the caller can emit a
+ * 400 with a clear error message.
+ */
+async function resolveSessionKey(
+    req: express.Request,
+    packageId: string,
+): Promise<SessionKey | null> {
+    const sessionHeader = req.headers["x-seal-session"] as string | undefined;
+    if (sessionHeader) {
+        const exportedJson = Buffer.from(sessionHeader, "base64").toString("utf8");
+        const exported = JSON.parse(exportedJson);
+        return SessionKey.import(exported, suiClient as any);
+    }
+
+    const privateKey = req.headers["x-delegate-key"] as string | undefined;
+    if (!privateKey) return null;
+
+    let keypair: Ed25519Keypair;
+    if (privateKey.startsWith("suiprivkey")) {
+        const { secretKey } = decodeSuiPrivateKey(privateKey);
+        keypair = Ed25519Keypair.fromSecretKey(secretKey);
+    } else {
+        // LOW-12: Validate hex format before parsing to prevent injection
+        if (!/^[0-9a-fA-F]+$/.test(privateKey) || privateKey.length !== 64) {
+            throw new Error("privateKey must be 64-char hex string or suiprivkey bech32");
+        }
+        const keyBytes = Uint8Array.from(
+            privateKey.match(/.{1,2}/g)!.map((b: string) => parseInt(b, 16)),
+        );
+        keypair = Ed25519Keypair.fromSecretKey(keyBytes);
+    }
+    return await SessionKey.create({
+        address: keypair.getPublicKey().toSuiAddress(),
+        packageId,
+        ttlMin: 5,
+        signer: keypair,
+        suiClient: suiClient as any,
+    });
+}
+
 // ============================================================
 // POST /seal/decrypt
 // ============================================================
 app.post("/seal/decrypt", async (req, res) => {
     try {
         const { data, packageId, accountId } = req.body;
-        const privateKey = req.headers["x-delegate-key"] as string | undefined;
-        if (!data || !privateKey || !packageId || !accountId) {
-            return res.status(400).json({ error: "Missing required fields: data, packageId, accountId, or x-delegate-key header" });
+        if (!data || !packageId || !accountId) {
+            return res.status(400).json({ error: "Missing required fields: data, packageId, accountId" });
         }
 
-        // Decode delegate keypair — supports both bech32 (suiprivkey1...) and raw hex
-        let keypair: Ed25519Keypair;
-        if (privateKey.startsWith("suiprivkey")) {
-            const { secretKey } = decodeSuiPrivateKey(privateKey);
-            keypair = Ed25519Keypair.fromSecretKey(secretKey);
-        } else {
-            // LOW-12: Validate hex format before parsing to prevent injection
-            if (!/^[0-9a-fA-F]+$/.test(privateKey) || privateKey.length !== 64) {
-                return res.status(400).json({ error: "privateKey must be 64-char hex string or suiprivkey bech32" });
-            }
-            // Raw hex private key (32 bytes = 64 hex chars)
-            const keyBytes = Uint8Array.from(privateKey.match(/.{1,2}/g)!.map((b: string) => parseInt(b, 16)));
-            keypair = Ed25519Keypair.fromSecretKey(keyBytes);
+        // ENG-1697: resolve credential (x-seal-session preferred; legacy
+        // x-delegate-key supported during the deprecation window).
+        const sessionKey = await resolveSessionKey(req, packageId);
+        if (!sessionKey) {
+            return res.status(400).json({
+                error: "Missing credential: provide x-seal-session (preferred) or x-delegate-key header",
+            });
         }
-        const signerAddress = keypair.getPublicKey().toSuiAddress();
 
         // Parse encrypted object to get key ID
         const encryptedData = new Uint8Array(Buffer.from(data, "base64"));
@@ -400,15 +444,6 @@ app.post("/seal/decrypt", async (req, res) => {
         const idBytes = Array.from(
             Uint8Array.from(fullId.match(/.{1,2}/g)!.map((b: string) => parseInt(b, 16)))
         );
-
-        // Create session key
-        const sessionKey = await SessionKey.create({
-            address: signerAddress,
-            packageId,
-            ttlMin: 5,
-            signer: keypair,
-            suiClient: suiClient as any,
-        });
 
         // Build seal_approve PTB — pass MemWalAccount (owned object) instead of AccountRegistry
         const tx = new Transaction();
@@ -455,7 +490,6 @@ app.post("/seal/decrypt", async (req, res) => {
 app.post("/seal/decrypt-batch", express.json({ limit: "8mb" }), async (req, res) => {
     try {
         const { items, packageId, accountId } = req.body;
-        const privateKey = req.headers["x-delegate-key"] as string | undefined;
         if (!items || !Array.isArray(items) || items.length === 0) {
             return res.status(400).json({ error: "Missing required field: items (array of base64 encrypted data)" });
         }
@@ -465,20 +499,18 @@ app.post("/seal/decrypt-batch", express.json({ limit: "8mb" }), async (req, res)
         if (items.length > 25) {
             return res.status(400).json({ error: "items array exceeds maximum of 25 elements" });
         }
-        if (!privateKey || !packageId || !accountId) {
-            return res.status(400).json({ error: "Missing required fields: packageId, accountId, or x-delegate-key header" });
+        if (!packageId || !accountId) {
+            return res.status(400).json({ error: "Missing required fields: packageId, accountId" });
         }
 
-        // Decode delegate keypair
-        let keypair: Ed25519Keypair;
-        if (privateKey.startsWith("suiprivkey")) {
-            const { secretKey } = decodeSuiPrivateKey(privateKey);
-            keypair = Ed25519Keypair.fromSecretKey(secretKey);
-        } else {
-            const keyBytes = Uint8Array.from(privateKey.match(/.{1,2}/g)!.map((b: string) => parseInt(b, 16)));
-            keypair = Ed25519Keypair.fromSecretKey(keyBytes);
+        // ENG-1697: resolve credential (x-seal-session preferred; legacy
+        // x-delegate-key supported during the deprecation window).
+        const sessionKey = await resolveSessionKey(req, packageId);
+        if (!sessionKey) {
+            return res.status(400).json({
+                error: "Missing credential: provide x-seal-session (preferred) or x-delegate-key header",
+            });
         }
-        const signerAddress = keypair.getPublicKey().toSuiAddress();
 
         // Parse all encrypted objects and collect unique SEAL IDs
         const parsedItems: { index: number; encryptedData: Uint8Array; fullId: string }[] = [];
@@ -500,15 +532,6 @@ app.post("/seal/decrypt-batch", express.json({ limit: "8mb" }), async (req, res)
 
         // Collect all unique IDs
         const allIds = [...new Set(parsedItems.map(p => p.fullId))];
-
-        // Create ONE SessionKey
-        const sessionKey = await SessionKey.create({
-            address: signerAddress,
-            packageId,
-            ttlMin: 5,
-            signer: keypair,
-            suiClient: suiClient as any,
-        });
 
         // Build ONE PTB with seal_approve for ALL IDs
         const tx = new Transaction();

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -68,11 +68,35 @@ pub async fn verify_signature(
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
-    // Optional delegate private key (hex) for SEAL decrypt
+    // Optional delegate private key (hex) for SEAL decrypt — legacy path.
+    // Modern clients send `x-seal-session` instead (ENG-1697).
     let delegate_key_hex = headers
         .get("x-delegate-key")
         .and_then(|v| v.to_str().ok())
         .map(String::from);
+
+    // Optional SEAL SessionKey (base64 JSON) — replaces `x-delegate-key` on
+    // the wire. When present, it is preferred over `delegate_key_hex` for
+    // any SEAL decrypt operation. Phase 1 of the migration: both headers
+    // are accepted so existing SDKs continue to work unchanged.
+    let seal_session = headers
+        .get("x-seal-session")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+
+    if seal_session.is_some() && delegate_key_hex.is_some() {
+        tracing::debug!(
+            "both x-seal-session and x-delegate-key present; preferring x-seal-session"
+        );
+    }
+    if seal_session.is_none() && delegate_key_hex.is_some() {
+        // ENG-1697 telemetry: log (without value) so we can count legacy
+        // header usage per SDK version during the deprecation window.
+        tracing::warn!(
+            target: "memwal::deprecation",
+            "request using legacy x-delegate-key header — client should upgrade to SDK v0.4+ (x-seal-session)"
+        );
+    }
 
     // MED-1 fix: Extract nonce for replay protection.
     // Nonce must be a UUID v4, checked against Redis to prevent replay attacks.
@@ -216,6 +240,7 @@ pub async fn verify_signature(
         owner,
         account_id,
         delegate_key: delegate_key_hex,
+        seal_session,
     });
 
     // Rebuild request with the body re-injected
@@ -558,6 +583,34 @@ mod tests {
         // Swapping account_id → signature fails (LOW-23)
         let swapped = "1700000000.POST./api/recall.hash.nonce.0xaccount_b";
         assert!(verifying_key.verify(swapped.as_bytes(), &signature).is_err());
+    }
+
+    // ── ENG-1696: Manual-mode trust boundary ────────────────────────────
+    //
+    // Manual-mode routes (/api/remember/manual, /api/recall/manual) must
+    // succeed without the `x-delegate-key` header. The SDK no longer emits
+    // this header on those routes (packages/sdk/src/memwal.ts), and Manual-
+    // mode route handlers (services/server/src/routes.rs) never read
+    // `AuthInfo.delegate_key`. This test locks in the invariant that
+    // `AuthInfo` is valid with `delegate_key: None` so a future refactor
+    // cannot silently re-introduce a requirement on the header.
+
+    #[test]
+    fn auth_info_valid_without_delegate_key_for_manual_routes() {
+        let auth = AuthInfo {
+            public_key: "abcd".to_string(),
+            owner: "0xowner".to_string(),
+            account_id: "0xaccount".to_string(),
+            delegate_key: None,
+            seal_session: None,
+        };
+        assert!(auth.delegate_key.is_none());
+        assert!(auth.seal_session.is_none());
+        // Verify Debug impl still redacts (LOW-5 / ENG-1697) — even in
+        // Manual mode we must never leak any credential material in logs.
+        let debug_str = format!("{:?}", auth);
+        assert!(debug_str.contains("None"));
+        assert!(!debug_str.contains("<redacted>"));
     }
 }
 

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -187,10 +187,14 @@ async fn main() {
         ));
 
     // Public routes
-    // HIGH-13: /health accepts no body — cap at 16 KiB to reject oversized
-    // unauthenticated requests before they reach any handler.
+    // HIGH-13: /health and /config accept no body — cap at 16 KiB to reject
+    // oversized unauthenticated requests before they reach any handler.
+    // ENG-1697: /config exposes non-secret deployment parameters (packageId,
+    // network, sui_rpc_url) so the SDK can build SEAL SessionKey without
+    // the user adding packageId to MemWalConfig.
     let public_routes = Router::new()
         .route("/health", get(routes::health).layer(DefaultBodyLimit::max(16 * 1024)))
+        .route("/config", get(routes::get_config).layer(DefaultBodyLimit::max(16 * 1024)))
         .merge(sponsor_routes);
 
     // CORS — restrict to configured origins.
@@ -226,6 +230,8 @@ async fn main() {
                     "x-nonce".parse::<header::HeaderName>().unwrap(),
                     "x-account-id".parse::<header::HeaderName>().unwrap(),
                     "x-delegate-key".parse::<header::HeaderName>().unwrap(),
+                    // ENG-1697: SessionKey envelope replacing x-delegate-key
+                    "x-seal-session".parse::<header::HeaderName>().unwrap(),
                 ])
         }
     };

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -249,16 +249,18 @@ pub async fn recall(
         namespace
     );
 
-    // Use delegate key from SDK for SEAL decryption (falls back to server key)
-    let private_key = auth
-        .delegate_key
-        .as_deref()
-        .or(state.config.sui_private_key.as_deref())
-        .ok_or_else(|| {
-            AppError::Internal(
-                "Delegate key or SERVER_SUI_PRIVATE_KEY required for SEAL decryption".into(),
-            )
-        })?;
+    // ENG-1697: Prefer the client-built SessionKey (x-seal-session); fall
+    // back to the legacy x-delegate-key; finally fall back to the server's
+    // own key for background operation.
+    let credential = seal::SealCredential::from_auth_or_fallback(
+        &auth,
+        state.config.sui_private_key.as_deref(),
+    )
+    .ok_or_else(|| {
+        AppError::Internal(
+            "SEAL credential required (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)".into(),
+        )
+    })?;
 
     // Step 1: Embed query → vector
     let query_vector = generate_embedding(&state.http_client, &state.config, &body.query).await?;
@@ -280,7 +282,7 @@ pub async fn recall(
             let sidecar_secret = state.config.sidecar_secret.clone();
             let blob_id = hit.blob_id.clone();
             let distance = hit.distance;
-            let private_key = private_key.to_string();
+            let credential = credential.clone();
             let package_id = state.config.package_id.clone();
             let account_id = auth.account_id.clone();
             let owner_for_cleanup = owner.clone();
@@ -305,7 +307,7 @@ pub async fn recall(
                     &sidecar_url,
                     sidecar_secret.as_deref(),
                     &encrypted_data,
-                    &private_key,
+                    &credential,
                     &package_id,
                     &account_id,
                 )
@@ -795,6 +797,26 @@ pub async fn health() -> Json<HealthResponse> {
     })
 }
 
+/// GET /config
+///
+/// ENG-1697: public, unauthenticated endpoint returning deployment
+/// parameters the SDK needs to build a SEAL `SessionKey` client-side —
+/// specifically the Move `packageId` and the Sui network/RPC URL.
+///
+/// These values are public on-chain metadata (not secrets), so no auth is
+/// required. Exposing them here lets the SDK migrate from transmitting
+/// the raw delegate private key (`x-delegate-key`) to transmitting an
+/// exported SessionKey (`x-seal-session`) without forcing users to add
+/// `packageId` to their `MemWalConfig` — preserving backward-compatible
+/// UX for v0.3.x apps that only passed `{ key, accountId }`.
+pub async fn get_config(State(state): State<Arc<AppState>>) -> Json<ConfigResponse> {
+    Json(ConfigResponse {
+        package_id: state.config.package_id.clone(),
+        network: state.config.sui_network.clone(),
+        sui_rpc_url: state.config.sui_rpc_url.clone(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1091,16 +1113,17 @@ pub async fn ask(
         .search_similar(&query_vector, owner, namespace, limit)
         .await?;
 
-    // Use delegate key from SDK for SEAL decryption (falls back to server key)
-    let private_key = auth
-        .delegate_key
-        .as_deref()
-        .or(state.config.sui_private_key.as_deref())
-        .ok_or_else(|| {
-            AppError::Internal(
-                "Delegate key or SERVER_SUI_PRIVATE_KEY required for SEAL decryption".into(),
-            )
-        })?;
+    // ENG-1697: Prefer the client-built SessionKey; fall back to legacy
+    // delegate key, then to the server's own key.
+    let credential = seal::SealCredential::from_auth_or_fallback(
+        &auth,
+        state.config.sui_private_key.as_deref(),
+    )
+    .ok_or_else(|| {
+        AppError::Internal(
+            "SEAL credential required (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)".into(),
+        )
+    })?;
 
     // Download + SEAL decrypt all memories concurrently
     let db = &state.db;
@@ -1113,7 +1136,7 @@ pub async fn ask(
             let sidecar_secret = state.config.sidecar_secret.clone();
             let blob_id = hit.blob_id.clone();
             let distance = hit.distance;
-            let private_key = private_key.to_string();
+            let credential = credential.clone();
             let package_id = state.config.package_id.clone();
             let account_id = auth.account_id.clone();
             let owner_for_cleanup = owner.clone();
@@ -1136,7 +1159,7 @@ pub async fn ask(
                     &sidecar_url,
                     sidecar_secret.as_deref(),
                     &encrypted_data,
-                    &private_key,
+                    &credential,
                     &package_id,
                     &account_id,
                 )
@@ -1324,15 +1347,17 @@ pub async fn restore(
     let limit = body.limit;
     tracing::info!("restore: owner={} ns={} limit={}", owner, namespace, limit);
 
-    // Use delegate key for SEAL decryption
-    let private_key = auth
-        .delegate_key
-        .as_deref()
-        .or(state.config.sui_private_key.as_deref())
-        .ok_or_else(|| {
-            AppError::Internal("Delegate key or SERVER_SUI_PRIVATE_KEY required for restore".into())
-        })?
-        .to_string();
+    // ENG-1697: Prefer the client-built SessionKey; fall back to legacy
+    // delegate key, then to the server's own key for restore operations.
+    let credential = seal::SealCredential::from_auth_or_fallback(
+        &auth,
+        state.config.sui_private_key.as_deref(),
+    )
+    .ok_or_else(|| {
+        AppError::Internal(
+            "SEAL credential required for restore (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)".into(),
+        )
+    })?;
 
     // Step 1: Discover all blob_ids from on-chain (source of truth)
     tracing::info!(
@@ -1470,7 +1495,7 @@ pub async fn restore(
             let http_client = &state.http_client;
             let sidecar_url = state.config.sidecar_url.clone();
             let sidecar_secret = state.config.sidecar_secret.clone();
-            let private_key = private_key.clone();
+            let credential = credential.clone();
             // Use the package_id that was stored with this blob (supports contract upgrades)
             let package_id = blob_package_ids
                 .get(&blob_id)
@@ -1483,7 +1508,7 @@ pub async fn restore(
                     &sidecar_url,
                     sidecar_secret.as_deref(),
                     &encrypted_data,
-                    &private_key,
+                    &credential,
                     &package_id,
                     &account_id,
                 )

--- a/services/server/src/seal.rs
+++ b/services/server/src/seal.rs
@@ -1,5 +1,38 @@
-use crate::types::{AppError, SidecarError};
+use crate::types::{AppError, AuthInfo, SidecarError};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+
+/// Credential used to authorize a SEAL decrypt request against the sidecar.
+///
+/// ENG-1697: `Session` (an exported `SessionKey`, built on the client) is
+/// preferred. `DelegateKey` is the legacy path where the SDK transmits the
+/// raw Ed25519 private key — retained temporarily so existing clients keep
+/// working. At EOL the `DelegateKey` variant will be removed.
+///
+/// Owned so it can be cheaply cloned into async tasks.
+#[derive(Debug, Clone)]
+pub enum SealCredential {
+    Session(String),
+    DelegateKey(String),
+}
+
+impl SealCredential {
+    /// Build the credential from an `AuthInfo`, preferring `seal_session`
+    /// when present. Falls back to `delegate_key` (legacy), then to a
+    /// server-side fallback private key (used when a route lacks a user
+    /// context). Returns `None` if no credential is available.
+    pub fn from_auth_or_fallback(
+        auth: &AuthInfo,
+        fallback_private_key: Option<&str>,
+    ) -> Option<Self> {
+        if let Some(s) = auth.seal_session.as_deref() {
+            return Some(SealCredential::Session(s.to_string()));
+        }
+        if let Some(k) = auth.delegate_key.as_deref() {
+            return Some(SealCredential::DelegateKey(k.to_string()));
+        }
+        fallback_private_key.map(|k| SealCredential::DelegateKey(k.to_string()))
+    }
+}
 
 /// Request/response types for sidecar HTTP API
 #[derive(serde::Serialize)]
@@ -89,19 +122,20 @@ pub async fn seal_encrypt(
     Ok(encrypted_bytes)
 }
 
-/// Decrypt SEAL-encrypted data using a delegate keypair via HTTP sidecar.
+/// Decrypt SEAL-encrypted data via the sidecar.
 ///
-/// Calls the long-lived sidecar server at `POST /seal/decrypt`.
-/// The delegate keypair must be registered in the user's MemWalAccount
-/// as a delegate key to be authorized for `seal_approve`.
+/// Calls `POST /seal/decrypt` on the long-lived sidecar server. The
+/// credential (ENG-1697) is either an exported SessionKey token or a
+/// legacy delegate private key. The client must have authority for
+/// `seal_approve` against the given `account_id`.
 ///
-/// Returns: decrypted plaintext bytes
+/// Returns: decrypted plaintext bytes.
 pub async fn seal_decrypt(
     client: &reqwest::Client,
     sidecar_url: &str,
     sidecar_secret: Option<&str>,
     encrypted_data: &[u8],
-    private_key: &str,
+    credential: &SealCredential,
     package_id: &str,
     account_id: &str,
 ) -> Result<Vec<u8>, AppError> {
@@ -110,12 +144,15 @@ pub async fn seal_decrypt(
 
     let mut req = client
         .post(&url)
-        .header("x-delegate-key", private_key)
         .json(&SealDecryptRequest {
             data: data_b64,
             package_id: package_id.to_string(),
             account_id: account_id.to_string(),
         });
+    req = match credential {
+        SealCredential::Session(s) => req.header("x-seal-session", s),
+        SealCredential::DelegateKey(k) => req.header("x-delegate-key", k),
+    };
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -75,6 +75,10 @@ pub struct Config {
     pub port: u16,
     pub database_url: String,
     pub sui_rpc_url: String,
+    /// ENG-1697: network name (mainnet/testnet/devnet). Surfaced via
+    /// `GET /config` so the SDK can select the matching Sui fullnode
+    /// without the user having to configure it.
+    pub sui_network: String,
     pub memwal_account_id: Option<String>,
     pub openai_api_key: Option<String>,
     pub openai_api_base: String,
@@ -118,6 +122,7 @@ impl Config {
                 .expect("DATABASE_URL must be set (e.g. postgresql://memwal:memwal_secret@localhost:5432/memwal)"),
             sui_rpc_url: std::env::var("SUI_RPC_URL")
                 .unwrap_or_else(|_| default_rpc.to_string()),
+            sui_network: network.clone(),
             memwal_account_id: std::env::var("MEMWAL_ACCOUNT_ID").ok(),
             openai_api_key: std::env::var("OPENAI_API_KEY").ok(),
             openai_api_base: std::env::var("OPENAI_API_BASE")
@@ -376,6 +381,19 @@ pub struct HealthResponse {
     pub version: String,
 }
 
+/// GET /config response (ENG-1697).
+///
+/// Public deployment parameters the SDK needs to build a SEAL SessionKey
+/// client-side. All fields are non-secret (on-chain / public RPC URL).
+#[derive(Debug, Serialize)]
+pub struct ConfigResponse {
+    #[serde(rename = "packageId")]
+    pub package_id: String,
+    pub network: String,
+    #[serde(rename = "suiRpcUrl")]
+    pub sui_rpc_url: String,
+}
+
 // ============================================================
 // Sponsor Types
 // ============================================================
@@ -413,12 +431,20 @@ pub struct AuthInfo {
     pub owner: String,
     /// MemWalAccount object ID (set after onchain verification)
     pub account_id: String,
-    /// Delegate private key (hex) — used for SEAL decrypt SessionKey
+    /// Delegate private key (hex) — legacy path for SEAL decrypt. Optional;
+    /// modern SDKs send `seal_session` instead. Retained during the
+    /// transition so older clients keep working.
     pub delegate_key: Option<String>,
+    /// Exported SEAL SessionKey (base64-encoded JSON) — replaces the raw
+    /// delegate private key on the wire. When present it is preferred over
+    /// `delegate_key`. TTL-bounded, package-scoped, signed by the delegate
+    /// key on the client; the server never handles private-key material.
+    pub seal_session: Option<String>,
 }
 
-// LOW-5: Manual Debug redacts `delegate_key` so accidental `{:?}` formatting
-// never leaks delegate private key material into logs.
+// LOW-5 / ENG-1697: Manual Debug redacts both credential fields so accidental
+// `{:?}` formatting never leaks delegate private key material or session
+// tokens into logs.
 impl std::fmt::Debug for AuthInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AuthInfo")
@@ -428,6 +454,10 @@ impl std::fmt::Debug for AuthInfo {
             .field(
                 "delegate_key",
                 &self.delegate_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "seal_session",
+                &self.seal_session.as_ref().map(|_| "<redacted>"),
             )
             .finish()
     }
@@ -511,6 +541,7 @@ mod tests {
             owner: "0xowner".to_string(),
             account_id: "0xaccount".to_string(),
             delegate_key: Some("supersecretprivatekeyinhex1234567890abcdef".to_string()),
+            seal_session: None,
         };
 
         let debug_str = format!("{:?}", auth);
@@ -540,6 +571,7 @@ mod tests {
             owner: "0xowner".to_string(),
             account_id: "0xaccount".to_string(),
             delegate_key: None,
+            seal_session: None,
         };
 
         let debug_str = format!("{:?}", auth);
@@ -547,6 +579,27 @@ mod tests {
         // None variant should render as None
         assert!(debug_str.contains("None"), "expected None in debug: {}", debug_str);
         assert!(!debug_str.contains("<redacted>"));
+    }
+
+    // ENG-1697: seal_session must also be redacted in Debug output. While
+    // less catastrophic than the raw private key (bounded TTL, bounded
+    // scope), it is still an authorization token and must not surface in
+    // structured logs.
+    #[test]
+    fn auth_info_debug_redacts_seal_session() {
+        let auth = AuthInfo {
+            public_key: "aabbccdd".to_string(),
+            owner: "0xowner".to_string(),
+            account_id: "0xaccount".to_string(),
+            delegate_key: None,
+            seal_session: Some(
+                "eyJhZGRyZXNzIjoiMHhhYmMiLCJwYWNrYWdlSWQiOiIweGRlZiJ9".to_string(),
+            ),
+        };
+
+        let debug_str = format!("{:?}", auth);
+        assert!(debug_str.contains("<redacted>"));
+        assert!(!debug_str.contains("eyJhZGRyZXNzIjo"));
     }
 
     // ── AppError: status code mapping ───────────────────────────────────


### PR DESCRIPTION
## Summary

  Closes the external security reviewer's CRITICAL finding: the SDK transmits the raw Ed25519 delegate private key
   in `x-delegate-key` on every authenticated request, giving anyone who captures the header full retroactive
  decryption of all stored ciphertext plus Sui signing authority. Implements the reviewer's preferred resolution:
  
**(Manual-mode fix) + (SessionKey migration)**.

Linear: ENG-1696, ENG-1697
Branch: `sec/seal-session-migration` → base `sec/security_fix`

## What changed

  ### ENG-1696 — Manual-mode fix
  Docstrings promise Manual mode keeps the key client-side; code sent it anyway because `rememberManual` /
  `recallManual` routed through the same `signedRequest()` as Relayer methods. Gated on an `includeDelegateKey`
  option.

  ### ENG-1697 — SessionKey migration (reviewer §3 / Option A)
  SDK builds a SEAL `SessionKey` client-side (5-min TTL, scoped to the server's `packageId`), signs the personal
  message eagerly, exports to a base64-JSON envelope, and transmits via `x-seal-session`. Sidecar calls
  `SessionKey.import()` instead of `SessionKey.create()`. Server accepts both headers during the deprecation
  window.

  ## Zero breaking change for users

  - `new MemWal({ key, accountId })` — public API unchanged
  - SDK fetches `packageId` lazily from a new public `GET /config` endpoint; users do not add `packageId` to their
   config
  - SDK v0.3.x users continue working against the dual-accept server
  - SDK v0.4 users without `@mysten/seal` / `@mysten/sui` peer deps fall back to legacy header with a one-time
  `console.warn`
