### PR TITLE
ENG-1406 + ENG-1408: Async remember pipeline and bulk remember

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ const memwal = MemWal.create({
   namespace: "demo",
 });
 
-await memwal.remember("User prefers dark mode and uses TypeScript.");
+const job = await memwal.remember("User prefers dark mode and uses TypeScript.");
+await memwal.waitForRememberJob(job.job_id);
 const memories = await memwal.recall("What are the user's preferences?");
 await memwal.restore("demo");
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,14 +95,16 @@ const memwal = MemWal.create({
 
 ```ts
 // Store a memory
-await memwal.remember("User prefers dark mode and works in TypeScript.");
+const job = await memwal.remember("User prefers dark mode and works in TypeScript.");
+await memwal.waitForRememberJob(job.job_id);
 
 // Recall by meaning
 const result = await memwal.recall("What are the user's preferences?");
 console.log(result.results);
 
 // Extract and store facts from text
-await memwal.analyze("I live in Hanoi and prefer dark mode.");
+const analyzed = await memwal.analyze("I live in Hanoi and prefer dark mode.");
+await memwal.waitForRememberJobs(analyzed.job_ids);
 
 // Check relayer health
 await memwal.health();
@@ -127,9 +129,11 @@ await memwal.health();
 
 | Method | Description | Returns |
 |---|---|---|
-| `remember(text, namespace?)` | Store one memory (relayer embeds, encrypts, uploads) | `{ id, blob_id, owner, namespace }` |
+| `remember(text, namespace?)` | Accept one memory job immediately | `{ job_id, status }` |
+| `rememberAndWait(text, namespace?, opts?)` | Store one memory and wait for completion | `{ id, job_id, blob_id, owner, namespace }` |
 | `recall(query, limit?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
-| `analyze(text, namespace?)` | Extract facts via LLM, store each as a memory | `{ facts: [{ text, id, blob_id }], total, owner }` |
+| `analyze(text, namespace?)` | Extract facts and accept one memory job per fact | `{ job_ids, facts, fact_count, status, owner }` |
+| `analyzeAndWait(text, namespace?, opts?)` | Extract facts and wait for all fact jobs to complete | `{ results, facts, total, succeeded, failed, owner }` |
 | `restore(namespace, limit?)` | Rebuild missing index entries from Walrus | `{ restored, skipped, total, namespace, owner }` |
 | `health()` | Check relayer health | `{ status, version }` |
 | `getPublicKeyHex()` | Get hex-encoded public key | `string` |

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -243,7 +243,8 @@ const memwal = MemWal.create({
 })
 
 // Remember something
-await memwal.remember("I'm allergic to peanuts")
+const job = await memwal.remember("I'm allergic to peanuts")
+await memwal.waitForRememberJob(job.job_id)
 
 // Recall memories
 const result = await memwal.recall("food allergies")

--- a/apps/app/src/pages/Playground.tsx
+++ b/apps/app/src/pages/Playground.tsx
@@ -515,15 +515,15 @@ const data = await memwal.health()
                 <DemoStep
                     number={2}
                     title="remember"
-                    description="store a memory → embed → encrypt → Walrus"
+                    description="accept a memory job → embed → encrypt → Walrus"
                     code={`const result = await memwal.remember(
   "${rememberText.slice(0, 60)}..."
 )
 // namespace: "${namespace || 'default'}"
-// → { id, blob_id, owner, namespace }`}
+// → { job_id, status }`}
                     onRun={runRemember}
                     result={rememberResult}
-                    resultLabel="stored on Walrus (encrypted)"
+                    resultLabel="memory job accepted"
                     error={rememberError}
                     loading={rememberLoading}
                 >
@@ -568,15 +568,15 @@ const data = await memwal.health()
                 <DemoStep
                     number={4}
                     title="analyze"
-                    description="LLM extracts facts → stores each as memory"
+                    description="LLM extracts facts → accepts memory jobs"
                     code={`const result = await memwal.analyze(
   "${analyzeText.slice(0, 50)}..."
 )
-// Server: LLM extracts facts → embed → encrypt → Walrus → store
-// → { facts: [{ text, id, blob_id }], total, owner }`}
+// Server: LLM extracts facts → async memory jobs
+// → { job_ids, facts, fact_count, status, owner }`}
                     onRun={runAnalyze}
                     result={analyzeResult}
-                    resultLabel="facts extracted & stored"
+                    resultLabel="fact jobs accepted"
                     error={analyzeError}
                     loading={analyzeLoading}
                 >

--- a/apps/chatbot/lib/ai/tools/save-memory.ts
+++ b/apps/chatbot/lib/ai/tools/save-memory.ts
@@ -34,7 +34,7 @@ export const saveMemory = ({
 
       try {
         const memwal = MemWal.create({ key, accountId, serverUrl });
-        await memwal.remember(text);
+        await memwal.rememberAndWait(text);
         return { saved: true, text };
       } catch (error) {
         console.error("[Tool] saveMemory error:", error);

--- a/apps/noter/package/feature/note/lib/pdw-client.ts
+++ b/apps/noter/package/feature/note/lib/pdw-client.ts
@@ -58,14 +58,14 @@ export async function extractMemories(
   }
 }
 
-/** Remember a single text — server handles embed + encrypt + store. */
+/** Remember a single text and wait until it is stored. */
 export async function rememberText(
   text: string,
   key?: string | null,
   accountId?: string | null,
 ) {
   const memwal = getMemWalClient(key, accountId);
-  return memwal.remember(text);
+  return memwal.rememberAndWait(text);
 }
 
 /** Recall memories similar to a query — server handles search + decrypt. */

--- a/apps/researcher/lib/sprint/memwal.ts
+++ b/apps/researcher/lib/sprint/memwal.ts
@@ -49,7 +49,7 @@ export async function rememberSprintReport({
   console.log(
     `[sprint:memwal] Storing sprint report (${fullText.length} chars)`
   );
-  const result = await memwal.remember(fullText);
+  const result = await memwal.rememberAndWait(fullText);
   console.log(`[sprint:memwal] Stored. blobId=${result.blob_id}`);
   return result;
 }

--- a/docs/examples/example-apps.md
+++ b/docs/examples/example-apps.md
@@ -27,7 +27,8 @@ const memwal = MemWal.create({
   namespace,
 });
 
-await memwal.remember(rememberText);
+const job = await memwal.remember(rememberText);
+await memwal.waitForRememberJob(job.job_id);
 await memwal.recall(recallQuery, 5);
 await memwal.analyze(analyzeText);
 ```
@@ -64,7 +65,7 @@ export const extractMemories = async (text: string): Promise<string[]> => {
 };
 ```
 
-This app shows note-to-memory extraction. Noter keeps a shared server-side MemWal client, lets the user configure the key and account at runtime, and uses `analyze()` to turn note content into structured facts that can be reused by the editor and AI features.
+This app shows note-to-memory extraction. Noter keeps a shared server-side MemWal client, lets the user configure the key and account at runtime, and uses `analyze()` to turn note content into structured facts while the relayer stores them asynchronously.
 
 ## [Researcher](https://github.com/MystenLabs/MemWal/tree/main/apps/researcher)
 
@@ -77,7 +78,8 @@ const fullText =
   `References:\n${references}\n\n` +
   `Sources: ${sourceList}`;
 
-await memwal.remember(fullText);
+const job = await memwal.remember(fullText);
+await memwal.waitForRememberJob(job.job_id);
 const { results } = await memwal.recall(query, 5);
 ```
 

--- a/docs/fundamentals/architecture/core-components.md
+++ b/docs/fundamentals/architecture/core-components.md
@@ -43,7 +43,8 @@ const memwal = MemWal.create({
   namespace: "my-app",
 });
 
-await memwal.remember("User prefers dark mode.");
+const job = await memwal.remember("User prefers dark mode.");
+await memwal.waitForRememberJob(job.job_id);
 ```
 
 ## Relayer

--- a/docs/fundamentals/architecture/how-storage-works.md
+++ b/docs/fundamentals/architecture/how-storage-works.md
@@ -3,7 +3,7 @@ title: "How Storage Works"
 description: "The lifecycle of a memory in MemWal — from plaintext to encrypted blob on Walrus and searchable vector in the database."
 ---
 
-When you call `memwal.remember(...)`, your data goes through several steps before it's stored. Here's what happens.
+When you call `memwal.remember(...)`, the relayer accepts a background job immediately and then stores the memory asynchronously. Here's what happens.
 
 ## Storing a memory
 
@@ -16,13 +16,15 @@ sequenceDiagram
     participant DB as Indexed Database
 
     App->>Relayer: plaintext memory
+    Relayer->>DB: create remember job
+    Relayer-->>App: job_id + running status
     Relayer->>Relayer: generate vector embedding
     Relayer->>SEAL: encrypt content
     SEAL-->>Relayer: encrypted payload
     Relayer->>Walrus: upload blob + namespace metadata
     Walrus-->>Relayer: blob ID
     Relayer->>DB: store vector + blob ID + owner + namespace
-    Relayer-->>App: success
+    Relayer->>DB: mark job done
 ```
 
 <Steps>

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -153,7 +153,8 @@ The fastest way to get MemWal running is through the TypeScript SDK.
     ### Store and recall your first memory
 
     ```ts
-    await memwal.remember("User prefers dark mode and works in TypeScript.");
+    const job = await memwal.remember("User prefers dark mode and works in TypeScript.");
+    await memwal.waitForRememberJob(job.job_id);
 
     const result = await memwal.recall("What do we know about this user?");
     console.log(result.results);

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -49,7 +49,8 @@ const memwal = MemWal.create({
 });
 
 await memwal.health();
-await memwal.remember("I live in Hanoi and prefer dark mode.");
+const job = await memwal.remember("I live in Hanoi and prefer dark mode.");
+await memwal.waitForRememberJob(job.job_id);
 
 const result = await memwal.recall("What do we know about this user?");
 console.log(result.results);
@@ -85,19 +86,19 @@ Config:
 | `serverUrl` | `string` | No | `http://localhost:8000` | Relayer URL |
 | `namespace` | `string` | No | `"default"` | Default namespace for memory isolation |
 
-### `remember(text, namespace?): Promise<RememberResult>`
+### `remember(text, namespace?): Promise<RememberAcceptedResult>`
 
-Store one memory through the relayer. The relayer handles embedding, SEAL encryption, Walrus upload, and vector indexing.
+Submit one memory through the relayer. The relayer returns after creating a background job; embedding, SEAL encryption, Walrus upload, and vector indexing continue asynchronously.
 
 Returns:
 ```ts
 {
-  id: string;        // UUID for this entry
-  blob_id: string;   // Walrus blob ID
-  owner: string;     // Owner Sui address
-  namespace: string; // Namespace used
+  job_id: string; // Polling id
+  status: string; // Usually "running"
 }
 ```
+
+Use `rememberAndWait(text, namespace?, opts?)` or `waitForRememberJob(job_id, opts?)` to resolve the completed `{ id, job_id, blob_id, owner, namespace }` result.
 
 ### `recall(query, limit?, namespace?): Promise<RecallResult>`
 
@@ -119,20 +120,24 @@ Returns:
 
 ### `analyze(text, namespace?): Promise<AnalyzeResult>`
 
-Extract memorable facts from text using an LLM, then store each fact as a separate memory.
+Extract memorable facts from text using an LLM, then return accepted background jobs for storing each fact.
 
 Returns:
 ```ts
 {
+  job_ids: string[];
   facts: Array<{
     text: string;     // Extracted fact
-    id: string;       // UUID
-    blob_id: string;  // Walrus blob ID
+    id: string;       // Same value as job_id
+    job_id: string;   // Polling id
   }>;
-  total: number;
+  fact_count: number;
+  status: string;     // Usually "pending"
   owner: string;
 }
 ```
+
+Use `analyzeAndWait(text, namespace?, opts?)` to wait for every extracted fact job to finish.
 
 ### `restore(namespace, limit?): Promise<RestoreResult>`
 

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -61,7 +61,7 @@ Proxy to the sidecar's `/sponsor/execute` endpoint. No authentication required.
 
 ### `POST /api/remember`
 
-Store text as an encrypted memory. The relayer handles embedding, SEAL encryption, Walrus upload, and vector indexing.
+Submit text as an encrypted memory job. The relayer returns after creating a background job; embedding, SEAL encryption, Walrus upload, and vector indexing continue asynchronously.
 
 **Request:**
 
@@ -74,14 +74,76 @@ Store text as an encrypted memory. The relayer handles embedding, SEAL encryptio
 
 `namespace` defaults to `"default"` if omitted.
 
+**Response:** `202 Accepted`
+
+```json
+{
+  "job_id": "uuid",
+  "status": "running"
+}
+```
+
+### `GET /api/remember/:job_id`
+
+Poll a remember job.
+
 **Response:**
 
 ```json
 {
-  "id": "uuid",
-  "blob_id": "walrus-blob-id",
+  "job_id": "uuid",
+  "status": "done",
   "owner": "0x...",
-  "namespace": "demo"
+  "namespace": "demo",
+  "blob_id": "walrus-blob-id"
+}
+```
+
+### `POST /api/remember/bulk`
+
+Submit up to 20 memories in one request. `job_ids[i]` corresponds to `items[i]`.
+
+**Request:**
+
+```json
+{
+  "items": [
+    { "text": "User prefers dark mode", "namespace": "demo" },
+    { "text": "User works in TypeScript", "namespace": "demo" }
+  ]
+}
+```
+
+**Response:** `202 Accepted`
+
+```json
+{
+  "job_ids": ["uuid-1", "uuid-2"],
+  "total": 2,
+  "status": "running"
+}
+```
+
+### `POST /api/remember/bulk/status`
+
+Poll a batch of remember jobs.
+
+**Request:**
+
+```json
+{
+  "job_ids": ["uuid-1", "uuid-2"]
+}
+```
+
+**Response:**
+
+```json
+{
+  "results": [
+    { "job_id": "uuid-1", "status": "done", "blob_id": "walrus-blob-id" },
+    { "job_id": "uuid-2", "status": "running" }
+  ]
 }
 ```
 
@@ -171,7 +233,7 @@ Search with a precomputed query vector. Returns blob IDs and distances only — 
 
 ### `POST /api/analyze`
 
-Extract facts from text using an LLM, then store each fact as a separate memory (embed, encrypt, upload, index).
+Extract facts from text using an LLM, then enqueue each fact as a separate memory job.
 
 **Request:**
 
@@ -182,23 +244,17 @@ Extract facts from text using an LLM, then store each fact as a separate memory 
 }
 ```
 
-**Response:**
+**Response:** `202 Accepted`
 
 ```json
 {
+  "job_ids": ["uuid-1", "uuid-2"],
   "facts": [
-    {
-      "text": "User lives in Hanoi",
-      "id": "uuid",
-      "blob_id": "walrus-blob-id"
-    },
-    {
-      "text": "User prefers dark mode",
-      "id": "uuid",
-      "blob_id": "walrus-blob-id"
-    }
+    { "text": "User lives in Hanoi", "id": "uuid-1", "job_id": "uuid-1" },
+    { "text": "User prefers dark mode", "id": "uuid-2", "job_id": "uuid-2" }
   ],
-  "total": 2,
+  "fact_count": 2,
+  "status": "pending",
   "owner": "0x..."
 }
 ```

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -26,20 +26,56 @@ For the full config surface, see [Configuration](/reference/configuration).
 
 ## `MemWal` Methods
 
-### `remember(text, namespace?): Promise<RememberResult>`
+### `remember(text, namespace?): Promise<RememberAcceptedResult>`
 
-Store one memory through the relayer. The relayer handles embedding, SEAL encryption, Walrus upload, and vector indexing.
+Submit one memory through the relayer. The method returns after the relayer creates a background job; embedding, SEAL encryption, Walrus upload, and vector indexing continue asynchronously.
 
 **Returns:**
 
 ```ts
 {
-  id: string;        // UUID for this entry
+  job_id: string; // Polling id
+  status: string; // Usually "running"
+}
+```
+
+### `rememberAndWait(text, namespace?, opts?): Promise<RememberResult>`
+
+Submit one memory and poll until the background job completes.
+
+**Returns:**
+
+```ts
+{
+  id: string;        // Stable job id/vector row id
+  job_id: string;    // Polling id
   blob_id: string;   // Walrus blob ID
   owner: string;     // Owner Sui address
   namespace: string; // Namespace used
 }
 ```
+
+### `waitForRememberJob(jobId, opts?): Promise<RememberResult>`
+
+Poll a previously accepted remember job until it reaches `done` or `failed`.
+
+### `rememberBulk(items): Promise<RememberBulkAcceptedResult>`
+
+Submit up to 20 memories in one request and return the accepted job IDs immediately.
+
+**Returns:**
+
+```ts
+{
+  job_ids: string[];
+  total: number;
+  status: string; // Usually "running"
+}
+```
+
+### `rememberBulkAndWait(items, opts?): Promise<RememberBulkResult>`
+
+Submit a bulk remember request and wait until every job reaches a terminal state.
 
 ### `recall(query, limit?, namespace?): Promise<RecallResult>`
 
@@ -62,21 +98,25 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 
 ### `analyze(text, namespace?): Promise<AnalyzeResult>`
 
-Extract memorable facts from text using an LLM, then store each fact as a separate memory.
+Extract memorable facts from text using an LLM, then return accepted background jobs for storing each fact.
 
 **Returns:**
 
 ```ts
 {
+  job_ids: string[];
   facts: Array<{
     text: string;     // Extracted fact
-    id: string;       // UUID
-    blob_id: string;  // Walrus blob ID
+    id: string;       // Same value as job_id
+    job_id: string;   // Polling id
   }>;
-  total: number;
+  fact_count: number;
+  status: string;     // Usually "pending"
   owner: string;
 }
 ```
+
+Use `analyzeAndWait(text, namespace?, opts?)` to wait for every extracted fact job to finish and return per-job storage results.
 
 ### `restore(namespace, limit?): Promise<RestoreResult>`
 

--- a/docs/sdk/examples.md
+++ b/docs/sdk/examples.md
@@ -18,9 +18,10 @@ const memwal = MemWal.create({
 
 await memwal.health();
 
-const stored = await memwal.remember(
+const accepted = await memwal.remember(
   "User prefers dark mode and works in TypeScript."
 );
+const stored = await memwal.waitForRememberJob(accepted.job_id);
 
 const recalled = await memwal.recall(
   "What do we know about this user?",
@@ -34,7 +35,8 @@ console.log(recalled.results);
 What you should see:
 
 - `health()` succeeds
-- `remember()` returns a `blob_id`
+- `remember()` returns a `job_id` immediately
+- `waitForRememberJob()` returns a `blob_id`
 - `recall()` returns plaintext results for the same namespace
 
 ## Advanced: Manual Methods and Analyze
@@ -53,7 +55,7 @@ memories.
 const analyzed = await memwal.analyze(
   "I live in Hanoi, prefer dark mode, and usually work late at night."
 );
-console.log(analyzed.facts);
+console.log(analyzed.facts, analyzed.job_ids);
 ```
 
 ### AI Middleware
@@ -65,7 +67,7 @@ See [AI Integration](/sdk/ai-integration) for the full setup.
 
 Use this when you want to store structured research findings and recall them in later sessions.
 
-1. Save a structured summary with `remember()`
+1. Submit a structured summary with `remember()` and wait for completion when immediate recall is needed
 2. Generate targeted queries later
 3. Use `recall()` to pull relevant findings back into context
 

--- a/docs/sdk/quick-start.md
+++ b/docs/sdk/quick-start.md
@@ -99,7 +99,8 @@ const memwal = MemWal.create({
 });
 
 await memwal.health();
-await memwal.remember("I live in Hanoi and prefer dark mode.");
+const job = await memwal.remember("I live in Hanoi and prefer dark mode.");
+await memwal.waitForRememberJob(job.job_id);
 
 const result = await memwal.recall("What do we know about this user?");
 console.log(result.results);

--- a/docs/sdk/usage/memwal.md
+++ b/docs/sdk/usage/memwal.md
@@ -9,7 +9,7 @@ The recommended default client. The relayer handles embeddings, SEAL encryption,
 
 1. The SDK signs each request with your delegate key
 2. The relayer verifies delegate access
-3. `remember` encrypts via SEAL, uploads to Walrus, and indexes the vector embedding
+3. `remember` returns an accepted job while the relayer encrypts, uploads, and indexes in the background
 4. `recall` searches by Memory Space and returns decrypted matches
 
 ```ts
@@ -27,7 +27,8 @@ const memwal = MemWal.create({
 
 ```ts
 // Store a memory
-await memwal.remember("User prefers dark mode and works in TypeScript.");
+const job = await memwal.remember("User prefers dark mode and works in TypeScript.");
+await memwal.waitForRememberJob(job.job_id);
 
 // Recall relevant memories
 const result = await memwal.recall("What do we know about this user?", 5);
@@ -36,7 +37,7 @@ const result = await memwal.recall("What do we know about this user?", 5);
 const analyzed = await memwal.analyze(
   "I live in Hanoi, prefer dark mode, and usually work late at night."
 );
-console.log(analyzed.facts);
+console.log(analyzed.job_ids);
 
 // Check relayer health
 await memwal.health();

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -32,7 +32,8 @@ const memwal = MemWal.create({
   namespace: "demo",
 });
 
-await memwal.remember("User prefers dark mode and uses TypeScript.");
+const job = await memwal.remember("User prefers dark mode and uses TypeScript.");
+await memwal.waitForRememberJob(job.job_id);
 const memories = await memwal.recall("What are the user's preferences?");
 await memwal.restore("demo");
 ```

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -28,4 +28,8 @@ export type {
     AnalyzedFact,
     HealthResult,
     RestoreResult,
+    RememberBulkItem,
+    RememberBulkOptions,
+    RememberBulkResult,
+    RememberBulkItemResult,
 } from "./types.js";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -20,16 +20,22 @@ export { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "./utils.js";
 // Types (server-mode only — no manual types here)
 export type {
     MemWalConfig,
+    RememberAcceptedResult,
+    RememberJobStatus,
     RememberResult,
     RecallResult,
     RecallMemory,
     EmbedResult,
     AnalyzeResult,
+    AnalyzeWaitResult,
     AnalyzedFact,
     HealthResult,
     RestoreResult,
     RememberBulkItem,
     RememberBulkOptions,
+    RememberBulkAcceptedResult,
+    RememberBulkStatusItem,
+    RememberBulkStatusResult,
     RememberBulkResult,
     RememberBulkItemResult,
 } from "./types.js";

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -40,6 +40,15 @@ import type {
     RecallManualOptions,
     RecallManualResult,
     RestoreResult,
+    RememberBulkItem,
+    RememberBulkOptions,
+    RememberBulkResult,
+    RememberAcceptedResult,
+    RememberJobStatus,
+    RememberBulkAcceptedResult,
+    RememberBulkStatusResult,
+    RememberBulkStatusItem,
+    RememberBulkItemResult,
 } from "./types.js";
 import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerError } from "./utils.js";
 
@@ -137,22 +146,251 @@ export class MemWal {
     // ============================================================
 
     /**
-     * Remember something — server handles: verify → embed → encrypt → Walrus upload → store
+     * Submit a remember request and return as soon as the server accepts the job.
+     */
+    async rememberAsync(text: string, namespace?: string): Promise<RememberAcceptedResult> {
+        return this.signedRequest<RememberAcceptedResult>(
+            "POST",
+            "/api/remember",
+            { text, namespace: namespace ?? this.namespace },
+            [200, 202],
+        );
+    }
+
+    /**
+     * Poll an accepted remember job until it reaches a terminal state.
+     */
+    async waitForRememberJob(
+        jobId: string,
+        opts: { pollIntervalMs?: number; timeoutMs?: number } = {},
+    ): Promise<RememberResult> {
+        const { pollIntervalMs = 1500, timeoutMs = 60_000 } = opts;
+        const deadline = Date.now() + timeoutMs;
+
+        while (Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, pollIntervalMs));
+
+            const status = await this.signedRequest<RememberJobStatus>(
+                "GET",
+                `/api/remember/${jobId}`,
+                {},
+            );
+
+            if (status.status === "done") {
+                return {
+                    id: jobId,
+                    blob_id: status.blob_id ?? "",
+                    owner: status.owner ?? "",
+                    namespace: status.namespace ?? this.namespace,
+                };
+            }
+            if (status.status === "failed") {
+                throw Object.assign(
+                    new Error(`remember job failed: ${status.error ?? "unknown error"}`),
+                    { status: 500, jobId },
+                );
+            }
+            if (status.status === "not_found") {
+                throw Object.assign(new Error(`remember job not found: ${jobId}`), {
+                    status: 404,
+                    jobId,
+                });
+            }
+        }
+
+        throw Object.assign(
+            new Error(`remember job timed out after ${timeoutMs}ms (job_id=${jobId})`),
+            { status: 504, jobId },
+        );
+    }
+
+    /**
+     * Remember something and wait for the background job to complete.
+     */
+    async rememberAndWait(
+        text: string,
+        namespace?: string,
+        opts: { pollIntervalMs?: number; timeoutMs?: number } = {},
+    ): Promise<RememberResult> {
+        const accepted = await this.rememberAsync(text, namespace);
+        return this.waitForRememberJob(accepted.job_id, opts);
+    }
+
+    /**
+     * Remember something — server handles: verify → embed → encrypt → Walrus upload → store.
+     *
+     * This keeps the historical SDK behavior by waiting for the async job to complete.
+     * Use rememberAsync() when you need fast-accept semantics.
      *
      * @param text - The text to remember
-     * @returns RememberResult with id, blob_id, owner
+     * @param namespace - Optional namespace override
+     * @param opts.pollIntervalMs - How often to poll (default 1500ms)
+     * @param opts.timeoutMs - Max wait time before throwing (default 60_000ms)
+     */
+    async remember(
+        text: string,
+        namespace?: string,
+        opts: { pollIntervalMs?: number; timeoutMs?: number } = {},
+    ): Promise<RememberResult> {
+        return this.rememberAndWait(text, namespace, opts);
+    }
+
+    /**
+     * Remember multiple memories in one batched request (ENG-1408).
+     *
+     * Server handles: verify → embed + SEAL-encrypt all items concurrently →
+     * upload N blobs to Walrus in parallel → 1 PTB per wallet slot for
+     * set-metadata + transfer. This collapses `N × (2 + 1)` Sui transactions
+     * into roughly `2N + K` where K ≤ wallet pool size.
+     *
+     * Returns `202 Accepted` immediately with `job_ids[]`; this method then
+     * polls the batch status endpoint and resolves
+     * once all jobs reach a terminal state (`done`, `failed`, or `timeout`).
+     *
+     * @param items - Array of `{ text, namespace? }` items (max 20 per call)
+     * @param opts.pollIntervalMs - How often to poll each job (default 1500ms)
+     * @param opts.timeoutMs - Max total wait (default 120_000ms)
      *
      * @example
      * ```typescript
-     * const result = await memwal.remember("I'm allergic to peanuts")
-     * console.log(result.blob_id) // "TY8mW0yr..."
+     * const result = await memwal.rememberBulk([
+     *     { text: "I love coffee" },
+     *     { text: "I live in Tokyo", namespace: "profile" },
+     * ])
+     * console.log(`${result.succeeded}/${result.total} stored`)
+     * for (const r of result.results) {
+     *     if (r.status === "done") console.log(r.blob_id)
+     * }
      * ```
      */
-    async remember(text: string, namespace?: string): Promise<RememberResult> {
-        return this.signedRequest<RememberResult>("POST", "/api/remember", {
-            text,
-            namespace: namespace ?? this.namespace,
-        });
+    async rememberBulkAsync(items: RememberBulkItem[]): Promise<RememberBulkAcceptedResult> {
+        if (!Array.isArray(items) || items.length === 0) {
+            throw new Error("rememberBulkAsync: items must be a non-empty array");
+        }
+
+        const normalised = items.map((item) => ({
+            text: item.text,
+            namespace: item.namespace ?? this.namespace,
+        }));
+
+        const accepted = await this.signedRequest<RememberBulkAcceptedResult>(
+            "POST",
+            "/api/remember/bulk",
+            { items: normalised },
+            [200, 202],
+        );
+
+        if (!accepted.job_ids || accepted.job_ids.length !== normalised.length) {
+            throw new Error(
+                `rememberBulkAsync: server returned ${accepted.job_ids?.length ?? 0} job_ids for ${normalised.length} items`,
+            );
+        }
+
+        return accepted;
+    }
+
+    async getRememberBulkStatus(jobIds: string[]): Promise<RememberBulkStatusResult> {
+        return this.signedRequest<RememberBulkStatusResult>(
+            "POST",
+            "/api/remember/bulk/status",
+            { job_ids: jobIds },
+        );
+    }
+
+    async waitForRememberJobs(
+        jobIds: string[],
+        namespaces: string[] = [],
+        opts: RememberBulkOptions = {},
+    ): Promise<RememberBulkResult> {
+        const { pollIntervalMs = 1500, timeoutMs = 120_000 } = opts;
+        const deadline = Date.now() + timeoutMs;
+        const results: RememberBulkItemResult[] = jobIds.map((jobId, idx) => ({
+            id: jobId,
+            blob_id: "",
+            status: "timeout",
+            namespace: namespaces[idx] ?? this.namespace,
+            error: `polling timed out after ${timeoutMs}ms`,
+        }));
+        const pending = new Set(jobIds);
+
+        while (pending.size > 0 && Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, pollIntervalMs));
+
+            const pendingIds = jobIds.filter((jobId) => pending.has(jobId));
+            if (pendingIds.length === 0) {
+                break;
+            }
+
+            let batchStatus: RememberBulkStatusResult;
+
+            try {
+                batchStatus = await this.getRememberBulkStatus(pendingIds);
+            } catch (err) {
+                const httpStatus = (err as { status?: number }).status ?? 0;
+                if (httpStatus === 429 || httpStatus >= 500 || httpStatus === 0) {
+                    continue;
+                }
+                throw err;
+            }
+
+            const statusById = new Map<string, RememberBulkStatusItem[]>();
+            for (const item of batchStatus.results) {
+                const bucket = statusById.get(item.job_id);
+                if (bucket) {
+                    bucket.push(item);
+                } else {
+                    statusById.set(item.job_id, [item]);
+                }
+            }
+
+            for (const jobId of pendingIds) {
+                const status = statusById.get(jobId)?.shift();
+                if (!status) {
+                    continue;
+                }
+
+                const idx = jobIds.indexOf(jobId);
+                if (status.status === "done") {
+                    results[idx] = {
+                        id: jobId,
+                        blob_id: status.blob_id ?? "",
+                        status: "done",
+                        namespace: namespaces[idx] ?? this.namespace,
+                    };
+                    pending.delete(jobId);
+                } else if (status.status === "failed" || status.status === "not_found") {
+                    results[idx] = {
+                        id: jobId,
+                        blob_id: "",
+                        status: "failed",
+                        namespace: namespaces[idx] ?? this.namespace,
+                        error:
+                            status.status === "not_found"
+                                ? "job not found"
+                                : status.error ?? "unknown error",
+                    };
+                    pending.delete(jobId);
+                }
+            }
+        }
+
+        const succeeded = results.filter((r) => r.status === "done").length;
+
+        return {
+            results,
+            total: results.length,
+            succeeded,
+            failed: results.length - succeeded,
+        };
+    }
+
+    async rememberBulk(
+        items: RememberBulkItem[],
+        opts: RememberBulkOptions = {},
+    ): Promise<RememberBulkResult> {
+        const namespaces = items.map((item) => item.namespace ?? this.namespace);
+        const accepted = await this.rememberBulkAsync(items);
+        return this.waitForRememberJobs(accepted.job_ids, namespaces, opts);
     }
 
     /**
@@ -527,16 +765,33 @@ export class MemWal {
      * (5-min TTL, scoped to the server's `packageId`) so a wire capture has
      * a bounded blast radius. Requires `@mysten/seal` and `@mysten/sui`.
      */
+    /**
+     * Make a signed request to the server.
+     *
+     * @param acceptedStatuses - HTTP status codes to treat as success (default [200]).
+     *   Pass [200, 202] for endpoints that return 202 Accepted.
+     */
     private async signedRequest<T>(
         method: string,
         path: string,
         body: object,
-        options: { includeDelegateKey?: boolean; signal?: AbortSignal } = {},
+        acceptedStatusesOrOptions: number[] | { includeDelegateKey?: boolean; signal?: AbortSignal } = [200],
+        requestOptions: { includeDelegateKey?: boolean; signal?: AbortSignal } = {},
     ): Promise<T> {
+        const acceptedStatuses = Array.isArray(acceptedStatusesOrOptions)
+            ? acceptedStatusesOrOptions
+            : [200];
+        const options = Array.isArray(acceptedStatusesOrOptions)
+            ? requestOptions
+            : acceptedStatusesOrOptions;
         const ed = await getEd();
 
         const timestamp = Math.floor(Date.now() / 1000).toString();
-        const bodyStr = JSON.stringify(body);
+        // Canonical body used for both: (a) the HTTP wire body and
+        // (b) the SHA-256 digest inside the signed message. GET requests
+        // carry no body, so the server will hash an EMPTY byte string —
+        // we must sign the same empty string for the signature to verify.
+        const bodyStr = method === "GET" ? "" : JSON.stringify(body);
         const bodySha256 = await sha256hex(bodyStr);
 
         // MED-1 fix: Generate per-request nonce (UUID v4) for replay protection
@@ -570,11 +825,11 @@ export class MemWal {
         const res = await fetch(url, {
             method,
             headers,
-            body: bodyStr,
+            body: method === "GET" ? undefined : bodyStr,
             signal: options.signal,
         });
 
-        if (!res.ok) {
+        if (!acceptedStatuses.includes(res.status)) {
             // LOW-26: sanitize server error bodies before surfacing to callers.
             const raw = await res.text();
             const { message, serverCode } = sanitizeServerError(res.status, raw);

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -18,8 +18,9 @@
  *     accountId: process.env.MEMWAL_ACCOUNT_ID, // MemWalAccount object ID
  * })
  *
- * // Remember — server: verify → embed → encrypt → Walrus → store
- * await memwal.remember("I'm allergic to peanuts")
+ * // Remember — returns an accepted background job immediately
+ * const accepted = await memwal.remember("I'm allergic to peanuts")
+ * await memwal.waitForRememberJob(accepted.job_id)
  *
  * // Recall — server: verify → embed query → search → download → decrypt
  * const result = await memwal.recall("food allergies")
@@ -34,6 +35,7 @@ import type {
     RecallMemory,
     EmbedResult,
     AnalyzeResult,
+    AnalyzeWaitResult,
     HealthResult,
     RememberManualOptions,
     RememberManualResult,
@@ -89,6 +91,23 @@ const SEAL_SESSION_TTL_MIN = 5;
 // the client thinks the session is valid but a just-received request hits
 // a key server that sees it as expired.
 const SEAL_SESSION_SAFETY_MARGIN_MS = 30_000;
+
+type RememberStatusResponse = RememberJobStatus | { error?: string };
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function pollingDelayMs(baseMs: number, attempt: number): number {
+    const base = Math.max(100, baseMs);
+    const capped = Math.min(10_000, base * 1.5 ** Math.min(attempt, 6));
+    const jitter = 0.75 + Math.random() * 0.5;
+    return Math.floor(capped * jitter);
+}
+
+function isTransientPollingStatus(status: number): boolean {
+    return status === 0 || status === 429 || status >= 500;
+}
 
 export class MemWal {
     private privateKey: Uint8Array;
@@ -166,19 +185,39 @@ export class MemWal {
     ): Promise<RememberResult> {
         const { pollIntervalMs = 1500, timeoutMs = 60_000 } = opts;
         const deadline = Date.now() + timeoutMs;
+        let attempt = 0;
 
         while (Date.now() < deadline) {
-            await new Promise((r) => setTimeout(r, pollIntervalMs));
+            await sleep(pollingDelayMs(pollIntervalMs, attempt++));
 
-            const status = await this.signedRequest<RememberJobStatus>(
-                "GET",
-                `/api/remember/${jobId}`,
-                {},
-            );
+            let status: RememberStatusResponse;
+
+            try {
+                status = await this.signedRequest<RememberStatusResponse>(
+                    "GET",
+                    `/api/remember/${jobId}`,
+                    {},
+                    [200, 404],
+                );
+            } catch (err) {
+                const httpStatus = (err as { status?: number }).status ?? 0;
+                if (isTransientPollingStatus(httpStatus)) {
+                    continue;
+                }
+                throw err;
+            }
+
+            if (!("status" in status) || status.status === "not_found") {
+                throw Object.assign(new Error(`remember job not found: ${jobId}`), {
+                    status: 404,
+                    jobId,
+                });
+            }
 
             if (status.status === "done") {
                 return {
-                    id: jobId,
+                    id: status.job_id,
+                    job_id: status.job_id,
                     blob_id: status.blob_id ?? "",
                     owner: status.owner ?? "",
                     namespace: status.namespace ?? this.namespace,
@@ -189,12 +228,6 @@ export class MemWal {
                     new Error(`remember job failed: ${status.error ?? "unknown error"}`),
                     { status: 500, jobId },
                 );
-            }
-            if (status.status === "not_found") {
-                throw Object.assign(new Error(`remember job not found: ${jobId}`), {
-                    status: 404,
-                    jobId,
-                });
             }
         }
 
@@ -217,22 +250,16 @@ export class MemWal {
     }
 
     /**
-     * Remember something — server handles: verify → embed → encrypt → Walrus upload → store.
+     * Remember something and return as soon as the server accepts the job.
      *
-     * This keeps the historical SDK behavior by waiting for the async job to complete.
-     * Use rememberAsync() when you need fast-accept semantics.
+     * The relayer continues embedding, encrypting, uploading, and indexing in the background.
+     * Use rememberAndWait() when the caller needs the final blob_id before continuing.
      *
      * @param text - The text to remember
      * @param namespace - Optional namespace override
-     * @param opts.pollIntervalMs - How often to poll (default 1500ms)
-     * @param opts.timeoutMs - Max wait time before throwing (default 60_000ms)
      */
-    async remember(
-        text: string,
-        namespace?: string,
-        opts: { pollIntervalMs?: number; timeoutMs?: number } = {},
-    ): Promise<RememberResult> {
-        return this.rememberAndWait(text, namespace, opts);
+    async remember(text: string, namespace?: string): Promise<RememberAcceptedResult> {
+        return this.rememberAsync(text, namespace);
     }
 
     /**
@@ -243,24 +270,17 @@ export class MemWal {
      * set-metadata + transfer. This collapses `N × (2 + 1)` Sui transactions
      * into roughly `2N + K` where K ≤ wallet pool size.
      *
-     * Returns `202 Accepted` immediately with `job_ids[]`; this method then
-     * polls the batch status endpoint and resolves
-     * once all jobs reach a terminal state (`done`, `failed`, or `timeout`).
+     * Returns `202 Accepted` immediately with `job_ids[]`.
      *
      * @param items - Array of `{ text, namespace? }` items (max 20 per call)
-     * @param opts.pollIntervalMs - How often to poll each job (default 1500ms)
-     * @param opts.timeoutMs - Max total wait (default 120_000ms)
      *
      * @example
      * ```typescript
-     * const result = await memwal.rememberBulk([
+     * const accepted = await memwal.rememberBulk([
      *     { text: "I love coffee" },
      *     { text: "I live in Tokyo", namespace: "profile" },
      * ])
-     * console.log(`${result.succeeded}/${result.total} stored`)
-     * for (const r of result.results) {
-     *     if (r.status === "done") console.log(r.blob_id)
-     * }
+     * console.log(accepted.job_ids)
      * ```
      */
     async rememberBulkAsync(items: RememberBulkItem[]): Promise<RememberBulkAcceptedResult> {
@@ -312,9 +332,10 @@ export class MemWal {
             error: `polling timed out after ${timeoutMs}ms`,
         }));
         const pending = new Set(jobIds);
+        let attempt = 0;
 
         while (pending.size > 0 && Date.now() < deadline) {
-            await new Promise((r) => setTimeout(r, pollIntervalMs));
+            await sleep(pollingDelayMs(pollIntervalMs, attempt++));
 
             const pendingIds = jobIds.filter((jobId) => pending.has(jobId));
             if (pendingIds.length === 0) {
@@ -327,7 +348,7 @@ export class MemWal {
                 batchStatus = await this.getRememberBulkStatus(pendingIds);
             } catch (err) {
                 const httpStatus = (err as { status?: number }).status ?? 0;
-                if (httpStatus === 429 || httpStatus >= 500 || httpStatus === 0) {
+                if (isTransientPollingStatus(httpStatus)) {
                     continue;
                 }
                 throw err;
@@ -384,7 +405,17 @@ export class MemWal {
         };
     }
 
-    async rememberBulk(
+    /**
+     * Remember multiple memories and return as soon as the server accepts the jobs.
+     */
+    async rememberBulk(items: RememberBulkItem[]): Promise<RememberBulkAcceptedResult> {
+        return this.rememberBulkAsync(items);
+    }
+
+    /**
+     * Remember multiple memories and wait until every job reaches a terminal state.
+     */
+    async rememberBulkAndWait(
         items: RememberBulkItem[],
         opts: RememberBulkOptions = {},
     ): Promise<RememberBulkResult> {
@@ -515,23 +546,43 @@ export class MemWal {
     }
 
     /**
-     * Analyze conversation text — server uses LLM to extract facts, then
-     * stores each one (embed → encrypt → Walrus → store).
+     * Analyze conversation text and return as soon as extracted facts are accepted.
+     *
+     * The relayer extracts facts synchronously, returns one job_id per fact, then
+     * embeds, encrypts, uploads, and indexes each fact in the background.
      *
      * @param text - Conversation text to analyze
-     * @returns AnalyzeResult with extracted and stored facts
+     * @returns AnalyzeResult with extracted facts and accepted job_ids
      *
      * @example
      * ```typescript
      * const result = await memwal.analyze("I love coffee and live in Tokyo")
-     * console.log(result.facts) // ["User loves coffee", "User lives in Tokyo"]
+     * console.log(result.job_ids)
      * ```
      */
     async analyze(text: string, namespace?: string): Promise<AnalyzeResult> {
         return this.signedRequest<AnalyzeResult>("POST", "/api/analyze", {
             text,
             namespace: namespace ?? this.namespace,
-        });
+        }, [200, 202]);
+    }
+
+    /**
+     * Analyze conversation text and wait until every extracted fact is stored.
+     */
+    async analyzeAndWait(
+        text: string,
+        namespace?: string,
+        opts: RememberBulkOptions = {},
+    ): Promise<AnalyzeWaitResult> {
+        const accepted = await this.analyze(text, namespace);
+        const namespaces = accepted.job_ids.map(() => namespace ?? this.namespace);
+        const completed = await this.waitForRememberJobs(accepted.job_ids, namespaces, opts);
+        return {
+            ...completed,
+            facts: accepted.facts,
+            owner: accepted.owner,
+        };
     }
 
     /**

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -24,7 +24,7 @@ export interface MemWalConfig {
 // API Types
 // ============================================================
 
-/** Accepted async remember job returned by the server */
+/** Result from remember() / rememberAsync() */
 export interface RememberAcceptedResult {
     job_id: string;
     status: string;
@@ -40,9 +40,12 @@ export interface RememberJobStatus {
     error?: string;
 }
 
-/** Result from remember() */
+/** Result from rememberAndWait() / waitForRememberJob() */
 export interface RememberResult {
+    /** Stable server job_id used as the vector row id. */
     id: string;
+    /** Async job id returned by remember(). */
+    job_id?: string;
     blob_id: string;
     owner: string;
     namespace: string;
@@ -61,7 +64,7 @@ export interface RecallResult {
     total: number;
 }
 
-/** Result from rememberBulkAsync() */
+/** Result from rememberBulk() / rememberBulkAsync() */
 export interface RememberBulkAcceptedResult {
     job_ids: string[];
     total: number;
@@ -97,7 +100,7 @@ export interface RememberBulkOptions {
     timeoutMs?: number;
 }
 
-/** Per-item result returned from rememberBulk() */
+/** Per-item result returned from rememberBulkAndWait() / waitForRememberJobs() */
 export interface RememberBulkItemResult {
     /** job_id returned by the server */
     id: string;
@@ -111,7 +114,7 @@ export interface RememberBulkItemResult {
     error?: string;
 }
 
-/** Result from rememberBulk() */
+/** Result from rememberBulkAndWait() / waitForRememberJobs() */
 export interface RememberBulkResult {
     /** One result per input item, in the same order */
     results: RememberBulkItemResult[];
@@ -128,17 +131,29 @@ export interface EmbedResult {
     vector: number[];
 }
 
-/** A single extracted fact */
+/** A fact extracted by analyze() and accepted for background storage. */
 export interface AnalyzedFact {
     text: string;
+    /** Stable job id/vector row id for this extracted fact. */
     id: string;
-    blob_id: string;
+    /** Polling id for this extracted fact. */
+    job_id?: string;
+    /** Walrus blob_id once the background job completes. */
+    blob_id?: string;
 }
 
 /** Result from analyze() */
 export interface AnalyzeResult {
+    job_ids: string[];
     facts: AnalyzedFact[];
-    total: number;
+    fact_count: number;
+    status: string;
+    owner: string;
+}
+
+/** Result from analyzeAndWait() */
+export interface AnalyzeWaitResult extends RememberBulkResult {
+    facts: AnalyzedFact[];
     owner: string;
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -24,6 +24,22 @@ export interface MemWalConfig {
 // API Types
 // ============================================================
 
+/** Accepted async remember job returned by the server */
+export interface RememberAcceptedResult {
+    job_id: string;
+    status: string;
+}
+
+/** Status returned for an async remember job */
+export interface RememberJobStatus {
+    job_id: string;
+    status: "pending" | "running" | "uploaded" | "done" | "failed" | "not_found";
+    owner?: string;
+    namespace?: string;
+    blob_id?: string;
+    error?: string;
+}
+
 /** Result from remember() */
 export interface RememberResult {
     id: string;
@@ -43,6 +59,68 @@ export interface RecallMemory {
 export interface RecallResult {
     results: RecallMemory[];
     total: number;
+}
+
+/** Result from rememberBulkAsync() */
+export interface RememberBulkAcceptedResult {
+    job_ids: string[];
+    total: number;
+    status: string;
+}
+
+/** Per-item status returned from the bulk status endpoint */
+export interface RememberBulkStatusItem {
+    job_id: string;
+    status: "pending" | "running" | "uploaded" | "done" | "failed" | "not_found";
+    blob_id?: string;
+    error?: string;
+}
+
+/** Result from getRememberBulkStatus() */
+export interface RememberBulkStatusResult {
+    results: RememberBulkStatusItem[];
+}
+
+/** One item in a bulk remember request */
+export interface RememberBulkItem {
+    /** The text to remember */
+    text: string;
+    /** Optional per-item namespace override (falls back to client default) */
+    namespace?: string;
+}
+
+/** Options for remember bulk polling behaviour */
+export interface RememberBulkOptions {
+    /** How often to poll each job_id (default: 1500ms) */
+    pollIntervalMs?: number;
+    /** Max total wait time before throwing (default: 120_000ms) */
+    timeoutMs?: number;
+}
+
+/** Per-item result returned from rememberBulk() */
+export interface RememberBulkItemResult {
+    /** job_id returned by the server */
+    id: string;
+    /** Walrus blob_id once the job completes ("" if failed) */
+    blob_id: string;
+    /** Final status reported by the server: "done" | "failed" | "timeout" */
+    status: "done" | "failed" | "timeout";
+    /** Namespace the memory was stored under */
+    namespace: string;
+    /** Error message if status !== "done" */
+    error?: string;
+}
+
+/** Result from rememberBulk() */
+export interface RememberBulkResult {
+    /** One result per input item, in the same order */
+    results: RememberBulkItemResult[];
+    /** Total items submitted */
+    total: number;
+    /** Count of items that reached status=done */
+    succeeded: number;
+    /** Count of items that failed or timed out */
+    failed: number;
 }
 
 /** Result from embed() */

--- a/scripts/test-namespace.ts
+++ b/scripts/test-namespace.ts
@@ -37,7 +37,7 @@ async function main() {
     // Step 1: Remember with namespace
     console.log("1. Remember (with namespace)...");
     try {
-        const rememberResult = await memwal.remember("I love Sui blockchain and Move language");
+        const rememberResult = await memwal.rememberAndWait("I love Sui blockchain and Move language");
         console.log(`   ✅ Remember OK`);
         console.log(`   id: ${rememberResult.id}`);
         console.log(`   blob_id: ${rememberResult.blob_id}`);

--- a/services/server/Cargo.lock
+++ b/services/server/Cargo.lock
@@ -33,12 +33,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apalis"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504d52557a16b7b202941660f339c9182910d498cac40f93d15f6b31e6bef290"
+dependencies = [
+ "apalis-core",
+ "futures",
+ "pin-project-lite",
+ "serde",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "apalis-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3948d2051795c769e6a44a46549879af39d5e8e4fb113e0011cf99f7cd21b657"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tower",
+ "ulid",
+]
+
+[[package]]
+name = "apalis-sql"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d96124556e2190523c1a52acf3b3e02af564343b4fa888f0b712775ac80ee04"
+dependencies = [
+ "apalis-core",
+ "async-stream",
+ "chrono",
+ "futures",
+ "futures-lite",
+ "log",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -210,6 +282,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -591,6 +664,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +698,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -653,13 +745,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1169,6 +1273,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "memwal-server"
 version = "0.1.0"
 dependencies = [
+ "apalis",
+ "apalis-sql",
  "axum",
  "base64",
  "chrono",
@@ -1267,7 +1373,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1498,6 +1604,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1509,8 +1621,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1520,7 +1642,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1530,6 +1662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1660,7 +1801,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1904,7 +2045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2078,7 +2219,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -2118,7 +2259,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -2472,6 +2613,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +2661,16 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
 
 [[package]]
 name = "unicase"
@@ -2756,6 +2916,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/services/server/Cargo.toml
+++ b/services/server/Cargo.toml
@@ -22,6 +22,10 @@ hex = "0.4"
 # SEAL encryption is handled by TS sidecar scripts (@mysten/seal)
 # (no Rust crypto deps needed)
 
+# Background job queue — persistent metadata+transfer tasks (ENG-1406)
+apalis     = { version = "0.7", default-features = false, features = ["tracing"] }
+apalis-sql = { version = "0.7", features = ["postgres", "migrate"] }
+
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -50,3 +54,4 @@ uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 base64 = "0.22"
 percent-encoding = "2"
+

--- a/services/server/migrations/005_remember_jobs.sql
+++ b/services/server/migrations/005_remember_jobs.sql
@@ -9,7 +9,7 @@
 --   uploaded → failed   (metadata+transfer permanently failed)
 
 CREATE TABLE IF NOT EXISTS remember_jobs (
-    id          TEXT PRIMARY KEY,          -- UUID, returned as jobId in 202 response
+    id          TEXT PRIMARY KEY,          -- UUID, returned as job_id in 202 response
     owner       TEXT NOT NULL,             -- Sui address of the calling user
     namespace   TEXT NOT NULL DEFAULT 'default',
     status      TEXT NOT NULL DEFAULT 'pending'

--- a/services/server/migrations/005_remember_jobs.sql
+++ b/services/server/migrations/005_remember_jobs.sql
@@ -1,0 +1,24 @@
+-- ENG-1406 v3: Job status tracking for async remember pipeline
+-- Each row tracks one remember request from enqueue → done/failed.
+--
+-- Status transitions:
+--   pending  → running  (worker picked up the job)
+--   running  → uploaded (blob certified on Walrus; metadata+transfer still pending)
+--   uploaded → done     (metadata+transfer succeeded and vector is recallable)
+--   running  → failed   (any error before upload completed)
+--   uploaded → failed   (metadata+transfer permanently failed)
+
+CREATE TABLE IF NOT EXISTS remember_jobs (
+    id          TEXT PRIMARY KEY,          -- UUID, returned as jobId in 202 response
+    owner       TEXT NOT NULL,             -- Sui address of the calling user
+    namespace   TEXT NOT NULL DEFAULT 'default',
+    status      TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'running', 'uploaded', 'done', 'failed')),
+    blob_id     TEXT,                      -- set once status reaches 'uploaded'
+    error_msg   TEXT,                      -- set when status = 'failed'
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_remember_jobs_owner  ON remember_jobs (owner);
+CREATE INDEX IF NOT EXISTS idx_remember_jobs_status ON remember_jobs (status);

--- a/services/server/migrations/006_bulk_remember.sql
+++ b/services/server/migrations/006_bulk_remember.sql
@@ -1,0 +1,5 @@
+-- ENG-1408: Bulk remember support
+--
+-- Composite index for owner-scoped job listing/sweeper queries.
+CREATE INDEX IF NOT EXISTS remember_jobs_status_owner_idx
+    ON remember_jobs (owner, status, updated_at DESC);

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -588,6 +588,95 @@ app.post("/seal/decrypt-batch", express.json({ limit: "8mb" }), async (req, res)
 // ============================================================
 // POST /walrus/upload
 // ============================================================
+
+type MetadataTransferBlob = {
+    blobObjectId: string;
+    namespace?: string;
+};
+
+function extractBlobObjectId(blob: any): string | null {
+    const rawId = blob?.blobObject?.id;
+    if (typeof rawId === "string") {
+        return rawId;
+    }
+    if (rawId && typeof rawId === "object" && typeof rawId.id === "string") {
+        return rawId.id;
+    }
+    return null;
+}
+
+async function setMetadataAndTransferBlobs(
+    signer: Ed25519Keypair,
+    blobs: MetadataTransferBlob[],
+    owner: string,
+    packageId?: string,
+    agentId?: string,
+): Promise<string> {
+    if (blobs.length === 0) {
+        throw new Error("No blobs to transfer");
+    }
+
+    const signerAddress = signer.toSuiAddress();
+    return runExclusiveBySigner(signerAddress, async () => {
+        const metaTx = new Transaction();
+        const blobArgs = [];
+
+        for (const blob of blobs) {
+            const blobArg = metaTx.object(blob.blobObjectId);
+            blobArgs.push(blobArg);
+
+            metaTx.moveCall({
+                target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+                arguments: [
+                    blobArg,
+                    metaTx.pure.string("memwal_namespace"),
+                    metaTx.pure.string(blob.namespace || "default"),
+                ],
+                typeArguments: [],
+            });
+
+            metaTx.moveCall({
+                target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+                arguments: [
+                    blobArg,
+                    metaTx.pure.string("memwal_owner"),
+                    metaTx.pure.string(owner),
+                ],
+                typeArguments: [],
+            });
+
+            if (packageId) {
+                metaTx.moveCall({
+                    target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+                    arguments: [
+                        blobArg,
+                        metaTx.pure.string("memwal_package_id"),
+                        metaTx.pure.string(packageId),
+                    ],
+                    typeArguments: [],
+                });
+            }
+
+            if (agentId) {
+                metaTx.moveCall({
+                    target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+                    arguments: [
+                        blobArg,
+                        metaTx.pure.string("memwal_agent_id"),
+                        metaTx.pure.string(agentId),
+                    ],
+                    typeArguments: [],
+                });
+            }
+        }
+
+        metaTx.transferObjects(blobArgs, owner);
+        const digest = await executeWithEnokiSponsor(metaTx, signer, dedupeAddresses([signerAddress, owner]));
+        await suiClient.waitForTransaction({ digest });
+        return digest;
+    });
+}
+
 // HIGH-13: /walrus/upload receives a base64-encoded SEAL ciphertext which can
 // be up to ~87 KiB per 64 KiB plaintext (SEAL overhead + base64 ≈ 1.37×).
 // The 10 MB ceiling matches the sidecar's original global Walrus limit and is
@@ -601,6 +690,7 @@ app.post("/walrus/upload", express.json({ limit: "10mb" }), async (req, res) => 
             namespace,
             packageId,
             agentId,
+            deferTransfer = false,
             epochs: rawEpochs = DEFAULT_WALRUS_EPOCHS,
         } = req.body;
         // LOW-17: Cap epochs at 5 to prevent accidental large storage purchases
@@ -669,77 +759,18 @@ app.post("/walrus/upload", express.json({ limit: "10mb" }), async (req, res) => 
             return flow.getBlob();
         });
 
-        // Extract objectId — handle both { id: "0x..." } and { id: { id: "0x..." } }
-        let blobObjectId: string | null = null;
-        const rawId = (blob.blobObject as any)?.id;
-        if (typeof rawId === 'string') {
-            blobObjectId = rawId;
-        } else if (rawId && typeof rawId === 'object' && typeof rawId.id === 'string') {
-            blobObjectId = rawId.id;
-        }
-
-        // Walrus package for on-chain Move calls (from env-driven WALRUS_PACKAGE_ID)
-        const WALRUS_PKG = WALRUS_PACKAGE_ID;
+        const blobObjectId = extractBlobObjectId(blob);
 
         // Set on-chain metadata + transfer blob to user in a single transaction
-        if (owner && owner !== signerAddress && blobObjectId) {
+        if (!deferTransfer && owner && owner !== signerAddress && blobObjectId) {
             try {
-                const metaTx = new Transaction();
-                const blobArg = metaTx.object(blobObjectId);
-
-                // Set memwal_namespace metadata on-chain
-                metaTx.moveCall({
-                    target: `${WALRUS_PKG}::blob::insert_or_update_metadata_pair`,
-                    arguments: [
-                        blobArg,
-                        metaTx.pure.string("memwal_namespace"),
-                        metaTx.pure.string(namespace || "default"),
-                    ],
-                    typeArguments: [],
-                });
-
-                // Set memwal_owner
-                metaTx.moveCall({
-                    target: `${WALRUS_PKG}::blob::insert_or_update_metadata_pair`,
-                    arguments: [
-                        blobArg,
-                        metaTx.pure.string("memwal_owner"),
-                        metaTx.pure.string(owner),
-                    ],
-                    typeArguments: [],
-                });
-
-                // Set memwal_package_id
-                if (packageId) {
-                    metaTx.moveCall({
-                        target: `${WALRUS_PKG}::blob::insert_or_update_metadata_pair`,
-                        arguments: [
-                            blobArg,
-                            metaTx.pure.string("memwal_package_id"),
-                            metaTx.pure.string(packageId),
-                        ],
-                        typeArguments: [],
-                    });
-                }
-
-                // Set memwal_agent_id
-                if (agentId) {
-                    metaTx.moveCall({
-                        target: `${WALRUS_PKG}::blob::insert_or_update_metadata_pair`,
-                        arguments: [
-                            blobArg,
-                            metaTx.pure.string("memwal_agent_id"),
-                            metaTx.pure.string(agentId),
-                        ],
-                        typeArguments: [],
-                    });
-                }
-
-                // Transfer blob to user
-                metaTx.transferObjects([blobArg], owner);
-
-                const metaDigest = await executeWithEnokiSponsor(metaTx, signer, dedupeAddresses([signerAddress, owner]));
-                await suiClient.waitForTransaction({ digest: metaDigest });
+                await setMetadataAndTransferBlobs(
+                    signer,
+                    [{ blobObjectId, namespace }],
+                    owner,
+                    packageId,
+                    agentId,
+                );
                 console.log(`[walrus/upload] metadata set + transferred blob ${blobObjectId} to owner (ns=${namespace})`);
             } catch (metaErr: any) {
                 // LOW-14: Previously the metadata-set + transfer failure was swallowed
@@ -764,11 +795,88 @@ app.post("/walrus/upload", express.json({ limit: "10mb" }), async (req, res) => 
         res.json({
             blobId: blob.blobId,
             objectId: blobObjectId,
-            transferStatus: "ok",
+            transferStatus: deferTransfer ? "deferred" : "ok",
         });
     } catch (err: any) {
         const traceId = randomUUID();
         console.error(`[walrus/upload] [${traceId}] error:`, err);
+        res.status(500).json({ error: "Internal server error", traceId });
+    }
+});
+
+// ============================================================
+// POST /walrus/set-metadata-batch
+// ============================================================
+app.post("/walrus/set-metadata-batch", express.json({ limit: "1mb" }), async (req, res) => {
+    try {
+        const { blobs, owner, packageId, agentId, keyIndex } = req.body;
+        if (!Array.isArray(blobs) || blobs.length === 0 || !owner || keyIndex === undefined) {
+            return res.status(400).json({ error: "Missing required fields: blobs, owner, keyIndex" });
+        }
+        if (blobs.length > 20) {
+            return res.status(400).json({ error: "Too many blobs in batch" });
+        }
+        if (!/^0x[0-9a-fA-F]{64}$/.test(owner)) {
+            return res.status(400).json({ error: "Invalid owner address format" });
+        }
+        if (packageId && !/^0x[0-9a-fA-F]{1,64}$/.test(packageId)) {
+            return res.status(400).json({ error: "Invalid packageId format" });
+        }
+
+        const privateKey = SERVER_SUI_PRIVATE_KEYS[keyIndex];
+        if (!privateKey) {
+            return res.status(400).json({ error: `Invalid keyIndex: ${keyIndex}` });
+        }
+
+        const normalized: MetadataTransferBlob[] = blobs.map((blob: any, idx: number) => {
+            const blobObjectId = blob?.blobObjectId;
+            if (typeof blobObjectId !== "string" || !/^0x[0-9a-fA-F]{1,64}$/.test(blobObjectId)) {
+                throw new Error(`Invalid blobs[${idx}].blobObjectId`);
+            }
+            const namespace = typeof blob?.namespace === "string" && blob.namespace.length > 0
+                ? blob.namespace
+                : "default";
+            return { blobObjectId, namespace };
+        });
+
+        const { secretKey } = decodeSuiPrivateKey(privateKey);
+        const signer = Ed25519Keypair.fromSecretKey(secretKey);
+        const digest = await setMetadataAndTransferBlobs(signer, normalized, owner, packageId, agentId);
+        console.log(`[walrus/set-metadata-batch] transferred ${normalized.length} blobs to owner`);
+        res.json({ transferred: normalized.length, digest });
+    } catch (err: any) {
+        const traceId = randomUUID();
+        console.error(`[walrus/set-metadata-batch] [${traceId}] error:`, err);
+        res.status(500).json({ error: "Internal server error", traceId });
+    }
+});
+
+// Legacy single-blob endpoint kept for older queued jobs.
+app.post("/walrus/set-metadata", express.json({ limit: "128kb" }), async (req, res) => {
+    try {
+        const { blobObjectId, owner, namespace, packageId, agentId, keyIndex } = req.body;
+        if (!blobObjectId || !owner || keyIndex === undefined) {
+            return res.status(400).json({ error: "Missing required fields: blobObjectId, owner, keyIndex" });
+        }
+        req.body.blobs = [{ blobObjectId, namespace: namespace || "default" }];
+
+        const privateKey = SERVER_SUI_PRIVATE_KEYS[keyIndex];
+        if (!privateKey) {
+            return res.status(400).json({ error: `Invalid keyIndex: ${keyIndex}` });
+        }
+        const { secretKey } = decodeSuiPrivateKey(privateKey);
+        const signer = Ed25519Keypair.fromSecretKey(secretKey);
+        const digest = await setMetadataAndTransferBlobs(
+            signer,
+            [{ blobObjectId, namespace: namespace || "default" }],
+            owner,
+            packageId,
+            agentId,
+        );
+        res.json({ transferred: 1, digest });
+    } catch (err: any) {
+        const traceId = randomUUID();
+        console.error(`[walrus/set-metadata] [${traceId}] error:`, err);
         res.status(500).json({ error: "Internal server error", traceId });
     }
 });

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -26,6 +26,7 @@ use crate::types::{AppState, AuthInfo};
 /// 3. Verify onchain: public_key ∈ MemWalAccount.delegate_keys
 /// 4. Cache the mapping for future requests
 /// 5. Store AuthInfo { public_key, owner } in request extensions
+///
 /// LOW-2 fix: Normalize response timing across all auth failure paths.
 /// Returns UNAUTHORIZED after a constant 100 ms delay so that an attacker
 /// cannot distinguish "account does not exist" (fast RPC fail) from
@@ -108,18 +109,21 @@ pub async fn verify_signature(
     let nonce = headers
         .get("x-nonce")
         .and_then(|v| v.to_str().ok())
-        .map(String::from)
         .ok_or_else(|| {
             tracing::warn!(
                 target: "memwal::deprecation",
                 "request missing x-nonce; rejecting unsupported legacy SDK"
             );
             unsupported_legacy_sdk()
-        })?;
+        })?
+        .to_string();
 
     // Validate nonce is UUID format (prevents injection attacks)
     if uuid::Uuid::parse_str(&nonce).is_err() {
-        tracing::warn!("Invalid nonce format (not UUID): {}", &nonce[..nonce.len().min(36)]);
+        tracing::warn!(
+            "Invalid nonce format (not UUID): {}",
+            &nonce[..nonce.len().min(36)]
+        );
         return Err(constant_time_reject().await);
     }
 
@@ -130,31 +134,32 @@ pub async fn verify_signature(
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
     let now = chrono::Utc::now().timestamp();
     let age = now.checked_sub(timestamp).unwrap_or(i64::MAX);
-    if age > 300 || age < -300 {
-        tracing::warn!("Request timestamp too old or future: {} (now: {})", timestamp, now);
+    if !(-300..=300).contains(&age) {
+        tracing::warn!(
+            "Request timestamp too old or future: {} (now: {})",
+            timestamp,
+            now
+        );
         // LOW-2: Use constant_time_reject to normalize timing on timestamp failures
         return Err(constant_time_reject().await);
     }
 
     // Decode public key
     let pk_bytes = hex::decode(&public_key_hex).map_err(|_| StatusCode::UNAUTHORIZED)?;
-    let pk_array: [u8; 32] = pk_bytes
-        .try_into()
-        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    let pk_array: [u8; 32] = pk_bytes.try_into().map_err(|_| StatusCode::UNAUTHORIZED)?;
     let verifying_key =
         VerifyingKey::from_bytes(&pk_array).map_err(|_| StatusCode::UNAUTHORIZED)?;
 
     // Decode signature
     let sig_bytes = hex::decode(&signature_hex).map_err(|_| StatusCode::UNAUTHORIZED)?;
-    let sig_array: [u8; 64] = sig_bytes
-        .try_into()
-        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    let sig_array: [u8; 64] = sig_bytes.try_into().map_err(|_| StatusCode::UNAUTHORIZED)?;
     let signature = Signature::from_bytes(&sig_array);
 
     // Build the signed message: "{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}"
     // LOW-1: Include query parameters in signed message to prevent query-param tampering
     let method = request.method().as_str().to_string();
-    let path = request.uri()
+    let path = request
+        .uri()
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
         .unwrap_or_else(|| request.uri().path().to_string());
@@ -234,13 +239,14 @@ pub async fn verify_signature(
     // Step 2: Resolve account — cache → indexed accounts → registry scan → header hint → config fallback
     // LOW-2: Always use constant_time_reject so that timing of the resolution error
     // ("account not found" vs "key not in account") cannot be observed by callers.
-    let (account_id, owner) = match resolve_account(&state, &public_key_hex, &pk_array, account_id_hint).await {
-        Ok(pair) => pair,
-        Err(e) => {
-            tracing::warn!("Account resolution failed: {}", e);
-            return Err(constant_time_reject().await);
-        }
-    };
+    let (account_id, owner) =
+        match resolve_account(&state, &public_key_hex, &pk_array, account_id_hint).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::warn!("Account resolution failed: {}", e);
+                return Err(constant_time_reject().await);
+            }
+        };
 
     tracing::debug!("account resolved: {} (owner: {})", account_id, owner);
 
@@ -313,7 +319,10 @@ async fn resolve_account(
     {
         Ok((account_id, owner)) => {
             // Cache for future requests
-            let _ = state.db.cache_delegate_key(public_key_hex, &account_id, &owner).await;
+            let _ = state
+                .db
+                .cache_delegate_key(public_key_hex, &account_id, &owner)
+                .await;
             return Ok((account_id, owner));
         }
         Err(e) => {
@@ -333,10 +342,18 @@ async fn resolve_account(
         pk_bytes,
     )
     .await
-    .map_err(|e| format!("fallback account {} verification failed: {}", fallback_account_id, e))?;
+    .map_err(|e| {
+        format!(
+            "fallback account {} verification failed: {}",
+            fallback_account_id, e
+        )
+    })?;
 
     // Cache for future requests
-    let _ = state.db.cache_delegate_key(public_key_hex, &fallback_account_id, &owner).await;
+    let _ = state
+        .db
+        .cache_delegate_key(public_key_hex, &fallback_account_id, &owner)
+        .await;
 
     Ok((fallback_account_id, owner))
 }
@@ -363,7 +380,7 @@ mod tests {
             "",
             "not-a-uuid",
             "12345",
-            "550e8400-e29b-41d4-a716",            // truncated
+            "550e8400-e29b-41d4-a716",              // truncated
             "ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ", // non-hex
             "../../../etc/passwd",                  // injection attempt
         ];
@@ -389,7 +406,6 @@ mod tests {
         // age is a huge negative value, well below -300
         assert!(age < -300, "age {} should be less than -300", age);
     }
-
 
     #[test]
     fn checked_sub_handles_negative_overflow() {
@@ -427,8 +443,8 @@ mod tests {
         let timestamp_past = now - 300;
         let age_past = now.checked_sub(timestamp_past).unwrap_or(i64::MAX);
         assert_eq!(age_past, 300);
-        // The check is `age > 300 || age < -300`, so exactly 300 passes
-        assert!(!(age_past > 300 || age_past < -300));
+        // The check is `!(-300..=300).contains(&age)`, so exactly 300 passes
+        assert!((-300..=300).contains(&age_past));
 
         // At +301s — should be rejected
         let timestamp_expired = now - 301;
@@ -502,8 +518,7 @@ mod tests {
 
     #[test]
     fn canonical_message_without_account_id_uses_empty_string() {
-        let account_id_hint: Option<String> = None;
-        let account_id_for_sig = account_id_hint.unwrap_or_default();
+        let account_id_for_sig = String::new();
 
         let message = format!(
             "{}.{}.{}.{}.{}.{}",
@@ -541,10 +556,9 @@ mod tests {
     /// Uses a fixed 32-byte secret key — NOT for production use.
     fn test_signing_key() -> ed25519_dalek::SigningKey {
         let secret: [u8; 32] = [
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-            0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
-            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
-            0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+            0x1d, 0x1e, 0x1f, 0x20,
         ];
         ed25519_dalek::SigningKey::from_bytes(&secret)
     }
@@ -556,15 +570,19 @@ mod tests {
         let signing_key = test_signing_key();
         let verifying_key = signing_key.verifying_key();
 
-        let message = "1700000000.POST./api/remember.abc123.f47ac10b-58cc-4372-a567-0e02b2c3d479.0xdead";
+        let message =
+            "1700000000.POST./api/remember.abc123.f47ac10b-58cc-4372-a567-0e02b2c3d479.0xdead";
         let signature = signing_key.sign(message.as_bytes());
 
         // Valid signature passes
         assert!(verifying_key.verify(message.as_bytes(), &signature).is_ok());
 
         // Tampered message fails
-        let tampered = "1700000001.POST./api/remember.abc123.f47ac10b-58cc-4372-a567-0e02b2c3d479.0xdead";
-        assert!(verifying_key.verify(tampered.as_bytes(), &signature).is_err());
+        let tampered =
+            "1700000001.POST./api/remember.abc123.f47ac10b-58cc-4372-a567-0e02b2c3d479.0xdead";
+        assert!(verifying_key
+            .verify(tampered.as_bytes(), &signature)
+            .is_err());
     }
 
     #[test]
@@ -597,7 +615,9 @@ mod tests {
 
         // Swapping account_id → signature fails (LOW-23)
         let swapped = "1700000000.POST./api/recall.hash.nonce.0xaccount_b";
-        assert!(verifying_key.verify(swapped.as_bytes(), &signature).is_err());
+        assert!(verifying_key
+            .verify(swapped.as_bytes(), &signature)
+            .is_err());
     }
 
     // ── ENG-1696: Manual-mode trust boundary ────────────────────────────

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use crate::sui::{find_account_by_delegate_key, verify_delegate_key_onchain};
 use crate::types::{AppState, AuthInfo};
 
+const AUTH_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024;
+
 /// Ed25519 signature verification + onchain delegate key verification middleware
 ///
 /// Expects these headers:
@@ -167,7 +169,7 @@ pub async fn verify_signature(
     // Split request to consume body
     let (mut parts, body) = request.into_parts();
 
-    let body_bytes = axum::body::to_bytes(body, 1024 * 1024)
+    let body_bytes = axum::body::to_bytes(body, AUTH_BODY_LIMIT_BYTES)
         .await
         .map_err(|_| StatusCode::BAD_REQUEST)?;
 

--- a/services/server/src/db.rs
+++ b/services/server/src/db.rs
@@ -42,10 +42,28 @@ impl VectorDb {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 004: {}", e)))?;
 
+        let migration_005 = include_str!("../migrations/005_remember_jobs.sql");
+        sqlx::raw_sql(migration_005)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 005: {}", e)))?;
+
+        // ENG-1408: composite index on (owner, status, updated_at DESC) for bulk poll
+        let migration_006 = include_str!("../migrations/006_bulk_remember.sql");
+        sqlx::raw_sql(migration_006)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 006: {}", e)))?;
 
         tracing::info!("database connected and migrations applied");
 
         Ok(Self { pool })
+    }
+
+    /// Expose a reference to the underlying `PgPool` so job handlers
+    /// can run ad-hoc queries (e.g. `remember_jobs` status updates).
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
     }
 
     /// Insert a vector entry (with blob size tracking for storage quota)
@@ -74,7 +92,14 @@ impl VectorDb {
         .await
         .map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)))?;
 
-        tracing::debug!("inserted vector: id={}, blob_id={}, owner={}, ns={}, size={}B", id, blob_id, owner, namespace, blob_size_bytes);
+        tracing::debug!(
+            "inserted vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
+            id,
+            blob_id,
+            owner,
+            namespace,
+            blob_size_bytes
+        );
         Ok(())
     }
 
@@ -133,22 +158,21 @@ impl VectorDb {
 
     /// Delete all vector entries for a given owner + namespace
     #[allow(dead_code)]
-    pub async fn delete_by_namespace(
-        &self,
-        owner: &str,
-        namespace: &str,
-    ) -> Result<u64, AppError> {
-        let result = sqlx::query(
-            "DELETE FROM vector_entries WHERE owner = $1 AND namespace = $2",
-        )
-        .bind(owner)
-        .bind(namespace)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)))?;
+    pub async fn delete_by_namespace(&self, owner: &str, namespace: &str) -> Result<u64, AppError> {
+        let result = sqlx::query("DELETE FROM vector_entries WHERE owner = $1 AND namespace = $2")
+            .bind(owner)
+            .bind(namespace)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)))?;
 
         let rows = result.rows_affected();
-        tracing::info!("deleted {} entries for owner={}, ns={}", rows, owner, namespace);
+        tracing::info!(
+            "deleted {} entries for owner={}, ns={}",
+            rows,
+            owner,
+            namespace
+        );
         Ok(rows)
     }
 
@@ -161,11 +185,18 @@ impl VectorDb {
             .bind(owner)
             .execute(&self.pool)
             .await
-            .map_err(|e| AppError::Internal(format!("Failed to delete vector by blob_id: {}", e)))?;
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to delete vector by blob_id: {}", e))
+            })?;
 
         let rows = result.rows_affected();
         if rows > 0 {
-            tracing::info!("deleted expired blob from DB: blob_id={}, owner={}, rows={}", blob_id, owner, rows);
+            tracing::info!(
+                "deleted expired blob from DB: blob_id={}, owner={}, rows={}",
+                blob_id,
+                owner,
+                rows
+            );
         }
         Ok(rows)
     }
@@ -211,7 +242,11 @@ impl VectorDb {
         .await
         .map_err(|e| AppError::Internal(format!("Failed to cache delegate key: {}", e)))?;
 
-        tracing::debug!("cached delegate key: {} -> account {}", public_key_hex, account_id);
+        tracing::debug!(
+            "cached delegate key: {} -> account {}",
+            public_key_hex,
+            account_id
+        );
         Ok(())
     }
 
@@ -220,8 +255,10 @@ impl VectorDb {
         let result = sqlx::query("DELETE FROM delegate_key_cache WHERE expires_at <= NOW()")
             .execute(&self.pool)
             .await
-            .map_err(|e| AppError::Internal(format!("Failed to evict expired delegate keys: {}", e)))?;
-        
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to evict expired delegate keys: {}", e))
+            })?;
+
         let rows = result.rows_affected();
         if rows > 0 {
             tracing::info!("Evicted {} expired delegate keys from cache", rows);
@@ -236,14 +273,11 @@ impl VectorDb {
     /// request with the revoked key would hit the cache, fail the RPC verify, log
     /// noise, and waste an RPC call — in an infinite loop until TTL expiry.
     pub async fn delete_cached_key(&self, public_key_hex: &str) -> Result<u64, AppError> {
-        let result =
-            sqlx::query("DELETE FROM delegate_key_cache WHERE public_key = $1")
-                .bind(public_key_hex)
-                .execute(&self.pool)
-                .await
-                .map_err(|e| {
-                    AppError::Internal(format!("Failed to delete stale cached key: {}", e))
-                })?;
+        let result = sqlx::query("DELETE FROM delegate_key_cache WHERE public_key = $1")
+            .bind(public_key_hex)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to delete stale cached key: {}", e)))?;
 
         let rows = result.rows_affected();
         if rows > 0 {
@@ -264,8 +298,15 @@ impl VectorDb {
     /// MED-21 bugfix: using `pg_advisory_lock` with a connection pool causes deadlocks
     /// because it's session-level. We use `pg_advisory_xact_lock` inside an explicit
     /// transaction so the lock is automatically released on commit/rollback.
-    pub async fn get_storage_used_with_lock(&self, owner: &str, lock_key: i64) -> Result<i64, AppError> {
-        let mut tx = self.pool.begin().await
+    pub async fn get_storage_used_with_lock(
+        &self,
+        owner: &str,
+        lock_key: i64,
+    ) -> Result<i64, AppError> {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
             .map_err(|e| AppError::Internal(format!("Failed to begin tx: {}", e)))?;
 
         sqlx::query("SELECT pg_advisory_xact_lock($1)")
@@ -282,7 +323,9 @@ impl VectorDb {
         .await
         .map_err(|e| AppError::Internal(format!("Failed to get storage used: {}", e)))?;
 
-        tx.commit().await.map_err(|e| AppError::Internal(format!("Failed to commit tx: {}", e)))?;
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit tx: {}", e)))?;
 
         Ok(row.0)
     }
@@ -294,17 +337,13 @@ impl VectorDb {
     /// Find an account by owner address (from indexed accounts table).
     /// Returns `Some(account_id)` if the owner has a registered account.
     #[allow(dead_code)]
-    pub async fn find_account_by_owner(
-        &self,
-        owner: &str,
-    ) -> Result<Option<String>, AppError> {
-        let result: Option<(String,)> = sqlx::query_as(
-            "SELECT account_id FROM accounts WHERE owner = $1",
-        )
-        .bind(owner)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to query accounts: {}", e)))?;
+    pub async fn find_account_by_owner(&self, owner: &str) -> Result<Option<String>, AppError> {
+        let result: Option<(String,)> =
+            sqlx::query_as("SELECT account_id FROM accounts WHERE owner = $1")
+                .bind(owner)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| AppError::Internal(format!("Failed to query accounts: {}", e)))?;
 
         Ok(result.map(|(id,)| id))
     }

--- a/services/server/src/db.rs
+++ b/services/server/src/db.rs
@@ -80,7 +80,13 @@ impl VectorDb {
 
         sqlx::query(
             "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes)
-             VALUES ($1, $2, $3, $4, $5, $6)",
+             VALUES ($1, $2, $3, $4, $5, $6)
+             ON CONFLICT (id) DO UPDATE SET
+                owner = EXCLUDED.owner,
+                namespace = EXCLUDED.namespace,
+                blob_id = EXCLUDED.blob_id,
+                embedding = EXCLUDED.embedding,
+                blob_size_bytes = EXCLUDED.blob_size_bytes",
         )
         .bind(id)
         .bind(owner)
@@ -262,6 +268,34 @@ impl VectorDb {
         let rows = result.rows_affected();
         if rows > 0 {
             tracing::info!("Evicted {} expired delegate keys from cache", rows);
+        }
+        Ok(rows)
+    }
+
+    /// Mark worker-claimed remember jobs as failed when no worker has updated
+    /// them within the stale TTL. Pending rows are left alone because they may
+    /// simply be waiting behind legitimate queue backlog.
+    pub async fn fail_stale_remember_jobs(
+        &self,
+        stale_after: std::time::Duration,
+    ) -> Result<u64, AppError> {
+        let stale_after_secs = stale_after.as_secs().min(i64::MAX as u64) as i64;
+        let result = sqlx::query(
+            "UPDATE remember_jobs
+             SET status = 'failed',
+                 error_msg = COALESCE(error_msg, 'stale/orphaned remember job'),
+                 updated_at = NOW()
+             WHERE status IN ('running', 'uploaded')
+               AND updated_at < NOW() - ($1 * INTERVAL '1 second')",
+        )
+        .bind(stale_after_secs)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to fail stale remember jobs: {}", e)))?;
+
+        let rows = result.rows_affected();
+        if rows > 0 {
+            tracing::warn!("Marked {} stale remember jobs as failed", rows);
         }
         Ok(rows)
     }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1,0 +1,1256 @@
+/// Per-wallet Apalis job queue.
+///
+/// Every operation that requires a Sui wallet signature is modelled as a
+/// `WalletJob` and routed to the queue that is **pinned to that wallet index**.
+/// This guarantees that:
+///   - upload → metadata+transfer always use the SAME key (no wrong-signer retries)
+///   - each wallet queue processes jobs serially (no coin-object lock conflicts)
+///   - jobs survive server restarts (persisted in Postgres via Apalis)
+///
+/// Retry policy: up to MAX_ATTEMPTS attempts with exponential back-off.
+/// Failed jobs are visible in the `apalis_jobs` table (status = 'Dead').
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use apalis::prelude::*;
+use apalis_sql::postgres::PostgresStorage;
+use base64::Engine as _;
+use futures::stream::{self, StreamExt as _};
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{AppState, BULK_UPLOAD_CONCURRENCY};
+
+// ============================================================
+// WalletJob — unified job type for all wallet-signing operations
+// ============================================================
+
+/// All operations that require a Sui private key to sign a transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum WalletOperation {
+    /// Upload SEAL-encrypted blob to Walrus, index vector, set on-chain
+    /// metadata, then transfer the Blob object to the user's wallet.
+    ///
+    /// This collapses the old RememberJob + MetaTransferJob into one unit
+    /// that always executes with the same wallet key.
+    UploadAndTransfer {
+        /// SEAL-encrypted ciphertext (base64). Pre-computed in route handler.
+        encrypted_b64: String,
+        /// Pre-computed embedding vector (1536-dim).
+        vector: Vec<f32>,
+        /// MemWal owner address.
+        owner: String,
+        /// Namespace for isolation.
+        namespace: String,
+        /// MemWal package ID.
+        package_id: String,
+        /// Delegate public key (used as agent_id on-chain).
+        agent_public_key: Option<String>,
+        /// `remember_jobs` row ID to update with status/blob_id.
+        remember_job_id: Option<String>,
+        /// Storage epochs for Walrus upload.
+        #[serde(default = "default_epochs")]
+        epochs: u32,
+    },
+    /// Set on-chain metadata attributes + transfer a blob that was ALREADY
+    /// uploaded (used by remember_manual and analyze routes which upload
+    /// synchronously and only need the background metadata+transfer step).
+    SetMetadataAndTransfer {
+        /// Sui object ID of the certified Walrus Blob.
+        blob_object_id: String,
+        /// Sui address of the MemWal user.
+        owner: String,
+        /// MemWal namespace.
+        namespace: String,
+        /// MemWal package ID.
+        package_id: Option<String>,
+        /// Agent / delegate public key.
+        agent_id: Option<String>,
+    },
+}
+
+fn default_epochs() -> u32 {
+    50
+}
+
+/// A wallet-pinned job. `wallet_index` determines which per-wallet worker
+/// picks up and executes this job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WalletJob {
+    /// Index into `config.sui_private_keys` — both for routing (queue name)
+    /// and for signing within the worker. Set once at enqueue time and never
+    /// changed, so upload and transfer always use the identical key.
+    pub wallet_index: usize,
+    pub operation: WalletOperation,
+}
+
+/// Convenience type alias
+pub type WalletJobStorage = PostgresStorage<WalletJob>;
+
+// ============================================================
+// Legacy MetaTransferJob — kept for backward-compat with existing
+// DB rows. New code should enqueue WalletJob::SetMetadataAndTransfer.
+// ============================================================
+
+/// Payload stored as JSON in the `apalis_jobs` Postgres table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetaTransferJob {
+    /// Sui object ID of the certified Walrus Blob (0x...).
+    pub blob_object_id: String,
+    /// Sui address of the MemWal user who should own the blob.
+    pub owner: String,
+    /// MemWal namespace (e.g. "default").
+    pub namespace: String,
+    /// MemWal package ID (optional — stored as on-chain attribute).
+    pub package_id: Option<String>,
+    /// Agent ID (optional — stored as on-chain attribute).
+    pub agent_id: Option<String>,
+    /// Index of the pool key that registered/certified this blob.
+    /// The set-metadata + transfer transaction MUST be signed by the same key
+    /// (the blob is currently owned by that key's address).
+    pub key_index: usize,
+}
+
+// ============================================================
+// Error type
+// ============================================================
+
+#[derive(Debug)]
+pub enum MetaTransferError {
+    SidecarError(String),
+    Http { status: u16, body: String },
+}
+
+impl std::fmt::Display for MetaTransferError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MetaTransferError::SidecarError(msg) => write!(f, "sidecar call failed: {}", msg),
+            MetaTransferError::Http { status, body } => {
+                write!(f, "http error ({}): {}", status, body)
+            }
+        }
+    }
+}
+
+impl std::error::Error for MetaTransferError {}
+
+// ============================================================
+// Sidecar request/response types
+// ============================================================
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SetMetadataRequest<'a> {
+    blob_object_id: &'a str,
+    owner: &'a str,
+    namespace: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_id: Option<&'a str>,
+    key_index: usize,
+}
+
+// ============================================================
+// Job handler
+// ============================================================
+
+/// Apalis calls this function for each `MetaTransferJob`.
+///
+/// It POSTs to the sidecar `POST /walrus/set-metadata` endpoint which
+/// builds and executes a Sui transaction that:
+///   1. Sets `memwal_namespace`, `memwal_owner`, `memwal_package_id`,
+///      and `memwal_agent_id` on-chain attributes on the Blob object.
+///   2. Transfers the Blob object to the user's wallet.
+///
+/// Returns `Err(MetaTransferError)` to trigger the Tower retry policy.
+pub async fn execute_meta_transfer(
+    job: MetaTransferJob,
+    ctx: Data<Arc<AppState>>,
+) -> Result<(), MetaTransferError> {
+    // Data<T> implements Deref<Target=T>, so &*ctx gives &Arc<AppState>
+    let state: &AppState = &ctx;
+    let url = format!("{}/walrus/set-metadata", state.config.sidecar_url);
+
+    // Use the key_index stored in the job — this is the same key that
+    // registered/certified the blob, so the signer address will match
+    // the blob's current owner. No round-robin selection here.
+    let key_index = job.key_index;
+
+    tracing::info!(
+        "[meta-transfer] blob={} owner={} ns={} key={}",
+        job.blob_object_id,
+        &job.owner[..10.min(job.owner.len())],
+        job.namespace,
+        key_index,
+    );
+
+    let mut req = state.http_client.post(&url).json(&SetMetadataRequest {
+        blob_object_id: &job.blob_object_id,
+        owner: &job.owner,
+        namespace: &job.namespace,
+        package_id: job.package_id.as_deref(),
+        agent_id: job.agent_id.as_deref(),
+        key_index,
+    });
+
+    if let Some(secret) = state.config.sidecar_secret.as_deref() {
+        req = req.header("authorization", format!("Bearer {}", secret));
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| MetaTransferError::SidecarError(format!("request failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        tracing::warn!(
+            "[meta-transfer] sidecar returned {}: {}",
+            status,
+            &body[..200.min(body.len())]
+        );
+        return Err(MetaTransferError::Http { status, body });
+    }
+
+    tracing::info!(
+        "[meta-transfer] ok: blob={} transferred to owner",
+        job.blob_object_id
+    );
+    Ok(())
+}
+
+// ============================================================
+// Retry policy (Tower middleware)
+// ============================================================
+
+/// Maximum number of attempts (1 initial + N-1 retries).
+#[allow(dead_code)]
+pub const MAX_ATTEMPTS: u32 = 3;
+
+/// Exponential back-off: attempt 1→2s, 2→4s, 3→8s.
+#[allow(dead_code)]
+pub fn backoff_duration(attempt: u32) -> std::time::Duration {
+    std::time::Duration::from_secs(2u64.pow(attempt))
+}
+
+/// Type alias for the Apalis Postgres storage used throughout the codebase.
+pub type JobStorage = PostgresStorage<MetaTransferJob>;
+
+// ============================================================
+// execute_wallet_job — dispatcher for WalletJob
+// ============================================================
+
+/// Apalis worker handler for WalletJob.
+///
+/// The worker is pinned to a specific `wallet_index` via `Data<(Arc<AppState>, usize)>`.
+/// Every operation inside uses that fixed index — never round-robin.
+pub async fn execute_wallet_job(
+    job: WalletJob,
+    ctx: Data<Arc<AppState>>,
+) -> Result<(), WalletJobError> {
+    let state: &AppState = &ctx;
+    // The wallet_index stored in the job is authoritative.
+    // The worker queue name is just for routing; actual signing uses job.wallet_index.
+    let wallet_index = job.wallet_index;
+
+    match job.operation {
+        WalletOperation::UploadAndTransfer {
+            encrypted_b64,
+            vector,
+            owner,
+            namespace,
+            package_id,
+            agent_public_key,
+            remember_job_id,
+            epochs,
+        } => {
+            execute_upload_and_transfer(
+                state,
+                wallet_index,
+                encrypted_b64,
+                vector,
+                owner,
+                namespace,
+                package_id,
+                agent_public_key,
+                remember_job_id,
+                epochs,
+            )
+            .await
+        }
+        WalletOperation::SetMetadataAndTransfer {
+            blob_object_id,
+            owner,
+            namespace,
+            package_id,
+            agent_id,
+        } => {
+            execute_set_metadata_and_transfer(
+                state,
+                wallet_index,
+                blob_object_id,
+                owner,
+                namespace,
+                package_id,
+                agent_id,
+            )
+            .await
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// WalletOperation::SetMetadataAndTransfer
+// ────────────────────────────────────────────────────────────
+
+async fn execute_set_metadata_and_transfer(
+    state: &AppState,
+    wallet_index: usize,
+    blob_object_id: String,
+    owner: String,
+    namespace: String,
+    package_id: Option<String>,
+    agent_id: Option<String>,
+) -> Result<(), WalletJobError> {
+    let url = format!("{}/walrus/set-metadata", state.config.sidecar_url);
+
+    tracing::info!(
+        "[wallet-job:set-meta] blob={} owner={} ns={} key={}",
+        blob_object_id,
+        &owner[..10.min(owner.len())],
+        namespace,
+        wallet_index,
+    );
+
+    // Retry transient network failures (sidecar overload / connection drop /
+    // Enoki sponsor flake). Each attempt re-builds the request because reqwest
+    // RequestBuilder is not Clone-able once a body is attached.
+    const MAX_ATTEMPTS: u32 = 4;
+    let mut attempt: u32 = 0;
+
+    loop {
+        attempt += 1;
+
+        let mut req = state.http_client.post(&url).json(&SetMetadataRequest {
+            blob_object_id: &blob_object_id,
+            owner: &owner,
+            namespace: &namespace,
+            package_id: package_id.as_deref(),
+            agent_id: agent_id.as_deref(),
+            key_index: wallet_index,
+        });
+
+        if let Some(secret) = state.config.sidecar_secret.as_deref() {
+            req = req.header("authorization", format!("Bearer {}", secret));
+        }
+
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::info!(
+                    "[wallet-job:set-meta] ok: blob={} transferred to owner (attempt {})",
+                    blob_object_id,
+                    attempt
+                );
+                return Ok(());
+            }
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                let snippet = &body[..200.min(body.len())];
+                // Retry on 5xx and 408/429; fail fast on other 4xx (bad input).
+                let retriable = status >= 500 || status == 408 || status == 429;
+                tracing::warn!(
+                    "[wallet-job:set-meta] sidecar returned {} (attempt {}/{}, retriable={}): {}",
+                    status,
+                    attempt,
+                    MAX_ATTEMPTS,
+                    retriable,
+                    snippet
+                );
+                if !retriable || attempt >= MAX_ATTEMPTS {
+                    return Err(WalletJobError::Internal(format!(
+                        "set-metadata failed ({}): {}",
+                        status, snippet
+                    )));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[wallet-job:set-meta] network error (attempt {}/{}): {}",
+                    attempt,
+                    MAX_ATTEMPTS,
+                    e
+                );
+                if attempt >= MAX_ATTEMPTS {
+                    return Err(WalletJobError::Internal(format!(
+                        "set-metadata request failed after {} attempts: {}",
+                        MAX_ATTEMPTS, e
+                    )));
+                }
+            }
+        }
+
+        // Exponential backoff: 500ms, 1s, 2s
+        let backoff_ms = 500u64 * (1u64 << (attempt - 1));
+        tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+        tracing::info!(
+            "[wallet-job:set-meta] retry {} after {}ms",
+            attempt + 1,
+            backoff_ms,
+        );
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// WalletOperation::UploadAndTransfer
+// ────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_upload_and_transfer(
+    state: &AppState,
+    wallet_index: usize,
+    encrypted_b64: String,
+    vector: Vec<f32>,
+    owner: String,
+    namespace: String,
+    package_id: String,
+    agent_public_key: Option<String>,
+    remember_job_id: Option<String>,
+    epochs: u32,
+) -> Result<(), WalletJobError> {
+    // ── Mark running ───────────────────────────────────────────
+    if let Some(ref jid) = remember_job_id {
+        let _ = sqlx::query(
+            "UPDATE remember_jobs SET status = 'running', updated_at = NOW() WHERE id = $1",
+        )
+        .bind(jid)
+        .execute(state.db.pool())
+        .await;
+    }
+
+    // Helper: mark failed and return Err
+    let fail = |msg: String| -> WalletJobError {
+        tracing::error!("[wallet-job:upload] {}", msg);
+        WalletJobError::Internal(msg)
+    };
+
+    // ── Decode encrypted bytes ─────────────────────────────────
+    let encrypted = match base64::engine::general_purpose::STANDARD.decode(&encrypted_b64) {
+        Ok(b) => b,
+        Err(e) => {
+            let msg = format!("base64 decode failed: {}", e);
+            if let Some(ref jid) = remember_job_id {
+                let _ = sqlx::query(
+                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                )
+                .bind(&msg)
+                .bind(jid)
+                .execute(state.db.pool())
+                .await;
+            }
+            return Err(fail(msg));
+        }
+    };
+
+    tracing::info!(
+        "[wallet-job:upload] owner={} ns={} key={} bytes={}",
+        &owner[..10.min(owner.len())],
+        namespace,
+        wallet_index,
+        encrypted.len(),
+    );
+
+    // ── Upload to Walrus via sidecar (using pinned wallet_index) ─
+    let upload_result = crate::walrus::upload_blob(
+        &state.http_client,
+        &state.config.sidecar_url,
+        state.config.sidecar_secret.as_deref(),
+        &encrypted,
+        epochs as u64,
+        &owner,
+        wallet_index,
+        &namespace,
+        &package_id,
+        agent_public_key.as_deref(),
+    )
+    .await;
+
+    let upload = match upload_result {
+        Ok(u) => u,
+        Err(e) => {
+            let msg = format!("walrus upload failed: {}", e);
+            if let Some(ref jid) = remember_job_id {
+                let _ = sqlx::query(
+                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                )
+                .bind(&msg)
+                .bind(jid)
+                .execute(state.db.pool())
+                .await;
+            }
+            return Err(fail(msg));
+        }
+    };
+    let blob_id = upload.blob_id.clone();
+
+    // ── Set metadata + transfer via sidecar (SAME wallet_index!) ─
+    let blob_object_id = match upload.object_id.as_deref() {
+        Some(object_id) if !object_id.is_empty() => object_id.to_string(),
+        _ => {
+            let msg = "walrus upload returned no object_id; cannot transfer".to_string();
+            if let Some(ref jid) = remember_job_id {
+                let _ = sqlx::query(
+                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                )
+                .bind(&msg)
+                .bind(jid)
+                .execute(state.db.pool())
+                .await;
+            }
+            return Err(fail(msg));
+        }
+    };
+
+    if let Some(ref jid) = remember_job_id {
+        let _ = sqlx::query(
+            "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(&blob_id)
+        .bind(jid)
+        .execute(state.db.pool())
+        .await;
+    }
+
+    if let Err(e) = execute_set_metadata_and_transfer(
+        state,
+        wallet_index,
+        blob_object_id,
+        owner.clone(),
+        namespace.clone(),
+        Some(package_id.clone()),
+        agent_public_key.clone(),
+    )
+    .await
+    {
+        let msg = format!("metadata+transfer failed: {}", e);
+        if let Some(ref jid) = remember_job_id {
+            let _ = sqlx::query(
+                "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+            )
+            .bind(&msg)
+            .bind(jid)
+            .execute(state.db.pool())
+            .await;
+        }
+        tracing::warn!(
+            "[wallet-job:upload] set-metadata failed: {} blob_id={}",
+            e,
+            blob_id
+        );
+        return Ok(());
+    }
+
+    // ── Insert vector only after transfer succeeds ─────────────────
+    let blob_size = encrypted.len() as i64;
+    let vector_id = uuid::Uuid::new_v4().to_string();
+    if let Err(e) = state
+        .db
+        .insert_vector(&vector_id, &owner, &namespace, &blob_id, &vector, blob_size)
+        .await
+    {
+        let msg = format!("insert_vector failed: {}", e);
+        if let Some(ref jid) = remember_job_id {
+            let _ = sqlx::query(
+                "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+            )
+            .bind(&msg)
+            .bind(jid)
+            .execute(state.db.pool())
+            .await;
+        }
+        return Err(fail(msg));
+    }
+
+    // ── Mark final status ──────────────────────────────────────
+    if let Some(ref jid) = remember_job_id {
+        let _ = sqlx::query(
+            "UPDATE remember_jobs SET status = 'done', blob_id = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(&blob_id)
+        .bind(jid)
+        .execute(state.db.pool())
+        .await;
+    }
+
+    tracing::info!(
+        "[wallet-job:upload] done blob_id={} owner={} ns={} key={}",
+        blob_id,
+        &owner[..10.min(owner.len())],
+        namespace,
+        wallet_index,
+    );
+    Ok(())
+}
+
+// ============================================================
+// WalletJobError
+// ============================================================
+
+#[derive(Debug)]
+pub enum WalletJobError {
+    Internal(String),
+}
+
+impl std::fmt::Display for WalletJobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WalletJobError::Internal(msg) => write!(f, "wallet job error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for WalletJobError {}
+
+// ============================================================
+// RememberJob — full async pipeline (ENG-1406 v3)
+// ============================================================
+
+/// Payload for the full async remember pipeline stored in `apalis_jobs`.
+///
+/// The route handler enqueues this job and returns HTTP 202 immediately.
+/// The Apalis worker executes embed → encrypt → upload → insert_vector → MetaTransferJob.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RememberJob {
+    /// Stable job ID returned to the client in the 202 response.
+    pub job_id: String,
+    /// SEAL-encrypted ciphertext (base64). Plaintext is NOT stored here.
+    /// Embed + SEAL encrypt happen in the route handler before enqueuing.
+    pub encrypted_b64: String,
+    /// Pre-computed embedding vector (generated in route handler alongside encrypt).
+    pub vector: Vec<f32>,
+    /// MemWal owner address (from auth middleware).
+    pub owner: String,
+    /// Namespace for isolation.
+    pub namespace: String,
+    /// MemWal package ID (needed by metadata tx).
+    pub package_id: String,
+    /// Delegate public key (agent_id for MetaTransferJob).
+    pub agent_public_key: Option<String>,
+}
+
+/// Type alias for the RememberJob Apalis storage.
+pub type RememberJobStorage = PostgresStorage<RememberJob>;
+
+/// Error type for the RememberJob handler.
+#[derive(Debug)]
+pub enum RememberJobError {
+    Internal(String),
+}
+
+impl std::fmt::Display for RememberJobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RememberJobError::Internal(msg) => write!(f, "remember job error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for RememberJobError {}
+
+/// Apalis handler for the full remember pipeline.
+///
+/// Steps:
+///   1. Mark job `running` in `remember_jobs`
+///   2. embed() + seal_encrypt() concurrently
+///   3. walrus upload_blob()
+///   4. insert_vector()
+///   5. push(MetaTransferJob)
+///   6. Mark job `done` with blob_id
+///
+/// On any error: mark job `failed` with error_msg, then return Err to
+/// prevent Apalis from re-enqueueing (we handle status ourselves).
+pub async fn execute_remember(
+    job: RememberJob,
+    ctx: Data<Arc<AppState>>,
+) -> Result<(), RememberJobError> {
+    let state: &AppState = &ctx;
+
+    // ── Step 1: mark running ──────────────────────────────────────
+    let _ = sqlx::query(
+        "UPDATE remember_jobs SET status = 'running', updated_at = NOW() WHERE id = $1",
+    )
+    .bind(&job.job_id)
+    .execute(state.db.pool())
+    .await;
+
+    // Helper: mark failed and return Err
+    macro_rules! fail {
+        ($msg:expr) => {{
+            let msg = $msg.to_string();
+            tracing::error!("[remember-job] {} job_id={}", msg, job.job_id);
+            let _ = sqlx::query(
+                "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+            )
+            .bind(&msg)
+            .bind(&job.job_id)
+            .execute(state.db.pool())
+            .await;
+            return Err(RememberJobError::Internal(msg));
+        }};
+    }
+
+    // ── Step 2: decode ciphertext (already SEAL-encrypted in route handler) ──
+    let encrypted = match base64::engine::general_purpose::STANDARD.decode(&job.encrypted_b64) {
+        Ok(b) => b,
+        Err(e) => fail!(format!("base64 decode failed: {}", e)),
+    };
+    // vector is also pre-computed in route handler — no network call needed here.
+
+    let key_index = match state.key_pool.next_index() {
+        Some(idx) => idx,
+        None => fail!("No Sui keys configured in pool"),
+    };
+
+    // ── Step 3: walrus upload (the slow part ~2-3s) ───────────────
+    let upload_result = crate::walrus::upload_blob(
+        &state.http_client,
+        &state.config.sidecar_url,
+        state.config.sidecar_secret.as_deref(),
+        &encrypted,
+        50,
+        &job.owner,
+        key_index,
+        &job.namespace,
+        &job.package_id,
+        job.agent_public_key.as_deref(),
+    )
+    .await;
+
+    let upload = match upload_result {
+        Ok(u) => u,
+        Err(e) => fail!(format!("walrus upload failed: {}", e)),
+    };
+    let blob_id = upload.blob_id.clone();
+
+    // ── Step 4: insert_vector ────────────────────────────────────
+    let blob_size = encrypted.len() as i64;
+    let vector_id = uuid::Uuid::new_v4().to_string();
+    if let Err(e) = state
+        .db
+        .insert_vector(
+            &vector_id,
+            &job.owner,
+            &job.namespace,
+            &blob_id,
+            &job.vector,
+            blob_size,
+        )
+        .await
+    {
+        fail!(format!("insert_vector failed: {}", e));
+    }
+
+    // ── Step 5: enqueue MetaTransferJob (with correct key_index) ─────────
+    if !upload.object_id.as_deref().unwrap_or("").is_empty() {
+        let mut meta_storage = state.job_storage.clone();
+        if let Err(e) = meta_storage
+            .push(MetaTransferJob {
+                blob_object_id: upload.object_id.clone().unwrap_or_default(),
+                owner: job.owner.clone(),
+                namespace: job.namespace.clone(),
+                package_id: Some(job.package_id.clone()),
+                agent_id: job.agent_public_key.clone(),
+                // Pass the SAME key_index used for upload — the blob is owned
+                // by this key's address, so set-metadata must also sign with it.
+                key_index,
+            })
+            .await
+        {
+            // Non-fatal — blob is already indexed; log and continue.
+            tracing::warn!(
+                "[remember-job] failed to enqueue meta-transfer: {} job_id={}",
+                e,
+                job.job_id
+            );
+        }
+    }
+
+    // ── Step 6: mark uploaded ────────────────────────────────────
+    // Note: legacy `RememberJob` enqueues a separate `MetaTransferJob` for the
+    // transfer step, so we cannot mark `done` here — the transfer hasn't
+    // happened yet. The (legacy) `MetaTransferJob` worker does NOT update this
+    // row (it predates the status table); for callers using this legacy path,
+    // a successful upload visible to the client is `status=uploaded` with
+    // a non-null `blob_id`. New code should use `WalletJob::UploadAndTransfer`
+    // which atomically transitions to `done` after transfer.
+    let _ = sqlx::query(
+        "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
+    )
+    .bind(&blob_id)
+    .bind(&job.job_id)
+    .execute(state.db.pool())
+    .await;
+
+    tracing::info!(
+        "[remember-job] uploaded job_id={} blob_id={} owner={} ns={} (transfer enqueued separately)",
+        job.job_id,
+        blob_id,
+        &job.owner[..10.min(job.owner.len())],
+        job.namespace
+    );
+    Ok(())
+}
+
+// ============================================================
+// BulkRememberJob — ENG-1408
+//
+// Batches N memories into:
+//   - N×2 Sui txs (register + certify per blob, unavoidable)
+//   - K Sui txs for set-metadata+transfer, where K = number of wallet slots used
+//     (one PTB per wallet-slot via /walrus/set-metadata-batch on sidecar)
+// ============================================================
+
+/// One pre-processed item (embed + encrypt already done in route handler).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkRememberItem {
+    /// remember_jobs row ID to update with status/blob_id.
+    pub job_id: String,
+    /// SEAL-encrypted ciphertext (base64). Pre-computed in route handler.
+    pub encrypted_b64: String,
+    /// Pre-computed embedding vector (1536-dim).
+    pub vector: Vec<f32>,
+    pub namespace: String,
+    /// Wallet pool index assigned at enqueue time (round-robin).
+    pub wallet_index: usize,
+}
+
+/// Batch job payload — one BulkRememberJob per POST /api/remember/bulk call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkRememberJob {
+    pub owner: String,
+    pub package_id: String,
+    pub agent_public_key: Option<String>,
+    pub items: Vec<BulkRememberItem>,
+    #[serde(default = "default_epochs")]
+    pub epochs: u32,
+}
+
+/// Type alias for the BulkRememberJob Apalis storage.
+pub type BulkRememberJobStorage = PostgresStorage<BulkRememberJob>;
+
+// ─────────────────────────────────────────────────────────────
+// BulkRememberError
+// ─────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum BulkRememberError {
+    #[allow(dead_code)]
+    Internal(String),
+}
+
+impl std::fmt::Display for BulkRememberError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BulkRememberError::Internal(msg) => write!(f, "bulk-remember job error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for BulkRememberError {}
+
+// ─────────────────────────────────────────────────────────────
+// Sidecar request types for POST /walrus/set-metadata-batch
+// ─────────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SetMetadataBatchEntry<'a> {
+    blob_object_id: &'a str,
+    namespace: &'a str,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SetMetadataBatchRequest<'a> {
+    blobs: Vec<SetMetadataBatchEntry<'a>>,
+    owner: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_id: Option<&'a str>,
+    key_index: usize,
+}
+
+// ─────────────────────────────────────────────────────────────
+// execute_bulk_remember — Apalis handler
+// ─────────────────────────────────────────────────────────────
+
+/// Apalis worker handler for BulkRememberJob (ENG-1408).
+///
+/// Steps:
+///   1. Mark all items `running`
+///   2. Upload N blobs to Walrus concurrently (bounded by BULK_UPLOAD_CONCURRENCY)
+///   3. Group blobs with objectId by wallet_index
+///   4. For each group → POST /walrus/set-metadata-batch (1 PTB per wallet slot)
+///      Falls back to per-blob /walrus/set-metadata if batch endpoint unavailable.
+///   5. Insert vectors and mark rows done only after transfer succeeds.
+pub async fn execute_bulk_remember(
+    job: BulkRememberJob,
+    ctx: Data<Arc<AppState>>,
+) -> Result<(), BulkRememberError> {
+    let state: &AppState = &ctx;
+
+    if job.items.is_empty() {
+        return Ok(());
+    }
+
+    let items_total = job.items.len();
+
+    tracing::info!(
+        "[bulk-remember] start: {} items owner={} epochs={}",
+        items_total,
+        &job.owner[..10.min(job.owner.len())],
+        job.epochs,
+    );
+
+    // ── Step 1: mark all items running ────────────────────────────────────
+    for item in &job.items {
+        let _ = sqlx::query(
+            "UPDATE remember_jobs SET status = 'running', updated_at = NOW() WHERE id = $1",
+        )
+        .bind(&item.job_id)
+        .execute(state.db.pool())
+        .await;
+    }
+
+    // ── Step 2: upload N blobs concurrently ───────────────
+    struct UploadOk {
+        job_id: String,
+        blob_id: String,
+        object_id: Option<String>,
+        wallet_index: usize,
+        namespace: String,
+        vector: Vec<f32>,
+        blob_size: i64,
+    }
+
+    let db = &state.db;
+    let http = &state.http_client;
+    let sidecar_url = state.config.sidecar_url.clone();
+    let sidecar_secret = state.config.sidecar_secret.clone();
+    let owner = job.owner.clone();
+    let package_id = job.package_id.clone();
+    let agent = job.agent_public_key.clone();
+    let epochs = job.epochs as u64;
+
+    let upload_results: Vec<Result<UploadOk, ()>> = stream::iter(job.items)
+        .map(|item| {
+            let sidecar_url = sidecar_url.clone();
+            let sidecar_secret = sidecar_secret.clone();
+            let owner = owner.clone();
+            let package_id = package_id.clone();
+            let agent = agent.clone();
+            async move {
+                let encrypted = match base64::engine::general_purpose::STANDARD.decode(&item.encrypted_b64) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        let msg = format!("base64 decode failed: {}", e);
+                        tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
+                        let _ = sqlx::query(
+                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                        )
+                        .bind(&msg).bind(&item.job_id).execute(db.pool()).await;
+                        return Err(());
+                    }
+                };
+
+                let upload = match crate::walrus::upload_blob(
+                    http,
+                    &sidecar_url,
+                    sidecar_secret.as_deref(),
+                    &encrypted,
+                    epochs,
+                    &owner,
+                    item.wallet_index,
+                    &item.namespace,
+                    &package_id,
+                    agent.as_deref(),
+                ).await {
+                    Ok(u) => u,
+                    Err(e) => {
+                        let msg = format!("walrus upload failed: {}", e);
+                        tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
+                        let _ = sqlx::query(
+                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                        )
+                        .bind(&msg).bind(&item.job_id).execute(db.pool()).await;
+                        return Err(());
+                    }
+                };
+                let blob_id = upload.blob_id.clone();
+                let blob_size = encrypted.len() as i64;
+
+                let _ = sqlx::query(
+                    "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
+                )
+                .bind(&blob_id).bind(&item.job_id).execute(db.pool()).await;
+
+                Ok(UploadOk {
+                    job_id: item.job_id.clone(),
+                    blob_id,
+                    object_id: upload.object_id,
+                    wallet_index: item.wallet_index,
+                    namespace: item.namespace.clone(),
+                    vector: item.vector,
+                    blob_size,
+                })
+            }
+        })
+        .buffer_unordered(BULK_UPLOAD_CONCURRENCY)
+        .collect()
+        .await;
+
+    // ── Step 3: group successful blobs by wallet_index ────────────────────
+    struct TransferReady {
+        object_id: String,
+        namespace: String,
+        job_id: String,
+        blob_id: String,
+        vector: Vec<f32>,
+        blob_size: i64,
+    }
+    let mut groups: HashMap<usize, Vec<TransferReady>> = HashMap::new();
+    let mut upload_count = 0usize;
+    let mut success_count = 0usize;
+    let mut fail_count = 0usize;
+
+    for r in upload_results {
+        match r {
+            Ok(ok) => match ok.object_id {
+                Some(object_id) if !object_id.is_empty() => {
+                    upload_count += 1;
+                    groups
+                        .entry(ok.wallet_index)
+                        .or_default()
+                        .push(TransferReady {
+                            object_id,
+                            namespace: ok.namespace,
+                            job_id: ok.job_id,
+                            blob_id: ok.blob_id,
+                            vector: ok.vector,
+                            blob_size: ok.blob_size,
+                        });
+                }
+                _ => {
+                    fail_count += 1;
+                    let msg = "walrus upload returned no object_id; cannot transfer";
+                    let _ = sqlx::query(
+                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                        )
+                        .bind(msg)
+                        .bind(&ok.job_id)
+                        .execute(state.db.pool())
+                        .await;
+                }
+            },
+            Err(()) => fail_count += 1,
+        }
+    }
+
+    tracing::info!(
+        "[bulk-remember] uploads done: ok={} fail={} wallet_groups={}",
+        upload_count,
+        fail_count,
+        groups.len(),
+    );
+
+    // ── Step 4: batch set-metadata + transfer per wallet group ────────────
+    //
+    // For each wallet slot we try ONE batched PTB; if that fails we fall back
+    // to per-blob set-metadata calls. Only after a blob's transfer definitively
+    // succeeds do we mark its remember_jobs row `done`. Permanent failures
+    // transition the row from `uploaded → failed` with a diagnostic error.
+    let insert_vector_after_transfer = |blob: &TransferReady| {
+        let state = Arc::clone(&ctx);
+        let pool = state.db.pool().clone();
+        let owner = job.owner.clone();
+        let namespace = blob.namespace.clone();
+        let blob_id = blob.blob_id.clone();
+        let vector = blob.vector.clone();
+        let blob_size = blob.blob_size;
+        let job_id = blob.job_id.clone();
+        async move {
+            let vector_id = uuid::Uuid::new_v4().to_string();
+            if let Err(e) = state
+                .db
+                .insert_vector(&vector_id, &owner, &namespace, &blob_id, &vector, blob_size)
+                .await
+            {
+                let msg = format!("insert_vector failed: {}", e);
+                tracing::error!("[bulk-remember] job_id={} {}", job_id, msg);
+                let _ = sqlx::query(
+                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                )
+                .bind(&msg)
+                .bind(&job_id)
+                .execute(&pool)
+                .await;
+                return false;
+            }
+
+            let _ = sqlx::query(
+                "UPDATE remember_jobs SET status = 'done', updated_at = NOW() WHERE id = $1",
+            )
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+            true
+        }
+    };
+    let mark_transfer_failed = |jid: &str, err: &str| {
+        let pool = state.db.pool().clone();
+        let jid = jid.to_string();
+        let err = err.to_string();
+        async move {
+            let _ = sqlx::query(
+                "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+            )
+            .bind(&err)
+            .bind(&jid)
+            .execute(&pool)
+            .await;
+        }
+    };
+
+    for (wallet_index, blobs) in &groups {
+        if blobs.is_empty() {
+            continue;
+        }
+
+        let url = format!("{}/walrus/set-metadata-batch", state.config.sidecar_url);
+        let blob_entries: Vec<SetMetadataBatchEntry<'_>> = blobs
+            .iter()
+            .map(|blob| SetMetadataBatchEntry {
+                blob_object_id: blob.object_id.as_str(),
+                namespace: blob.namespace.as_str(),
+            })
+            .collect();
+
+        let mut req = state.http_client.post(&url).json(&SetMetadataBatchRequest {
+            blobs: blob_entries,
+            owner: &job.owner,
+            package_id: Some(job.package_id.as_str()),
+            agent_id: job.agent_public_key.as_deref(),
+            key_index: *wallet_index,
+        });
+        if let Some(secret) = state.config.sidecar_secret.as_deref() {
+            req = req.header("authorization", format!("Bearer {}", secret));
+        }
+
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::info!(
+                    "[bulk-remember] set-metadata-batch ok: {} blobs wallet={}",
+                    blobs.len(),
+                    wallet_index,
+                );
+                for blob in blobs {
+                    if insert_vector_after_transfer(blob).await {
+                        success_count += 1;
+                    }
+                }
+            }
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                tracing::warn!(
+                    "[bulk-remember] set-metadata-batch ({}) failed: {} wallet={} — falling back per-blob",
+                    status, &body[..200.min(body.len())], wallet_index,
+                );
+                for blob in blobs {
+                    match execute_set_metadata_and_transfer(
+                        state,
+                        *wallet_index,
+                        blob.object_id.clone(),
+                        job.owner.clone(),
+                        blob.namespace.clone(),
+                        Some(job.package_id.clone()),
+                        job.agent_public_key.clone(),
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            if insert_vector_after_transfer(blob).await {
+                                success_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            fail_count += 1;
+                            tracing::warn!(
+                                "[bulk-remember] fallback set-metadata failed blob={}: {}",
+                                blob.object_id,
+                                e
+                            );
+                            mark_transfer_failed(
+                                &blob.job_id,
+                                &format!("metadata+transfer permanently failed: {}", e),
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[bulk-remember] set-metadata-batch network error: {} wallet={} — falling back per-blob",
+                    e, wallet_index,
+                );
+                for blob in blobs {
+                    match execute_set_metadata_and_transfer(
+                        state,
+                        *wallet_index,
+                        blob.object_id.clone(),
+                        job.owner.clone(),
+                        blob.namespace.clone(),
+                        Some(job.package_id.clone()),
+                        job.agent_public_key.clone(),
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            if insert_vector_after_transfer(blob).await {
+                                success_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            fail_count += 1;
+                            tracing::warn!(
+                                "[bulk-remember] fallback set-metadata failed blob={}: {}",
+                                blob.object_id,
+                                e
+                            );
+                            mark_transfer_failed(
+                                &blob.job_id,
+                                &format!("metadata+transfer permanently failed: {}", e),
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::info!(
+        "[bulk-remember] complete: owner={} total={} ok={} fail={}",
+        &job.owner[..10.min(job.owner.len())],
+        items_total,
+        success_count,
+        fail_count,
+    );
+
+    Ok(())
+}

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -20,6 +20,7 @@ use futures::stream::{self, StreamExt as _};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{AppState, BULK_UPLOAD_CONCURRENCY};
+use crate::walrus::SetMetadataBatchEntry;
 
 // ============================================================
 // WalletJob — unified job type for all wallet-signing operations
@@ -53,9 +54,8 @@ pub enum WalletOperation {
         #[serde(default = "default_epochs")]
         epochs: u32,
     },
-    /// Set on-chain metadata attributes + transfer a blob that was ALREADY
-    /// uploaded (used by remember_manual and analyze routes which upload
-    /// synchronously and only need the background metadata+transfer step).
+    /// Legacy metadata+transfer operation for rows created before `/walrus/upload`
+    /// started doing metadata+transfer atomically.
     SetMetadataAndTransfer {
         /// Sui object ID of the certified Walrus Blob.
         blob_object_id: String,
@@ -89,8 +89,7 @@ pub struct WalletJob {
 pub type WalletJobStorage = PostgresStorage<WalletJob>;
 
 // ============================================================
-// Legacy MetaTransferJob — kept for backward-compat with existing
-// DB rows. New code should enqueue WalletJob::SetMetadataAndTransfer.
+// Legacy MetaTransferJob — kept for backward-compat with existing DB rows.
 // ============================================================
 
 /// Payload stored as JSON in the `apalis_jobs` Postgres table.
@@ -119,16 +118,12 @@ pub struct MetaTransferJob {
 #[derive(Debug)]
 pub enum MetaTransferError {
     SidecarError(String),
-    Http { status: u16, body: String },
 }
 
 impl std::fmt::Display for MetaTransferError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MetaTransferError::SidecarError(msg) => write!(f, "sidecar call failed: {}", msg),
-            MetaTransferError::Http { status, body } => {
-                write!(f, "http error ({}): {}", status, body)
-            }
         }
     }
 }
@@ -136,90 +131,34 @@ impl std::fmt::Display for MetaTransferError {
 impl std::error::Error for MetaTransferError {}
 
 // ============================================================
-// Sidecar request/response types
-// ============================================================
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SetMetadataRequest<'a> {
-    blob_object_id: &'a str,
-    owner: &'a str,
-    namespace: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    package_id: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    agent_id: Option<&'a str>,
-    key_index: usize,
-}
-
-// ============================================================
 // Job handler
 // ============================================================
 
 /// Apalis calls this function for each `MetaTransferJob`.
 ///
-/// It POSTs to the sidecar `POST /walrus/set-metadata` endpoint which
-/// builds and executes a Sui transaction that:
-///   1. Sets `memwal_namespace`, `memwal_owner`, `memwal_package_id`,
-///      and `memwal_agent_id` on-chain attributes on the Blob object.
-///   2. Transfers the Blob object to the user's wallet.
-///
-/// Returns `Err(MetaTransferError)` to trigger the Tower retry policy.
+/// Legacy handler for rows created before upload and transfer were collapsed.
 pub async fn execute_meta_transfer(
     job: MetaTransferJob,
     ctx: Data<Arc<AppState>>,
 ) -> Result<(), MetaTransferError> {
     // Data<T> implements Deref<Target=T>, so &*ctx gives &Arc<AppState>
     let state: &AppState = &ctx;
-    let url = format!("{}/walrus/set-metadata", state.config.sidecar_url);
-
     // Use the key_index stored in the job — this is the same key that
     // registered/certified the blob, so the signer address will match
     // the blob's current owner. No round-robin selection here.
     let key_index = job.key_index;
 
-    tracing::info!(
-        "[meta-transfer] blob={} owner={} ns={} key={}",
+    execute_set_metadata_and_transfer(
+        state,
+        key_index,
         job.blob_object_id,
-        &job.owner[..10.min(job.owner.len())],
+        job.owner,
         job.namespace,
-        key_index,
-    );
-
-    let mut req = state.http_client.post(&url).json(&SetMetadataRequest {
-        blob_object_id: &job.blob_object_id,
-        owner: &job.owner,
-        namespace: &job.namespace,
-        package_id: job.package_id.as_deref(),
-        agent_id: job.agent_id.as_deref(),
-        key_index,
-    });
-
-    if let Some(secret) = state.config.sidecar_secret.as_deref() {
-        req = req.header("authorization", format!("Bearer {}", secret));
-    }
-
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| MetaTransferError::SidecarError(format!("request failed: {}", e)))?;
-
-    if !resp.status().is_success() {
-        let status = resp.status().as_u16();
-        let body = resp.text().await.unwrap_or_default();
-        tracing::warn!(
-            "[meta-transfer] sidecar returned {}: {}",
-            status,
-            &body[..200.min(body.len())]
-        );
-        return Err(MetaTransferError::Http { status, body });
-    }
-
-    tracing::info!(
-        "[meta-transfer] ok: blob={} transferred to owner",
-        job.blob_object_id
-    );
-    Ok(())
+        job.package_id,
+        job.agent_id,
+    )
+    .await
+    .map_err(|e| MetaTransferError::SidecarError(e.to_string()))
 }
 
 // ============================================================
@@ -235,9 +174,6 @@ pub const MAX_ATTEMPTS: u32 = 3;
 pub fn backoff_duration(attempt: u32) -> std::time::Duration {
     std::time::Duration::from_secs(2u64.pow(attempt))
 }
-
-/// Type alias for the Apalis Postgres storage used throughout the codebase.
-pub type JobStorage = PostgresStorage<MetaTransferJob>;
 
 // ============================================================
 // execute_wallet_job — dispatcher for WalletJob
@@ -315,93 +251,22 @@ async fn execute_set_metadata_and_transfer(
     package_id: Option<String>,
     agent_id: Option<String>,
 ) -> Result<(), WalletJobError> {
-    let url = format!("{}/walrus/set-metadata", state.config.sidecar_url);
-
-    tracing::info!(
-        "[wallet-job:set-meta] blob={} owner={} ns={} key={}",
-        blob_object_id,
-        &owner[..10.min(owner.len())],
-        namespace,
+    crate::walrus::set_metadata_batch(
+        &state.http_client,
+        &state.config.sidecar_url,
+        state.config.sidecar_secret.as_deref(),
         wallet_index,
-    );
-
-    // Retry transient network failures (sidecar overload / connection drop /
-    // Enoki sponsor flake). Each attempt re-builds the request because reqwest
-    // RequestBuilder is not Clone-able once a body is attached.
-    const MAX_ATTEMPTS: u32 = 4;
-    let mut attempt: u32 = 0;
-
-    loop {
-        attempt += 1;
-
-        let mut req = state.http_client.post(&url).json(&SetMetadataRequest {
-            blob_object_id: &blob_object_id,
-            owner: &owner,
-            namespace: &namespace,
-            package_id: package_id.as_deref(),
-            agent_id: agent_id.as_deref(),
-            key_index: wallet_index,
-        });
-
-        if let Some(secret) = state.config.sidecar_secret.as_deref() {
-            req = req.header("authorization", format!("Bearer {}", secret));
-        }
-
-        match req.send().await {
-            Ok(resp) if resp.status().is_success() => {
-                tracing::info!(
-                    "[wallet-job:set-meta] ok: blob={} transferred to owner (attempt {})",
-                    blob_object_id,
-                    attempt
-                );
-                return Ok(());
-            }
-            Ok(resp) => {
-                let status = resp.status().as_u16();
-                let body = resp.text().await.unwrap_or_default();
-                let snippet = &body[..200.min(body.len())];
-                // Retry on 5xx and 408/429; fail fast on other 4xx (bad input).
-                let retriable = status >= 500 || status == 408 || status == 429;
-                tracing::warn!(
-                    "[wallet-job:set-meta] sidecar returned {} (attempt {}/{}, retriable={}): {}",
-                    status,
-                    attempt,
-                    MAX_ATTEMPTS,
-                    retriable,
-                    snippet
-                );
-                if !retriable || attempt >= MAX_ATTEMPTS {
-                    return Err(WalletJobError::Internal(format!(
-                        "set-metadata failed ({}): {}",
-                        status, snippet
-                    )));
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "[wallet-job:set-meta] network error (attempt {}/{}): {}",
-                    attempt,
-                    MAX_ATTEMPTS,
-                    e
-                );
-                if attempt >= MAX_ATTEMPTS {
-                    return Err(WalletJobError::Internal(format!(
-                        "set-metadata request failed after {} attempts: {}",
-                        MAX_ATTEMPTS, e
-                    )));
-                }
-            }
-        }
-
-        // Exponential backoff: 500ms, 1s, 2s
-        let backoff_ms = 500u64 * (1u64 << (attempt - 1));
-        tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
-        tracing::info!(
-            "[wallet-job:set-meta] retry {} after {}ms",
-            attempt + 1,
-            backoff_ms,
-        );
-    }
+        &owner,
+        package_id.as_deref().unwrap_or(&state.config.package_id),
+        agent_id.as_deref(),
+        vec![SetMetadataBatchEntry {
+            blob_object_id,
+            namespace,
+        }],
+    )
+    .await
+    .map(|_| ())
+    .map_err(|e| WalletJobError::Internal(e.to_string()))
 }
 
 // ────────────────────────────────────────────────────────────
@@ -496,24 +361,6 @@ async fn execute_upload_and_transfer(
     };
     let blob_id = upload.blob_id.clone();
 
-    // ── Set metadata + transfer via sidecar (SAME wallet_index!) ─
-    let blob_object_id = match upload.object_id.as_deref() {
-        Some(object_id) if !object_id.is_empty() => object_id.to_string(),
-        _ => {
-            let msg = "walrus upload returned no object_id; cannot transfer".to_string();
-            if let Some(ref jid) = remember_job_id {
-                let _ = sqlx::query(
-                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-                )
-                .bind(&msg)
-                .bind(jid)
-                .execute(state.db.pool())
-                .await;
-            }
-            return Err(fail(msg));
-        }
-    };
-
     if let Some(ref jid) = remember_job_id {
         let _ = sqlx::query(
             "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
@@ -524,38 +371,14 @@ async fn execute_upload_and_transfer(
         .await;
     }
 
-    if let Err(e) = execute_set_metadata_and_transfer(
-        state,
-        wallet_index,
-        blob_object_id,
-        owner.clone(),
-        namespace.clone(),
-        Some(package_id.clone()),
-        agent_public_key.clone(),
-    )
-    .await
-    {
-        let msg = format!("metadata+transfer failed: {}", e);
-        if let Some(ref jid) = remember_job_id {
-            let _ = sqlx::query(
-                "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-            )
-            .bind(&msg)
-            .bind(jid)
-            .execute(state.db.pool())
-            .await;
-        }
-        tracing::warn!(
-            "[wallet-job:upload] set-metadata failed: {} blob_id={}",
-            e,
-            blob_id
-        );
-        return Ok(());
-    }
-
-    // ── Insert vector only after transfer succeeds ─────────────────
+    // ── Insert vector after upload ─────────────────────────────────
+    //
+    // The sidecar's `/walrus/upload` endpoint already performs metadata+transfer
+    // atomically. A successful upload response means the blob is ready to index.
     let blob_size = encrypted.len() as i64;
-    let vector_id = uuid::Uuid::new_v4().to_string();
+    let vector_id = remember_job_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     if let Err(e) = state
         .db
         .insert_vector(&vector_id, &owner, &namespace, &blob_id, &vector, blob_size)
@@ -621,7 +444,7 @@ impl std::error::Error for WalletJobError {}
 /// Payload for the full async remember pipeline stored in `apalis_jobs`.
 ///
 /// The route handler enqueues this job and returns HTTP 202 immediately.
-/// The Apalis worker executes embed → encrypt → upload → insert_vector → MetaTransferJob.
+/// The Apalis worker executes embed → encrypt → upload → insert_vector.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RememberJob {
     /// Stable job ID returned to the client in the 202 response.
@@ -637,7 +460,7 @@ pub struct RememberJob {
     pub namespace: String,
     /// MemWal package ID (needed by metadata tx).
     pub package_id: String,
-    /// Delegate public key (agent_id for MetaTransferJob).
+    /// Delegate public key (agent_id for upload metadata).
     pub agent_public_key: Option<String>,
 }
 
@@ -667,8 +490,7 @@ impl std::error::Error for RememberJobError {}
 ///   2. embed() + seal_encrypt() concurrently
 ///   3. walrus upload_blob()
 ///   4. insert_vector()
-///   5. push(MetaTransferJob)
-///   6. Mark job `done` with blob_id
+///   5. Mark job `done` with blob_id
 ///
 /// On any error: mark job `failed` with error_msg, then return Err to
 /// prevent Apalis from re-enqueueing (we handle status ourselves).
@@ -737,7 +559,7 @@ pub async fn execute_remember(
 
     // ── Step 4: insert_vector ────────────────────────────────────
     let blob_size = encrypted.len() as i64;
-    let vector_id = uuid::Uuid::new_v4().to_string();
+    let vector_id = job.job_id.clone();
     if let Err(e) = state
         .db
         .insert_vector(
@@ -753,41 +575,9 @@ pub async fn execute_remember(
         fail!(format!("insert_vector failed: {}", e));
     }
 
-    // ── Step 5: enqueue MetaTransferJob (with correct key_index) ─────────
-    if !upload.object_id.as_deref().unwrap_or("").is_empty() {
-        let mut meta_storage = state.job_storage.clone();
-        if let Err(e) = meta_storage
-            .push(MetaTransferJob {
-                blob_object_id: upload.object_id.clone().unwrap_or_default(),
-                owner: job.owner.clone(),
-                namespace: job.namespace.clone(),
-                package_id: Some(job.package_id.clone()),
-                agent_id: job.agent_public_key.clone(),
-                // Pass the SAME key_index used for upload — the blob is owned
-                // by this key's address, so set-metadata must also sign with it.
-                key_index,
-            })
-            .await
-        {
-            // Non-fatal — blob is already indexed; log and continue.
-            tracing::warn!(
-                "[remember-job] failed to enqueue meta-transfer: {} job_id={}",
-                e,
-                job.job_id
-            );
-        }
-    }
-
-    // ── Step 6: mark uploaded ────────────────────────────────────
-    // Note: legacy `RememberJob` enqueues a separate `MetaTransferJob` for the
-    // transfer step, so we cannot mark `done` here — the transfer hasn't
-    // happened yet. The (legacy) `MetaTransferJob` worker does NOT update this
-    // row (it predates the status table); for callers using this legacy path,
-    // a successful upload visible to the client is `status=uploaded` with
-    // a non-null `blob_id`. New code should use `WalletJob::UploadAndTransfer`
-    // which atomically transitions to `done` after transfer.
+    // ── Step 5: mark done ────────────────────────────────────────
     let _ = sqlx::query(
-        "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
+        "UPDATE remember_jobs SET status = 'done', blob_id = $1, updated_at = NOW() WHERE id = $2",
     )
     .bind(&blob_id)
     .bind(&job.job_id)
@@ -795,7 +585,7 @@ pub async fn execute_remember(
     .await;
 
     tracing::info!(
-        "[remember-job] uploaded job_id={} blob_id={} owner={} ns={} (transfer enqueued separately)",
+        "[remember-job] done job_id={} blob_id={} owner={} ns={}",
         job.job_id,
         blob_id,
         &job.owner[..10.min(job.owner.len())],
@@ -807,10 +597,7 @@ pub async fn execute_remember(
 // ============================================================
 // BulkRememberJob — ENG-1408
 //
-// Batches N memories into:
-//   - N×2 Sui txs (register + certify per blob, unavoidable)
-//   - K Sui txs for set-metadata+transfer, where K = number of wallet slots used
-//     (one PTB per wallet-slot via /walrus/set-metadata-batch on sidecar)
+// Fans a preprocessed bulk request out into N wallet-pinned jobs.
 // ============================================================
 
 /// One pre-processed item (embed + encrypt already done in route handler).
@@ -862,46 +649,21 @@ impl std::fmt::Display for BulkRememberError {
 impl std::error::Error for BulkRememberError {}
 
 // ─────────────────────────────────────────────────────────────
-// Sidecar request types for POST /walrus/set-metadata-batch
-// ─────────────────────────────────────────────────────────────
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SetMetadataBatchEntry<'a> {
-    blob_object_id: &'a str,
-    namespace: &'a str,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SetMetadataBatchRequest<'a> {
-    blobs: Vec<SetMetadataBatchEntry<'a>>,
-    owner: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    package_id: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    agent_id: Option<&'a str>,
-    key_index: usize,
-}
-
-// ─────────────────────────────────────────────────────────────
 // execute_bulk_remember — Apalis handler
 // ─────────────────────────────────────────────────────────────
 
 /// Apalis worker handler for BulkRememberJob (ENG-1408).
 ///
 /// Steps:
-///   1. Mark all items `running`
-///   2. Upload N blobs to Walrus concurrently (bounded by BULK_UPLOAD_CONCURRENCY)
-///   3. Group blobs with objectId by wallet_index
-///   4. For each group → POST /walrus/set-metadata-batch (1 PTB per wallet slot)
-///      Falls back to per-blob /walrus/set-metadata if batch endpoint unavailable.
-///   5. Insert vectors and mark rows done only after transfer succeeds.
+///   1. Upload each encrypted item with `deferTransfer=true`.
+///   2. Insert vectors once each blob is certified.
+///   3. Group certified Blob object IDs by wallet and transfer each group in
+///      one set-metadata PTB.
 pub async fn execute_bulk_remember(
     job: BulkRememberJob,
     ctx: Data<Arc<AppState>>,
 ) -> Result<(), BulkRememberError> {
-    let state: &AppState = &ctx;
+    let state: Arc<AppState> = Arc::clone(&ctx);
 
     if job.items.is_empty() {
         return Ok(());
@@ -916,7 +678,6 @@ pub async fn execute_bulk_remember(
         job.epochs,
     );
 
-    // ── Step 1: mark all items running ────────────────────────────────────
     for item in &job.items {
         let _ = sqlx::query(
             "UPDATE remember_jobs SET status = 'running', updated_at = NOW() WHERE id = $1",
@@ -926,86 +687,107 @@ pub async fn execute_bulk_remember(
         .await;
     }
 
-    // ── Step 2: upload N blobs concurrently ───────────────
     struct UploadOk {
         job_id: String,
         blob_id: String,
-        object_id: Option<String>,
+        object_id: String,
         wallet_index: usize,
         namespace: String,
         vector: Vec<f32>,
         blob_size: i64,
     }
 
-    let db = &state.db;
-    let http = &state.http_client;
-    let sidecar_url = state.config.sidecar_url.clone();
-    let sidecar_secret = state.config.sidecar_secret.clone();
     let owner = job.owner.clone();
     let package_id = job.package_id.clone();
-    let agent = job.agent_public_key.clone();
+    let agent_public_key = job.agent_public_key.clone();
     let epochs = job.epochs as u64;
 
     let upload_results: Vec<Result<UploadOk, ()>> = stream::iter(job.items)
         .map(|item| {
-            let sidecar_url = sidecar_url.clone();
-            let sidecar_secret = sidecar_secret.clone();
+            let state = Arc::clone(&state);
             let owner = owner.clone();
             let package_id = package_id.clone();
-            let agent = agent.clone();
+            let agent_public_key = agent_public_key.clone();
             async move {
-                let encrypted = match base64::engine::general_purpose::STANDARD.decode(&item.encrypted_b64) {
-                    Ok(b) => b,
+                let encrypted = match base64::engine::general_purpose::STANDARD
+                    .decode(&item.encrypted_b64)
+                {
+                    Ok(bytes) => bytes,
                     Err(e) => {
                         let msg = format!("base64 decode failed: {}", e);
                         tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
                         let _ = sqlx::query(
                             "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
                         )
-                        .bind(&msg).bind(&item.job_id).execute(db.pool()).await;
+                        .bind(&msg)
+                        .bind(&item.job_id)
+                        .execute(state.db.pool())
+                        .await;
                         return Err(());
                     }
                 };
 
-                let upload = match crate::walrus::upload_blob(
-                    http,
-                    &sidecar_url,
-                    sidecar_secret.as_deref(),
+                let upload = match crate::walrus::upload_blob_deferred(
+                    &state.http_client,
+                    &state.config.sidecar_url,
+                    state.config.sidecar_secret.as_deref(),
                     &encrypted,
                     epochs,
                     &owner,
                     item.wallet_index,
                     &item.namespace,
                     &package_id,
-                    agent.as_deref(),
-                ).await {
-                    Ok(u) => u,
+                    agent_public_key.as_deref(),
+                )
+                .await
+                {
+                    Ok(upload) => upload,
                     Err(e) => {
                         let msg = format!("walrus upload failed: {}", e);
                         tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
                         let _ = sqlx::query(
                             "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
                         )
-                        .bind(&msg).bind(&item.job_id).execute(db.pool()).await;
+                        .bind(&msg)
+                        .bind(&item.job_id)
+                        .execute(state.db.pool())
+                        .await;
                         return Err(());
                     }
                 };
-                let blob_id = upload.blob_id.clone();
-                let blob_size = encrypted.len() as i64;
+
+                let object_id = match upload.object_id {
+                    Some(object_id) if !object_id.is_empty() => object_id,
+                    _ => {
+                        let msg = "walrus deferred upload returned no object_id".to_string();
+                        tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
+                        let _ = sqlx::query(
+                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                        )
+                        .bind(&msg)
+                        .bind(&item.job_id)
+                        .execute(state.db.pool())
+                        .await;
+                        return Err(());
+                    }
+                };
 
                 let _ = sqlx::query(
                     "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
                 )
-                .bind(&blob_id).bind(&item.job_id).execute(db.pool()).await;
+                .bind(&upload.blob_id)
+                .bind(&item.job_id)
+                .execute(state.db.pool())
+                .await;
 
                 Ok(UploadOk {
-                    job_id: item.job_id.clone(),
-                    blob_id,
-                    object_id: upload.object_id,
+                    job_id: item.job_id,
+                    blob_id: upload.blob_id,
+                    object_id,
                     wallet_index: item.wallet_index,
-                    namespace: item.namespace.clone(),
+                    namespace: item.namespace,
                     vector: item.vector,
-                    blob_size,
+                    blob_size: encrypted.len() as i64,
                 })
             }
         })
@@ -1013,241 +795,113 @@ pub async fn execute_bulk_remember(
         .collect()
         .await;
 
-    // ── Step 3: group successful blobs by wallet_index ────────────────────
-    struct TransferReady {
-        object_id: String,
-        namespace: String,
-        job_id: String,
-        blob_id: String,
-        vector: Vec<f32>,
-        blob_size: i64,
-    }
-    let mut groups: HashMap<usize, Vec<TransferReady>> = HashMap::new();
-    let mut upload_count = 0usize;
-    let mut success_count = 0usize;
+    let mut groups: HashMap<usize, Vec<UploadOk>> = HashMap::new();
     let mut fail_count = 0usize;
+    let mut uploaded_count = 0usize;
 
-    for r in upload_results {
-        match r {
-            Ok(ok) => match ok.object_id {
-                Some(object_id) if !object_id.is_empty() => {
-                    upload_count += 1;
-                    groups
-                        .entry(ok.wallet_index)
-                        .or_default()
-                        .push(TransferReady {
-                            object_id,
-                            namespace: ok.namespace,
-                            job_id: ok.job_id,
-                            blob_id: ok.blob_id,
-                            vector: ok.vector,
-                            blob_size: ok.blob_size,
-                        });
-                }
-                _ => {
+    for result in upload_results {
+        match result {
+            Ok(upload) => {
+                uploaded_count += 1;
+                let vector_id = upload.job_id.clone();
+                if let Err(e) = state
+                    .db
+                    .insert_vector(
+                        &vector_id,
+                        &job.owner,
+                        &upload.namespace,
+                        &upload.blob_id,
+                        &upload.vector,
+                        upload.blob_size,
+                    )
+                    .await
+                {
                     fail_count += 1;
-                    let msg = "walrus upload returned no object_id; cannot transfer";
+                    let msg = format!("insert_vector failed: {}", e);
+                    tracing::error!("[bulk-remember] job_id={} {}", upload.job_id, msg);
                     let _ = sqlx::query(
-                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-                        )
-                        .bind(msg)
-                        .bind(&ok.job_id)
-                        .execute(state.db.pool())
-                        .await;
+                        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+                    )
+                    .bind(&msg)
+                    .bind(&upload.job_id)
+                    .execute(state.db.pool())
+                    .await;
+                    continue;
                 }
-            },
-            Err(()) => fail_count += 1,
+                groups.entry(upload.wallet_index).or_default().push(upload);
+            }
+            Err(()) => {
+                fail_count += 1;
+            }
         }
     }
 
-    tracing::info!(
-        "[bulk-remember] uploads done: ok={} fail={} wallet_groups={}",
-        upload_count,
-        fail_count,
-        groups.len(),
-    );
-
-    // ── Step 4: batch set-metadata + transfer per wallet group ────────────
-    //
-    // For each wallet slot we try ONE batched PTB; if that fails we fall back
-    // to per-blob set-metadata calls. Only after a blob's transfer definitively
-    // succeeds do we mark its remember_jobs row `done`. Permanent failures
-    // transition the row from `uploaded → failed` with a diagnostic error.
-    let insert_vector_after_transfer = |blob: &TransferReady| {
-        let state = Arc::clone(&ctx);
-        let pool = state.db.pool().clone();
-        let owner = job.owner.clone();
-        let namespace = blob.namespace.clone();
-        let blob_id = blob.blob_id.clone();
-        let vector = blob.vector.clone();
-        let blob_size = blob.blob_size;
-        let job_id = blob.job_id.clone();
-        async move {
-            let vector_id = uuid::Uuid::new_v4().to_string();
-            if let Err(e) = state
-                .db
-                .insert_vector(&vector_id, &owner, &namespace, &blob_id, &vector, blob_size)
-                .await
-            {
-                let msg = format!("insert_vector failed: {}", e);
-                tracing::error!("[bulk-remember] job_id={} {}", job_id, msg);
-                let _ = sqlx::query(
-                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-                )
-                .bind(&msg)
-                .bind(&job_id)
-                .execute(&pool)
-                .await;
-                return false;
-            }
-
-            let _ = sqlx::query(
-                "UPDATE remember_jobs SET status = 'done', updated_at = NOW() WHERE id = $1",
-            )
-            .bind(&job_id)
-            .execute(&pool)
-            .await;
-            true
-        }
-    };
-    let mark_transfer_failed = |jid: &str, err: &str| {
-        let pool = state.db.pool().clone();
-        let jid = jid.to_string();
-        let err = err.to_string();
-        async move {
-            let _ = sqlx::query(
-                "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-            )
-            .bind(&err)
-            .bind(&jid)
-            .execute(&pool)
-            .await;
-        }
-    };
-
-    for (wallet_index, blobs) in &groups {
-        if blobs.is_empty() {
-            continue;
-        }
-
-        let url = format!("{}/walrus/set-metadata-batch", state.config.sidecar_url);
-        let blob_entries: Vec<SetMetadataBatchEntry<'_>> = blobs
+    let mut success_count = 0usize;
+    for (wallet_index, uploads) in groups {
+        let entries: Vec<SetMetadataBatchEntry> = uploads
             .iter()
-            .map(|blob| SetMetadataBatchEntry {
-                blob_object_id: blob.object_id.as_str(),
-                namespace: blob.namespace.as_str(),
+            .map(|upload| SetMetadataBatchEntry {
+                blob_object_id: upload.object_id.clone(),
+                namespace: upload.namespace.clone(),
             })
             .collect();
 
-        let mut req = state.http_client.post(&url).json(&SetMetadataBatchRequest {
-            blobs: blob_entries,
-            owner: &job.owner,
-            package_id: Some(job.package_id.as_str()),
-            agent_id: job.agent_public_key.as_deref(),
-            key_index: *wallet_index,
-        });
-        if let Some(secret) = state.config.sidecar_secret.as_deref() {
-            req = req.header("authorization", format!("Bearer {}", secret));
-        }
-
-        match req.send().await {
-            Ok(resp) if resp.status().is_success() => {
+        match crate::walrus::set_metadata_batch(
+            &state.http_client,
+            &state.config.sidecar_url,
+            state.config.sidecar_secret.as_deref(),
+            wallet_index,
+            &job.owner,
+            &job.package_id,
+            job.agent_public_key.as_deref(),
+            entries,
+        )
+        .await
+        {
+            Ok(transferred) => {
                 tracing::info!(
-                    "[bulk-remember] set-metadata-batch ok: {} blobs wallet={}",
-                    blobs.len(),
-                    wallet_index,
+                    "[bulk-remember] metadata batch transferred {} blobs wallet={}",
+                    transferred,
+                    wallet_index
                 );
-                for blob in blobs {
-                    if insert_vector_after_transfer(blob).await {
-                        success_count += 1;
-                    }
-                }
-            }
-            Ok(resp) => {
-                let status = resp.status().as_u16();
-                let body = resp.text().await.unwrap_or_default();
-                tracing::warn!(
-                    "[bulk-remember] set-metadata-batch ({}) failed: {} wallet={} — falling back per-blob",
-                    status, &body[..200.min(body.len())], wallet_index,
-                );
-                for blob in blobs {
-                    match execute_set_metadata_and_transfer(
-                        state,
-                        *wallet_index,
-                        blob.object_id.clone(),
-                        job.owner.clone(),
-                        blob.namespace.clone(),
-                        Some(job.package_id.clone()),
-                        job.agent_public_key.clone(),
+                for upload in uploads {
+                    let _ = sqlx::query(
+                        "UPDATE remember_jobs SET status = 'done', blob_id = $1, updated_at = NOW() WHERE id = $2",
                     )
-                    .await
-                    {
-                        Ok(()) => {
-                            if insert_vector_after_transfer(blob).await {
-                                success_count += 1;
-                            }
-                        }
-                        Err(e) => {
-                            fail_count += 1;
-                            tracing::warn!(
-                                "[bulk-remember] fallback set-metadata failed blob={}: {}",
-                                blob.object_id,
-                                e
-                            );
-                            mark_transfer_failed(
-                                &blob.job_id,
-                                &format!("metadata+transfer permanently failed: {}", e),
-                            )
-                            .await;
-                        }
-                    }
+                    .bind(&upload.blob_id)
+                    .bind(&upload.job_id)
+                    .execute(state.db.pool())
+                    .await;
+                    success_count += 1;
                 }
             }
             Err(e) => {
+                fail_count += uploads.len();
+                let msg = format!("metadata batch failed: {}", e);
                 tracing::warn!(
-                    "[bulk-remember] set-metadata-batch network error: {} wallet={} — falling back per-blob",
-                    e, wallet_index,
+                    "[bulk-remember] wallet={} {} ({} blobs)",
+                    wallet_index,
+                    msg,
+                    uploads.len()
                 );
-                for blob in blobs {
-                    match execute_set_metadata_and_transfer(
-                        state,
-                        *wallet_index,
-                        blob.object_id.clone(),
-                        job.owner.clone(),
-                        blob.namespace.clone(),
-                        Some(job.package_id.clone()),
-                        job.agent_public_key.clone(),
-                    )
-                    .await
-                    {
-                        Ok(()) => {
-                            if insert_vector_after_transfer(blob).await {
-                                success_count += 1;
-                            }
-                        }
-                        Err(e) => {
-                            fail_count += 1;
-                            tracing::warn!(
-                                "[bulk-remember] fallback set-metadata failed blob={}: {}",
-                                blob.object_id,
-                                e
-                            );
-                            mark_transfer_failed(
-                                &blob.job_id,
-                                &format!("metadata+transfer permanently failed: {}", e),
-                            )
-                            .await;
-                        }
-                    }
-                }
+                let failed_job_ids: Vec<String> =
+                    uploads.iter().map(|upload| upload.job_id.clone()).collect();
+                let _ = sqlx::query(
+                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = ANY($2)",
+                )
+                .bind(&msg)
+                .bind(&failed_job_ids)
+                .execute(state.db.pool())
+                .await;
             }
         }
     }
 
     tracing::info!(
-        "[bulk-remember] complete: owner={} total={} ok={} fail={}",
+        "[bulk-remember] complete: owner={} total={} uploaded={} done={} fail={}",
         &job.owner[..10.min(job.owner.len())],
         items_total,
+        uploaded_count,
         success_count,
         fail_count,
     );

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -30,6 +30,9 @@ use jobs::{
 };
 use types::{AppState, Config, KeyPool};
 
+const STALE_REMEMBER_JOB_AFTER: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+const APALIS_MONITOR_RESTART_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
 #[tokio::main]
 async fn main() {
     // Load .env file (optional, won't error if missing)
@@ -183,7 +186,6 @@ async fn main() {
         key_pool,
         redis,
         fallback_rate_limit: tokio::sync::Mutex::new(crate::rate_limit::InMemoryFallback::default()),
-        job_storage: job_storage.clone(),
         remember_job_storage: remember_job_storage.clone(),
         wallet_storages: wallet_storages.clone(),
         bulk_job_storage: bulk_job_storage.clone(),
@@ -194,17 +196,18 @@ async fn main() {
         let worker_state = state.clone();
         let storage = job_storage.clone();
         tokio::spawn(async move {
-            let worker = WorkerBuilder::new("meta-transfer")
-                .data(worker_state)
-                .backend(storage)
-                .build_fn(jobs::execute_meta_transfer);
+            loop {
+                let worker = WorkerBuilder::new("meta-transfer")
+                    .data(worker_state.clone())
+                    .backend(storage.clone())
+                    .build_fn(jobs::execute_meta_transfer);
 
-            #[allow(deprecated)]
-            Monitor::new()
-                .register_with_count(2, worker)
-                .run()
-                .await
-                .unwrap_or_else(|e| tracing::error!("Apalis monitor exited: {}", e));
+                #[allow(deprecated)]
+                if let Err(e) = Monitor::new().register_with_count(2, worker).run().await {
+                    tracing::error!("Apalis monitor exited: {}", e);
+                }
+                tokio::time::sleep(APALIS_MONITOR_RESTART_DELAY).await;
+            }
         });
         tracing::info!("  Apalis: worker 'meta-transfer' spawned (concurrency=2)");
     }
@@ -214,17 +217,18 @@ async fn main() {
         let worker_state = state.clone();
         let storage = remember_job_storage.clone();
         tokio::spawn(async move {
-            let worker = WorkerBuilder::new("remember")
-                .data(worker_state)
-                .backend(storage)
-                .build_fn(jobs::execute_remember);
+            loop {
+                let worker = WorkerBuilder::new("remember")
+                    .data(worker_state.clone())
+                    .backend(storage.clone())
+                    .build_fn(jobs::execute_remember);
 
-            #[allow(deprecated)]
-            Monitor::new()
-                .register_with_count(3, worker) // up to 3 concurrent remember pipelines
-                .run()
-                .await
-                .unwrap_or_else(|e| tracing::error!("Apalis remember monitor exited: {}", e));
+                #[allow(deprecated)]
+                if let Err(e) = Monitor::new().register_with_count(3, worker).run().await {
+                    tracing::error!("Apalis remember monitor exited: {}", e);
+                }
+                tokio::time::sleep(APALIS_MONITOR_RESTART_DELAY).await;
+            }
         });
         tracing::info!("  Apalis: worker 'remember' spawned (concurrency=3)");
     }
@@ -234,17 +238,18 @@ async fn main() {
         let worker_state = state.clone();
         let storage = bulk_job_storage.clone();
         tokio::spawn(async move {
-            let worker = WorkerBuilder::new("bulk-remember")
-                .data(worker_state)
-                .backend(storage)
-                .build_fn(execute_bulk_remember);
+            loop {
+                let worker = WorkerBuilder::new("bulk-remember")
+                    .data(worker_state.clone())
+                    .backend(storage.clone())
+                    .build_fn(execute_bulk_remember);
 
-            #[allow(deprecated)]
-            Monitor::new()
-                .register_with_count(2, worker) // 2 concurrent batch jobs
-                .run()
-                .await
-                .unwrap_or_else(|e| tracing::error!("Apalis bulk-remember monitor exited: {}", e));
+                #[allow(deprecated)]
+                if let Err(e) = Monitor::new().register_with_count(2, worker).run().await {
+                    tracing::error!("Apalis bulk-remember monitor exited: {}", e);
+                }
+                tokio::time::sleep(APALIS_MONITOR_RESTART_DELAY).await;
+            }
         });
         tracing::info!("  Apalis: worker 'bulk-remember' spawned (concurrency=2)");
     }
@@ -257,19 +262,18 @@ async fn main() {
         let queue_name = format!("wallet-{}", i);
         let queue_label = queue_name.clone();
         tokio::spawn(async move {
-            let worker = WorkerBuilder::new(&queue_name)
-                .data(worker_state)
-                .backend(storage)
-                .build_fn(execute_wallet_job);
+            loop {
+                let worker = WorkerBuilder::new(&queue_name)
+                    .data(worker_state.clone())
+                    .backend(storage.clone())
+                    .build_fn(execute_wallet_job);
 
-            #[allow(deprecated)]
-            Monitor::new()
-                .register_with_count(1, worker) // serial per wallet — no coin lock conflicts
-                .run()
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::error!("Apalis wallet worker {} exited: {}", queue_label, e)
-                });
+                #[allow(deprecated)]
+                if let Err(e) = Monitor::new().register_with_count(1, worker).run().await {
+                    tracing::error!("Apalis wallet worker {} exited: {}", queue_label, e);
+                }
+                tokio::time::sleep(APALIS_MONITOR_RESTART_DELAY).await;
+            }
         });
         tracing::info!(
             "  Apalis: wallet worker '{}' spawned (serial)",
@@ -290,11 +294,26 @@ async fn main() {
         }
     });
 
+    // Spawn background task for orphaned async remember jobs
+    let stale_job_state = state.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            if let Err(e) = stale_job_state
+                .db
+                .fail_stale_remember_jobs(STALE_REMEMBER_JOB_AFTER)
+                .await
+            {
+                tracing::error!("Stale remember job sweep failed: {}", e);
+            }
+        }
+    });
+
     // Build routes
     // Protected routes (require Ed25519 signature + onchain verification)
-    // HIGH-13: 256 KiB covers the largest realistic JSON body (64 KiB plaintext
-    // + base64 overhead + JSON framing) while blocking abusive uploads before
-    // auth + rate-limit middleware even sees the request.
+    // Auth middleware caps signed JSON bodies at 2 MiB, which covers bulk remember
+    // payloads while still rejecting oversized requests before route handling.
     let protected_routes = Router::new()
         .route("/api/remember", post(routes::remember))
         .route(

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod db;
+mod jobs;
 mod rate_limit;
 mod routes;
 mod seal;
@@ -7,14 +8,26 @@ mod sui;
 mod types;
 mod walrus;
 
-use axum::{extract::DefaultBodyLimit, middleware, routing::{get, post}, Router};
-use std::net::SocketAddr;
 use axum::http::{header, HeaderValue, Method};
+use axum::{
+    extract::DefaultBodyLimit,
+    middleware,
+    routing::{get, post},
+    Router,
+};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 
+use apalis::prelude::*;
+use apalis_sql::postgres::PostgresStorage;
+
 use db::VectorDb;
+use jobs::{
+    execute_bulk_remember, execute_wallet_job, BulkRememberJob, MetaTransferJob, RememberJob,
+    WalletJobStorage,
+};
 use types::{AppState, Config, KeyPool};
 
 #[tokio::main]
@@ -36,14 +49,22 @@ async fn main() {
     tracing::info!("  Sui RPC: {}", config.sui_rpc_url);
     tracing::info!("  package id: {}", config.package_id);
     tracing::info!("  registry id: {}", config.registry_id);
-    tracing::info!("  memwal account: {}", config.memwal_account_id.as_deref().unwrap_or("(from client header)"));
-    tracing::info!("  rate limit: burst={}/min, sustained={}/hr, per-key={}/min, quota={}MB/user",
+    tracing::info!(
+        "  memwal account: {}",
+        config
+            .memwal_account_id
+            .as_deref()
+            .unwrap_or("(from client header)")
+    );
+    tracing::info!(
+        "  rate limit: burst={}/min, sustained={}/hr, per-key={}/min, quota={}MB/user",
         config.rate_limit.max_requests_per_minute,
         config.rate_limit.max_requests_per_hour,
         config.rate_limit.max_requests_per_delegate_key,
         config.rate_limit.max_storage_bytes / 1_048_576
     );
-    tracing::info!("  sponsor rate limit: {}/min, {}/hr per IP+sender",
+    tracing::info!(
+        "  sponsor rate limit: {}/min, {}/hr per IP+sender",
         config.sponsor_rate_limit.per_minute,
         config.sponsor_rate_limit.per_hour,
     );
@@ -96,18 +117,50 @@ async fn main() {
         .await
         .expect("Failed to connect to PostgreSQL");
 
+    // Setup Apalis job queue — auto-creates `apalis_jobs` table if not present
+    // Uses the same DATABASE_URL as the main DB; no extra infrastructure needed.
+    let apalis_pool = sqlx::PgPool::connect(&config.database_url)
+        .await
+        .expect("Failed to connect to PostgreSQL for Apalis");
+    // setup() is defined only on PostgresStorage<()> — creates schema tables.
+    PostgresStorage::<()>::setup(&apalis_pool)
+        .await
+        .expect("Apalis postgres migration failed");
+    let job_storage: PostgresStorage<MetaTransferJob> = PostgresStorage::new(apalis_pool.clone());
+    let remember_job_storage: PostgresStorage<RememberJob> =
+        PostgresStorage::new(apalis_pool.clone());
+    // ENG-1408: BulkRememberJob storage
+    let bulk_job_storage: PostgresStorage<BulkRememberJob> =
+        PostgresStorage::new(apalis_pool.clone());
+
+    // Create N per-wallet queues (one per pool key) for WalletJob.
+    // Each queue name is "wallet-{i}" and has a single dedicated worker.
+    let pool_size = config.sui_private_keys.len();
+    let mut wallet_storages: Vec<WalletJobStorage> = Vec::with_capacity(pool_size.max(1));
+    for i in 0..pool_size.max(1) {
+        let config_name = format!("wallet-{}", i);
+        let storage: WalletJobStorage = PostgresStorage::new_with_config(
+            apalis_pool.clone(),
+            apalis_sql::Config::new(&config_name),
+        );
+        wallet_storages.push(storage);
+    }
+    tracing::info!("  Apalis: job queue ready (table=apalis_jobs)");
+
     // Initialize Walrus client (SDK wraps Publisher + Aggregator HTTP APIs)
-    let walrus_client = walrus_rs::WalrusClient::new(
-        &config.walrus_aggregator_url,
-        &config.walrus_publisher_url,
-    )
-    .expect("Failed to initialize Walrus client (invalid URL?)");
+    let walrus_client =
+        walrus_rs::WalrusClient::new(&config.walrus_aggregator_url, &config.walrus_publisher_url)
+            .expect("Failed to initialize Walrus client (invalid URL?)");
     tracing::info!("  Walrus publisher: {}", config.walrus_publisher_url);
     tracing::info!("  Walrus aggregator: {}", config.walrus_aggregator_url);
     // Log upload key pool status
     let pool_size = config.sui_private_keys.len();
     if pool_size > 0 {
-        tracing::info!("  Walrus upload: {} key(s) in pool (parallel uploads up to {}x)", pool_size, pool_size);
+        tracing::info!(
+            "  Walrus upload: {} key(s) in pool (parallel uploads up to {}x)",
+            pool_size,
+            pool_size
+        );
     } else {
         tracing::warn!("  Walrus upload: no Sui private keys configured, uploads will fail");
     }
@@ -130,7 +183,99 @@ async fn main() {
         key_pool,
         redis,
         fallback_rate_limit: tokio::sync::Mutex::new(crate::rate_limit::InMemoryFallback::default()),
+        job_storage: job_storage.clone(),
+        remember_job_storage: remember_job_storage.clone(),
+        wallet_storages: wallet_storages.clone(),
+        bulk_job_storage: bulk_job_storage.clone(),
     });
+
+    // Worker 1: MetaTransferJob (legacy — backward compat with existing DB rows)
+    {
+        let worker_state = state.clone();
+        let storage = job_storage.clone();
+        tokio::spawn(async move {
+            let worker = WorkerBuilder::new("meta-transfer")
+                .data(worker_state)
+                .backend(storage)
+                .build_fn(jobs::execute_meta_transfer);
+
+            #[allow(deprecated)]
+            Monitor::new()
+                .register_with_count(2, worker)
+                .run()
+                .await
+                .unwrap_or_else(|e| tracing::error!("Apalis monitor exited: {}", e));
+        });
+        tracing::info!("  Apalis: worker 'meta-transfer' spawned (concurrency=2)");
+    }
+
+    // Worker 2: RememberJob (legacy full pipeline)
+    {
+        let worker_state = state.clone();
+        let storage = remember_job_storage.clone();
+        tokio::spawn(async move {
+            let worker = WorkerBuilder::new("remember")
+                .data(worker_state)
+                .backend(storage)
+                .build_fn(jobs::execute_remember);
+
+            #[allow(deprecated)]
+            Monitor::new()
+                .register_with_count(3, worker) // up to 3 concurrent remember pipelines
+                .run()
+                .await
+                .unwrap_or_else(|e| tracing::error!("Apalis remember monitor exited: {}", e));
+        });
+        tracing::info!("  Apalis: worker 'remember' spawned (concurrency=3)");
+    }
+
+    // Worker 3: BulkRememberJob (ENG-1408)
+    {
+        let worker_state = state.clone();
+        let storage = bulk_job_storage.clone();
+        tokio::spawn(async move {
+            let worker = WorkerBuilder::new("bulk-remember")
+                .data(worker_state)
+                .backend(storage)
+                .build_fn(execute_bulk_remember);
+
+            #[allow(deprecated)]
+            Monitor::new()
+                .register_with_count(2, worker) // 2 concurrent batch jobs
+                .run()
+                .await
+                .unwrap_or_else(|e| tracing::error!("Apalis bulk-remember monitor exited: {}", e));
+        });
+        tracing::info!("  Apalis: worker 'bulk-remember' spawned (concurrency=2)");
+    }
+
+    // Workers 3..N: Per-wallet WalletJob workers (one per pool key).
+    // Each worker is pinned to wallet_index i and processes jobs from queue "wallet-{i}".
+    // This guarantees upload and set-metadata+transfer always use the same signing key.
+    for (i, storage) in wallet_storages.into_iter().enumerate() {
+        let worker_state = state.clone();
+        let queue_name = format!("wallet-{}", i);
+        let queue_label = queue_name.clone();
+        tokio::spawn(async move {
+            let worker = WorkerBuilder::new(&queue_name)
+                .data(worker_state)
+                .backend(storage)
+                .build_fn(execute_wallet_job);
+
+            #[allow(deprecated)]
+            Monitor::new()
+                .register_with_count(1, worker) // serial per wallet — no coin lock conflicts
+                .run()
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!("Apalis wallet worker {} exited: {}", queue_label, e)
+                });
+        });
+        tracing::info!(
+            "  Apalis: wallet worker '{}' spawned (serial)",
+            format!("wallet-{}", i)
+        );
+    }
 
     // Spawn background task for cache eviction
     let evict_state = state.clone();
@@ -152,10 +297,22 @@ async fn main() {
     // auth + rate-limit middleware even sees the request.
     let protected_routes = Router::new()
         .route("/api/remember", post(routes::remember))
+        .route(
+            "/api/remember/{job_id}",
+            axum::routing::get(routes::remember_status),
+        )
+        .route(
+            "/api/remember/bulk/status",
+            post(routes::remember_bulk_status),
+        )
         .route("/api/recall", post(routes::recall))
         .route("/api/remember/manual", post(routes::remember_manual))
         .route("/api/recall/manual", post(routes::recall_manual))
-
+        // ENG-1408: Bulk remember — higher body limit (20 items × max 64 KiB each ≈ 1.5 MB)
+        .route(
+            "/api/remember/bulk",
+            post(routes::remember_bulk).layer(DefaultBodyLimit::max(2 * 1024 * 1024)),
+        )
         .route("/api/analyze", post(routes::analyze))
         .route("/api/ask", post(routes::ask))
         .route("/api/restore", post(routes::restore))
@@ -193,8 +350,14 @@ async fn main() {
     // network, sui_rpc_url) so the SDK can build SEAL SessionKey without
     // the user adding packageId to MemWalConfig.
     let public_routes = Router::new()
-        .route("/health", get(routes::health).layer(DefaultBodyLimit::max(16 * 1024)))
-        .route("/config", get(routes::get_config).layer(DefaultBodyLimit::max(16 * 1024)))
+        .route(
+            "/health",
+            get(routes::health).layer(DefaultBodyLimit::max(16 * 1024)),
+        )
+        .route(
+            "/config",
+            get(routes::get_config).layer(DefaultBodyLimit::max(16 * 1024)),
+        )
         .merge(sponsor_routes);
 
     // CORS — restrict to configured origins.
@@ -207,7 +370,9 @@ async fn main() {
             .split(',')
             .filter_map(|s| {
                 let s = s.trim();
-                if s.is_empty() { return None; }
+                if s.is_empty() {
+                    return None;
+                }
                 s.parse::<HeaderValue>().ok()
             })
             .collect();
@@ -251,7 +416,10 @@ async fn main() {
 
     tracing::info!("memwal server listening on {}", addr);
     tracing::info!("  health: http://localhost:{}/health", config.port);
-    tracing::info!("  api:    http://localhost:{}/api/{{remember,recall,analyze}}", config.port);
+    tracing::info!(
+        "  api:    http://localhost:{}/api/{{remember,recall,analyze}}",
+        config.port
+    );
 
     // Graceful shutdown: kill sidecar when server stops
     let shutdown = async {
@@ -259,10 +427,13 @@ async fn main() {
         tracing::info!("shutting down...");
     };
 
-    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
-        .with_graceful_shutdown(shutdown)
-        .await
-        .expect("Server failed");
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown)
+    .await
+    .expect("Server failed");
 
     // Cleanup sidecar after shutdown
     sidecar_child.kill().await.ok();

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -111,8 +111,8 @@ impl RateLimitConfig {
 ///   1. Percent-decode the path to neutralise URL-encoded variants
 ///      (e.g. `/api/anal%79ze` → `/api/analyze`).
 ///   2. Strip any trailing slash so `/api/analyze/` == `/api/analyze`.
-///   Both transforms are applied before the match, so no variant can
-///   slip through with a cost of 1 instead of its true weight.
+///      Both transforms are applied before the match, so no variant can
+///      slip through with a cost of 1 instead of its true weight.
 fn endpoint_weight(path: &str) -> i64 {
     // Step 1 — percent-decode (e.g. "%2F" → "/", "%79" → "y")
     // Use lossy decoding: malformed sequences are replaced with U+FFFD
@@ -123,12 +123,13 @@ fn endpoint_weight(path: &str) -> i64 {
     let path = decoded.trim_end_matches('/');
 
     match path {
-        "/api/analyze" => 5,           // LLM extract + N × (1 pt per fact)
-        "/api/remember" => 5,          // embed + SEAL encrypt + Walrus upload
-        "/api/remember/manual" => 3,   // Walrus upload only (client did embed/encrypt)
-        "/api/restore" => 3,           // download + decrypt + re-embed
-        "/api/ask" => 2,               // recall + LLM
-        _ => 1,                        // recall, recall/manual, etc.
+        "/api/analyze" => 5,         // LLM extract + N × (1 pt per fact)
+        "/api/remember" => 5,        // embed + SEAL encrypt + Walrus upload
+        "/api/remember/bulk" => 10,  // N × embed/encrypt/upload in one request
+        "/api/remember/manual" => 3, // Walrus upload only (client did embed/encrypt)
+        "/api/restore" => 3,         // download + decrypt + re-embed
+        "/api/ask" => 2,             // recall + LLM
+        _ => 1,                      // recall, recall/manual, etc.
     }
 }
 
@@ -137,11 +138,14 @@ fn endpoint_weight(path: &str) -> i64 {
 // ============================================================
 
 /// Create a Redis multiplexed connection for shared use across the app.
-pub async fn create_redis_client(redis_url: &str) -> Result<redis::aio::MultiplexedConnection, String> {
+pub async fn create_redis_client(
+    redis_url: &str,
+) -> Result<redis::aio::MultiplexedConnection, String> {
     let client = redis::Client::open(redis_url)
         .map_err(|e| format!("Failed to create Redis client: {}", e))?;
 
-    let conn = client.get_multiplexed_async_connection()
+    let conn = client
+        .get_multiplexed_async_connection()
         .await
         .map_err(|e| format!("Failed to connect to Redis: {}", e))?;
 
@@ -243,9 +247,18 @@ pub struct InMemoryFallback {
 }
 
 impl InMemoryFallback {
-    pub fn can_consume(&mut self, key: &str, weight: f64, capacity: f64, refill_duration_secs: f64) -> bool {
+    pub fn can_consume(
+        &mut self,
+        key: &str,
+        weight: f64,
+        capacity: f64,
+        refill_duration_secs: f64,
+    ) -> bool {
         let refill_rate = capacity / refill_duration_secs;
-        let bucket = self.buckets.entry(key.to_string()).or_insert_with(|| TokenBucket::new(capacity));
+        let bucket = self
+            .buckets
+            .entry(key.to_string())
+            .or_insert_with(|| TokenBucket::new(capacity));
         bucket.peek(weight, capacity, refill_rate)
     }
 
@@ -254,24 +267,28 @@ impl InMemoryFallback {
         if let Some(bucket) = self.buckets.get_mut(key) {
             bucket.consume(weight, capacity, refill_rate);
         }
-        
+
         self.cleanup_counter += 1;
         if self.cleanup_counter >= 1000 {
             self.cleanup_counter = 0;
             let now = std::time::Instant::now();
-            self.buckets.retain(|_, b| now.duration_since(b.last_update).as_secs_f64() < 7200.0);
+            self.buckets
+                .retain(|_, b| now.duration_since(b.last_update).as_secs_f64() < 7200.0);
         }
     }
 }
 
-pub struct TokenBucket {    
+pub struct TokenBucket {
     pub tokens: f64,
     pub last_update: std::time::Instant,
 }
 
 impl TokenBucket {
     pub fn new(capacity: f64) -> Self {
-        Self { tokens: capacity, last_update: std::time::Instant::now() }
+        Self {
+            tokens: capacity,
+            last_update: std::time::Instant::now(),
+        }
     }
 
     pub fn peek(&self, weight: f64, capacity: f64, refill_rate_per_sec: f64) -> bool {
@@ -307,7 +324,9 @@ fn rate_limit_response(layer: &str, limit: i64, window: &str, retry_after: u64) 
         .status(StatusCode::TOO_MANY_REQUESTS)
         .header("Content-Type", "application/json")
         .header("Retry-After", retry_after.to_string())
-        .body(axum::body::Body::from(serde_json::to_string(&body).unwrap()))
+        .body(axum::body::Body::from(
+            serde_json::to_string(&body).unwrap(),
+        ))
         .unwrap()
 }
 
@@ -324,7 +343,9 @@ fn rate_limiter_unavailable_response() -> Response {
         .status(StatusCode::SERVICE_UNAVAILABLE)
         .header("Content-Type", "application/json")
         .header("Retry-After", "30")
-        .body(axum::body::Body::from(serde_json::to_string(&body).unwrap()))
+        .body(axum::body::Body::from(
+            serde_json::to_string(&body).unwrap(),
+        ))
         .unwrap()
 }
 
@@ -375,13 +396,13 @@ pub async fn rate_limit_middleware(
     let weight = endpoint_weight(request.uri().path());
 
     // --- Key definitions for all three rate-limit buckets ---
-    let dk_key           = format!("rate:dk:{}", auth.public_key);
-    let burst_key        = format!("rate:{}", auth.owner);
-    let hourly_key       = format!("rate:hr:{}", auth.owner);
+    let dk_key = format!("rate:dk:{}", auth.public_key);
+    let burst_key = format!("rate:{}", auth.owner);
+    let hourly_key = format!("rate:hr:{}", auth.owner);
 
-    let dk_window_start      = now - 60_000.0;      // 1-min window (ms)
-    let burst_window_start   = now - 60_000.0;      // 1-min window (ms)
-    let hourly_window_start  = now - 3_600_000.0;   // 1-hr  window (ms)
+    let dk_window_start = now - 60_000.0; // 1-min window (ms)
+    let burst_window_start = now - 60_000.0; // 1-min window (ms)
+    let hourly_window_start = now - 3_600_000.0; // 1-hr  window (ms)
 
     // --- MED-19: Atomic check-and-record via Lua script for all 3 layers ---
     // Each layer is checked+recorded atomically. If Redis is unavailable,
@@ -398,14 +419,21 @@ pub async fn rate_limit_middleware(
         config.max_requests_per_delegate_key,
         weight,
         120, // TTL 2 min
-    ).await {
+    )
+    .await
+    {
         Ok(WindowCheckResult::Denied) => {
             tracing::warn!(
                 "rate limit [delegate-key]: key={}... denied (limit={})",
                 &auth.public_key[..16.min(auth.public_key.len())],
                 config.max_requests_per_delegate_key
             );
-            return rate_limit_response("delegate_key", config.max_requests_per_delegate_key, "min", 60);
+            return rate_limit_response(
+                "delegate_key",
+                config.max_requests_per_delegate_key,
+                "min",
+                60,
+            );
         }
         Err(e) => {
             tracing::warn!("rate limit [delegate-key] Redis error: {}", e);
@@ -424,15 +452,23 @@ pub async fn rate_limit_middleware(
             config.max_requests_per_minute,
             weight,
             120, // TTL 2 min
-        ).await {
+        )
+        .await
+        {
             Ok(WindowCheckResult::Denied) => {
                 tracing::warn!(
                     "rate limit [burst]: owner={} denied (limit={})",
-                    auth.owner, config.max_requests_per_minute
+                    auth.owner,
+                    config.max_requests_per_minute
                 );
                 // Roll back the delegate-key window entry just recorded above
                 // (best-effort; a Lua multi-key script would be fully atomic across keys)
-                return rate_limit_response("account_burst", config.max_requests_per_minute, "min", 60);
+                return rate_limit_response(
+                    "account_burst",
+                    config.max_requests_per_minute,
+                    "min",
+                    60,
+                );
             }
             Err(e) => {
                 tracing::warn!("rate limit [burst] Redis error: {}", e);
@@ -452,13 +488,21 @@ pub async fn rate_limit_middleware(
             config.max_requests_per_hour,
             weight,
             3700, // TTL ~1hr + buffer
-        ).await {
+        )
+        .await
+        {
             Ok(WindowCheckResult::Denied) => {
                 tracing::warn!(
                     "rate limit [sustained]: owner={} denied (limit={})",
-                    auth.owner, config.max_requests_per_hour
+                    auth.owner,
+                    config.max_requests_per_hour
                 );
-                return rate_limit_response("account_sustained", config.max_requests_per_hour, "hour", 300);
+                return rate_limit_response(
+                    "account_sustained",
+                    config.max_requests_per_hour,
+                    "hour",
+                    300,
+                );
             }
             Err(e) => {
                 tracing::warn!("rate limit [sustained] Redis error: {}", e);
@@ -473,19 +517,59 @@ pub async fn rate_limit_middleware(
         tracing::warn!("rate limit: Redis is unreachable, using in-memory fallback");
         let mut fallback = state.fallback_rate_limit.lock().await;
 
-        if !fallback.can_consume(&dk_key, weight as f64, config.max_requests_per_delegate_key as f64, 60.0) {
-            return rate_limit_response("delegate_key", config.max_requests_per_delegate_key, "min", 60);
+        if !fallback.can_consume(
+            &dk_key,
+            weight as f64,
+            config.max_requests_per_delegate_key as f64,
+            60.0,
+        ) {
+            return rate_limit_response(
+                "delegate_key",
+                config.max_requests_per_delegate_key,
+                "min",
+                60,
+            );
         }
-        if !fallback.can_consume(&burst_key, weight as f64, config.max_requests_per_minute as f64, 60.0) {
+        if !fallback.can_consume(
+            &burst_key,
+            weight as f64,
+            config.max_requests_per_minute as f64,
+            60.0,
+        ) {
             return rate_limit_response("account_burst", config.max_requests_per_minute, "min", 60);
         }
-        if !fallback.can_consume(&hourly_key, weight as f64, config.max_requests_per_hour as f64, 3600.0) {
-            return rate_limit_response("account_sustained", config.max_requests_per_hour, "hour", 300);
+        if !fallback.can_consume(
+            &hourly_key,
+            weight as f64,
+            config.max_requests_per_hour as f64,
+            3600.0,
+        ) {
+            return rate_limit_response(
+                "account_sustained",
+                config.max_requests_per_hour,
+                "hour",
+                300,
+            );
         }
 
-        fallback.consume(&dk_key, weight as f64, config.max_requests_per_delegate_key as f64, 60.0);
-        fallback.consume(&burst_key, weight as f64, config.max_requests_per_minute as f64, 60.0);
-        fallback.consume(&hourly_key, weight as f64, config.max_requests_per_hour as f64, 3600.0);
+        fallback.consume(
+            &dk_key,
+            weight as f64,
+            config.max_requests_per_delegate_key as f64,
+            60.0,
+        );
+        fallback.consume(
+            &burst_key,
+            weight as f64,
+            config.max_requests_per_minute as f64,
+            60.0,
+        );
+        fallback.consume(
+            &hourly_key,
+            weight as f64,
+            config.max_requests_per_hour as f64,
+            3600.0,
+        );
 
         return next.run(request).await;
     }
@@ -522,7 +606,7 @@ pub async fn check_storage_quota(
     // preventing TOCTOU race conditions.
     // We use a stable hash of the owner string as the lock key.
     let lock_key = stable_hash_i64(owner);
-    
+
     // Use the combined method which uses an explicit transaction and pg_advisory_xact_lock
     let used = state.db.get_storage_used_with_lock(owner, lock_key).await?;
     let projected = used + additional_bytes;
@@ -532,7 +616,10 @@ pub async fn check_storage_quota(
         let max_mb = max_bytes as f64 / 1_048_576.0;
         tracing::warn!(
             "storage quota exceeded: owner={} used={:.1}MB + {:.1}MB > max={:.1}MB",
-            owner, used_mb, additional_bytes as f64 / 1_048_576.0, max_mb
+            owner,
+            used_mb,
+            additional_bytes as f64 / 1_048_576.0,
+            max_mb
         );
         return Err(AppError::QuotaExceeded(format!(
             "Storage quota exceeded: {:.1}MB used of {:.1}MB allowed",
@@ -549,9 +636,9 @@ fn stable_hash_i64(s: &str) -> i64 {
     const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
     const FNV_PRIME: u64 = 1_099_511_628_211;
 
-    let hash = s.bytes().fold(FNV_OFFSET, |acc, b| {
-        acc.wrapping_mul(FNV_PRIME) ^ b as u64
-    });
+    let hash = s
+        .bytes()
+        .fold(FNV_OFFSET, |acc, b| acc.wrapping_mul(FNV_PRIME) ^ b as u64);
 
     // Fold into i64 range (XOR high and low 32 bits)
     ((hash >> 32) ^ (hash & 0xFFFF_FFFF)) as i64
@@ -582,9 +669,9 @@ pub async fn check_sender_rate_limit(
     let mut redis = state.redis.clone();
 
     let min_key = format!("rate:sponsor:min:{}", sender);
-    let hr_key  = format!("rate:sponsor:hr:{}",  sender);
+    let hr_key = format!("rate:sponsor:hr:{}", sender);
     let min_window_start = now - 60_000.0;
-    let hr_window_start  = now - 3_600_000.0;
+    let hr_window_start = now - 3_600_000.0;
 
     let mut redis_down = false;
 
@@ -597,7 +684,9 @@ pub async fn check_sender_rate_limit(
         per_minute,
         1, // weight = 1 per sponsor request
         120,
-    ).await {
+    )
+    .await
+    {
         Ok(WindowCheckResult::Denied) => return Ok(SponsorRlResult::MinuteLimitExceeded),
         Err(e) => {
             tracing::warn!("check_sender_rate_limit: Redis error (minute): {} — switching to in-memory fallback", e);
@@ -616,7 +705,9 @@ pub async fn check_sender_rate_limit(
             per_hour,
             1, // weight = 1 per sponsor request
             3700,
-        ).await {
+        )
+        .await
+        {
             Ok(WindowCheckResult::Denied) => return Ok(SponsorRlResult::HourLimitExceeded),
             Err(e) => {
                 tracing::warn!("check_sender_rate_limit: Redis error (hour): {} — switching to in-memory fallback", e);
@@ -636,7 +727,7 @@ pub async fn check_sender_rate_limit(
             return Ok(SponsorRlResult::HourLimitExceeded);
         }
         fallback.consume(&min_key, 1.0, per_minute as f64, 60.0);
-        fallback.consume(&hr_key,  1.0, per_hour as f64, 3600.0);
+        fallback.consume(&hr_key, 1.0, per_hour as f64, 3600.0);
         return Ok(SponsorRlResult::Allowed);
     }
 
@@ -650,6 +741,7 @@ pub async fn check_sender_rate_limit(
 /// Cost of the /api/analyze endpoint already reserved by the middleware
 /// for the first (LLM extraction) step. The weight value must match
 /// `endpoint_weight("/api/analyze")` = 5.
+#[allow(dead_code)]
 const ANALYZE_BASE_WEIGHT: i64 = 5;
 
 /// Additional weight to charge after fact-count is known.
@@ -665,6 +757,7 @@ pub fn analyze_additional_weight(fact_count: usize) -> i64 {
 }
 
 /// Total effective weight of an `/api/analyze` call given `fact_count`.
+#[allow(dead_code)]
 pub fn analyze_total_weight(fact_count: usize) -> i64 {
     ANALYZE_BASE_WEIGHT + analyze_additional_weight(fact_count)
 }
@@ -688,17 +781,27 @@ pub async fn charge_explicit_weight(
     let mut redis = state.redis.clone();
     let now = chrono::Utc::now().timestamp_millis() as f64;
 
-    let dk_key    = format!("rate:dk:{}", auth.public_key);
+    let dk_key = format!("rate:dk:{}", auth.public_key);
     let burst_key = format!("rate:{}", auth.owner);
-    let hr_key    = format!("rate:hr:{}", auth.owner);
+    let hr_key = format!("rate:hr:{}", auth.owner);
 
     // MED-19: Use the same atomic Lua script for explicit weight charges
     // (called from /api/analyze after fact count is known).
     // Ignore WindowCheckResult here — this is a post-hoc charge after
     // the expensive work is done; we prefer not to block the response.
-    let _ = check_and_record_window(&mut redis, &dk_key,    now,       now,       i64::MAX, weight, 120).await;
-    let _ = check_and_record_window(&mut redis, &burst_key, now,       now + 0.1, i64::MAX, weight, 120).await;
-    let _ = check_and_record_window(&mut redis, &hr_key,    now,       now + 0.2, i64::MAX, weight, 3700).await;
+    let _ = check_and_record_window(&mut redis, &dk_key, now, now, i64::MAX, weight, 120).await;
+    let _ = check_and_record_window(
+        &mut redis,
+        &burst_key,
+        now,
+        now + 0.1,
+        i64::MAX,
+        weight,
+        120,
+    )
+    .await;
+    let _ =
+        check_and_record_window(&mut redis, &hr_key, now, now + 0.2, i64::MAX, weight, 3700).await;
 
     Ok(())
 }
@@ -750,9 +853,9 @@ pub async fn sponsor_rate_limit_middleware(
     let now = chrono::Utc::now().timestamp_millis() as f64;
 
     let min_key = format!("rate:sponsor:ip:min:{}", ip);
-    let hr_key  = format!("rate:sponsor:ip:hr:{}",  ip);
+    let hr_key = format!("rate:sponsor:ip:hr:{}", ip);
     let min_window_start = now - 60_000.0;
-    let hr_window_start  = now - 3_600_000.0;
+    let hr_window_start = now - 3_600_000.0;
 
     let mut redis_down = false;
 
@@ -765,9 +868,15 @@ pub async fn sponsor_rate_limit_middleware(
         config.per_minute,
         1,
         120,
-    ).await {
+    )
+    .await
+    {
         Ok(WindowCheckResult::Denied) => {
-            tracing::warn!("sponsor rate limit [IP/min]: ip={} denied (limit={})", ip, config.per_minute);
+            tracing::warn!(
+                "sponsor rate limit [IP/min]: ip={} denied (limit={})",
+                ip,
+                config.per_minute
+            );
             return rate_limit_response("sponsor_ip_burst", config.per_minute, "min", 60);
         }
         Err(e) => {
@@ -787,9 +896,15 @@ pub async fn sponsor_rate_limit_middleware(
             config.per_hour,
             1,
             3700,
-        ).await {
+        )
+        .await
+        {
             Ok(WindowCheckResult::Denied) => {
-                tracing::warn!("sponsor rate limit [IP/hr]: ip={} denied (limit={})", ip, config.per_hour);
+                tracing::warn!(
+                    "sponsor rate limit [IP/hr]: ip={} denied (limit={})",
+                    ip,
+                    config.per_hour
+                );
                 return rate_limit_response("sponsor_ip_sustained", config.per_hour, "hour", 300);
             }
             Err(e) => {
@@ -813,7 +928,7 @@ pub async fn sponsor_rate_limit_middleware(
         }
 
         fallback.consume(&min_key, 1.0, config.per_minute as f64, 60.0);
-        fallback.consume(&hr_key,  1.0, config.per_hour as f64, 3600.0);
+        fallback.consume(&hr_key, 1.0, config.per_hour as f64, 3600.0);
 
         return next.run(request).await;
     }
@@ -841,8 +956,16 @@ mod tests {
         assert_eq!(endpoint_weight("/api/ask"), 2);
 
         // With trailing slash — must return SAME weight (MED-20 fix)
-        assert_eq!(endpoint_weight("/api/analyze/"), 5, "trailing slash bypass!");
-        assert_eq!(endpoint_weight("/api/remember/"), 5, "trailing slash bypass!");
+        assert_eq!(
+            endpoint_weight("/api/analyze/"),
+            5,
+            "trailing slash bypass!"
+        );
+        assert_eq!(
+            endpoint_weight("/api/remember/"),
+            5,
+            "trailing slash bypass!"
+        );
         assert_eq!(endpoint_weight("/api/ask/"), 2, "trailing slash bypass!");
 
         // Unknown path → weight 1
@@ -905,7 +1028,10 @@ mod tests {
     /// the TOCTOU race is reintroduced.
     #[test]
     fn test_lua_script_contains_atomic_guard() {
-        assert!(!SLIDING_WINDOW_LUA.is_empty(), "Lua script must not be empty");
+        assert!(
+            !SLIDING_WINDOW_LUA.is_empty(),
+            "Lua script must not be empty"
+        );
         assert!(
             SLIDING_WINDOW_LUA.contains("count + weight > limit"),
             "Lua script must contain atomic count+weight guard"
@@ -928,9 +1054,9 @@ mod tests {
     #[test]
     fn test_window_check_result_variants() {
         let allowed = WindowCheckResult::Allowed;
-        let denied  = WindowCheckResult::Denied;
+        let denied = WindowCheckResult::Denied;
         assert_eq!(allowed, WindowCheckResult::Allowed);
-        assert_eq!(denied,  WindowCheckResult::Denied);
+        assert_eq!(denied, WindowCheckResult::Denied);
         assert_ne!(allowed, denied, "Allowed and Denied must be distinct");
     }
 
@@ -939,13 +1065,21 @@ mod tests {
     #[test]
     fn test_endpoint_weight_percent_encoded_analyze() {
         // "%79" = 'y', so "/api/anal%79ze" = "/api/analyze"
-        assert_eq!(endpoint_weight("/api/anal%79ze"), 5, "percent-encoded 'y' bypass");
+        assert_eq!(
+            endpoint_weight("/api/anal%79ze"),
+            5,
+            "percent-encoded 'y' bypass"
+        );
     }
 
     #[test]
     fn test_endpoint_weight_percent_encoded_remember() {
         // "%72" = 'r', so "/api/%72emember" = "/api/remember"
-        assert_eq!(endpoint_weight("/api/%72emember"), 5, "percent-encoded 'r' bypass");
+        assert_eq!(
+            endpoint_weight("/api/%72emember"),
+            5,
+            "percent-encoded 'r' bypass"
+        );
     }
 
     #[test]
@@ -987,9 +1121,17 @@ mod tests {
     fn test_fallback_token_bucket_consume_reduces_tokens() {
         let mut bucket = TokenBucket::new(10.0);
         bucket.consume(3.0, 10.0, 1.0); // consume 3 of 10
-        // tokens should be ~7.0 (with tiny time delta adding a fraction)
-        assert!(bucket.tokens < 8.0, "tokens should be around 7, got {}", bucket.tokens);
-        assert!(bucket.tokens > 6.0, "tokens should be around 7, got {}", bucket.tokens);
+                                        // tokens should be ~7.0 (with tiny time delta adding a fraction)
+        assert!(
+            bucket.tokens < 8.0,
+            "tokens should be around 7, got {}",
+            bucket.tokens
+        );
+        assert!(
+            bucket.tokens > 6.0,
+            "tokens should be around 7, got {}",
+            bucket.tokens
+        );
     }
 
     #[test]
@@ -1007,22 +1149,25 @@ mod tests {
     fn test_fallback_token_bucket_rejects_when_empty() {
         let mut bucket = TokenBucket::new(5.0);
         bucket.consume(5.0, 5.0, 0.0); // consume all, no refill
-        // With 0 refill rate and ~0 elapsed time, no tokens available
+                                       // With 0 refill rate and ~0 elapsed time, no tokens available
         assert!(!bucket.peek(1.0, 5.0, 0.0));
     }
 
     #[test]
     fn test_fallback_inmemory_cleanup() {
-        let mut fb = InMemoryFallback::default();
-
-        // Force cleanup counter to ~1000
-        fb.cleanup_counter = 999;
+        let mut fb = InMemoryFallback {
+            cleanup_counter: 999,
+            ..Default::default()
+        };
 
         // Add a bucket and consume to trigger cleanup
         fb.consume("test_key", 1.0, 10.0, 60.0);
 
         // After cleanup_counter >= 1000, it resets to 0
-        assert_eq!(fb.cleanup_counter, 0, "cleanup counter should reset after reaching 1000");
+        assert_eq!(
+            fb.cleanup_counter, 0,
+            "cleanup counter should reset after reaching 1000"
+        );
     }
 
     #[test]
@@ -1086,9 +1231,21 @@ mod tests {
     #[test]
     fn test_sponsor_rl_result_variants() {
         assert_eq!(SponsorRlResult::Allowed, SponsorRlResult::Allowed);
-        assert_eq!(SponsorRlResult::MinuteLimitExceeded, SponsorRlResult::MinuteLimitExceeded);
-        assert_eq!(SponsorRlResult::HourLimitExceeded, SponsorRlResult::HourLimitExceeded);
-        assert_ne!(SponsorRlResult::Allowed, SponsorRlResult::MinuteLimitExceeded);
-        assert_ne!(SponsorRlResult::MinuteLimitExceeded, SponsorRlResult::HourLimitExceeded);
+        assert_eq!(
+            SponsorRlResult::MinuteLimitExceeded,
+            SponsorRlResult::MinuteLimitExceeded
+        );
+        assert_eq!(
+            SponsorRlResult::HourLimitExceeded,
+            SponsorRlResult::HourLimitExceeded
+        );
+        assert_ne!(
+            SponsorRlResult::Allowed,
+            SponsorRlResult::MinuteLimitExceeded
+        );
+        assert_ne!(
+            SponsorRlResult::MinuteLimitExceeded,
+            SponsorRlResult::HourLimitExceeded
+        );
     }
 }

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -1,15 +1,49 @@
 use axum::body::Body;
+use axum::extract::Path;
+use axum::http::StatusCode;
 use axum::response::Response;
 use axum::{extract::State, Extension, Json};
 use base64::Engine as _;
 use futures::stream::{self, StreamExt};
 use std::sync::Arc;
 
+use apalis::prelude::Storage as _;
+
 use crate::db::VectorDb;
+use crate::jobs::{BulkRememberItem, WalletJob, WalletOperation};
 use crate::rate_limit;
 use crate::seal;
 use crate::types::*;
 use crate::walrus;
+
+/// Enqueue a WalletJob to the correct per-wallet Apalis queue.
+///
+/// `wallet_index` must match the index used (or to be used) for the Walrus
+/// upload so that upload and set-metadata+transfer always sign with the
+/// same key. Returns the wallet_index for caller tracking.
+pub async fn enqueue_wallet_job(
+    state: &AppState,
+    wallet_index: usize,
+    operation: WalletOperation,
+) -> Result<usize, AppError> {
+    let storages = &state.wallet_storages;
+    if wallet_index >= storages.len() {
+        return Err(AppError::Internal(format!(
+            "wallet_index {} out of range (pool size={})",
+            wallet_index,
+            storages.len()
+        )));
+    }
+    let mut storage = storages[wallet_index].clone();
+    storage
+        .push(WalletJob {
+            wallet_index,
+            operation,
+        })
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to enqueue WalletJob: {}", e)))?;
+    Ok(wallet_index)
+}
 
 const MAX_ANALYZE_FACTS: usize = 20;
 const ANALYZE_CONCURRENCY: usize = 5;
@@ -38,7 +72,7 @@ fn truncate_str(s: &str, max_bytes: usize) -> &str {
 }
 
 // ============================================================
-// Embedding — OpenRouter/OpenAI API (with mock fallback)
+// Embedding — OpenRouter/OpenAI API (with mock fallback) [pub for jobs.rs]
 // ============================================================
 
 /// OpenAI-compatible embedding request
@@ -128,22 +162,20 @@ async fn generate_embedding(
 // Routes
 // ============================================================
 
-/// POST /api/remember
+/// POST /api/remember  (ENG-1406 v3 — fully async)
 ///
-/// Full TEE flow:
-/// 1. Verify auth (middleware) → get owner from delegate key onchain lookup
-/// 2. Embed text + Encrypt text concurrently (independent operations)
-/// 3. Upload encrypted blob → Walrus → blobId
-/// 4. Store {vector, blobId} in Vector DB
+/// Validates the request, enqueues a RememberJob into Apalis Postgres,
+/// inserts a `pending` row into `remember_jobs`, then returns **HTTP 202**
+/// with `{ job_id }`. The caller polls `GET /api/remember/:job_id` to
+/// get status and, once done, the `blob_id`.
 pub async fn remember(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthInfo>,
     Json(body): Json<RememberRequest>,
-) -> Result<Json<RememberResponse>, AppError> {
+) -> Result<(StatusCode, Json<RememberAcceptedResponse>), AppError> {
     if body.text.is_empty() {
         return Err(AppError::BadRequest("Text cannot be empty".into()));
     }
-    // LOW-6: Reject oversize plaintext before spending embed + encrypt compute.
     if body.text.len() > MAX_REMEMBER_TEXT_BYTES {
         return Err(AppError::BadRequest(format!(
             "Text exceeds maximum length of {} bytes",
@@ -151,24 +183,20 @@ pub async fn remember(
         )));
     }
 
-    // Owner is derived from delegate key via onchain verification (auth middleware)
     let owner = &auth.owner;
-    let text = &body.text;
     let namespace = &body.namespace;
-    tracing::info!(
-        "remember: text=\"{}...\" owner={} ns={}",
-        truncate_str(text, 50),
-        owner,
-        namespace
-    );
 
-    // Step 1: Embed text + SEAL encrypt concurrently (they're independent)
-    let embed_fut = generate_embedding(&state.http_client, &state.config, text);
-    let encrypt_fut = seal::seal_encrypt(
+    // Step 1: embed + SEAL encrypt concurrently in the route handler.
+    // (~300ms total, parallel). This ensures:
+    //   - No plaintext is stored in the Apalis job payload
+    //   - Exact encrypted size is known for quota check
+    //   - Worker only needs to upload (the slow ~2-3s part)
+    let embed_fut = generate_embedding(&state.http_client, &state.config, &body.text);
+    let encrypt_fut = crate::seal::seal_encrypt(
         &state.http_client,
         &state.config.sidecar_url,
         state.config.sidecar_secret.as_deref(),
-        text.as_bytes(),
+        body.text.as_bytes(),
         owner,
         &state.config.package_id,
     );
@@ -176,51 +204,349 @@ pub async fn remember(
     let vector = vector_result?;
     let encrypted = encrypted_result?;
 
-    // LOW-11: Quota is stored using encrypted blob size (blob_size_bytes), so check
-    // quota against ciphertext length — not plaintext — to avoid under-counting
-    // the SEAL framing overhead that is actually persisted.
+    // Step 2: Quota check with exact ciphertext size (restored from sync path).
+    // LOW-11: Use encrypted size, not plaintext, to match what's stored in DB.
     rate_limit::check_storage_quota(&state, owner, encrypted.len() as i64).await?;
 
-    // Step 2: Upload encrypted blob → Walrus (via sidecar)
-    let key_index = state.key_pool.next_index()
-        .ok_or_else(|| AppError::Internal("No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into()))?;
-    let upload_result = walrus::upload_blob(
-        &state.http_client,
-        &state.config.sidecar_url,
-        state.config.sidecar_secret.as_deref(),
-        &encrypted,
-        50,
-        owner,
-        key_index,
-        namespace,
-        &state.config.package_id,
-        Some(&auth.public_key),
-    )
-    .await?;
-    let blob_id = upload_result.blob_id;
+    let job_id = uuid::Uuid::new_v4().to_string();
 
-    // Step 3: Store {vector, blobId, namespace} in Vector DB
-    let blob_size = encrypted.len() as i64;
-    let id = uuid::Uuid::new_v4().to_string();
-    state
-        .db
-        .insert_vector(&id, owner, namespace, &blob_id, &vector, blob_size)
-        .await?;
+    // Encode encrypted bytes for job payload (base64, no plaintext stored)
+    let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+
+    // Step 3: Insert status row BEFORE enqueuing so GET can immediately find it.
+    sqlx::query(
+        "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
+    )
+    .bind(&job_id)
+    .bind(owner)
+    .bind(namespace)
+    .execute(state.db.pool())
+    .await
+    .map_err(|e| AppError::Internal(format!("Failed to create job row: {}", e)))?;
+
+    // Step 4: Pin a wallet slot at enqueue time and enqueue WalletJob::UploadAndTransfer.
+    // Using WalletJob (vs the legacy RememberJob) guarantees that the upload AND the
+    // subsequent set-metadata + transfer both sign with the SAME wallet — eliminating
+    // the wrong-signer race that occurred when set-metadata picked a different key
+    // from the round-robin pool than the one that owned the freshly-certified blob.
+    let wallet_index = state.key_pool.next_index().ok_or_else(|| {
+        AppError::Internal(
+            "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into(),
+        )
+    })?;
+
+    if let Err(e) = enqueue_wallet_job(
+        &state,
+        wallet_index,
+        WalletOperation::UploadAndTransfer {
+            encrypted_b64,
+            vector,
+            owner: owner.clone(),
+            namespace: namespace.clone(),
+            package_id: state.config.package_id.clone(),
+            agent_public_key: Some(auth.public_key.clone()),
+            remember_job_id: Some(job_id.clone()),
+            epochs: 50,
+        },
+    )
+    .await
+    {
+        let msg = format!("Failed to enqueue remember job: {}", e);
+        let _ = sqlx::query(
+            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+        )
+        .bind(&msg)
+        .bind(&job_id)
+        .execute(state.db.pool())
+        .await;
+        return Err(AppError::Internal(msg));
+    }
 
     tracing::info!(
-        "remember complete: blob_id={}, owner={}, ns={}, dims={}",
-        blob_id,
+        "remember accepted: job_id={} owner={} ns={} encrypted_bytes={} wallet={}",
+        job_id,
         owner,
         namespace,
-        vector.len()
+        encrypted.len(),
+        wallet_index,
     );
 
-    Ok(Json(RememberResponse {
-        id,
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(RememberAcceptedResponse {
+            job_id,
+            status: "pending".to_string(),
+        }),
+    ))
+}
+
+/// GET /api/remember/:job_id  — poll job status
+///
+/// Returns `{ job_id, status, blob_id?, error? }` where status is one of
+/// `pending | running | done | failed`.
+pub async fn remember_status(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthInfo>,
+    Path(job_id): Path<String>,
+) -> Result<Json<RememberJobStatusResponse>, AppError> {
+    // Query by job_id — no compile-time check since table is created at runtime
+    #[allow(clippy::type_complexity)]
+    let row: Option<(
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+    )> = sqlx::query_as(
+        "SELECT id, owner, namespace, status, blob_id, error_msg FROM remember_jobs WHERE id = $1",
+    )
+    .bind(&job_id)
+    .fetch_optional(state.db.pool())
+    .await
+    .map_err(|e| AppError::Internal(format!("DB error: {}", e)))?;
+
+    // Security: collapse "not found" and "exists but not yours" into the same
+    // BlobNotFound response to prevent enumeration of other users' job IDs.
+    let (id, owner_db, namespace, status, blob_id, error_msg) = match row {
+        Some(r) if r.1 == auth.owner => r,
+        _ => return Err(AppError::BlobNotFound(format!("Job {} not found", job_id))),
+    };
+    let _ = owner_db; // already validated equal to auth.owner
+
+    Ok(Json(RememberJobStatusResponse {
+        job_id: id,
+        status,
+        owner: auth.owner.clone(),
+        namespace,
         blob_id,
-        owner: owner.clone(),
-        namespace: namespace.clone(),
+        error: error_msg,
     }))
+}
+
+/// POST /api/remember/bulk  (ENG-1408)
+///
+/// Batch async remember — accepts up to MAX_BULK_ITEMS memories in one call.
+/// Returns 202 with job_ids[]; poll each via GET /api/remember/:job_id.
+pub async fn remember_bulk(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthInfo>,
+    Json(body): Json<RememberBulkRequest>,
+) -> Result<(StatusCode, Json<RememberBulkAcceptedResponse>), AppError> {
+    // ── Validate ──────────────────────────────────────────────────────────
+    if body.items.is_empty() {
+        return Err(AppError::BadRequest("items cannot be empty".into()));
+    }
+    if body.items.len() > MAX_BULK_ITEMS {
+        return Err(AppError::BadRequest(format!(
+            "items exceeds maximum of {} per bulk request",
+            MAX_BULK_ITEMS
+        )));
+    }
+    for (i, item) in body.items.iter().enumerate() {
+        if item.text.is_empty() {
+            return Err(AppError::BadRequest(format!(
+                "items[{}].text cannot be empty",
+                i
+            )));
+        }
+        if item.text.len() > MAX_REMEMBER_TEXT_BYTES {
+            return Err(AppError::BadRequest(format!(
+                "items[{}].text exceeds {} bytes",
+                i, MAX_REMEMBER_TEXT_BYTES
+            )));
+        }
+    }
+
+    let owner = &auth.owner;
+    tracing::info!(
+        "remember_bulk: {} items owner={}",
+        body.items.len(),
+        &owner[..10.min(owner.len())],
+    );
+
+    // ── Concurrent embed + SEAL-encrypt (bounded concurrency) ─────────────
+    let prep_tasks: Vec<_> = body
+        .items
+        .iter()
+        .map(|item| {
+            let state = Arc::clone(&state);
+            let owner = owner.clone();
+            let text = item.text.clone();
+            let namespace = item.namespace.clone();
+            async move {
+                let embed_fut = generate_embedding(&state.http_client, &state.config, &text);
+                let encrypt_fut = crate::seal::seal_encrypt(
+                    &state.http_client,
+                    &state.config.sidecar_url,
+                    state.config.sidecar_secret.as_deref(),
+                    text.as_bytes(),
+                    &owner,
+                    &state.config.package_id,
+                );
+                let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
+                Ok::<_, AppError>((namespace, vector_result?, encrypted_result?))
+            }
+        })
+        .collect();
+
+    let prep_results = collect_bounded_results(prep_tasks, BULK_EMBED_CONCURRENCY).await;
+
+    let mut prepared: Vec<(String, Vec<f32>, Vec<u8>)> = Vec::with_capacity(prep_results.len());
+    let mut total_encrypted_bytes: i64 = 0;
+    for r in prep_results {
+        let (namespace, vector, encrypted) = r?;
+        total_encrypted_bytes += encrypted.len() as i64;
+        prepared.push((namespace, vector, encrypted));
+    }
+
+    // ── Quota check ───────────────────────────────────────────────────────
+    rate_limit::check_storage_quota(&state, owner, total_encrypted_bytes).await?;
+
+    // ── Insert N remember_jobs rows + build BulkRememberItems ─────────────
+    let mut job_ids: Vec<String> = Vec::with_capacity(prepared.len());
+    let mut bulk_items: Vec<BulkRememberItem> = Vec::with_capacity(prepared.len());
+
+    for (namespace, vector, encrypted) in prepared {
+        let job_id = uuid::Uuid::new_v4().to_string();
+
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
+        )
+        .bind(&job_id)
+        .bind(owner)
+        .bind(&namespace)
+        .execute(state.db.pool())
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to create bulk job row: {}", e)))?;
+
+        let wallet_index = state
+            .key_pool
+            .next_index()
+            .ok_or_else(|| AppError::Internal("No Sui keys configured".into()))?;
+
+        let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+        bulk_items.push(BulkRememberItem {
+            job_id: job_id.clone(),
+            encrypted_b64,
+            vector,
+            namespace,
+            wallet_index,
+        });
+        job_ids.push(job_id);
+    }
+
+    let total = job_ids.len();
+
+    // ── Enqueue 1 BulkRememberJob ─────────────────────────────────────────
+    let mut storage = state.bulk_job_storage.clone();
+    if let Err(e) = storage
+        .push(crate::jobs::BulkRememberJob {
+            owner: owner.clone(),
+            package_id: state.config.package_id.clone(),
+            agent_public_key: Some(auth.public_key.clone()),
+            items: bulk_items,
+            epochs: 50,
+        })
+        .await
+    {
+        let msg = format!("Failed to enqueue bulk remember job: {}", e);
+        let _ = sqlx::query(
+            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = ANY($2)",
+        )
+        .bind(&msg)
+        .bind(&job_ids)
+        .execute(state.db.pool())
+        .await;
+        return Err(AppError::Internal(msg));
+    }
+
+    tracing::info!(
+        "remember_bulk accepted: {} items owner={} total_encrypted_bytes={}",
+        total,
+        owner,
+        total_encrypted_bytes,
+    );
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(RememberBulkAcceptedResponse {
+            job_ids,
+            total,
+            status: "pending".to_string(),
+        }),
+    ))
+}
+
+type BulkStatusRow = (String, String, String, Option<String>, Option<String>);
+
+fn build_bulk_status_results(
+    job_ids: Vec<String>,
+    rows: Vec<BulkStatusRow>,
+) -> Vec<RememberBulkStatusItem> {
+    let mut by_id = std::collections::HashMap::with_capacity(rows.len());
+    for (id, _owner_db, status, blob_id, error_msg) in rows {
+        by_id.insert(
+            id.clone(),
+            RememberBulkStatusItem {
+                job_id: id,
+                status,
+                blob_id,
+                error: error_msg,
+            },
+        );
+    }
+
+    let mut results = Vec::with_capacity(job_ids.len());
+    for job_id in job_ids {
+        let item = by_id
+            .get(&job_id)
+            .cloned()
+            .unwrap_or_else(|| RememberBulkStatusItem {
+                job_id,
+                status: "not_found".to_string(),
+                blob_id: None,
+                error: None,
+            });
+        results.push(item);
+    }
+
+    results
+}
+
+/// POST /api/remember/bulk/status  — poll multiple job statuses at once
+///
+/// Returns `{ results: [{ job_id, status, blob_id?, error? }] }` preserving the
+/// same order as `job_ids[]` in the request. All jobs must belong to the
+/// authenticated owner.
+pub async fn remember_bulk_status(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthInfo>,
+    Json(body): Json<RememberBulkStatusRequest>,
+) -> Result<Json<RememberBulkStatusResponse>, AppError> {
+    if body.job_ids.is_empty() {
+        return Err(AppError::BadRequest("job_ids cannot be empty".into()));
+    }
+    if body.job_ids.len() > MAX_BULK_ITEMS {
+        return Err(AppError::BadRequest(format!(
+            "job_ids exceeds maximum of {} per bulk status request",
+            MAX_BULK_ITEMS
+        )));
+    }
+
+    let rows: Vec<BulkStatusRow> =
+        sqlx::query_as(
+            "SELECT id, owner, status, blob_id, error_msg FROM remember_jobs WHERE id = ANY($1) AND owner = $2",
+        )
+        .bind(&body.job_ids)
+        .bind(&auth.owner)
+        .fetch_all(state.db.pool())
+        .await
+        .map_err(|e| AppError::Internal(format!("DB error: {}", e)))?;
+
+    let results = build_bulk_status_results(body.job_ids, rows);
+
+    Ok(Json(RememberBulkStatusResponse { results }))
 }
 
 /// POST /api/recall
@@ -229,7 +555,7 @@ pub async fn remember(
 /// 1. Verify auth (middleware) → get owner from delegate key onchain lookup
 /// 2. Embed query → vector
 /// 3. Search Vector DB → top-K {blobId}
-/// 4. Download + Decrypt all blobs concurrently (via sidecar HTTP)
+/// 4. Download all blobs concurrently + SEAL decrypt each
 /// 5. Return plaintext results
 pub async fn recall(
     State(state): State<Arc<AppState>>,
@@ -253,15 +579,14 @@ pub async fn recall(
     // ENG-1697: Prefer the client-built SessionKey (x-seal-session); fall
     // back to the legacy x-delegate-key; finally fall back to the server's
     // own key for background operation.
-    let credential = seal::SealCredential::from_auth_or_fallback(
-        &auth,
-        state.config.sui_private_key.as_deref(),
-    )
-    .ok_or_else(|| {
-        AppError::Internal(
-            "SEAL credential required (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)".into(),
+    let credential =
+        seal::SealCredential::from_auth_or_fallback(&auth, state.config.sui_private_key.as_deref())
+            .ok_or_else(|| {
+                AppError::Internal(
+            "SEAL credential required (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)"
+                .into(),
         )
-    })?;
+            })?;
 
     // Step 1: Embed query → vector
     let query_vector = generate_embedding(&state.http_client, &state.config, &body.query).await?;
@@ -270,7 +595,10 @@ pub async fn recall(
     // MED-3 fix: Cap limit to prevent unbounded DB scans / memory use.
     // Without this, an attacker could send limit=999999 to scan the entire DB.
     let limit = body.limit.min(100);
-    let hits = state.db.search_similar(&query_vector, owner, namespace, limit).await?;
+    let hits = state
+        .db
+        .search_similar(&query_vector, owner, namespace, limit)
+        .await?;
 
     // Step 3: Download + SEAL decrypt all results concurrently
     let db = &state.db;
@@ -412,8 +740,11 @@ pub async fn remember_manual(
     rate_limit::check_storage_quota(&state, owner, encrypted_bytes.len() as i64).await?;
 
     // Upload encrypted bytes to Walrus via sidecar (pool key pays gas)
-    let key_index = state.key_pool.next_index()
-        .ok_or_else(|| AppError::Internal("No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into()))?;
+    let key_index = state.key_pool.next_index().ok_or_else(|| {
+        AppError::Internal(
+            "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into(),
+        )
+    })?;
 
     let upload = walrus::upload_blob(
         &state.http_client,
@@ -439,6 +770,25 @@ pub async fn remember_manual(
         .db
         .insert_vector(&id, owner, namespace, &blob_id, &body.vector, blob_size)
         .await?;
+
+    // Enqueue metadata+transfer background job (WalletJob, pinned to same key)
+    if !upload.object_id.as_deref().unwrap_or("").is_empty() {
+        if let Err(e) = enqueue_wallet_job(
+            &state,
+            key_index,
+            WalletOperation::SetMetadataAndTransfer {
+                blob_object_id: upload.object_id.clone().unwrap_or_default(),
+                owner: owner.clone(),
+                namespace: namespace.clone(),
+                package_id: Some(state.config.package_id.clone()),
+                agent_id: Some(auth.public_key.clone()),
+            },
+        )
+        .await
+        {
+            tracing::warn!("[remember_manual] failed to enqueue wallet job: {}", e);
+        }
+    }
 
     tracing::info!(
         "remember_manual complete: id={}, blob_id={}, ns={}",
@@ -482,7 +832,10 @@ pub async fn recall_manual(
     // Search Vector DB — return blob IDs + distances only
     // MED-3 fix: Cap limit on recall_manual as well
     let limit = body.limit.min(100);
-    let hits = state.db.search_similar(&body.vector, owner, namespace, limit).await?;
+    let hits = state
+        .db
+        .search_similar(&body.vector, owner, namespace, limit)
+        .await?;
     let total = hits.len();
 
     tracing::info!(
@@ -508,7 +861,7 @@ pub async fn analyze(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthInfo>,
     Json(body): Json<AnalyzeRequest>,
-) -> Result<Json<AnalyzeResponse>, AppError> {
+) -> Result<(StatusCode, Json<AnalyzeAcceptedResponse>), AppError> {
     if body.text.is_empty() {
         return Err(AppError::BadRequest("Text cannot be empty".into()));
     }
@@ -522,116 +875,139 @@ pub async fn analyze(
         namespace
     );
 
-    // Step 1: Extract facts using LLM
+    // Step 1: Extract facts using LLM (sync — fast, ~1-2s)
     let extracted = extract_facts_llm(&state.http_client, &state.config, &body.text).await?;
     let raw_fact_count = extracted.raw_count;
     let facts = extracted.facts;
     let reserved_additional_weight = rate_limit::analyze_additional_weight(facts.len());
-    let total_weight = rate_limit::analyze_total_weight(facts.len());
     tracing::info!(
-        "  → Extracted {} facts (accepted={} cap={} concurrency={} total_weight={} additional_weight={})",
+        "  → Extracted {} facts (accepted={} cap={})",
         raw_fact_count,
         facts.len(),
         MAX_ANALYZE_FACTS,
-        ANALYZE_CONCURRENCY,
-        total_weight,
-        reserved_additional_weight
     );
 
     if facts.is_empty() {
-        return Ok(Json(AnalyzeResponse {
-            facts: vec![],
-            total: 0,
-            owner: owner.clone(),
-        }));
+        return Ok((
+            StatusCode::ACCEPTED,
+            Json(AnalyzeAcceptedResponse {
+                job_ids: vec![],
+                fact_count: 0,
+                status: "pending".to_string(),
+                owner: owner.clone(),
+            }),
+        ));
     }
 
-    rate_limit::charge_explicit_weight(
-        &state,
-        &auth,
-        reserved_additional_weight,
-        "/api/analyze",
-    )
-    .await?;
+    rate_limit::charge_explicit_weight(&state, &auth, reserved_additional_weight, "/api/analyze")
+        .await?;
 
-    // Check storage quota before processing all facts
-    let total_text_bytes: i64 = facts.iter().map(|f| f.len() as i64).sum();
-    rate_limit::check_storage_quota(&state, owner, total_text_bytes).await?;
-
-    // Step 2: Process all facts concurrently (embed + encrypt → upload → store)
-    // Each fact gets its own key from the pool so sidecar can upload them in parallel
-    // (different signer addresses bypass the per-signer serialization lock).
+    // Step 2: embed + SEAL encrypt all facts concurrently (no wallet needed yet).
+    // This is the fast part (~300-500ms), done in the request handler so:
+    //   - No plaintext stored in job payload
+    //   - Exact ciphertext size known for quota check
     let auth_pubkey_base = auth.public_key.clone();
-    let tasks: Vec<_> = facts.iter().map(|fact_text| {
-        let state = Arc::clone(&state);
-        let owner = owner.clone();
-        let fact_text = fact_text.clone();
-        let auth_pubkey = auth_pubkey_base.clone();
-        // Pick the next key in round-robin order at task construction time.
-        // Convert to owned String *before* async move so we don't borrow-then-move `state`.
-        let key_index: Result<usize, AppError> = state.key_pool.next_index()
-            .ok_or_else(|| AppError::Internal("No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into()));
-        let namespace = namespace.clone();
-        async move {
-            let key_index = key_index?;
-            // Embed + SEAL encrypt concurrently (independent operations)
-            let embed_fut = generate_embedding(&state.http_client, &state.config, &fact_text);
-            let encrypt_fut = seal::seal_encrypt(
-                &state.http_client, &state.config.sidecar_url,
-                state.config.sidecar_secret.as_deref(),
-                fact_text.as_bytes(), &owner, &state.config.package_id,
-            );
-            let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
-            let vector = vector_result?;
-            let encrypted = encrypted_result?;
+    let prep_tasks: Vec<_> = facts
+        .iter()
+        .map(|fact_text| {
+            let state = Arc::clone(&state);
+            let owner = owner.clone();
+            let fact_text = fact_text.clone();
+            async move {
+                let embed_fut = generate_embedding(&state.http_client, &state.config, &fact_text);
+                let encrypt_fut = crate::seal::seal_encrypt(
+                    &state.http_client,
+                    &state.config.sidecar_url,
+                    state.config.sidecar_secret.as_deref(),
+                    fact_text.as_bytes(),
+                    &owner,
+                    &state.config.package_id,
+                );
+                let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
+                Ok::<_, AppError>((fact_text, vector_result?, encrypted_result?))
+            }
+        })
+        .collect();
 
-            // Upload to Walrus (via sidecar HTTP)
-            let upload_result = walrus::upload_blob(
-                &state.http_client,
-                &state.config.sidecar_url,
-                state.config.sidecar_secret.as_deref(),
-                &encrypted,
-                50,
-                &owner,
-                key_index,
-                &namespace,
-                &state.config.package_id,
-                Some(&auth_pubkey),
-            ).await?;
+    let prep_results = collect_bounded_results(prep_tasks, ANALYZE_CONCURRENCY).await;
 
-            // Store in Vector DB with namespace
-            let blob_size = encrypted.len() as i64;
-            let id = uuid::Uuid::new_v4().to_string();
-            state.db.insert_vector(&id, &owner, &namespace, &upload_result.blob_id, &vector, blob_size).await?;
+    // Quota check on total ciphertext size
+    let mut prepared: Vec<(String, Vec<f32>, Vec<u8>)> = Vec::with_capacity(prep_results.len());
+    let mut total_encrypted_bytes: i64 = 0;
+    for r in prep_results {
+        let (fact_text, vector, encrypted) = r?;
+        total_encrypted_bytes += encrypted.len() as i64;
+        prepared.push((fact_text, vector, encrypted));
+    }
+    rate_limit::check_storage_quota(&state, owner, total_encrypted_bytes).await?;
 
-            Ok::<AnalyzedFact, AppError>(AnalyzedFact {
-                text: fact_text,
-                id,
-                blob_id: upload_result.blob_id,
-            })
-        }
-    }).collect();
+    // Step 3: For each prepared fact — insert remember_jobs row + enqueue WalletJob.
+    // Round-robin across wallet pool so facts upload in parallel.
+    let mut job_ids: Vec<String> = Vec::with_capacity(prepared.len());
+    for (fact_text, vector, encrypted) in prepared {
+        let job_id = uuid::Uuid::new_v4().to_string();
 
-    let results = collect_bounded_results(tasks, ANALYZE_CONCURRENCY).await;
+        // Insert status row
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
+        )
+        .bind(&job_id)
+        .bind(owner)
+        .bind(namespace)
+        .execute(state.db.pool())
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to create analyze job row: {}", e)))?;
 
-    // Collect successes, fail on first error (same semantics as sequential version)
-    let mut stored_facts = Vec::with_capacity(results.len());
-    for result in results {
-        stored_facts.push(result?);
+        // Pick next wallet slot (round-robin) and enqueue UploadAndTransfer
+        let wallet_index = state
+            .key_pool
+            .next_index()
+            .ok_or_else(|| AppError::Internal("No Sui keys configured".into()))?;
+        let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+
+        enqueue_wallet_job(
+            &state,
+            wallet_index,
+            WalletOperation::UploadAndTransfer {
+                encrypted_b64,
+                vector,
+                owner: owner.clone(),
+                namespace: namespace.clone(),
+                package_id: state.config.package_id.clone(),
+                agent_public_key: Some(auth_pubkey_base.clone()),
+                remember_job_id: Some(job_id.clone()),
+                epochs: 50,
+            },
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to enqueue analyze job: {}", e)))?;
+
+        tracing::info!(
+            "analyze: fact enqueued job_id={} wallet={} fact=\"{}...\"",
+            job_id,
+            wallet_index,
+            truncate_str(&fact_text, 40)
+        );
+        job_ids.push(job_id);
     }
 
-    let total = stored_facts.len();
+    let fact_count = job_ids.len();
     tracing::info!(
-        "analyze complete: {} facts stored for owner={}",
-        total,
-        owner
+        "analyze accepted: {} facts enqueued owner={} ns={}",
+        fact_count,
+        owner,
+        namespace
     );
 
-    Ok(Json(AnalyzeResponse {
-        facts: stored_facts,
-        total,
-        owner: owner.clone(),
-    }))
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(AnalyzeAcceptedResponse {
+            job_ids,
+            fact_count,
+            status: "pending".to_string(),
+            owner: owner.clone(),
+        }),
+    ))
 }
 
 // ============================================================
@@ -823,7 +1199,8 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> Json<ConfigRespon
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_bounded_results, parse_extracted_facts, ANALYZE_CONCURRENCY, MAX_ANALYZE_FACTS,
+        build_bulk_status_results, collect_bounded_results, parse_extracted_facts,
+        ANALYZE_CONCURRENCY, MAX_ANALYZE_FACTS,
     };
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
@@ -857,6 +1234,46 @@ mod tests {
         assert_eq!(parsed.facts.len(), MAX_ANALYZE_FACTS);
         assert_eq!(parsed.facts.first().map(String::as_str), Some("Fact 0"));
         assert_eq!(parsed.facts.last().map(String::as_str), Some("Fact 19"));
+    }
+
+    #[test]
+    fn bulk_status_results_preserve_order_duplicates_and_missing_items() {
+        let results = build_bulk_status_results(
+            vec![
+                "job-2".to_string(),
+                "missing".to_string(),
+                "job-1".to_string(),
+                "job-2".to_string(),
+            ],
+            vec![
+                (
+                    "job-1".to_string(),
+                    "owner".to_string(),
+                    "done".to_string(),
+                    Some("blob-1".to_string()),
+                    None,
+                ),
+                (
+                    "job-2".to_string(),
+                    "owner".to_string(),
+                    "failed".to_string(),
+                    None,
+                    Some("boom".to_string()),
+                ),
+            ],
+        );
+
+        assert_eq!(results.len(), 4);
+        assert_eq!(results[0].job_id, "job-2");
+        assert_eq!(results[0].status, "failed");
+        assert_eq!(results[0].error.as_deref(), Some("boom"));
+        assert_eq!(results[1].job_id, "missing");
+        assert_eq!(results[1].status, "not_found");
+        assert_eq!(results[2].job_id, "job-1");
+        assert_eq!(results[2].status, "done");
+        assert_eq!(results[2].blob_id.as_deref(), Some("blob-1"));
+        assert_eq!(results[3].job_id, "job-2");
+        assert_eq!(results[3].status, "failed");
     }
 
     #[tokio::test]
@@ -906,12 +1323,15 @@ mod tests {
 
     #[test]
     fn recall_limit_capped_at_100() {
-        // The code does body.limit.min(100)
-        assert_eq!(999999_usize.min(100), 100);
-        assert_eq!(100_usize.min(100), 100);
-        assert_eq!(50_usize.min(100), 50);
-        assert_eq!(1_usize.min(100), 1);
-        assert_eq!(0_usize.min(100), 0);
+        fn cap_limit(limit: usize) -> usize {
+            limit.min(100)
+        }
+
+        assert_eq!(cap_limit(999999), 100);
+        assert_eq!(cap_limit(100), 100);
+        assert_eq!(cap_limit(50), 50);
+        assert_eq!(cap_limit(1), 1);
+        assert_eq!(cap_limit(0), 0);
     }
 
     // ── LOW-7: RecallResponse dropped_count serialization ───────────────
@@ -944,7 +1364,7 @@ mod tests {
     #[test]
     fn memory_context_uses_xml_tags() {
         // Simulate what /api/ask does
-        let memories = vec![super::RecallResult {
+        let memories = [super::RecallResult {
             blob_id: "blob123".into(),
             text: "User likes coffee".into(),
             distance: 0.1,
@@ -1081,7 +1501,6 @@ mod tests {
     }
 }
 
-
 /// POST /api/ask
 ///
 /// Full AI-with-memory demo:
@@ -1118,15 +1537,14 @@ pub async fn ask(
 
     // ENG-1697: Prefer the client-built SessionKey; fall back to legacy
     // delegate key, then to the server's own key.
-    let credential = seal::SealCredential::from_auth_or_fallback(
-        &auth,
-        state.config.sui_private_key.as_deref(),
-    )
-    .ok_or_else(|| {
-        AppError::Internal(
-            "SEAL credential required (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)".into(),
+    let credential =
+        seal::SealCredential::from_auth_or_fallback(&auth, state.config.sui_private_key.as_deref())
+            .ok_or_else(|| {
+                AppError::Internal(
+            "SEAL credential required (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)"
+                .into(),
         )
-    })?;
+            })?;
 
     // Download + SEAL decrypt all memories concurrently
     let db = &state.db;
@@ -1493,7 +1911,7 @@ pub async fn restore(
     // Step 4: SEAL decrypt with bounded concurrency (3 at a time)
     // Use per-blob package_id from on-chain metadata, fall back to current server config
     use futures::stream::{self, StreamExt};
-    let decrypt_results: Vec<Option<(String, String)>> = stream::iter(downloaded.into_iter())
+    let decrypt_results: Vec<Option<(String, String)>> = stream::iter(downloaded)
         .map(|(blob_id, encrypted_data)| {
             let http_client = &state.http_client;
             let sidecar_url = state.config.sidecar_url.clone();
@@ -1622,7 +2040,10 @@ fn mask_upstream(status: u16) -> (axum::http::StatusCode, &'static str) {
             "Sponsor service misconfigured",
         ),
         500..=599 => (axum::http::StatusCode::BAD_GATEWAY, "Sponsor service error"),
-        _ => (axum::http::StatusCode::BAD_REQUEST, "Sponsor request rejected"),
+        _ => (
+            axum::http::StatusCode::BAD_REQUEST,
+            "Sponsor request rejected",
+        ),
     }
 }
 
@@ -1630,9 +2051,7 @@ fn json_error_response(status: axum::http::StatusCode, msg: &'static str) -> Res
     Response::builder()
         .status(status)
         .header("Content-Type", "application/json")
-        .body(Body::from(
-            serde_json::json!({ "error": msg }).to_string(),
-        ))
+        .body(Body::from(serde_json::json!({ "error": msg }).to_string()))
         .unwrap()
 }
 
@@ -1679,10 +2098,13 @@ pub async fn sponsor_proxy(
         return Err(AppError::BadRequest("Invalid sender address".into()));
     }
 
-    let tx_bytes = decode_base64(&req.transaction_block_kind_bytes)
-        .ok_or_else(|| AppError::BadRequest("transactionBlockKindBytes must be valid base64".into()))?;
+    let tx_bytes = decode_base64(&req.transaction_block_kind_bytes).ok_or_else(|| {
+        AppError::BadRequest("transactionBlockKindBytes must be valid base64".into())
+    })?;
     if tx_bytes.len() < 10 || tx_bytes.len() > 7000 {
-        return Err(AppError::BadRequest("transactionBlockKindBytes out of range".into()));
+        return Err(AppError::BadRequest(
+            "transactionBlockKindBytes out of range".into(),
+        ));
     }
 
     // Per-sender rate limit — second axis that a distributed IP attack cannot bypass.
@@ -1698,14 +2120,20 @@ pub async fn sponsor_proxy(
         .await
         {
             Ok(rate_limit::SponsorRlResult::MinuteLimitExceeded) => {
-                tracing::warn!("sponsor rate limit [sender/min]: sender={}...", &req.sender[..16]);
+                tracing::warn!(
+                    "sponsor rate limit [sender/min]: sender={}...",
+                    &req.sender[..16]
+                );
                 return Ok(json_error_response(
                     axum::http::StatusCode::TOO_MANY_REQUESTS,
                     "Rate limit exceeded",
                 ));
             }
             Ok(rate_limit::SponsorRlResult::HourLimitExceeded) => {
-                tracing::warn!("sponsor rate limit [sender/hr]: sender={}...", &req.sender[..16]);
+                tracing::warn!(
+                    "sponsor rate limit [sender/hr]: sender={}...",
+                    &req.sender[..16]
+                );
                 return Ok(json_error_response(
                     axum::http::StatusCode::TOO_MANY_REQUESTS,
                     "Rate limit exceeded",
@@ -1714,7 +2142,9 @@ pub async fn sponsor_proxy(
             Ok(rate_limit::SponsorRlResult::Allowed) => {}
             Err(_) => {
                 // HIGH-2: Redis and in-memory fallback both unavailable — deny to fail-closed.
-                tracing::error!("sponsor sender rate limit unavailable for sponsor_proxy, denying request");
+                tracing::error!(
+                    "sponsor sender rate limit unavailable for sponsor_proxy, denying request"
+                );
                 return Ok(json_error_response(
                     axum::http::StatusCode::SERVICE_UNAVAILABLE,
                     "Rate limiter temporarily unavailable",
@@ -1793,14 +2223,33 @@ pub async fn sponsor_execute_proxy(
             return Err(AppError::BadRequest("Invalid sender address".into()));
         }
         let config = &state.config.sponsor_rate_limit;
-        match rate_limit::check_sender_rate_limit(&state, sender, config.per_minute, config.per_hour).await {
+        match rate_limit::check_sender_rate_limit(
+            &state,
+            sender,
+            config.per_minute,
+            config.per_hour,
+        )
+        .await
+        {
             Ok(rate_limit::SponsorRlResult::MinuteLimitExceeded) => {
-                tracing::warn!("sponsor/execute rate limit [sender/min]: sender={}...", &sender[..16]);
-                return Ok(json_error_response(axum::http::StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"));
+                tracing::warn!(
+                    "sponsor/execute rate limit [sender/min]: sender={}...",
+                    &sender[..16]
+                );
+                return Ok(json_error_response(
+                    axum::http::StatusCode::TOO_MANY_REQUESTS,
+                    "Rate limit exceeded",
+                ));
             }
             Ok(rate_limit::SponsorRlResult::HourLimitExceeded) => {
-                tracing::warn!("sponsor/execute rate limit [sender/hr]: sender={}...", &sender[..16]);
-                return Ok(json_error_response(axum::http::StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"));
+                tracing::warn!(
+                    "sponsor/execute rate limit [sender/hr]: sender={}...",
+                    &sender[..16]
+                );
+                return Ok(json_error_response(
+                    axum::http::StatusCode::TOO_MANY_REQUESTS,
+                    "Rate limit exceeded",
+                ));
             }
             Ok(rate_limit::SponsorRlResult::Allowed) => {}
             Err(_) => {

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -57,6 +57,205 @@ const MAX_SPONSORED_SIGNATURE_BYTES: usize = 2048;
 // payloads that will fail downstream.
 const MAX_REMEMBER_TEXT_BYTES: usize = 64 * 1024;
 
+struct PendingBulkRememberItem {
+    job_id: String,
+    text: String,
+    namespace: String,
+}
+
+async fn mark_remember_job_failed(state: &AppState, job_id: &str, msg: &str) {
+    let _ = sqlx::query(
+        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+    )
+    .bind(msg)
+    .bind(job_id)
+    .execute(state.db.pool())
+    .await;
+}
+
+async fn mark_remember_jobs_failed(state: &AppState, job_ids: &[String], msg: &str) {
+    if job_ids.is_empty() {
+        return;
+    }
+    let _ = sqlx::query(
+        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = ANY($2)",
+    )
+    .bind(msg)
+    .bind(job_ids)
+    .execute(state.db.pool())
+    .await;
+}
+
+fn spawn_prepare_remember_job(
+    state: Arc<AppState>,
+    job_id: String,
+    text: String,
+    owner: String,
+    namespace: String,
+    agent_public_key: String,
+) {
+    tokio::spawn(async move {
+        let result: Result<(), AppError> = async {
+            let embed_fut = generate_embedding(&state.http_client, &state.config, &text);
+            let encrypt_fut = crate::seal::seal_encrypt(
+                &state.http_client,
+                &state.config.sidecar_url,
+                state.config.sidecar_secret.as_deref(),
+                text.as_bytes(),
+                &owner,
+                &state.config.package_id,
+            );
+            let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
+            let vector = vector_result?;
+            let encrypted = encrypted_result?;
+
+            rate_limit::check_storage_quota(&state, &owner, encrypted.len() as i64).await?;
+
+            let wallet_index = state.key_pool.next_index().ok_or_else(|| {
+                AppError::Internal(
+                    "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)"
+                        .into(),
+                )
+            })?;
+            let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+
+            enqueue_wallet_job(
+                &state,
+                wallet_index,
+                WalletOperation::UploadAndTransfer {
+                    encrypted_b64,
+                    vector,
+                    owner: owner.clone(),
+                    namespace: namespace.clone(),
+                    package_id: state.config.package_id.clone(),
+                    agent_public_key: Some(agent_public_key.clone()),
+                    remember_job_id: Some(job_id.clone()),
+                    epochs: 50,
+                },
+            )
+            .await?;
+
+            tracing::info!(
+                "remember prepared: job_id={} owner={} ns={} encrypted_bytes={} wallet={}",
+                job_id,
+                owner,
+                namespace,
+                encrypted.len(),
+                wallet_index,
+            );
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            let msg = e.to_string();
+            tracing::error!("remember preparation failed: job_id={} {}", job_id, msg);
+            mark_remember_job_failed(&state, &job_id, &msg).await;
+        }
+    });
+}
+
+fn spawn_prepare_bulk_remember_job(
+    state: Arc<AppState>,
+    owner: String,
+    agent_public_key: String,
+    pending_items: Vec<PendingBulkRememberItem>,
+) {
+    tokio::spawn(async move {
+        let job_ids: Vec<String> = pending_items
+            .iter()
+            .map(|item| item.job_id.clone())
+            .collect();
+        let result: Result<(), AppError> = async {
+            let prep_tasks: Vec<_> = pending_items
+                .into_iter()
+                .map(|item| {
+                    let state = Arc::clone(&state);
+                    let owner = owner.clone();
+                    async move {
+                        let embed_fut =
+                            generate_embedding(&state.http_client, &state.config, &item.text);
+                        let encrypt_fut = crate::seal::seal_encrypt(
+                            &state.http_client,
+                            &state.config.sidecar_url,
+                            state.config.sidecar_secret.as_deref(),
+                            item.text.as_bytes(),
+                            &owner,
+                            &state.config.package_id,
+                        );
+                        let (vector_result, encrypted_result) =
+                            tokio::join!(embed_fut, encrypt_fut);
+                        Ok::<_, AppError>((
+                            item.job_id,
+                            item.namespace,
+                            vector_result?,
+                            encrypted_result?,
+                        ))
+                    }
+                })
+                .collect();
+
+            let prep_results = collect_bounded_results(prep_tasks, BULK_EMBED_CONCURRENCY).await;
+
+            let mut prepared: Vec<(String, String, Vec<f32>, Vec<u8>)> =
+                Vec::with_capacity(prep_results.len());
+            let mut total_encrypted_bytes: i64 = 0;
+            for result in prep_results {
+                let (job_id, namespace, vector, encrypted) = result?;
+                total_encrypted_bytes += encrypted.len() as i64;
+                prepared.push((job_id, namespace, vector, encrypted));
+            }
+
+            rate_limit::check_storage_quota(&state, &owner, total_encrypted_bytes).await?;
+
+            let mut bulk_items: Vec<BulkRememberItem> = Vec::with_capacity(prepared.len());
+            for (job_id, namespace, vector, encrypted) in prepared {
+                let wallet_index = state
+                    .key_pool
+                    .next_index()
+                    .ok_or_else(|| AppError::Internal("No Sui keys configured".into()))?;
+                let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+                bulk_items.push(BulkRememberItem {
+                    job_id,
+                    encrypted_b64,
+                    vector,
+                    namespace,
+                    wallet_index,
+                });
+            }
+
+            let mut storage = state.bulk_job_storage.clone();
+            storage
+                .push(crate::jobs::BulkRememberJob {
+                    owner: owner.clone(),
+                    package_id: state.config.package_id.clone(),
+                    agent_public_key: Some(agent_public_key.clone()),
+                    items: bulk_items,
+                    epochs: 50,
+                })
+                .await
+                .map_err(|e| {
+                    AppError::Internal(format!("Failed to enqueue bulk remember job: {}", e))
+                })?;
+
+            tracing::info!(
+                "remember_bulk prepared: {} items owner={} total_encrypted_bytes={}",
+                job_ids.len(),
+                owner,
+                total_encrypted_bytes
+            );
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            let msg = e.to_string();
+            tracing::error!("remember_bulk preparation failed: {}", msg);
+            mark_remember_jobs_failed(&state, &job_ids, &msg).await;
+        }
+    });
+}
+
 /// Truncate a string to at most `max_bytes` bytes without splitting a UTF-8
 /// character.  Falls back to the nearest char boundary when `max_bytes` lands
 /// inside a multi-byte sequence (e.g. emoji).
@@ -164,10 +363,9 @@ async fn generate_embedding(
 
 /// POST /api/remember  (ENG-1406 v3 — fully async)
 ///
-/// Validates the request, enqueues a RememberJob into Apalis Postgres,
-/// inserts a `pending` row into `remember_jobs`, then returns **HTTP 202**
-/// with `{ job_id }`. The caller polls `GET /api/remember/:job_id` to
-/// get status and, once done, the `blob_id`.
+/// Validates the request, inserts a job row, and returns HTTP 202 before
+/// embed/encrypt/upload work starts. Preparation runs in-process and then
+/// enqueues the durable wallet job.
 pub async fn remember(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthInfo>,
@@ -185,37 +383,14 @@ pub async fn remember(
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
-
-    // Step 1: embed + SEAL encrypt concurrently in the route handler.
-    // (~300ms total, parallel). This ensures:
-    //   - No plaintext is stored in the Apalis job payload
-    //   - Exact encrypted size is known for quota check
-    //   - Worker only needs to upload (the slow ~2-3s part)
-    let embed_fut = generate_embedding(&state.http_client, &state.config, &body.text);
-    let encrypt_fut = crate::seal::seal_encrypt(
-        &state.http_client,
-        &state.config.sidecar_url,
-        state.config.sidecar_secret.as_deref(),
-        body.text.as_bytes(),
-        owner,
-        &state.config.package_id,
-    );
-    let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
-    let vector = vector_result?;
-    let encrypted = encrypted_result?;
-
-    // Step 2: Quota check with exact ciphertext size (restored from sync path).
-    // LOW-11: Use encrypted size, not plaintext, to match what's stored in DB.
-    rate_limit::check_storage_quota(&state, owner, encrypted.len() as i64).await?;
+    let owner_owned = owner.clone();
+    let namespace_owned = namespace.clone();
+    let text = body.text;
 
     let job_id = uuid::Uuid::new_v4().to_string();
 
-    // Encode encrypted bytes for job payload (base64, no plaintext stored)
-    let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
-
-    // Step 3: Insert status row BEFORE enqueuing so GET can immediately find it.
     sqlx::query(
-        "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
+        "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'running')",
     )
     .bind(&job_id)
     .bind(owner)
@@ -224,58 +399,27 @@ pub async fn remember(
     .await
     .map_err(|e| AppError::Internal(format!("Failed to create job row: {}", e)))?;
 
-    // Step 4: Pin a wallet slot at enqueue time and enqueue WalletJob::UploadAndTransfer.
-    // Using WalletJob (vs the legacy RememberJob) guarantees that the upload AND the
-    // subsequent set-metadata + transfer both sign with the SAME wallet — eliminating
-    // the wrong-signer race that occurred when set-metadata picked a different key
-    // from the round-robin pool than the one that owned the freshly-certified blob.
-    let wallet_index = state.key_pool.next_index().ok_or_else(|| {
-        AppError::Internal(
-            "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into(),
-        )
-    })?;
-
-    if let Err(e) = enqueue_wallet_job(
-        &state,
-        wallet_index,
-        WalletOperation::UploadAndTransfer {
-            encrypted_b64,
-            vector,
-            owner: owner.clone(),
-            namespace: namespace.clone(),
-            package_id: state.config.package_id.clone(),
-            agent_public_key: Some(auth.public_key.clone()),
-            remember_job_id: Some(job_id.clone()),
-            epochs: 50,
-        },
-    )
-    .await
-    {
-        let msg = format!("Failed to enqueue remember job: {}", e);
-        let _ = sqlx::query(
-            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-        )
-        .bind(&msg)
-        .bind(&job_id)
-        .execute(state.db.pool())
-        .await;
-        return Err(AppError::Internal(msg));
-    }
+    spawn_prepare_remember_job(
+        Arc::clone(&state),
+        job_id.clone(),
+        text,
+        owner_owned,
+        namespace_owned,
+        auth.public_key.clone(),
+    );
 
     tracing::info!(
-        "remember accepted: job_id={} owner={} ns={} encrypted_bytes={} wallet={}",
+        "remember accepted: job_id={} owner={} ns={}",
         job_id,
         owner,
         namespace,
-        encrypted.len(),
-        wallet_index,
     );
 
     Ok((
         StatusCode::ACCEPTED,
         Json(RememberAcceptedResponse {
             job_id,
-            status: "pending".to_string(),
+            status: "running".to_string(),
         }),
     ))
 }
@@ -326,8 +470,9 @@ pub async fn remember_status(
 
 /// POST /api/remember/bulk  (ENG-1408)
 ///
-/// Batch async remember — accepts up to MAX_BULK_ITEMS memories in one call.
-/// Returns 202 with job_ids[]; poll each via GET /api/remember/:job_id.
+/// Accepts up to MAX_BULK_ITEMS memories and returns HTTP 202 after creating
+/// status rows. Embed/encrypt runs in the background; the bulk worker batches
+/// metadata+transfer by wallet after deferred Walrus uploads.
 pub async fn remember_bulk(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthInfo>,
@@ -365,115 +510,47 @@ pub async fn remember_bulk(
         &owner[..10.min(owner.len())],
     );
 
-    // ── Concurrent embed + SEAL-encrypt (bounded concurrency) ─────────────
-    let prep_tasks: Vec<_> = body
-        .items
-        .iter()
-        .map(|item| {
-            let state = Arc::clone(&state);
-            let owner = owner.clone();
-            let text = item.text.clone();
-            let namespace = item.namespace.clone();
-            async move {
-                let embed_fut = generate_embedding(&state.http_client, &state.config, &text);
-                let encrypt_fut = crate::seal::seal_encrypt(
-                    &state.http_client,
-                    &state.config.sidecar_url,
-                    state.config.sidecar_secret.as_deref(),
-                    text.as_bytes(),
-                    &owner,
-                    &state.config.package_id,
-                );
-                let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
-                Ok::<_, AppError>((namespace, vector_result?, encrypted_result?))
-            }
-        })
-        .collect();
+    let mut job_ids: Vec<String> = Vec::with_capacity(body.items.len());
+    let mut pending_items: Vec<PendingBulkRememberItem> = Vec::with_capacity(body.items.len());
 
-    let prep_results = collect_bounded_results(prep_tasks, BULK_EMBED_CONCURRENCY).await;
-
-    let mut prepared: Vec<(String, Vec<f32>, Vec<u8>)> = Vec::with_capacity(prep_results.len());
-    let mut total_encrypted_bytes: i64 = 0;
-    for r in prep_results {
-        let (namespace, vector, encrypted) = r?;
-        total_encrypted_bytes += encrypted.len() as i64;
-        prepared.push((namespace, vector, encrypted));
-    }
-
-    // ── Quota check ───────────────────────────────────────────────────────
-    rate_limit::check_storage_quota(&state, owner, total_encrypted_bytes).await?;
-
-    // ── Insert N remember_jobs rows + build BulkRememberItems ─────────────
-    let mut job_ids: Vec<String> = Vec::with_capacity(prepared.len());
-    let mut bulk_items: Vec<BulkRememberItem> = Vec::with_capacity(prepared.len());
-
-    for (namespace, vector, encrypted) in prepared {
+    for item in body.items {
         let job_id = uuid::Uuid::new_v4().to_string();
 
         sqlx::query(
-            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'running')",
         )
         .bind(&job_id)
         .bind(owner)
-        .bind(&namespace)
+        .bind(&item.namespace)
         .execute(state.db.pool())
         .await
         .map_err(|e| AppError::Internal(format!("Failed to create bulk job row: {}", e)))?;
 
-        let wallet_index = state
-            .key_pool
-            .next_index()
-            .ok_or_else(|| AppError::Internal("No Sui keys configured".into()))?;
-
-        let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
-        bulk_items.push(BulkRememberItem {
+        pending_items.push(PendingBulkRememberItem {
             job_id: job_id.clone(),
-            encrypted_b64,
-            vector,
-            namespace,
-            wallet_index,
+            text: item.text,
+            namespace: item.namespace,
         });
         job_ids.push(job_id);
     }
 
     let total = job_ids.len();
 
-    // ── Enqueue 1 BulkRememberJob ─────────────────────────────────────────
-    let mut storage = state.bulk_job_storage.clone();
-    if let Err(e) = storage
-        .push(crate::jobs::BulkRememberJob {
-            owner: owner.clone(),
-            package_id: state.config.package_id.clone(),
-            agent_public_key: Some(auth.public_key.clone()),
-            items: bulk_items,
-            epochs: 50,
-        })
-        .await
-    {
-        let msg = format!("Failed to enqueue bulk remember job: {}", e);
-        let _ = sqlx::query(
-            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = ANY($2)",
-        )
-        .bind(&msg)
-        .bind(&job_ids)
-        .execute(state.db.pool())
-        .await;
-        return Err(AppError::Internal(msg));
-    }
-
-    tracing::info!(
-        "remember_bulk accepted: {} items owner={} total_encrypted_bytes={}",
-        total,
-        owner,
-        total_encrypted_bytes,
+    spawn_prepare_bulk_remember_job(
+        Arc::clone(&state),
+        owner.clone(),
+        auth.public_key.clone(),
+        pending_items,
     );
+
+    tracing::info!("remember_bulk accepted: {} items owner={}", total, owner,);
 
     Ok((
         StatusCode::ACCEPTED,
         Json(RememberBulkAcceptedResponse {
             job_ids,
             total,
-            status: "pending".to_string(),
+            status: "running".to_string(),
         }),
     ))
 }
@@ -771,25 +848,6 @@ pub async fn remember_manual(
         .insert_vector(&id, owner, namespace, &blob_id, &body.vector, blob_size)
         .await?;
 
-    // Enqueue metadata+transfer background job (WalletJob, pinned to same key)
-    if !upload.object_id.as_deref().unwrap_or("").is_empty() {
-        if let Err(e) = enqueue_wallet_job(
-            &state,
-            key_index,
-            WalletOperation::SetMetadataAndTransfer {
-                blob_object_id: upload.object_id.clone().unwrap_or_default(),
-                owner: owner.clone(),
-                namespace: namespace.clone(),
-                package_id: Some(state.config.package_id.clone()),
-                agent_id: Some(auth.public_key.clone()),
-            },
-        )
-        .await
-        {
-            tracing::warn!("[remember_manual] failed to enqueue wallet job: {}", e);
-        }
-    }
-
     tracing::info!(
         "remember_manual complete: id={}, blob_id={}, ns={}",
         id,
@@ -892,6 +950,7 @@ pub async fn analyze(
             StatusCode::ACCEPTED,
             Json(AnalyzeAcceptedResponse {
                 job_ids: vec![],
+                facts: vec![],
                 fact_count: 0,
                 status: "pending".to_string(),
                 owner: owner.clone(),
@@ -944,6 +1003,7 @@ pub async fn analyze(
     // Step 3: For each prepared fact — insert remember_jobs row + enqueue WalletJob.
     // Round-robin across wallet pool so facts upload in parallel.
     let mut job_ids: Vec<String> = Vec::with_capacity(prepared.len());
+    let mut accepted_facts: Vec<AnalyzeAcceptedFact> = Vec::with_capacity(prepared.len());
     for (fact_text, vector, encrypted) in prepared {
         let job_id = uuid::Uuid::new_v4().to_string();
 
@@ -988,6 +1048,11 @@ pub async fn analyze(
             wallet_index,
             truncate_str(&fact_text, 40)
         );
+        accepted_facts.push(AnalyzeAcceptedFact {
+            text: fact_text,
+            id: job_id.clone(),
+            job_id: job_id.clone(),
+        });
         job_ids.push(job_id);
     }
 
@@ -1003,6 +1068,7 @@ pub async fn analyze(
         StatusCode::ACCEPTED,
         Json(AnalyzeAcceptedResponse {
             job_ids,
+            facts: accepted_facts,
             fact_count,
             status: "pending".to_string(),
             owner: owner.clone(),

--- a/services/server/src/seal.rs
+++ b/services/server/src/seal.rs
@@ -80,38 +80,40 @@ pub async fn seal_encrypt(
     let url = format!("{}/seal/encrypt", sidecar_url);
     let data_b64 = BASE64.encode(data);
 
-    let mut req = client
-        .post(&url)
-        .json(&SealEncryptRequest {
-            data: data_b64,
-            owner: owner_address.to_string(),
-            package_id: package_id.to_string(),
-        });
+    let mut req = client.post(&url).json(&SealEncryptRequest {
+        data: data_b64,
+        owner: owner_address.to_string(),
+        package_id: package_id.to_string(),
+    });
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| {
-            AppError::Internal(format!("Sidecar seal/encrypt request failed: {}. Is the sidecar running?", e))
-        })?;
+    let resp = req.send().await.map_err(|e| {
+        AppError::Internal(format!(
+            "Sidecar seal/encrypt request failed: {}. Is the sidecar running?",
+            e
+        ))
+    })?;
 
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
-            return Err(AppError::Internal(format!("seal encrypt failed: {}", err.error)));
+            return Err(AppError::Internal(format!(
+                "seal encrypt failed: {}",
+                err.error
+            )));
         }
         return Err(AppError::Internal(format!("seal encrypt failed: {}", body)));
     }
 
-    let result: SealEncryptResponse = resp.json().await.map_err(|e| {
-        AppError::Internal(format!("Failed to parse seal/encrypt response: {}", e))
-    })?;
+    let result: SealEncryptResponse = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse seal/encrypt response: {}", e)))?;
 
-    let encrypted_bytes = BASE64.decode(&result.encrypted_data).map_err(|e| {
-        AppError::Internal(format!("Failed to decode encrypted base64: {}", e))
-    })?;
+    let encrypted_bytes = BASE64
+        .decode(&result.encrypted_data)
+        .map_err(|e| AppError::Internal(format!("Failed to decode encrypted base64: {}", e)))?;
 
     tracing::info!(
         "seal encrypt ok: {} bytes -> {} encrypted bytes",
@@ -142,13 +144,11 @@ pub async fn seal_decrypt(
     let url = format!("{}/seal/decrypt", sidecar_url);
     let data_b64 = BASE64.encode(encrypted_data);
 
-    let mut req = client
-        .post(&url)
-        .json(&SealDecryptRequest {
-            data: data_b64,
-            package_id: package_id.to_string(),
-            account_id: account_id.to_string(),
-        });
+    let mut req = client.post(&url).json(&SealDecryptRequest {
+        data: data_b64,
+        package_id: package_id.to_string(),
+        account_id: account_id.to_string(),
+    });
     req = match credential {
         SealCredential::Session(s) => req.header("x-seal-session", s),
         SealCredential::DelegateKey(k) => req.header("x-delegate-key", k),
@@ -156,28 +156,32 @@ pub async fn seal_decrypt(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| {
-            AppError::Internal(format!("Sidecar seal/decrypt request failed: {}. Is the sidecar running?", e))
-        })?;
+    let resp = req.send().await.map_err(|e| {
+        AppError::Internal(format!(
+            "Sidecar seal/decrypt request failed: {}. Is the sidecar running?",
+            e
+        ))
+    })?;
 
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
-            return Err(AppError::Internal(format!("seal decrypt failed: {}", err.error)));
+            return Err(AppError::Internal(format!(
+                "seal decrypt failed: {}",
+                err.error
+            )));
         }
         return Err(AppError::Internal(format!("seal decrypt failed: {}", body)));
     }
 
-    let result: SealDecryptResponse = resp.json().await.map_err(|e| {
-        AppError::Internal(format!("Failed to parse seal/decrypt response: {}", e))
-    })?;
+    let result: SealDecryptResponse = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse seal/decrypt response: {}", e)))?;
 
-    let decrypted_bytes = BASE64.decode(&result.decrypted_data).map_err(|e| {
-        AppError::Internal(format!("Failed to decode decrypted base64: {}", e))
-    })?;
+    let decrypted_bytes = BASE64
+        .decode(&result.decrypted_data)
+        .map_err(|e| AppError::Internal(format!("Failed to decode decrypted base64: {}", e)))?;
 
     tracing::info!(
         "seal decrypt ok: {} encrypted bytes -> {} decrypted bytes",
@@ -187,6 +191,3 @@ pub async fn seal_decrypt(
 
     Ok(decrypted_bytes)
 }
-
-
-

--- a/services/server/src/sui.rs
+++ b/services/server/src/sui.rs
@@ -31,10 +31,9 @@ pub async fn verify_delegate_key_onchain(
         .await
         .map_err(|e| OnchainVerifyError::RpcError(format!("HTTP request failed: {}", e)))?;
 
-    let rpc_response: RpcResponse = response
-        .json()
-        .await
-        .map_err(|e| OnchainVerifyError::RpcError(format!("Failed to parse RPC response: {}", e)))?;
+    let rpc_response: RpcResponse = response.json().await.map_err(|e| {
+        OnchainVerifyError::RpcError(format!("Failed to parse RPC response: {}", e))
+    })?;
 
     if let Some(error) = rpc_response.error {
         return Err(OnchainVerifyError::RpcError(format!(
@@ -97,18 +96,13 @@ pub async fn verify_delegate_key_onchain(
     for dk in delegate_keys {
         // Each delegate key is a struct with fields: { public_key, label, created_at }
         // The onchain representation has a "fields" wrapper
-        let dk_fields = dk
-            .get("fields")
-            .or(Some(dk)); // fallback if no "fields" wrapper
+        let dk_fields = dk.get("fields").or(Some(dk)); // fallback if no "fields" wrapper
 
         if let Some(stored_key) = dk_fields.and_then(|f| f.get("public_key")) {
             // Compare as arrays of numbers
             if let Some(stored_arr) = stored_key.as_array() {
                 if *stored_arr == pk_as_numbers {
-                    tracing::info!(
-                        "delegate key verified onchain, owner: {}",
-                        owner
-                    );
+                    tracing::info!("delegate key verified onchain, owner: {}", owner);
                     return Ok(owner);
                 }
             }
@@ -184,10 +178,9 @@ pub async fn find_account_by_delegate_key(
             .await
             .map_err(|e| OnchainVerifyError::RpcError(format!("HTTP request failed: {}", e)))?;
 
-        let resp_json: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| OnchainVerifyError::RpcError(format!("Failed to parse response: {}", e)))?;
+        let resp_json: serde_json::Value = response.json().await.map_err(|e| {
+            OnchainVerifyError::RpcError(format!("Failed to parse response: {}", e))
+        })?;
 
         if let Some(error) = resp_json.get("error") {
             return Err(OnchainVerifyError::RpcError(format!(
@@ -246,13 +239,8 @@ pub async fn find_account_by_delegate_key(
             }
 
             // Fetch the actual MemWalAccount to check delegate_keys
-            match verify_delegate_key_onchain(
-                http_client,
-                rpc_url,
-                account_id,
-                public_key_bytes,
-            )
-            .await
+            match verify_delegate_key_onchain(http_client, rpc_url, account_id, public_key_bytes)
+                .await
             {
                 Ok(owner) => {
                     tracing::info!(
@@ -340,7 +328,9 @@ impl std::fmt::Display for OnchainVerifyError {
         match self {
             OnchainVerifyError::RpcError(msg) => write!(f, "Sui RPC error: {}", msg),
             OnchainVerifyError::KeyNotFound(msg) => write!(f, "Key not found: {}", msg),
-            OnchainVerifyError::AccountDeactivated(msg) => write!(f, "Account deactivated: {}", msg),
+            OnchainVerifyError::AccountDeactivated(msg) => {
+                write!(f, "Account deactivated: {}", msg)
+            }
         }
     }
 }
@@ -359,7 +349,8 @@ mod tests {
 
     #[test]
     fn test_account_deactivated_display() {
-        let err = OnchainVerifyError::AccountDeactivated("Account 0xabc has been deactivated".into());
+        let err =
+            OnchainVerifyError::AccountDeactivated("Account 0xabc has been deactivated".into());
         assert!(err.to_string().contains("deactivated"));
     }
 
@@ -382,7 +373,10 @@ mod tests {
         let deactivated = OnchainVerifyError::AccountDeactivated("msg".into());
         let not_found = OnchainVerifyError::KeyNotFound("msg".into());
         // Both are Err variants but must match differently:
-        assert!(matches!(deactivated, OnchainVerifyError::AccountDeactivated(_)));
+        assert!(matches!(
+            deactivated,
+            OnchainVerifyError::AccountDeactivated(_)
+        ));
         assert!(matches!(not_found, OnchainVerifyError::KeyNotFound(_)));
     }
 
@@ -396,26 +390,41 @@ mod tests {
         // active: true → account is active
         let fields_active: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"active": true, "owner": "0xabc"}"#).unwrap();
-        let active = fields_active.get("active").and_then(|v| v.as_bool()).unwrap_or(true);
+        let active = fields_active
+            .get("active")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
         assert!(active);
 
         // active: false → account is deactivated
         let fields_inactive: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"active": false, "owner": "0xabc"}"#).unwrap();
-        let inactive = fields_inactive.get("active").and_then(|v| v.as_bool()).unwrap_or(true);
+        let inactive = fields_inactive
+            .get("active")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
         assert!(!inactive);
 
         // active field missing → defaults to true (backward compat)
         let fields_missing: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"owner": "0xabc"}"#).unwrap();
-        let missing = fields_missing.get("active").and_then(|v| v.as_bool()).unwrap_or(true);
+        let missing = fields_missing
+            .get("active")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
         assert!(missing, "missing 'active' field should default to true");
 
         // active field is a string (malformed) → defaults to true
         let fields_string: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"active": "false", "owner": "0xabc"}"#).unwrap();
-        let string_val = fields_string.get("active").and_then(|v| v.as_bool()).unwrap_or(true);
-        assert!(string_val, "string 'false' should not be treated as bool false");
+        let string_val = fields_string
+            .get("active")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        assert!(
+            string_val,
+            "string 'false' should not be treated as bool false"
+        );
     }
 
     // ── Delegate key matching — public key as JSON array ────────────────
@@ -424,9 +433,7 @@ mod tests {
     fn test_public_key_to_json_array_conversion() {
         // Test the exact conversion done in verify_delegate_key_onchain
         let pk_bytes: [u8; 32] = [
-            1, 2, 3, 4, 5, 6, 7, 8,
-            9, 10, 11, 12, 13, 14, 15, 16,
-            17, 18, 19, 20, 21, 22, 23, 24,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
         ];
 
@@ -474,11 +481,14 @@ mod tests {
         let dk_fields = dk_json.get("fields").or(Some(&dk_json));
         let stored_key = dk_fields.and_then(|f| f.get("public_key"));
         assert!(stored_key.is_some());
-        assert_eq!(stored_key.unwrap().as_array().unwrap(), &vec![
-            serde_json::json!(1),
-            serde_json::json!(2),
-            serde_json::json!(3),
-        ]);
+        assert_eq!(
+            stored_key.unwrap().as_array().unwrap(),
+            &vec![
+                serde_json::json!(1),
+                serde_json::json!(2),
+                serde_json::json!(3),
+            ]
+        );
     }
 
     #[test]
@@ -492,18 +502,22 @@ mod tests {
         let dk_fields = dk_json.get("fields").or(Some(&dk_json));
         let stored_key = dk_fields.and_then(|f| f.get("public_key"));
         assert!(stored_key.is_some());
-        assert_eq!(stored_key.unwrap().as_array().unwrap(), &vec![
-            serde_json::json!(4),
-            serde_json::json!(5),
-            serde_json::json!(6),
-        ]);
+        assert_eq!(
+            stored_key.unwrap().as_array().unwrap(),
+            &vec![
+                serde_json::json!(4),
+                serde_json::json!(5),
+                serde_json::json!(6),
+            ]
+        );
     }
 
     // ── OnchainVerifyError: Display correctness ─────────────────────────
 
     #[test]
     fn test_account_deactivated_display_includes_account_id() {
-        let err = OnchainVerifyError::AccountDeactivated("Account 0xabc has been deactivated".into());
+        let err =
+            OnchainVerifyError::AccountDeactivated("Account 0xabc has been deactivated".into());
         let display = err.to_string();
         assert!(display.contains("deactivated"));
         assert!(display.contains("0xabc"));
@@ -517,4 +531,3 @@ mod tests {
         assert!(err.to_string().contains("deactivated"));
     }
 }
-

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::db::VectorDb;
-use crate::jobs::{BulkRememberJobStorage, JobStorage, RememberJobStorage, WalletJobStorage};
+use crate::jobs::{BulkRememberJobStorage, RememberJobStorage, WalletJobStorage};
 use crate::rate_limit::RateLimitConfig;
 
 /// ENG-1408: Max items in a single POST /api/remember/bulk request.
@@ -11,13 +11,8 @@ pub const MAX_BULK_ITEMS: usize = 20;
 /// ENG-1408: Bounded concurrency for concurrent embed+encrypt in bulk route handler.
 pub const BULK_EMBED_CONCURRENCY: usize = 5;
 
-/// ENG-1408: Bounded concurrency for concurrent Walrus uploads inside BulkRememberJob worker.
-pub const BULK_UPLOAD_CONCURRENCY: usize = 3;
-
-/// ENG-1408: Max blobs transferred in one set-metadata-batch PTB.
-/// Sui PTB limit is ~1000 commands; 10 blobs × 4 metadata calls = 40 commands + 1 transfer — well within limits.
-#[allow(dead_code)]
-pub const BULK_PTB_MAX_BLOBS: usize = 20;
+/// ENG-1408: Bounded concurrency for Walrus uploads inside one bulk job.
+pub const BULK_UPLOAD_CONCURRENCY: usize = 5;
 
 // ============================================================
 // App State (shared across routes + middleware)
@@ -35,8 +30,6 @@ pub struct AppState {
     pub redis: redis::aio::MultiplexedConnection,
     /// In-memory token bucket fallback for when Redis is unavailable
     pub fallback_rate_limit: tokio::sync::Mutex<crate::rate_limit::InMemoryFallback>,
-    /// Apalis storage for MetaTransferJob (legacy backward-compat)
-    pub job_storage: JobStorage,
     /// Apalis storage for RememberJob — legacy full async pipeline.
     /// Kept so the legacy worker can drain any rows enqueued before the
     /// migration to WalletJob::UploadAndTransfer; new requests do NOT use this.
@@ -265,7 +258,7 @@ pub struct RememberBulkRequest {
 pub struct RememberBulkAcceptedResponse {
     pub job_ids: Vec<String>,
     pub total: usize,
-    pub status: String, // always "pending"
+    pub status: String, // "running" on accepted background work
 }
 
 /// POST /api/remember/bulk/status request body.
@@ -293,18 +286,18 @@ pub struct RememberBulkStatusResponse {
 }
 
 /// POST /api/remember (async, ENG-1406 v3)
-/// Returns 202 Accepted immediately with a jobId for polling.
+/// Returns 202 Accepted immediately with a job_id for polling.
 #[derive(Debug, Serialize)]
 pub struct RememberAcceptedResponse {
     pub job_id: String,
-    pub status: String, // always "pending"
+    pub status: String, // "running" on accepted background work
 }
 
 /// GET /api/remember/:job_id — job status polling response
 #[derive(Debug, Serialize)]
 pub struct RememberJobStatusResponse {
     pub job_id: String,
-    pub status: String, // "pending" | "running" | "done" | "failed"
+    pub status: String, // "pending" | "running" | "uploaded" | "done" | "failed"
     /// Owner address of the memory (from auth at enqueue time).
     pub owner: String,
     /// Namespace the memory was stored under.
@@ -388,11 +381,20 @@ pub struct AnalyzeRequest {
 pub struct AnalyzeAcceptedResponse {
     /// One job_id per extracted fact — poll GET /api/remember/:job_id for each
     pub job_ids: Vec<String>,
+    /// Extracted facts accepted for background storage. `id` equals `job_id`.
+    pub facts: Vec<AnalyzeAcceptedFact>,
     /// Number of facts extracted from the text
     pub fact_count: usize,
-    /// Always "pending" on 202 response
+    /// "pending" on accepted analyze jobs
     pub status: String,
     pub owner: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AnalyzeAcceptedFact {
+    pub text: String,
+    pub id: String,
+    pub job_id: String,
 }
 
 #[allow(dead_code)]

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1,8 +1,23 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::db::VectorDb;
+use crate::jobs::{BulkRememberJobStorage, JobStorage, RememberJobStorage, WalletJobStorage};
 use crate::rate_limit::RateLimitConfig;
+
+/// ENG-1408: Max items in a single POST /api/remember/bulk request.
+pub const MAX_BULK_ITEMS: usize = 20;
+
+/// ENG-1408: Bounded concurrency for concurrent embed+encrypt in bulk route handler.
+pub const BULK_EMBED_CONCURRENCY: usize = 5;
+
+/// ENG-1408: Bounded concurrency for concurrent Walrus uploads inside BulkRememberJob worker.
+pub const BULK_UPLOAD_CONCURRENCY: usize = 3;
+
+/// ENG-1408: Max blobs transferred in one set-metadata-batch PTB.
+/// Sui PTB limit is ~1000 commands; 10 blobs × 4 metadata calls = 40 commands + 1 transfer — well within limits.
+#[allow(dead_code)]
+pub const BULK_PTB_MAX_BLOBS: usize = 20;
 
 // ============================================================
 // App State (shared across routes + middleware)
@@ -20,6 +35,19 @@ pub struct AppState {
     pub redis: redis::aio::MultiplexedConnection,
     /// In-memory token bucket fallback for when Redis is unavailable
     pub fallback_rate_limit: tokio::sync::Mutex<crate::rate_limit::InMemoryFallback>,
+    /// Apalis storage for MetaTransferJob (legacy backward-compat)
+    pub job_storage: JobStorage,
+    /// Apalis storage for RememberJob — legacy full async pipeline.
+    /// Kept so the legacy worker can drain any rows enqueued before the
+    /// migration to WalletJob::UploadAndTransfer; new requests do NOT use this.
+    #[allow(dead_code)]
+    pub remember_job_storage: RememberJobStorage,
+    /// Per-wallet Apalis storages — wallet_storages[i] maps to pool key[i].
+    /// New code should enqueue WalletJob here instead of using
+    /// MetaTransferJob/RememberJob directly.
+    pub wallet_storages: Vec<WalletJobStorage>,
+    /// ENG-1408: Apalis storage for BulkRememberJob.
+    pub bulk_job_storage: BulkRememberJobStorage,
 }
 
 // ============================================================
@@ -105,8 +133,7 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> Self {
-        let network = std::env::var("SUI_NETWORK")
-            .unwrap_or_else(|_| "mainnet".to_string());
+        let network = std::env::var("SUI_NETWORK").unwrap_or_else(|_| "mainnet".to_string());
         let default_rpc = match network.as_str() {
             "testnet" => "https://fullnode.testnet.sui.io:443",
             "devnet" => "https://fullnode.devnet.sui.io:443",
@@ -213,9 +240,85 @@ pub struct RememberRequest {
     pub namespace: String,
 }
 
+// ============================================================
+// Bulk Remember types (ENG-1408)
+// ============================================================
+
+/// One item in a POST /api/remember/bulk request.
+#[derive(Debug, Deserialize)]
+pub struct RememberBulkItem {
+    pub text: String,
+    #[serde(default = "default_namespace")]
+    pub namespace: String,
+}
+
+/// POST /api/remember/bulk request body.
+#[derive(Debug, Deserialize)]
+pub struct RememberBulkRequest {
+    /// 1–MAX_BULK_ITEMS items to remember in one batched operation.
+    pub items: Vec<RememberBulkItem>,
+}
+
+/// POST /api/remember/bulk — 202 Accepted response.
+/// `job_ids[i]` corresponds to `items[i]`; poll each via GET /api/remember/:job_id.
+#[derive(Debug, Serialize)]
+pub struct RememberBulkAcceptedResponse {
+    pub job_ids: Vec<String>,
+    pub total: usize,
+    pub status: String, // always "pending"
+}
+
+/// POST /api/remember/bulk/status request body.
+#[derive(Debug, Deserialize)]
+pub struct RememberBulkStatusRequest {
+    /// 1–MAX_BULK_ITEMS job IDs from a prior POST /api/remember/bulk call.
+    pub job_ids: Vec<String>,
+}
+
+/// One item in a POST /api/remember/bulk/status response.
+#[derive(Debug, Serialize, Clone)]
+pub struct RememberBulkStatusItem {
+    pub job_id: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// POST /api/remember/bulk/status response.
+#[derive(Debug, Serialize)]
+pub struct RememberBulkStatusResponse {
+    pub results: Vec<RememberBulkStatusItem>,
+}
+
+/// POST /api/remember (async, ENG-1406 v3)
+/// Returns 202 Accepted immediately with a jobId for polling.
+#[derive(Debug, Serialize)]
+pub struct RememberAcceptedResponse {
+    pub job_id: String,
+    pub status: String, // always "pending"
+}
+
+/// GET /api/remember/:job_id — job status polling response
+#[derive(Debug, Serialize)]
+pub struct RememberJobStatusResponse {
+    pub job_id: String,
+    pub status: String, // "pending" | "running" | "done" | "failed"
+    /// Owner address of the memory (from auth at enqueue time).
+    pub owner: String,
+    /// Namespace the memory was stored under.
+    pub namespace: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// POST /api/remember (legacy sync response, kept for remember_manual)
+#[allow(dead_code)]
 #[derive(Debug, Serialize)]
 pub struct RememberResponse {
-    pub id: String,
     pub blob_id: String,
     pub owner: String,
     pub namespace: String,
@@ -268,8 +371,6 @@ pub struct SearchHit {
     pub distance: f64,
 }
 
-
-
 /// POST /api/analyze
 /// Extract facts from conversation text using LLM, then remember each fact
 /// Owner is derived from delegate key via onchain verification (auth middleware)
@@ -281,6 +382,20 @@ pub struct AnalyzeRequest {
     pub namespace: String,
 }
 
+/// POST /api/analyze (async, returns 202 immediately)
+/// Returns job_ids for each extracted fact; poll via GET /api/remember/:job_id
+#[derive(Debug, Serialize)]
+pub struct AnalyzeAcceptedResponse {
+    /// One job_id per extracted fact — poll GET /api/remember/:job_id for each
+    pub job_ids: Vec<String>,
+    /// Number of facts extracted from the text
+    pub fact_count: usize,
+    /// Always "pending" on 202 response
+    pub status: String,
+    pub owner: String,
+}
+
+#[allow(dead_code)]
 #[derive(Debug, Serialize)]
 pub struct AnalyzedFact {
     pub text: String,
@@ -288,6 +403,7 @@ pub struct AnalyzedFact {
     pub blob_id: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Serialize)]
 pub struct AnalyzeResponse {
     pub facts: Vec<AnalyzedFact>,
@@ -300,7 +416,7 @@ pub struct AnalyzeResponse {
 /// Server uploads to Walrus via sidecar, then stores the vector ↔ blobId mapping.
 #[derive(Debug, Deserialize)]
 pub struct RememberManualRequest {
-    pub encrypted_data: String,  // base64-encoded SEAL-encrypted bytes
+    pub encrypted_data: String, // base64-encoded SEAL-encrypted bytes
     pub vector: Vec<f32>,
     #[serde(default = "default_namespace")]
     pub namespace: String,
@@ -588,7 +704,11 @@ mod tests {
         let debug_str = format!("{:?}", auth);
 
         // None variant should render as None
-        assert!(debug_str.contains("None"), "expected None in debug: {}", debug_str);
+        assert!(
+            debug_str.contains("None"),
+            "expected None in debug: {}",
+            debug_str
+        );
         assert!(!debug_str.contains("<redacted>"));
     }
 
@@ -603,9 +723,7 @@ mod tests {
             owner: "0xowner".to_string(),
             account_id: "0xaccount".to_string(),
             delegate_key: None,
-            seal_session: Some(
-                "eyJhZGRyZXNzIjoiMHhhYmMiLCJwYWNrYWdlSWQiOiIweGRlZiJ9".to_string(),
-            ),
+            seal_session: Some("eyJhZGRyZXNzIjoiMHhhYmMiLCJwYWNrYWdlSWQiOiIweGRlZiJ9".to_string()),
         };
 
         let debug_str = format!("{:?}", auth);
@@ -681,11 +799,7 @@ mod tests {
 
     #[test]
     fn key_pool_round_robin() {
-        let pool = KeyPool::new(vec![
-            "key_a".into(),
-            "key_b".into(),
-            "key_c".into(),
-        ]);
+        let pool = KeyPool::new(vec!["key_a".into(), "key_b".into(), "key_c".into()]);
 
         assert_eq!(pool.next(), Some("key_a"));
         assert_eq!(pool.next(), Some("key_b"));
@@ -730,11 +844,23 @@ mod tests {
 
     #[test]
     fn app_error_display_all_variants() {
-        assert!(AppError::BadRequest("x".into()).to_string().contains("Bad Request"));
-        assert!(AppError::Unauthorized("x".into()).to_string().contains("Unauthorized"));
-        assert!(AppError::Internal("x".into()).to_string().contains("Internal"));
-        assert!(AppError::BlobNotFound("x".into()).to_string().contains("Blob Not Found"));
-        assert!(AppError::RateLimited("x".into()).to_string().contains("Rate Limited"));
-        assert!(AppError::QuotaExceeded("x".into()).to_string().contains("Quota Exceeded"));
+        assert!(AppError::BadRequest("x".into())
+            .to_string()
+            .contains("Bad Request"));
+        assert!(AppError::Unauthorized("x".into())
+            .to_string()
+            .contains("Unauthorized"));
+        assert!(AppError::Internal("x".into())
+            .to_string()
+            .contains("Internal"));
+        assert!(AppError::BlobNotFound("x".into())
+            .to_string()
+            .contains("Blob Not Found"));
+        assert!(AppError::RateLimited("x".into())
+            .to_string()
+            .contains("Rate Limited"));
+        assert!(AppError::QuotaExceeded("x".into())
+            .to_string()
+            .contains("Quota Exceeded"));
     }
 }

--- a/services/server/src/walrus.rs
+++ b/services/server/src/walrus.rs
@@ -44,6 +44,7 @@ struct WalrusUploadRequest {
     namespace: String,
     package_id: String,
     epochs: u64,
+    defer_transfer: bool,
     #[serde(rename = "agentId", skip_serializing_if = "Option::is_none")]
     agent_id: Option<String>,
 }
@@ -53,6 +54,32 @@ struct WalrusUploadRequest {
 struct WalrusUploadResponse {
     blob_id: String,
     object_id: Option<String>,
+    #[serde(default)]
+    transfer_status: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetMetadataBatchEntry {
+    pub blob_object_id: String,
+    pub namespace: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SetMetadataBatchRequest {
+    blobs: Vec<SetMetadataBatchEntry>,
+    owner: String,
+    package_id: String,
+    #[serde(rename = "agentId", skip_serializing_if = "Option::is_none")]
+    agent_id: Option<String>,
+    key_index: usize,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetMetadataBatchResponse {
+    transferred: usize,
 }
 
 /// Upload an encrypted blob to Walrus via the HTTP sidecar.
@@ -76,6 +103,68 @@ pub async fn upload_blob(
     package_id: &str,
     agent_id: Option<&str>,
 ) -> Result<UploadResult, AppError> {
+    upload_blob_inner(
+        client,
+        sidecar_url,
+        sidecar_secret,
+        data,
+        epochs,
+        owner_address,
+        key_index,
+        namespace,
+        package_id,
+        agent_id,
+        false,
+    )
+    .await
+}
+
+/// Upload an encrypted blob but leave the certified Blob object owned by the
+/// server wallet. Bulk remember uses this so one later PTB can transfer many
+/// blobs together.
+#[allow(clippy::too_many_arguments)]
+pub async fn upload_blob_deferred(
+    client: &reqwest::Client,
+    sidecar_url: &str,
+    sidecar_secret: Option<&str>,
+    data: &[u8],
+    epochs: u64,
+    owner_address: &str,
+    key_index: usize,
+    namespace: &str,
+    package_id: &str,
+    agent_id: Option<&str>,
+) -> Result<UploadResult, AppError> {
+    upload_blob_inner(
+        client,
+        sidecar_url,
+        sidecar_secret,
+        data,
+        epochs,
+        owner_address,
+        key_index,
+        namespace,
+        package_id,
+        agent_id,
+        true,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn upload_blob_inner(
+    client: &reqwest::Client,
+    sidecar_url: &str,
+    sidecar_secret: Option<&str>,
+    data: &[u8],
+    epochs: u64,
+    owner_address: &str,
+    key_index: usize,
+    namespace: &str,
+    package_id: &str,
+    agent_id: Option<&str>,
+    defer_transfer: bool,
+) -> Result<UploadResult, AppError> {
     let url = format!("{}/walrus/upload", sidecar_url);
     let data_b64 = BASE64.encode(data);
 
@@ -86,6 +175,7 @@ pub async fn upload_blob(
         namespace: namespace.to_string(),
         package_id: package_id.to_string(),
         epochs,
+        defer_transfer,
         agent_id: agent_id.map(|s| s.to_string()),
     });
     if let Some(secret) = sidecar_secret {
@@ -115,11 +205,22 @@ pub async fn upload_blob(
     let result: WalrusUploadResponse = resp.json().await.map_err(|e| {
         AppError::Internal(format!("Failed to parse walrus/upload response: {}", e))
     })?;
+    if result.transfer_status.as_deref() == Some("failed") {
+        return Err(AppError::Internal(
+            "walrus upload completed but metadata/transfer failed".into(),
+        ));
+    }
+    if defer_transfer && result.object_id.is_none() {
+        return Err(AppError::Internal(
+            "walrus deferred upload returned no object_id".into(),
+        ));
+    }
 
     tracing::info!(
-        "walrus upload via sidecar ok: blob_id={}, object_id={:?}, owner={}, ns={}",
+        "walrus upload via sidecar ok: blob_id={}, object_id={:?}, transfer_status={:?}, owner={}, ns={}",
         result.blob_id,
         result.object_id,
+        result.transfer_status,
         owner_address,
         namespace
     );
@@ -128,6 +229,57 @@ pub async fn upload_blob(
         blob_id: result.blob_id,
         object_id: result.object_id,
     })
+}
+
+pub async fn set_metadata_batch(
+    client: &reqwest::Client,
+    sidecar_url: &str,
+    sidecar_secret: Option<&str>,
+    key_index: usize,
+    owner_address: &str,
+    package_id: &str,
+    agent_id: Option<&str>,
+    blobs: Vec<SetMetadataBatchEntry>,
+) -> Result<usize, AppError> {
+    let url = format!("{}/walrus/set-metadata-batch", sidecar_url);
+    let mut req = client.post(&url).json(&SetMetadataBatchRequest {
+        blobs,
+        owner: owner_address.to_string(),
+        package_id: package_id.to_string(),
+        agent_id: agent_id.map(|s| s.to_string()),
+        key_index,
+    });
+    if let Some(secret) = sidecar_secret {
+        req = req.header("authorization", format!("Bearer {}", secret));
+    }
+
+    let resp = req.send().await.map_err(|e| {
+        AppError::Internal(format!(
+            "Sidecar walrus/set-metadata-batch request failed: {}",
+            e
+        ))
+    })?;
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
+            return Err(AppError::Internal(format!(
+                "walrus set-metadata-batch failed: {}",
+                err.error
+            )));
+        }
+        return Err(AppError::Internal(format!(
+            "walrus set-metadata-batch failed: {}",
+            body
+        )));
+    }
+
+    let result: SetMetadataBatchResponse = resp.json().await.map_err(|e| {
+        AppError::Internal(format!(
+            "Failed to parse walrus/set-metadata-batch response: {}",
+            e
+        ))
+    })?;
+    Ok(result.transferred)
 }
 
 /// Query user's Walrus Blob objects from the Sui chain via sidecar.

--- a/services/server/src/walrus.rs
+++ b/services/server/src/walrus.rs
@@ -79,33 +79,37 @@ pub async fn upload_blob(
     let url = format!("{}/walrus/upload", sidecar_url);
     let data_b64 = BASE64.encode(data);
 
-    let mut req = client
-        .post(&url)
-        .json(&WalrusUploadRequest {
-            data: data_b64,
-            key_index,
-            owner: owner_address.to_string(),
-            namespace: namespace.to_string(),
-            package_id: package_id.to_string(),
-            epochs,
-            agent_id: agent_id.map(|s| s.to_string()),
-        });
+    let mut req = client.post(&url).json(&WalrusUploadRequest {
+        data: data_b64,
+        key_index,
+        owner: owner_address.to_string(),
+        namespace: namespace.to_string(),
+        package_id: package_id.to_string(),
+        epochs,
+        agent_id: agent_id.map(|s| s.to_string()),
+    });
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| {
-            AppError::Internal(format!("Sidecar walrus/upload request failed: {}. Is the sidecar running?", e))
-        })?;
+    let resp = req.send().await.map_err(|e| {
+        AppError::Internal(format!(
+            "Sidecar walrus/upload request failed: {}. Is the sidecar running?",
+            e
+        ))
+    })?;
 
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
-            return Err(AppError::Internal(format!("walrus upload failed: {}", err.error)));
+            return Err(AppError::Internal(format!(
+                "walrus upload failed: {}",
+                err.error
+            )));
         }
-        return Err(AppError::Internal(format!("walrus upload failed: {}", body)));
+        return Err(AppError::Internal(format!(
+            "walrus upload failed: {}",
+            body
+        )));
     }
 
     let result: WalrusUploadResponse = resp.json().await.map_err(|e| {
@@ -149,31 +153,33 @@ pub async fn query_blobs_by_owner(
         body["packageId"] = serde_json::json!(pkg);
     }
 
-    let mut req = client
-        .post(&url)
-        .json(&body);
+    let mut req = client.post(&url).json(&body);
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
     let resp = req
         .send()
         .await
-        .map_err(|e| {
-            AppError::Internal(format!("Sidecar walrus/query-blobs failed: {}", e))
-        })?;
+        .map_err(|e| AppError::Internal(format!("Sidecar walrus/query-blobs failed: {}", e)))?;
 
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(AppError::Internal(format!("walrus query-blobs failed: {}", body)));
+        return Err(AppError::Internal(format!(
+            "walrus query-blobs failed: {}",
+            body
+        )));
     }
 
-    let result: QueryBlobsResponse = resp.json().await.map_err(|e| {
-        AppError::Internal(format!("Failed to parse query-blobs response: {}", e))
-    })?;
+    let result: QueryBlobsResponse = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse query-blobs response: {}", e)))?;
 
     tracing::info!(
         "walrus query-blobs ok: {} blobs for owner={}, ns={:?}",
-        result.total, owner_address, namespace
+        result.total,
+        owner_address,
+        namespace
     );
 
     Ok(result.blobs)
@@ -190,10 +196,7 @@ pub async fn download_blob(
 ) -> Result<Vec<u8>, AppError> {
     // Timeout to avoid hanging on broken/slow blobs (Walrus 500s can take 60s+)
     let download_fut = walrus_client.read_blob_by_id(blob_id);
-    let bytes = match tokio::time::timeout(
-        std::time::Duration::from_secs(15),
-        download_fut,
-    ).await {
+    let bytes = match tokio::time::timeout(std::time::Duration::from_secs(15), download_fut).await {
         Ok(Ok(data)) => data,
         Ok(Err(e)) => {
             let err_str = e.to_string();
@@ -201,13 +204,22 @@ pub async fn download_blob(
                 || err_str.to_lowercase().contains("not found")
                 || err_str.to_lowercase().contains("blob not found");
             if is_not_found {
-                return Err(AppError::BlobNotFound(format!("Blob {} expired or not found: {}", blob_id, err_str)));
+                return Err(AppError::BlobNotFound(format!(
+                    "Blob {} expired or not found: {}",
+                    blob_id, err_str
+                )));
             } else {
-                return Err(AppError::Internal(format!("Walrus download failed: {}", err_str)));
+                return Err(AppError::Internal(format!(
+                    "Walrus download failed: {}",
+                    err_str
+                )));
             }
         }
         Err(_) => {
-            return Err(AppError::Internal(format!("Walrus download timed out after 10s for blob {}", blob_id)));
+            return Err(AppError::Internal(format!(
+                "Walrus download timed out after 10s for blob {}",
+                blob_id
+            )));
         }
     };
 
@@ -218,4 +230,3 @@ pub async fn download_blob(
     );
     Ok(bytes)
 }
-

--- a/services/server/tests/e2e_test.py
+++ b/services/server/tests/e2e_test.py
@@ -72,12 +72,12 @@ def _sign(
 def make_signed_request(
     method: str,
     path: str,
-    body: dict,
+    body: dict | None,
     signing_key: SigningKey,
     account_id: str | None = None,
 ) -> dict:
     """Send a signed JSON request and return the decoded JSON response."""
-    body_bytes = json.dumps(body).encode()
+    body_bytes = b"" if method == "GET" else json.dumps(body or {}).encode()
     timestamp = str(int(time.time()))
     nonce = str(uuid.uuid4())
     signature_hex = _sign(
@@ -95,9 +95,29 @@ def make_signed_request(
     if account_id:
         headers["x-account-id"] = account_id
 
-    req = urllib.request.Request(f"{BASE_URL}{path}", data=body_bytes, headers=headers, method=method)
+    data = None if method == "GET" else body_bytes
+    req = urllib.request.Request(f"{BASE_URL}{path}", data=data, headers=headers, method=method)
     with urllib.request.urlopen(req) as resp:
         return json.loads(resp.read())
+
+
+def wait_for_remember_job(
+    signing_key: SigningKey,
+    account_id: str | None,
+    job_id: str,
+    timeout_s: int = 120,
+) -> dict:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        status = make_signed_request(
+            "GET", f"/api/remember/{job_id}", None, signing_key, account_id=account_id
+        )
+        if status.get("status") == "done":
+            return status
+        if status.get("status") == "failed":
+            raise AssertionError(f"remember job failed: {status}")
+        time.sleep(2)
+    raise AssertionError(f"remember job timed out after {timeout_s}s: {job_id}")
 
 
 def _load_delegate_key() -> SigningKey | None:
@@ -220,9 +240,14 @@ def test_remember_recall_happy_path(signing_key: SigningKey, account_id: str | N
     result = make_signed_request(
         "POST", "/api/remember", remember_body, signing_key, account_id=account_id
     )
-    assert "id" in result, f"Expected 'id' in remember response, got {result}"
-    assert result["namespace"] == "e2e-test", f"Unexpected namespace: {result}"
-    print(f"[pass] POST /api/remember → id={result['id']}, blob_id={result['blob_id']}")
+    assert "job_id" in result, f"Expected 'job_id' in remember response, got {result}"
+    assert result["status"] in ("pending", "running"), f"Unexpected status: {result}"
+    print(f"[pass] POST /api/remember → job_id={result['job_id']}, status={result['status']}")
+
+    completed = wait_for_remember_job(signing_key, account_id, result["job_id"])
+    assert completed["namespace"] == "e2e-test", f"Unexpected namespace: {completed}"
+    assert "blob_id" in completed, f"Expected completed job blob_id, got {completed}"
+    print(f"[pass] GET /api/remember/{result['job_id']} → blob_id={completed['blob_id']}")
 
     recall_body = {
         "query": "What is the capital of France?",


### PR DESCRIPTION
## Summary
- **ENG-1406**: Convert `/api/remember` to async — returns 202 Accepted with `job_id`, poll via `GET /api/remember/:job_id`
- **ENG-1408**: Add `/api/remember/bulk` — batch up to 20 items in one request, returns array of `job_id`s
- Add per-wallet pinned Apalis workers (`WalletJob`) to avoid wrong-signer races
- Add `POST /api/remember/bulk/status` for batch status polling
- SDK: `remember()` now polls automatically, add `rememberBulk()`

## Files changed (13 files, +2334/-149)
- `services/server/migrations/005_remember_jobs.sql` — job tracking table
- `services/server/migrations/006_bulk_remember.sql` — bulk job support
- `services/server/src/jobs.rs` — WalletJob, BulkRememberJob workers
- `services/server/src/routes.rs` — async remember, bulk endpoints
- `services/server/src/main.rs` — Apalis workers, per-wallet queues
- `services/server/src/types.rs` — async/bulk request/response types
- `packages/sdk/src/memwal.ts` — polling + rememberBulk
- `packages/sdk/src/types.ts` — SDK types

## Test plan
- [ ] `cargo check` passes
- [ ] Server starts and all Apalis workers spawn
- [ ] `POST /api/remember` returns 202 + job_id
- [ ] `GET /api/remember/:job_id` returns job status progression
- [ ] `POST /api/remember/bulk` accepts up to 20 items
- [ ] `POST /api/remember/bulk/status` returns batch statuses