### PR TITLE
ci: update oc-memwal release workflow

### DIFF
--- a/.github/workflows/release-oc-memwal.yml
+++ b/.github/workflows/release-oc-memwal.yml
@@ -3,7 +3,7 @@ name: Release OC-MemWal Plugin
 on:
   push:
     branches:
-      - sec/sec_fix
+      - sec/security_fix
     paths:
       - 'packages/openclaw-memory-memwal/**'
       - '.github/workflows/release-oc-memwal.yml'
@@ -48,7 +48,7 @@ jobs:
 
       # ── main branch → changeset version + stable release (latest) ──
       - name: Apply changesets (update version & CHANGELOG)
-        if: github.ref == 'refs/heads/sec/sec_fix'
+        if: github.ref == 'refs/heads/sec/security_fix'
         id: changeset_version
         run: |
           pnpm changeset version 2>/dev/null || true
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Commit changelog & version bump
-        if: github.ref == 'refs/heads/sec/sec_fix' && steps.changeset_version.outputs.has_changes == 'true'
+        if: github.ref == 'refs/heads/sec/security_fix' && steps.changeset_version.outputs.has_changes == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -68,7 +68,7 @@ jobs:
           git push
 
       - name: Publish stable release
-        if: github.ref == 'refs/heads/sec/sec_fix'
+        if: github.ref == 'refs/heads/sec/security_fix'
         id: publish_oc
         run: |
           VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
@@ -79,7 +79,7 @@ jobs:
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: github.ref == 'refs/heads/sec/sec_fix' && steps.publish_oc.outputs.published == 'true'
+        if: github.ref == 'refs/heads/sec/security_fix' && steps.publish_oc.outputs.published == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -104,7 +104,7 @@ jobs:
 
       # ── staging branch → release candidate (rc tag, auto-increment) ──
       - name: Publish staging release candidate
-        if: github.ref == 'refs/heads/sec/sec_fix'
+        if: github.ref == 'refs/heads/sec/security_fix'
         run: |
           BASE_VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
           LATEST=$(npm view @mysten-incubation/oc-memwal versions --json 2>/dev/null \
@@ -125,7 +125,7 @@ jobs:
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
-        if: github.ref == 'refs/heads/sec/sec_fix'
+        if: github.ref == 'refs/heads/sec/security_fix'
         run: |
           BASE_VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
           LATEST=$(npm view @mysten-incubation/oc-memwal versions --json 2>/dev/null \

--- a/.github/workflows/release-oc-memwal.yml
+++ b/.github/workflows/release-oc-memwal.yml
@@ -3,9 +3,7 @@ name: Release OC-MemWal Plugin
 on:
   push:
     branches:
-      - main
-      - staging
-      - dev
+      - sec/sec_fix
     paths:
       - 'packages/openclaw-memory-memwal/**'
       - '.github/workflows/release-oc-memwal.yml'
@@ -32,12 +30,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm for OIDC Trusted Publishing
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -46,14 +41,14 @@ jobs:
         run: pnpm build:sdk
 
       - name: Typecheck
-        run: cd packages/openclaw-memory-memwal && npm run typecheck
+        run: pnpm --filter @mysten-incubation/oc-memwal typecheck
 
       - name: Build plugin
-        run: cd packages/openclaw-memory-memwal && npm run build
+        run: pnpm --filter @mysten-incubation/oc-memwal build
 
       # ── main branch → changeset version + stable release (latest) ──
       - name: Apply changesets (update version & CHANGELOG)
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/sec/sec_fix'
         id: changeset_version
         run: |
           pnpm changeset version 2>/dev/null || true
@@ -64,7 +59,7 @@ jobs:
           fi
 
       - name: Commit changelog & version bump
-        if: github.ref == 'refs/heads/main' && steps.changeset_version.outputs.has_changes == 'true'
+        if: github.ref == 'refs/heads/sec/sec_fix' && steps.changeset_version.outputs.has_changes == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -73,7 +68,7 @@ jobs:
           git push
 
       - name: Publish stable release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/sec/sec_fix'
         id: publish_oc
         run: |
           VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
@@ -84,7 +79,7 @@ jobs:
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: github.ref == 'refs/heads/main' && steps.publish_oc.outputs.published == 'true'
+        if: github.ref == 'refs/heads/sec/sec_fix' && steps.publish_oc.outputs.published == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -109,7 +104,7 @@ jobs:
 
       # ── staging branch → release candidate (rc tag, auto-increment) ──
       - name: Publish staging release candidate
-        if: github.ref == 'refs/heads/staging'
+        if: github.ref == 'refs/heads/sec/sec_fix'
         run: |
           BASE_VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
           LATEST=$(npm view @mysten-incubation/oc-memwal versions --json 2>/dev/null \
@@ -130,7 +125,7 @@ jobs:
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/sec/sec_fix'
         run: |
           BASE_VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
           LATEST=$(npm view @mysten-incubation/oc-memwal versions --json 2>/dev/null \

--- a/.github/workflows/release-oc-memwal.yml
+++ b/.github/workflows/release-oc-memwal.yml
@@ -3,7 +3,9 @@ name: Release OC-MemWal Plugin
 on:
   push:
     branches:
-      - sec/security_fix
+      - main
+      - staging
+      - dev
     paths:
       - 'packages/openclaw-memory-memwal/**'
       - '.github/workflows/release-oc-memwal.yml'
@@ -48,7 +50,7 @@ jobs:
 
       # ── main branch → changeset version + stable release (latest) ──
       - name: Apply changesets (update version & CHANGELOG)
-        if: github.ref == 'refs/heads/sec/security_fix'
+        if: github.ref == 'refs/heads/main'
         id: changeset_version
         run: |
           pnpm changeset version 2>/dev/null || true
@@ -59,7 +61,7 @@ jobs:
           fi
 
       - name: Commit changelog & version bump
-        if: github.ref == 'refs/heads/sec/security_fix' && steps.changeset_version.outputs.has_changes == 'true'
+        if: github.ref == 'refs/heads/main' && steps.changeset_version.outputs.has_changes == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -68,7 +70,7 @@ jobs:
           git push
 
       - name: Publish stable release
-        if: github.ref == 'refs/heads/sec/security_fix'
+        if: github.ref == 'refs/heads/main'
         id: publish_oc
         run: |
           VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
@@ -79,7 +81,7 @@ jobs:
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: github.ref == 'refs/heads/sec/security_fix' && steps.publish_oc.outputs.published == 'true'
+        if: github.ref == 'refs/heads/main' && steps.publish_oc.outputs.published == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -104,7 +106,7 @@ jobs:
 
       # ── staging branch → release candidate (rc tag, auto-increment) ──
       - name: Publish staging release candidate
-        if: github.ref == 'refs/heads/sec/security_fix'
+        if: github.ref == 'refs/heads/staging'
         run: |
           BASE_VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
           LATEST=$(npm view @mysten-incubation/oc-memwal versions --json 2>/dev/null \
@@ -125,7 +127,7 @@ jobs:
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
-        if: github.ref == 'refs/heads/sec/security_fix'
+        if: github.ref == 'refs/heads/dev'
         run: |
           BASE_VERSION=$(node -p "require('./packages/openclaw-memory-memwal/package.json').version")
           LATEST=$(npm view @mysten-incubation/oc-memwal versions --json 2>/dev/null \

--- a/docs/openclaw/changelog.md
+++ b/docs/openclaw/changelog.md
@@ -7,6 +7,12 @@ Track what's new, changed, and fixed in `@mysten-incubation/oc-memwal`.
 
 For the latest version, see the [npm package page](https://www.npmjs.com/package/@mysten-incubation/oc-memwal).
 
+## 0.0.2
+
+### Internal
+
+- Update `@mysten-incubation/memwal` dependency to `^0.0.2`
+
 ## 0.0.1
 
 ### Initial Release

--- a/packages/openclaw-memory-memwal/CHANGELOG.md
+++ b/packages/openclaw-memory-memwal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mysten-incubation/oc-memwal
 
+## 0.0.2
+
+### Internal
+
+- Update `@mysten-incubation/memwal` dependency to `^0.0.2`
+
 ## 0.0.1
 
 ### Initial Release

--- a/packages/openclaw-memory-memwal/package.json
+++ b/packages/openclaw-memory-memwal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysten-incubation/oc-memwal",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "description": "NemoClaw/OpenClaw memory plugin — encrypted, decentralized long-term memory via MemWal + Walrus",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@mysten-incubation/memwal": "^0.0.1",
+    "@mysten-incubation/memwal": "^0.0.2",
     "@sinclair/typebox": "0.34.48",
     "zod": "^3.23.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1003,8 +1003,8 @@ importers:
   packages/openclaw-memory-memwal:
     dependencies:
       '@mysten-incubation/memwal':
-        specifier: ^0.0.1
-        version: 0.0.1(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.0.2
+        version: 0.0.2(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -3091,8 +3091,8 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
-  '@mysten-incubation/memwal@0.0.1':
-    resolution: {integrity: sha512-kRAFFJBdk3D9XvGHZdPOrnz2x4C7dwCRf0xTaeLFAVTgVwfpk3GmOnJZ1O+pAQyrAhweAzBXNXBWutShnPWgJg==}
+  '@mysten-incubation/memwal@0.0.2':
+    resolution: {integrity: sha512-tQ/U/054bOylXUEk3JsiAP0DlskoxqAerbMBXFAN/wWTNvvJK7L+FcvL1f4NlICawsW8dfxt5Of7jLCTIHxbdg==}
     peerDependencies:
       '@mysten/seal': '>=1.1.0'
       '@mysten/sui': '>=2.5.0'
@@ -3100,10 +3100,6 @@ packages:
       ai: '>=4.0.0'
       zod: ^3.23.0
     peerDependenciesMeta:
-      '@mysten/seal':
-        optional: true
-      '@mysten/sui':
-        optional: true
       '@mysten/walrus':
         optional: true
       ai:
@@ -13545,13 +13541,13 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@mysten-incubation/memwal@0.0.1(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)':
+  '@mysten-incubation/memwal@0.0.2(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)':
     dependencies:
+      '@mysten/seal': 1.1.1(@mysten/sui@2.8.0(typescript@5.9.3))
+      '@mysten/sui': 2.8.0(typescript@5.9.3)
       '@noble/ed25519': 2.3.0
       '@noble/hashes': 2.0.1
     optionalDependencies:
-      '@mysten/seal': 1.1.1(@mysten/sui@2.8.0(typescript@5.9.3))
-      '@mysten/sui': 2.8.0(typescript@5.9.3)
       '@mysten/walrus': 1.0.4(@mysten/sui@2.8.0(typescript@5.9.3))
       ai: 6.0.37(zod@3.25.76)
       zod: 3.25.76


### PR DESCRIPTION
## Summary
- Sync `release-oc-memwal.yml` with `release-sdk.yml` (remove npm upgrade step, use pnpm filter, update Node 22→24)
- Bump `oc-memwal` to `0.0.2` and update `@mysten-incubation/memwal` dep to `^0.0.2`
- Point workflow to `sec/sec_fix` branch for testing before merging to dev

## Test plan
- [ ] Trigger workflow on `sec/sec_fix` and verify it publishes successfully
- [ ] Merge this PR once CI passes