### PR TITLE
ENG-1409: Add benchmark scripts for Walrus, sidecar and recall latency

### DIFF
--- a/.github/workflows/benchmark-live.yml
+++ b/.github/workflows/benchmark-live.yml
@@ -1,0 +1,146 @@
+name: Benchmark Live
+
+on:
+  push:
+    branches:
+      - staging
+      - dev
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: GitHub benchmark environment to use
+        required: true
+        type: choice
+        default: staging
+        options:
+          - dev
+          - staging
+      server_url:
+        description: MemWal server URL. Empty uses BENCH_SERVER_URL environment variable.
+        required: false
+        default: ''
+      namespace:
+        description: Memory namespace
+        required: false
+        default: benchmark
+      remember_text:
+        description: Remember benchmark text
+        required: false
+        default: benchmark memory
+      query:
+        description: Recall query text
+        required: false
+        default: benchmark memory
+      limit:
+        description: Top-K recall result limit
+        required: false
+        default: '5'
+      remember_runs:
+        description: Remember runs
+        required: false
+        default: '3'
+      cold_runs:
+        description: Cold-path runs
+        required: false
+        default: '3'
+      warm_runs:
+        description: Warm-path runs
+        required: false
+        default: '10'
+  schedule:
+    - cron: '0 9 * * 1'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  memory-api:
+    name: Memory API Latency
+    runs-on: ubuntu-latest
+    environment:
+      name: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'staging' && 'staging' || 'dev') }}
+    timeout-minutes: 30
+
+    env:
+      SERVER_URL: ${{ github.event.inputs.server_url || vars.BENCH_SERVER_URL }}
+      NAMESPACE: ${{ github.event.inputs.namespace || 'benchmark' }}
+      REMEMBER_TEXT: ${{ github.event.inputs.remember_text || 'benchmark memory' }}
+      QUERY: ${{ github.event.inputs.query || 'benchmark memory' }}
+      LIMIT: ${{ github.event.inputs.limit || '5' }}
+      REMEMBER_RUNS: ${{ github.event.inputs.remember_runs || '3' }}
+      COLD_RUNS: ${{ github.event.inputs.cold_runs || '3' }}
+      WARM_RUNS: ${{ github.event.inputs.warm_runs || '10' }}
+      BENCH_DELEGATE_KEY: ${{ secrets.BENCH_DELEGATE_KEY }}
+      BENCH_ACCOUNT_ID: ${{ secrets.BENCH_ACCOUNT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: services/server/scripts/package-lock.json
+
+      - name: Install sidecar script dependencies
+        working-directory: services/server/scripts
+        run: npm ci
+
+      - name: Run memory API latency benchmark
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for name in SERVER_URL BENCH_DELEGATE_KEY BENCH_ACCOUNT_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::${name} is required"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          mkdir -p benchmark-results
+          services/server/scripts/node_modules/.bin/tsx services/server/scripts/bench-recall-latency.ts \
+            --server-url "$SERVER_URL" \
+            --delegate-key "$BENCH_DELEGATE_KEY" \
+            --account-id "$BENCH_ACCOUNT_ID" \
+            --remember-text "$REMEMBER_TEXT" \
+            --query "$QUERY" \
+            --namespace "$NAMESPACE" \
+            --limit "$LIMIT" \
+            --remember-runs "$REMEMBER_RUNS" \
+            --cold-runs "$COLD_RUNS" \
+            --warm-runs "$WARM_RUNS" \
+            --output benchmark-results/memory-api.json \
+            --no-color
+
+      - name: Write benchmark summary
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -f benchmark-results/memory-api.json ]; then
+            echo "No benchmark result file was produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs');
+          const json = JSON.parse(fs.readFileSync('benchmark-results/memory-api.json', 'utf8'));
+          console.log('## memory API benchmark');
+          console.log('');
+          console.log(json.markdownTable || 'No markdown table found in result JSON.');
+          console.log('');
+          NODE
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.run_id }}
+          path: benchmark-results/memory-api.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -1,0 +1,68 @@
+name: Benchmark Smoke
+
+on:
+  pull_request:
+    paths:
+      - 'services/server/scripts/**'
+      - '.github/workflows/benchmark-live.yml'
+      - '.github/workflows/benchmark-smoke.yml'
+      - 'docs/relayer/benchmark-ci-setup.md'
+  push:
+    branches:
+      - main
+      - staging
+      - dev
+    paths:
+      - 'services/server/scripts/**'
+      - '.github/workflows/benchmark-live.yml'
+      - '.github/workflows/benchmark-smoke.yml'
+      - 'docs/relayer/benchmark-ci-setup.md'
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  smoke:
+    name: Compile & CLI Smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: services/server
+
+      - name: Cargo check
+        working-directory: services/server
+        run: cargo check
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: services/server/scripts/package-lock.json
+
+      - name: Install sidecar script dependencies
+        working-directory: services/server/scripts
+        run: npm ci
+
+      - name: Typecheck benchmark scripts
+        working-directory: services/server/scripts
+        run: |
+          ./node_modules/.bin/tsc --noEmit --skipLibCheck \
+            --target ES2022 \
+            --module NodeNext \
+            --moduleResolution NodeNext \
+            bench-recall-latency.ts
+
+      - name: Benchmark CLI help smoke
+        working-directory: services/server/scripts
+        run: |
+          ./node_modules/.bin/tsx bench-recall-latency.ts --help

--- a/docs/relayer/benchmark-ci-setup.md
+++ b/docs/relayer/benchmark-ci-setup.md
@@ -1,0 +1,86 @@
+# Benchmark CI Setup
+
+This document records how to configure the relayer benchmark workflows.
+
+The live benchmark intentionally runs only the public relayer `/api/recall`
+path. Direct sidecar and Walrus upload benchmarks are out of scope because the
+hosted GitHub runner cannot reach the internal sidecar in the current Railway
+deployment.
+
+## Workflows
+
+- `.github/workflows/benchmark-smoke.yml`
+  - Runs on pull requests and pushes that touch benchmark scripts, benchmark workflows, or this setup doc.
+  - Runs `cargo check`.
+  - Typechecks `bench-recall-latency.ts`.
+  - Runs a `--help` smoke check for the recall benchmark CLI.
+  - Does not need secrets and does not call Sui, Walrus, SEAL, or OpenAI.
+
+- `.github/workflows/benchmark-live.yml`
+  - Runs automatically on pushes to `dev` and `staging`.
+  - Maps push benchmarks to `benchmark-dev` and `benchmark-staging`.
+  - Runs manually via `workflow_dispatch` on a selected branch/ref and target environment.
+  - Also runs weekly on Monday at 09:00 UTC against the default branch environment.
+  - Uses one GitHub Environment per target: `benchmark-dev` or
+    `benchmark-staging`.
+  - Runs `bench-recall-latency.ts` against `POST /api/remember` and `POST /api/recall`.
+  - Uses the `benchmark` namespace by default to isolate benchmark writes.
+  - Uploads `benchmark-results/memory-api.json` as a GitHub Actions artifact.
+  - Writes the benchmark markdown table into the Actions job summary.
+
+## Railway Relayer URLs
+
+Railway project: `MemWal`
+
+Railway service: `relayer`
+
+| Target | Railway environment | Public relayer URL | Sui network |
+| --- | --- | --- | --- |
+| dev | `dev` | `https://relayer.dev.memwal.ai` | `testnet` |
+| staging | `staging` | `https://relayer.staging.memwal.ai` | `testnet` |
+
+## Benchmark Test Accounts
+
+Do not commit private keys. Store private keys only in GitHub Environment
+Secrets or another secret manager.
+
+| Target | `BENCH_ACCOUNT_ID` | Public key |
+| --- | --- | --- |
+| dev/staging | `0x7fce97b1f4a72fff7b9457617234ddc251416a76382c44be7bc7652c84d06a1b` | `c36f131232950d7cc9f97846e368106c7a4b30864f560c2e518e3e7ea8c823f7` |
+| production | `0x57eb9feddfd98f98a5719e2a194431b63d24950acd138c52366bf02370ac6287` | `1477a32677be9ba81f86b96583beda4b0eec2dc953080961cefd9cbece41c448` |
+
+## GitHub Environment Setup
+
+Create these GitHub Environments:
+
+- `benchmark-dev`
+- `benchmark-staging`
+
+For each environment, set this Variable:
+
+| Variable | dev | staging |
+| --- | --- | --- |
+| `BENCH_SERVER_URL` | `https://relayer.dev.memwal.ai` | `https://relayer.staging.memwal.ai` |
+
+For each environment, set these Secrets:
+
+| Secret | dev/staging value |
+| --- | --- |
+| `BENCH_ACCOUNT_ID` | testnet account ID from the table above |
+| `BENCH_DELEGATE_KEY` | testnet private key, stored only as a secret |
+
+## Manual Run
+
+Remember and recall against staging:
+
+```bash
+cd services/server/scripts
+
+./node_modules/.bin/tsx bench-recall-latency.ts \
+  --server-url https://relayer.staging.memwal.ai \
+  --account-id "$BENCH_ACCOUNT_ID" \
+  --delegate-key "$BENCH_DELEGATE_KEY" \
+  --namespace benchmark \
+  --remember-text "benchmark memory" \
+  --query "benchmark memory"
+```

--- a/services/server/scripts/bench-recall-latency.ts
+++ b/services/server/scripts/bench-recall-latency.ts
@@ -1,0 +1,549 @@
+#!/usr/bin/env npx tsx
+/**
+ * bench-recall-latency.ts — ENG-1405
+ *
+ * End-to-end latency benchmark for public memory APIs.
+ * Measures POST /api/remember write latency and POST /api/recall cold/warm read latency.
+ *
+ * Usage:
+ *   npx tsx bench-recall-latency.ts \
+ *     --server-url    http://localhost:8000 \
+ *     --account-id    <0x...> \
+ *     --delegate-key  <suiprivkey1... or 64-hex> \
+ *     --remember-text "I prefer concise answers" \
+ *     --query         "what do I prefer?" \
+ *     --namespace     default \
+ *     --limit         5 \
+ *     --remember-runs 3 \
+ *     --cold-runs     3 \
+ *     --warm-runs     10 \
+ *     --output        benchmark-results/live.json
+ *
+ * The script runs `--remember-runs` remember calls first, then `--cold-runs`
+ * recall calls, then `--warm-runs` recall calls with the same query.
+ *
+ * Output:
+ *   • ANSI table with p50/p95/p99 per phase
+ *   • JSON file with raw per-request timings at --output
+ */
+
+import { createHash, randomUUID } from "crypto";
+import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+
+// ============================================================
+// CLI
+// ============================================================
+
+const API_METHOD = "POST";
+const REMEMBER_PATH = "/api/remember";
+const RECALL_PATH = "/api/recall";
+const TEXT_ENCODER = new TextEncoder();
+
+interface Auth {
+  delegateKey: string;
+  keypair: Ed25519Keypair;
+  publicKeyHex: string;
+}
+
+interface Args {
+  serverUrl: string;
+  accountId: string;
+  auth: Auth;
+  rememberBodyStr: string;
+  rememberBodyHash: string;
+  recallBodyStr: string;
+  recallBodyHash: string;
+  rememberText: string;
+  query: string;
+  namespace: string;
+  limit: number;
+  rememberRuns: number;
+  coldRuns: number;
+  warmRuns: number;
+  output: string;
+  color: boolean;
+}
+
+function printHelp(): void {
+  console.log(`
+bench-recall-latency.ts — ENG-1405: remember + recall latency benchmark
+
+Usage:
+  npx tsx bench-recall-latency.ts [options]
+
+Required auth options:
+  --account-id    <0x...>        x-account-id header value
+  --delegate-key  <key>          suiprivkey1... or 64-hex delegate private key
+
+Optional:
+  --server-url    <url>          Server URL             [default: http://localhost:8000]
+  --remember-text <text>         Remember text          [default: "benchmark memory"]
+  --query         <text>         Recall query text      [default: "benchmark memory"]
+  --namespace     <ns>           Namespace              [default: default]
+  --limit         <n>            Top-K results          [default: 5]
+  --remember-runs <n>            Remember runs          [default: 3]
+  --cold-runs     <n>            Cold recall runs       [default: 3]
+  --warm-runs     <n>            Warm recall runs       [default: 10]
+  --output        <file>         JSON output path       [default: bench-live-results.json]
+  --no-color                     Disable ANSI colors
+  --help                         Show this help
+`);
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const get = (flag: string, def?: string): string | undefined => {
+    const idx = argv.indexOf(flag);
+    if (idx !== -1 && idx + 1 < argv.length) return argv[idx + 1];
+    return def;
+  };
+
+  const required = (flag: string, env?: string): string => {
+    const v = get(flag) ?? (env ? process.env[env] : undefined);
+    if (!v) {
+      console.error(`error: ${flag} is required`);
+      process.exit(1);
+    }
+    return v;
+  };
+
+  const delegateKey = normalizeDelegateKey(required("--delegate-key", "BENCH_DELEGATE_KEY"));
+  const rememberText = get("--remember-text", "benchmark memory")!;
+  const query = get("--query", rememberText)!;
+  const namespace = get("--namespace", "default")!;
+  const limit = parseInt(get("--limit", "5")!, 10);
+  const rememberBodyStr = JSON.stringify({ text: rememberText, namespace });
+  const recallBodyStr = JSON.stringify({ query, namespace, limit });
+
+  return {
+    serverUrl: get("--server-url", "http://localhost:8000")!,
+    accountId: required("--account-id", "BENCH_ACCOUNT_ID"),
+    auth: buildAuth(delegateKey),
+    rememberBodyStr,
+    rememberBodyHash: sha256Hex(rememberBodyStr),
+    recallBodyStr,
+    recallBodyHash: sha256Hex(recallBodyStr),
+    rememberText,
+    query,
+    namespace,
+    limit,
+    rememberRuns: parseInt(get("--remember-runs", "3")!, 10),
+    coldRuns: parseInt(get("--cold-runs", "3")!, 10),
+    warmRuns: parseInt(get("--warm-runs", "10")!, 10),
+    output: get("--output", "bench-live-results.json")!,
+    color: !argv.includes("--no-color"),
+  };
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(idx, sorted.length - 1))];
+}
+
+function ms(n: number): string {
+  return `${n.toFixed(0)} ms`;
+}
+
+const C = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  red: "\x1b[31m",
+  cyan: "\x1b[36m",
+  magenta: "\x1b[35m",
+};
+
+function color(enabled: boolean, code: string, s: string): string {
+  return enabled ? `${code}${s}${C.reset}` : s;
+}
+
+function buildAuth(delegateKey: string): Auth {
+  const keypair = keypairFromDelegateKey(delegateKey);
+  return {
+    delegateKey,
+    keypair,
+    publicKeyHex: Buffer.from(keypair.getPublicKey().toRawBytes()).toString("hex"),
+  };
+}
+
+function keypairFromDelegateKey(delegateKey: string): Ed25519Keypair {
+  if (delegateKey.startsWith("suiprivkey")) {
+    const { scheme, secretKey } = decodeSuiPrivateKey(delegateKey);
+    if (scheme !== "ED25519") {
+      throw new Error(`delegate key must be Ed25519, got ${scheme}`);
+    }
+    return Ed25519Keypair.fromSecretKey(secretKey);
+  }
+
+  const hex = delegateKey.startsWith("0x") ? delegateKey.slice(2) : delegateKey;
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error("delegate key must be 64-char hex or suiprivkey bech32");
+  }
+  return Ed25519Keypair.fromSecretKey(Uint8Array.from(Buffer.from(hex, "hex")));
+}
+
+function normalizeDelegateKey(delegateKey: string): string {
+  if (delegateKey.startsWith("0x") && delegateKey.length === 66) {
+    return delegateKey.slice(2);
+  }
+  return delegateKey;
+}
+
+function sha256Hex(data: string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+async function buildSignedHeaders(
+  args: Args,
+  path: string,
+  bodyHash: string,
+): Promise<Record<string, string>> {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const nonce = randomUUID();
+  const message = `${timestamp}.${API_METHOD}.${path}.${bodyHash}.${nonce}.${args.accountId}`;
+  const signature = await args.auth.keypair.sign(TEXT_ENCODER.encode(message));
+
+  return {
+    "Content-Type": "application/json",
+    "x-public-key": args.auth.publicKeyHex,
+    "x-signature": Buffer.from(signature).toString("hex"),
+    "x-timestamp": timestamp,
+    "x-nonce": nonce,
+    "x-account-id": args.accountId,
+    "x-delegate-key": args.auth.delegateKey,
+  };
+}
+
+function stats(samples: number[]): {
+  p50: number; p95: number; p99: number; min: number; max: number; mean: number;
+} {
+  if (samples.length === 0) return { p50: 0, p95: 0, p99: 0, min: 0, max: 0, mean: 0 };
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mean = sorted.reduce((a, b) => a + b, 0) / sorted.length;
+  return {
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    mean,
+  };
+}
+
+// ============================================================
+// Single API calls
+// ============================================================
+
+interface ApiRunResult {
+  ok: boolean;
+  latencyMs: number;
+  resultCount?: number;
+  droppedCount?: number;
+  memoryId?: string;
+  blobId?: string;
+  statusCode?: number;
+  error?: string;
+}
+
+async function rememberOnce(args: Args): Promise<ApiRunResult> {
+  const start = performance.now();
+  try {
+    const headers = await buildSignedHeaders(args, REMEMBER_PATH, args.rememberBodyHash);
+
+    const resp = await fetch(`${args.serverUrl}${REMEMBER_PATH}`, {
+      method: API_METHOD,
+      headers,
+      body: args.rememberBodyStr,
+    });
+
+    const latencyMs = performance.now() - start;
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      return { ok: false, latencyMs, statusCode: resp.status, error: body.slice(0, 300) };
+    }
+
+    const json = (await resp.json()) as { id?: string; blob_id?: string };
+    return {
+      ok: true,
+      latencyMs,
+      statusCode: resp.status,
+      memoryId: json.id,
+      blobId: json.blob_id,
+    };
+  } catch (err: any) {
+    const latencyMs = performance.now() - start;
+    return { ok: false, latencyMs, error: err?.message ?? String(err) };
+  }
+}
+
+async function recallOnce(args: Args): Promise<ApiRunResult> {
+  const start = performance.now();
+  try {
+    const headers = await buildSignedHeaders(args, RECALL_PATH, args.recallBodyHash);
+
+    const resp = await fetch(`${args.serverUrl}${RECALL_PATH}`, {
+      method: API_METHOD,
+      headers,
+      body: args.recallBodyStr,
+    });
+
+    const latencyMs = performance.now() - start;
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      return { ok: false, latencyMs, statusCode: resp.status, error: body.slice(0, 300) };
+    }
+
+    const json = (await resp.json()) as { results?: unknown[]; total?: number; dropped_count?: number };
+    return {
+      ok: true,
+      latencyMs,
+      statusCode: resp.status,
+      resultCount: json.total ?? json.results?.length ?? 0,
+      droppedCount: json.dropped_count ?? 0,
+    };
+  } catch (err: any) {
+    const latencyMs = performance.now() - start;
+    return { ok: false, latencyMs, error: err?.message ?? String(err) };
+  }
+}
+
+// ============================================================
+// Run a batch of calls
+// ============================================================
+
+interface BatchResult {
+  label: string;
+  runs: number;
+  successCount: number;
+  failCount: number;
+  rawMs: number[];
+  errors: string[];
+}
+
+async function runBatch(
+  label: string,
+  runs: number,
+  callOnce: () => Promise<ApiRunResult>,
+  formatOk: (result: ApiRunResult) => string,
+): Promise<BatchResult> {
+  const rawMs: number[] = [];
+  const errors: string[] = [];
+  let successCount = 0;
+  let failCount = 0;
+
+  for (let i = 0; i < runs; i++) {
+    process.stdout.write(`  [${label}] run ${i + 1}/${runs}... `);
+    const result = await callOnce();
+    if (result.ok) {
+      rawMs.push(result.latencyMs);
+      successCount++;
+      console.log(`ok ${ms(result.latencyMs)} ${formatOk(result)}`);
+    } else {
+      failCount++;
+      const errMsg = result.error ?? `HTTP ${result.statusCode}`;
+      errors.push(errMsg);
+      console.log(`FAILED: ${errMsg.slice(0, 120)}`);
+    }
+
+    if (i < runs - 1) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+
+  return { label, runs, successCount, failCount, rawMs, errors };
+}
+
+// ============================================================
+// Reporting
+// ============================================================
+
+function printBatchTable(batches: BatchResult[], col: boolean): void {
+  const h = (s: string) => color(col, C.bold + C.cyan, s);
+  const ok = (s: string) => color(col, C.green, s);
+
+  const colW = [12, 8, 8, 8, 10, 8, 8];
+  const cols = ["phase", "p50", "p95", "p99", "mean", "min", "max"];
+
+  function row(cells: string[]): string {
+    return cells.map((c, i) => c.padStart(colW[i])).join("  ");
+  }
+
+  console.log();
+  console.log(h(row(cols)));
+  console.log(color(col, C.dim, row(cols.map((_, i) => "─".repeat(colW[i])))));
+
+  for (const b of batches) {
+    const s = stats(b.rawMs);
+    const cells = [
+      b.label,
+      ms(s.p50),
+      ms(s.p95),
+      ms(s.p99),
+      ms(s.mean),
+      ms(s.min),
+      ms(s.max),
+    ];
+    console.log(ok(row(cells)));
+  }
+  console.log();
+}
+
+function buildMarkdown(batches: BatchResult[]): string {
+  const lines = [
+    "## MemWal Live Benchmark — ENG-1405",
+    "",
+    "| phase | endpoint | runs | p50 | p95 | p99 | mean | min | max | fail% |",
+    "|-------|----------|------|-----|-----|-----|------|-----|-----|-------|",
+  ];
+  for (const b of batches) {
+    const s = stats(b.rawMs);
+    const endpoint = b.label === "remember" ? REMEMBER_PATH : RECALL_PATH;
+    const failPct = ((b.failCount / b.runs) * 100).toFixed(1);
+    lines.push(
+      `| ${b.label} | ${endpoint} | ${b.runs} | ${ms(s.p50)} | ${ms(s.p95)} | ${ms(s.p99)} | ${ms(s.mean)} | ${ms(s.min)} | ${ms(s.max)} | ${failPct}% |`
+    );
+  }
+  return lines.join("\n");
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const col = args.color && process.stdout.isTTY;
+
+  console.log(color(col, C.bold, "\n⚡ memwal-live-benchmark — ENG-1405\n"));
+  console.log(`  server:        ${args.serverUrl}`);
+  console.log(`  namespace:     ${args.namespace}`);
+  console.log(`  limit:         ${args.limit}`);
+  console.log(`  remember text: "${args.rememberText.slice(0, 60)}"`);
+  console.log(`  query:         "${args.query.slice(0, 60)}"`);
+  console.log(`  remember runs: ${args.rememberRuns}`);
+  console.log(`  cold runs:     ${args.coldRuns}`);
+  console.log(`  warm runs:     ${args.warmRuns}`);
+  console.log();
+
+  process.stdout.write(color(col, C.dim, "  health check... "));
+  const healthResp = await fetch(`${args.serverUrl}/health`).catch((e) => { throw new Error(`health check failed: ${e.message}`); });
+  if (!healthResp.ok) throw new Error(`health check failed: HTTP ${healthResp.status}`);
+  console.log(color(col, C.green, "ok\n"));
+
+  const batches: BatchResult[] = [];
+
+  console.log(color(col, C.magenta, `  ── Remember path (${args.rememberRuns} runs) ──`));
+  const rememberBatch = await runBatch(
+    "remember",
+    args.rememberRuns,
+    () => rememberOnce(args),
+    (result) => `(id=${result.memoryId ?? "unknown"}, blob=${result.blobId ?? "unknown"})`,
+  );
+  batches.push(rememberBatch);
+
+  console.log(color(col, C.magenta, `\n  ── Cold recall path (${args.coldRuns} runs) ──`));
+  const coldBatch = await runBatch(
+    "recall-cold",
+    args.coldRuns,
+    () => recallOnce(args),
+    (result) => `(${result.resultCount} results)`,
+  );
+  batches.push(coldBatch);
+
+  console.log(color(col, C.magenta, `\n  ── Warm recall path (${args.warmRuns} runs) ──`));
+  const warmBatch = await runBatch(
+    "recall-warm",
+    args.warmRuns,
+    () => recallOnce(args),
+    (result) => `(${result.resultCount} results)`,
+  );
+  batches.push(warmBatch);
+
+  printBatchTable(batches, col);
+
+  const md = buildMarkdown(batches);
+  console.log(md);
+  console.log();
+
+  const TARGET_RECALL_WARM_P50_MS = 500;
+  const warmStats = stats(warmBatch.rawMs);
+  const totalFailures = batches.reduce((sum, b) => sum + b.failCount, 0);
+  if (totalFailures > 0) {
+    console.log(color(col, C.red, `✘ Benchmark had ${totalFailures} failed request(s)`));
+  }
+  if (warmStats.p50 < TARGET_RECALL_WARM_P50_MS) {
+    console.log(
+      color(col, C.green, `✔ Warm recall p50 = ${ms(warmStats.p50)} — below ${TARGET_RECALL_WARM_P50_MS}ms target ✓`)
+    );
+  } else {
+    console.log(
+      color(col, C.red, `✘ Warm recall p50 = ${ms(warmStats.p50)} — still above ${TARGET_RECALL_WARM_P50_MS}ms target`)
+    );
+    console.log("  → Check server logs for per-phase breakdown (embed / vector_search / walrus_fetch / seal_batch_decrypt)");
+  }
+  console.log();
+
+  const jsonOut = {
+    timestamp: new Date().toISOString(),
+    config: {
+      serverUrl: args.serverUrl,
+      namespace: args.namespace,
+      limit: args.limit,
+      rememberText: args.rememberText,
+      query: args.query,
+      rememberRuns: args.rememberRuns,
+      coldRuns: args.coldRuns,
+      warmRuns: args.warmRuns,
+    },
+    target: { recallWarmP50Ms: TARGET_RECALL_WARM_P50_MS },
+    batches: batches.map((b) => {
+      const s = stats(b.rawMs);
+      return {
+        label: b.label,
+        endpoint: b.label === "remember" ? REMEMBER_PATH : RECALL_PATH,
+        runs: b.runs,
+        successCount: b.successCount,
+        failCount: b.failCount,
+        failureRate: +(b.failCount / b.runs).toFixed(4),
+        p50Ms: +s.p50.toFixed(1),
+        p95Ms: +s.p95.toFixed(1),
+        p99Ms: +s.p99.toFixed(1),
+        meanMs: +s.mean.toFixed(1),
+        minMs: +s.min.toFixed(1),
+        maxMs: +s.max.toFixed(1),
+        rawMs: b.rawMs.map((n) => +n.toFixed(1)),
+        errors: b.errors,
+      };
+    }),
+    markdownTable: md,
+  };
+
+  const { writeFileSync } = await import("fs");
+  writeFileSync(args.output, JSON.stringify(jsonOut, null, 2));
+  console.log(color(col, C.dim, `  Results written to ${args.output}\n`));
+
+  if (totalFailures > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`\nFatal error: ${msg}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `bench-recall-latency.ts` — end-to-end recall latency benchmark
- Add `bench-sidecar-concurrency.ts` — SEAL encrypt/decrypt concurrency benchmark
- Add `bench-walrus-concurrency.ts` — Walrus upload/download concurrency benchmark
- Add `get-bench-ciphertext.ts` — helper to generate test ciphertext for benchmarks
- Update `sidecar-server.ts` with batch decrypt endpoint support

## Test plan
- [ ] Scripts exist and parse without errors (`npx tsx <script> --help`)
- [ ] No server code changes — benchmark-only