### PR TITLE
fix(sdk): ENG-1725 `recallManual` broken after LOW-24

### DIFF
--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -475,31 +475,50 @@ export class MemWalManual {
     /**
      * SEAL-encrypt a payload.
      *
-     * LOW-24: The `id` passed to SEAL is the on-chain policy identifier used
-     * by `seal_approve` to gate decryption. Previously this was just the
-     * owner's Sui address, which meant every memory the owner ever encrypted
-     * shared one decryption scope — a delegate authorized for namespace "A"
-     * could obtain keys for namespace "B" ciphertext.
+     * LOW-24 (namespace scoping): The `id` passed to SEAL is the on-chain
+     * policy identifier used by `seal_approve` to gate decryption. We scope
+     * encryption keys by namespace so a delegate authorized to decrypt
+     * namespace "A" cannot unwrap ciphertext for namespace "B".
      *
-     * We now include both the account id and the namespace:
-     *   id = hex(accountId) || ":" || hex(utf8(namespace))
+     * ENG-1725 fix: The on-chain `seal_approve` does
+     * `has_suffix(id, bcs::to_bytes(account.owner))` for the owner-caller
+     * branch. The id MUST therefore end with the caller's 32 raw address
+     * bytes (in hex form on the SEAL side, raw on the Move side). The
+     * previous LOW-24 layout — `hex(accountId) || hex(namespace)` — used
+     * the MemWalAccount object id (not the owner address) and put the
+     * namespace as the suffix, so `has_suffix` always failed and owners
+     * could no longer recall their own manually-remembered data. (Delegate
+     * decrypt still worked because the delegate branch skips the suffix
+     * check.)
      *
-     * NOTE (breaking change): Ciphertext produced before this fix was scoped
-     * by ownerAddress only. Legacy blobs created with the old id will still
-     * decrypt against SEAL (the id travels inside the EncryptedObject), but
-     * any on-chain `seal_approve` policy that now expects namespace-scoped
-     * ids will need to be updated in lockstep.
+     * Layout:
+     *   id = hex(utf8(namespace)) || hex(callerAddress[2:])
+     *
+     * - namespace is the prefix → still distinct keys per namespace, so the
+     *   LOW-24 isolation property is preserved (different ns → different
+     *   SEAL key).
+     * - caller address (32 bytes) is the suffix → `has_suffix` passes for
+     *   owner mode; delegate mode still passes via the delegate-list check
+     *   in `seal_approve` regardless of suffix.
+     *
+     * NOTE: Ciphertext written between the original LOW-24 fix and this fix
+     * (id = accountHex + nsHex) is unrecoverable by the owner caller. There
+     * is no production data in that window per the team; if recovery is
+     * needed, decrypt via a delegate key (delegate branch ignores suffix).
      */
     private async sealEncrypt(plaintext: Uint8Array, namespace: string): Promise<Uint8Array> {
         const sealClient = await this.getSealClient();
 
-        // Build a namespace-scoped SEAL id. Hex-encode both components so
-        // the id is a stable ASCII hex string (SEAL expects a hex id).
-        const accountHex = this.config.accountId.startsWith("0x")
-            ? this.config.accountId.slice(2)
-            : this.config.accountId;
+        // Build a namespace-scoped SEAL id whose final 32 bytes are the
+        // caller's address bytes, so the on-chain `seal_approve` owner-branch
+        // `has_suffix(id, bcs::to_bytes(owner))` check passes. Hex-encoded
+        // throughout so the id is a stable ASCII hex string.
+        const callerAddress = await this.getOwnerAddress();
+        const callerHex = callerAddress.startsWith("0x")
+            ? callerAddress.slice(2)
+            : callerAddress;
         const nsHex = bytesToHex(new TextEncoder().encode(namespace));
-        const scopedId = `${accountHex}${nsHex}`;
+        const scopedId = `${nsHex}${callerHex}`;
 
         const result = await sealClient.encrypt({
             threshold: this.sealThreshold,


### PR DESCRIPTION
## Summary

Owner-mode `recallManual()` returns `NoAccessError` for any data stored via`rememberManual()` after the LOW-24 fix was released. The SDK now produces a  SEAL `id` that the on-chain `seal_approve` policy rejects, so SEAL key servers
  refuse to release decryption keys. This PR reorders the id layout to satisfy  the contract check while preserving LOW-24's cross-namespace isolation.



  ## Root Cause

  The on-chain `seal_approve` (`services/contract/sources/account.move:531`)  authorizes SEAL decryption. For an owner-caller it does:

  ```move
  let owner_bytes = sui::bcs::to_bytes(&account.owner);
  let is_owner = (caller == account.owner) && has_suffix(&id, &owner_bytes);
  ```

  The `id` MUST end with `bcs::to_bytes(owner)` i.e., the owner's 32 raw  address bytes.

  The LOW-24 fix in `packages/sdk/src/manual.ts:sealEncrypt()` changed the SEAL  id from `ownerAddress` to:

  ```ts
  const scopedId = `${accountHex}${nsHex}`;
  ```

Result: `has_suffix(id, owner_bytes)` always returns `false` for new  ciphertext → `is_owner` fails → `seal_approve` aborts with `ENoAccess` →  SEAL key servers respond `403 Forbidden` → `recallManual` cannot decrypt.

 ## Solution

  Reorder the SEAL id so the caller's address is the trailing 32 bytes:

  ```diff
  - const accountHex = this.config.accountId.startsWith("0x")
  -     ? this.config.accountId.slice(2)
  -     : this.config.accountId;
  - const nsHex = bytesToHex(new TextEncoder().encode(namespace));
  - const scopedId = `${accountHex}${nsHex}`;
  + const callerAddress = await this.getOwnerAddress();
  + const callerHex = callerAddress.startsWith("0x")
  +     ? callerAddress.slice(2)
  +     : callerAddress;
  + const nsHex = bytesToHex(new TextEncoder().encode(namespace));
  + const scopedId = `${nsHex}${callerHex}`;
  ```

  Properties:

  - **`has_suffix` passes** — the last 32 bytes of `id` are the caller's    address bytes; when caller == owner, this equals `bcs::to_bytes(owner)`.
  - **Namespace isolation preserved** — `nsHex` is still a distinct prefix,    so different namespaces produce different SEAL keys (the LOW-24 intent).
  - **Delegate mode** — unchanged (delegate branch does not check the suffix).

  The `[arbitrary_prefix + owner_bytes]` layout is already validated by the   existing Move test `test_seal_approve_owner_with_prefix`  (`services/contract/tests/account_tests.move:540`), which proves the
  contract accepts this shape.

# Output image (After fix): 
<img width="683" height="655" alt="image" src="https://github.com/user-attachments/assets/767d33c3-44f5-43e4-bec6-1951340e73df" />

<img width="684" height="615" alt="image" src="https://github.com/user-attachments/assets/e4c33d02-13a4-4fe7-8767-19bad5d6907c" />
