### PR TITLE
feat: add seal committee aggregator support

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -3,6 +3,20 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+const PRELOAD_RELOAD_KEY = 'memwal:preload-error-reloaded-at'
+
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault()
+
+  const now = Date.now()
+  const lastReloadAt = Number(sessionStorage.getItem(PRELOAD_RELOAD_KEY) || 0)
+
+  if (now - lastReloadAt > 10_000) {
+    sessionStorage.setItem(PRELOAD_RELOAD_KEY, String(now))
+    window.location.reload()
+  }
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -426,7 +426,7 @@ Add to `~/.openclaw/openclaw.json`:
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID |
 | `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | SEAL server config for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers |
 
-If `SUI_NETWORK=testnet` and neither SEAL variable is set, the sidecar defaults to the Mysten testnet committee aggregator.
+If neither SEAL variable is set, the sidecar uses built-in independent key server defaults for `SUI_NETWORK`: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`.
 
 ### Usually Required
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -419,7 +419,9 @@ Add to `~/.openclaw/openclaw.json`:
 | `DATABASE_URL` | PostgreSQL connection string. `pgvector` must already exist |
 | `MEMWAL_PACKAGE_ID` | Sui package ID |
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID |
-| `SEAL_KEY_SERVERS` | Comma-separated SEAL key server object IDs |
+| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | SEAL server config for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers |
+
+If `SUI_NETWORK=testnet` and neither SEAL variable is set, the sidecar defaults to the Mysten testnet committee aggregator.
 
 ### Usually Required
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -50,7 +50,9 @@ Walrus and network fields:
 | Field | Required | Notes |
 | --- | --- | --- |
 | `suiNetwork` | no | `testnet` or `mainnet`. Default: `mainnet` |
-| `sealKeyServers` | no | Override built-in SEAL key server object IDs for the selected network |
+| `sealServerConfigs` | no | Full SEAL configs for independent or committee servers. Committee entries require `aggregatorUrl` |
+| `sealKeyServers` | no | Legacy override for independent SEAL key server object IDs |
+| `sealThreshold` | no | Default: `2`, capped to total configured server weight |
 | `walrusEpochs` | no | Default: `50` |
 | `walrusAggregatorUrl` | no | Walrus download endpoint. Defaults follow `suiNetwork` |
 | `walrusPublisherUrl` | no | Walrus upload endpoint. Defaults follow `suiNetwork` |
@@ -73,4 +75,5 @@ Walrus and network fields:
 - `MemWalManual` is the manual client path, but it still uses the relayer for registration, search, and restore.
 - `withMemWal` builds on top of `MemWal`, so it uses the same relayer-backed config shape.
 - `MemWalManual` now defaults to `mainnet` network settings unless you pass `suiNetwork: "testnet"`.
-- `sealKeyServers` lets the client override the built-in SEAL key server list for the selected network.
+- `sealServerConfigs` takes priority over `sealKeyServers`; `sealKeyServers` remains supported for legacy independent key server lists.
+- The built-in testnet SEAL default uses the Mysten committee aggregator. Mainnet committee config must be provided explicitly until official values are published.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,4 +76,4 @@ Walrus and network fields:
 - `withMemWal` builds on top of `MemWal`, so it uses the same relayer-backed config shape.
 - `MemWalManual` now defaults to `mainnet` network settings unless you pass `suiNetwork: "testnet"`.
 - `sealServerConfigs` takes priority over `sealKeyServers`; `sealKeyServers` remains supported for legacy independent key server lists.
-- The built-in testnet SEAL default uses the Mysten committee aggregator. Mainnet committee config must be provided explicitly until official values are published.
+- Built-in SEAL defaults use independent key servers: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`. Use `sealServerConfigs` for committee aggregator configs.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -50,8 +50,8 @@ These are not all enforced at boot, but most real deployments need them.
 - `SUI_NETWORK` drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.
 - `SEAL_SERVER_CONFIGS` is a JSON array of `{ objectId, weight, aggregatorUrl?, apiKeyName?, apiKey? }`. Committee key server configs require `aggregatorUrl`.
 - `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset.
-- If `SUI_NETWORK=testnet` and neither SEAL variable is set, the sidecar defaults to the official Mysten testnet committee config: `[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]`.
-- Mainnet committee mode is supported through `SEAL_SERVER_CONFIGS`, but do not hardcode a mainnet default until Mysten publishes the object ID and aggregator URL.
+- If neither SEAL variable is set, the sidecar uses built-in independent key server defaults for `SUI_NETWORK`: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`.
+- Committee mode is supported through `SEAL_SERVER_CONFIGS` when you need an aggregator-backed key server.
 - The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -12,7 +12,7 @@ For setup steps and deployment context, see [Self-Hosting](/relayer/self-hosting
 | `DATABASE_URL` | PostgreSQL connection string. `pgvector` must already exist |
 | `MEMWAL_PACKAGE_ID` | Sui package ID. See [Contract Overview](/contract/overview) |
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID. See [Contract Overview](/contract/overview) |
-| `SEAL_KEY_SERVERS` | Comma-separated SEAL key server object IDs used by the sidecar for encrypt and decrypt |
+| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | SEAL server config used by the sidecar for encrypt and decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers |
 
 ## Usually Required
 
@@ -38,6 +38,7 @@ These are not all enforced at boot, but most real deployments need them.
 | `MEMWAL_ACCOUNT_ID` | none | Optional account ID in server config |
 | `WALRUS_PACKAGE_ID` | network default | Override the Walrus on-chain package used by the sidecar |
 | `WALRUS_UPLOAD_RELAY_URL` | network default | Override the Walrus upload relay used by the sidecar |
+| `SEAL_THRESHOLD` | `min(2, total configured weight)` | Required configured server weight for SEAL encrypt/decrypt |
 | `ENOKI_API_KEY` | none | Optional Enoki key for sponsored sidecar transactions |
 | `ENOKI_NETWORK` | `mainnet` | Network used for Enoki-sponsored flows |
 
@@ -47,6 +48,10 @@ These are not all enforced at boot, but most real deployments need them.
 - `OPENAI_API_KEY` and `OPENAI_API_BASE` control the embedding and fact-extraction provider used by `remember`, `recall`, `analyze`, `ask`, and restore re-indexing.
 - Without `OPENAI_API_KEY`, the server can fall back to mock embeddings. That is useful for local testing, not for normal production behavior.
 - `SUI_NETWORK` drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.
+- `SEAL_SERVER_CONFIGS` is a JSON array of `{ objectId, weight, aggregatorUrl?, apiKeyName?, apiKey? }`. Committee key server configs require `aggregatorUrl`.
+- `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset.
+- If `SUI_NETWORK=testnet` and neither SEAL variable is set, the sidecar defaults to the official Mysten testnet committee config: `[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]`.
+- Mainnet committee mode is supported through `SEAL_SERVER_CONFIGS`, but do not hardcode a mainnet default until Mysten publishes the object ID and aggregator URL.
 - The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -52,6 +52,6 @@ These are not all enforced at boot, but most real deployments need them.
 - `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset.
 - If `SUI_NETWORK=testnet` and neither SEAL variable is set, the sidecar defaults to the official Mysten testnet committee config: `[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]`.
 - Mainnet committee mode is supported through `SEAL_SERVER_CONFIGS`, but do not hardcode a mainnet default until Mysten publishes the object ID and aggregator URL.
-- The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network and caps uploads at `5` epochs: effective defaults are `5` on `testnet` and `3` on `mainnet` unless the request explicitly passes a lower `epochs` value.
+- The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -52,6 +52,6 @@ These are not all enforced at boot, but most real deployments need them.
 - `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset.
 - If `SUI_NETWORK=testnet` and neither SEAL variable is set, the sidecar defaults to the official Mysten testnet committee config: `[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]`.
 - Mainnet committee mode is supported through `SEAL_SERVER_CONFIGS`, but do not hardcode a mainnet default until Mysten publishes the object ID and aggregator URL.
-- The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.
+- The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network and caps uploads at `5` epochs: effective defaults are `5` on `testnet` and `3` on `mainnet` unless the request explicitly passes a lower `epochs` value.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -125,15 +125,15 @@ MEMWAL_PACKAGE_ID=0xcee7a6fd8de52ce645c38332bde23d4a30fd9426bc4681409733dd50958a
 MEMWAL_REGISTRY_ID=0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75a7edd
 ```
 
-Use `SEAL_SERVER_CONFIGS` for committee key servers because committee entries require an `aggregatorUrl`. The official Mysten testnet committee config is:
+If neither `SEAL_SERVER_CONFIGS` nor `SEAL_KEY_SERVERS` is set, the sidecar uses built-in independent key server defaults for the selected `SUI_NETWORK`: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`.
+
+Use `SEAL_SERVER_CONFIGS` for committee key servers because committee entries require an `aggregatorUrl`. For example, the Mysten testnet committee config is:
 
 ```env
 SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
 ```
 
-If `SUI_NETWORK=testnet` and neither `SEAL_SERVER_CONFIGS` nor `SEAL_KEY_SERVERS` is set, the sidecar uses that Mysten testnet committee by default.
-
-`SEAL_KEY_SERVERS=0x...,0x...` remains supported for independent key server object IDs. Mainnet committee mode is supported through `SEAL_SERVER_CONFIGS` once you have the official mainnet object ID and aggregator URL.
+`SEAL_KEY_SERVERS=0x...,0x...` remains supported for independent key server object IDs. Committee mode is supported through `SEAL_SERVER_CONFIGS` when you have the object ID and aggregator URL.
 
 Using official key server of SDK is recommended. 
 

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -101,7 +101,7 @@ By default, the relayer enforces rate limits and storage quotas via Redis to pre
 - `SIDECAR_URL` defaults to `http://localhost:9000`
 - `SUI_NETWORK` defaults to `mainnet`
 - `SUI_RPC_URL`, Walrus endpoints, and `WALRUS_PACKAGE_ID` fall back to network defaults based on `SUI_NETWORK`
-- The sidecar Walrus upload route defaults storage `epochs` by network: `50` on `testnet`, `2` on `mainnet` (unless the request passes `epochs`)
+- The sidecar Walrus upload route defaults storage `epochs` by network and caps uploads at `5` epochs: effective defaults are `5` on `testnet` and `3` on `mainnet` unless the request passes a lower `epochs` value.
 - `SEAL_THRESHOLD` defaults to `min(2, total configured server weight)`. A single committee server config defaults to threshold `1`.
 
 ### Server Keys

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -78,7 +78,7 @@ curl http://localhost:8000/health
 - `MEMWAL_PACKAGE_ID`
 - `MEMWAL_REGISTRY_ID`
 - `SERVER_SUI_PRIVATE_KEY` or `SERVER_SUI_PRIVATE_KEYS`
-- `SEAL_KEY_SERVERS` — comma-separated list of SEAL key server object IDs
+- `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` — SEAL server config for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers.
 
 ### Recommended
 
@@ -102,6 +102,7 @@ By default, the relayer enforces rate limits and storage quotas via Redis to pre
 - `SUI_NETWORK` defaults to `mainnet`
 - `SUI_RPC_URL`, Walrus endpoints, and `WALRUS_PACKAGE_ID` fall back to network defaults based on `SUI_NETWORK`
 - The sidecar Walrus upload route defaults storage `epochs` by network: `50` on `testnet`, `2` on `mainnet` (unless the request passes `epochs`)
+- `SEAL_THRESHOLD` defaults to `min(2, total configured server weight)`. A single committee server config defaults to threshold `1`.
 
 ### Server Keys
 
@@ -124,7 +125,15 @@ MEMWAL_PACKAGE_ID=0xcee7a6fd8de52ce645c38332bde23d4a30fd9426bc4681409733dd50958a
 MEMWAL_REGISTRY_ID=0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75a7edd
 ```
 
-For SEAL key server object IDs on testnet, see https://seal-docs.wal.app/Pricing.
+Use `SEAL_SERVER_CONFIGS` for committee key servers because committee entries require an `aggregatorUrl`. The official Mysten testnet committee config is:
+
+```env
+SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
+```
+
+If `SUI_NETWORK=testnet` and neither `SEAL_SERVER_CONFIGS` nor `SEAL_KEY_SERVERS` is set, the sidecar uses that Mysten testnet committee by default.
+
+`SEAL_KEY_SERVERS=0x...,0x...` remains supported for independent key server object IDs. Mainnet committee mode is supported through `SEAL_SERVER_CONFIGS` once you have the official mainnet object ID and aggregator URL.
 
 Using official key server of SDK is recommended. 
 

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -101,7 +101,7 @@ By default, the relayer enforces rate limits and storage quotas via Redis to pre
 - `SIDECAR_URL` defaults to `http://localhost:9000`
 - `SUI_NETWORK` defaults to `mainnet`
 - `SUI_RPC_URL`, Walrus endpoints, and `WALRUS_PACKAGE_ID` fall back to network defaults based on `SUI_NETWORK`
-- The sidecar Walrus upload route defaults storage `epochs` by network and caps uploads at `5` epochs: effective defaults are `5` on `testnet` and `3` on `mainnet` unless the request passes a lower `epochs` value.
+- The sidecar Walrus upload route defaults storage `epochs` by network: `50` on `testnet`, `2` on `mainnet` (unless the request passes `epochs`)
 - `SEAL_THRESHOLD` defaults to `min(2, total configured server weight)`. A single committee server config defaults to threshold `1`.
 
 ### Server Keys

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -143,7 +143,8 @@ Whether this client uses a connected wallet signer (vs. raw keypair).
 ### Config notes
 
 - `suiNetwork` defaults to `mainnet`
-- `sealKeyServers` lets the client override the built-in SEAL key server object IDs
+- `sealServerConfigs` lets the client configure independent or committee SEAL servers; committee entries require `aggregatorUrl`
+- `sealKeyServers` remains supported as a legacy independent key server object ID override
 - All `@mysten/*` peer dependencies are loaded dynamically — only needed if you use `MemWalManual`
 
 ## `withMemWal`

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -93,7 +93,8 @@ const manual = MemWalManual.create({
 ## Config Notes
 
 - `suiNetwork` defaults to `mainnet`
-- `sealKeyServers` lets the client override the built-in SEAL key server object IDs
+- `sealServerConfigs` lets the client configure independent or committee SEAL servers; committee entries require `aggregatorUrl`
+- `sealKeyServers` remains supported as a legacy independent key server object ID override
 - Walrus publisher, aggregator, and upload relay defaults follow `suiNetwork`
 - `embeddingModel` defaults to `text-embedding-3-small` (or `openai/text-embedding-3-small` for OpenRouter)
 - `walrusEpochs` defaults to `50` (storage duration)

--- a/packages/sdk/src/manual-entry.ts
+++ b/packages/sdk/src/manual-entry.ts
@@ -12,6 +12,7 @@ export { MemWalManual } from "./manual.js";
 
 export type {
     MemWalManualConfig,
+    SealServerConfig,
     WalletSigner,
     RememberManualOptions,
     RememberManualResult,

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -34,6 +34,7 @@ import type {
     RecallManualResult,
     RecallManualMemory,
     RestoreResult,
+    SealServerConfig,
 } from "./types.js";
 import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerError } from "./utils.js";
 
@@ -41,18 +42,76 @@ import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerEr
 // Constants
 // ============================================================
 
-// Default SEAL key server object IDs per network
-// Users can override via SEAL_KEY_SERVERS in their environment
-const DEFAULT_KEY_SERVERS: Record<string, string[]> = {
+type ResolvedSealServerConfig = Omit<SealServerConfig, "weight"> & { weight: number };
+
+// Default SEAL server configs per network.
+// Testnet uses the official Mysten committee aggregator. Mainnet remains on
+// independent servers until official mainnet committee values are published.
+const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = {
     mainnet: [
-        "0x145540d931f182fef76467dd8074c9839aea126852d90d18e1556fcbbd1208b6", // Overclock (Open)
-        "0xe0eb52eba9261b96e895bbb4deca10dcd64fbc626a1133017adcd5131353fd10", // Studio Mirai (Open)
+        {
+            objectId: "0x145540d931f182fef76467dd8074c9839aea126852d90d18e1556fcbbd1208b6", // Overclock (Open)
+            weight: 1,
+        },
+        {
+            objectId: "0xe0eb52eba9261b96e895bbb4deca10dcd64fbc626a1133017adcd5131353fd10", // Studio Mirai (Open)
+            weight: 1,
+        },
     ],
     testnet: [
-        "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
-        "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
+        {
+            objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
+            weight: 1,
+            aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
+        },
     ],
 };
+
+function normalizeSealServerConfigs(configs: SealServerConfig[]): ResolvedSealServerConfig[] {
+    return configs.map((config, index) => {
+        const objectId = config.objectId?.trim();
+        if (!objectId) {
+            throw new Error(`MemWalManual: sealServerConfigs[${index}].objectId is required`);
+        }
+
+        const weight = config.weight ?? 1;
+        if (!Number.isInteger(weight) || weight < 1) {
+            throw new Error(`MemWalManual: sealServerConfigs[${index}].weight must be a positive integer`);
+        }
+
+        const aggregatorUrl = config.aggregatorUrl?.trim();
+        const apiKeyName = config.apiKeyName?.trim();
+        const apiKey = config.apiKey?.trim();
+        if ((apiKeyName && !apiKey) || (!apiKeyName && apiKey)) {
+            throw new Error(
+                `MemWalManual: sealServerConfigs[${index}] must provide both apiKeyName and apiKey, or neither`,
+            );
+        }
+
+        return {
+            objectId,
+            weight,
+            ...(aggregatorUrl ? { aggregatorUrl } : {}),
+            ...(apiKeyName && apiKey ? { apiKeyName, apiKey } : {}),
+        };
+    });
+}
+
+function resolveSealServerConfigs(config: MemWalManualConfig, network: string): ResolvedSealServerConfig[] {
+    if (config.sealServerConfigs !== undefined) {
+        return normalizeSealServerConfigs(config.sealServerConfigs);
+    }
+
+    if (config.sealKeyServers !== undefined) {
+        return normalizeSealServerConfigs(config.sealKeyServers.map((objectId) => ({ objectId })));
+    }
+
+    return normalizeSealServerConfigs(DEFAULT_SEAL_SERVER_CONFIGS[network] ?? []);
+}
+
+function sealServerConfigTotalWeight(configs: ResolvedSealServerConfig[]): number {
+    return configs.reduce((sum, config) => sum + config.weight, 0);
+}
 
 // ============================================================
 // MemWalManual Client
@@ -200,28 +259,30 @@ export class MemWalManual {
             const { SealClient } = await import("@mysten/seal");
             const suiClient = await this.getSuiClient();
             const network = this.config.suiNetwork ?? "mainnet";
-            const keyServers = this.config.sealKeyServers ?? DEFAULT_KEY_SERVERS[network] ?? [];
-            if (keyServers.length === 0) {
+            const serverConfigs = resolveSealServerConfigs(this.config, network);
+            if (serverConfigs.length === 0) {
                 throw new Error(
                     `MemWalManual: no SEAL key servers configured for network "${network}". ` +
-                    "Please provide sealKeyServers in config or set SEAL_KEY_SERVERS env var."
+                    "Please provide sealServerConfigs or sealKeyServers in config."
                 );
             }
             this._sealClient = new SealClient({
                 suiClient,
-                serverConfigs: keyServers.map((id) => ({
-                    objectId: id,
-                    weight: 1,
-                })),
+                serverConfigs,
                 verifyKeyServers: true,
             });
         }
         return this._sealClient;
     }
 
-    /** MED-10: SEAL threshold — must match sidecar SEAL_THRESHOLD (default 2). */
+    /** MED-10: SEAL threshold — defaults to 2, capped to configured server weight. */
     private get sealThreshold(): number {
-        return this.config.sealThreshold ?? 2;
+        if (this.config.sealThreshold !== undefined) {
+            return this.config.sealThreshold;
+        }
+        const network = this.config.suiNetwork ?? "mainnet";
+        const totalWeight = sealServerConfigTotalWeight(resolveSealServerConfigs(this.config, network));
+        return totalWeight > 0 ? Math.min(2, totalWeight) : 2;
     }
 
     private async getWalrusClient() {

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -45,8 +45,9 @@ import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerEr
 type ResolvedSealServerConfig = Omit<SealServerConfig, "weight"> & { weight: number };
 
 // Default SEAL server configs per network.
-// Testnet uses the official Mysten committee aggregator. Mainnet remains on
-// independent servers until official mainnet committee values are published.
+// Keep testnet on the legacy independent servers so Manual mode can decrypt
+// data written by the hosted testnet relayer. Committee aggregators remain
+// supported through explicit sealServerConfigs.
 const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = {
     mainnet: [
         {
@@ -60,9 +61,12 @@ const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = 
     ],
     testnet: [
         {
-            objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
+            objectId: "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
             weight: 1,
-            aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
+        },
+        {
+            objectId: "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
+            weight: 1,
         },
     ],
 };

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -121,6 +121,20 @@ export interface RestoreResult {
 // Full Client-Side Manual Flow — MemWalManual class
 // ============================================================
 
+/** Full @mysten/seal server config. Committee servers require aggregatorUrl. */
+export interface SealServerConfig {
+    /** On-chain SEAL key server or committee object ID */
+    objectId: string;
+    /** Server weight for threshold encryption. Defaults to 1. */
+    weight?: number;
+    /** Committee aggregator URL. Required for committee mode servers. */
+    aggregatorUrl?: string;
+    /** Optional API key header name for permissioned key servers */
+    apiKeyName?: string;
+    /** Optional API key value for permissioned key servers */
+    apiKey?: string;
+}
+
 /** Config for MemWalManual (full client-side: SEAL + Walrus + embedding) */
 export interface MemWalManualConfig {
     /** Ed25519 delegate private key (hex or Uint8Array) for server auth */
@@ -157,15 +171,20 @@ export interface MemWalManualConfig {
     /** Sui network (default: mainnet) */
     suiNetwork?: "testnet" | "mainnet";
     /**
-     * Custom SEAL key server object IDs (overrides built-in defaults per network).
+     * Full SEAL server configs, including committee aggregators.
+     * Takes priority over legacy sealKeyServers when provided.
+     */
+    sealServerConfigs?: SealServerConfig[];
+    /**
+     * Legacy custom SEAL independent key server object IDs.
      * Array of on-chain object IDs, e.g. ["0x..."].
-     * If omitted, uses built-in defaults for the selected suiNetwork.
+     * If omitted, uses sealServerConfigs or built-in defaults for the selected suiNetwork.
      */
     sealKeyServers?: string[];
     /**
      * SEAL threshold — number of key server shares required for encrypt/decrypt.
-     * Must be ≤ number of entries in sealKeyServers.
-     * Default: 2 (matches sidecar SEAL_THRESHOLD default).
+     * Must be ≤ the total configured SEAL server weight.
+     * Default: 2, capped to the total configured SEAL server weight.
      */
     sealThreshold?: number;
     /** Walrus storage epochs (default: 50) */

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -43,7 +43,6 @@ SEAL_KEY_SERVERS=0x...,0x...
 # encrypt/decrypt to succeed. Must be <= total configured server weight.
 # Default: min(2, total configured weight); a single committee config defaults to 1.
 SEAL_THRESHOLD=2
-SEAL_DECRYPT_THRESHOLD=2
 
 # Walrus on-chain package ID (auto-detected from SUI_NETWORK if not set)
 # WALRUS_PACKAGE_ID=0x...

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -29,12 +29,13 @@ MEMWAL_PACKAGE_ID=0x...
 MEMWAL_REGISTRY_ID=0x...
 
 # SEAL server configs for sidecar encrypt/decrypt.
-# Prefer SEAL_SERVER_CONFIGS for committee key servers because committee entries
-# require an aggregatorUrl. Example Mysten testnet committee:
-# SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
+# If neither SEAL_SERVER_CONFIGS nor SEAL_KEY_SERVERS is set, the sidecar uses
+# built-in independent key server defaults for SUI_NETWORK: two testnet servers
+# on testnet, and Overclock + Studio Mirai on mainnet.
 #
-# If SUI_NETWORK=testnet and neither SEAL_SERVER_CONFIGS nor SEAL_KEY_SERVERS is
-# set, the sidecar uses the Mysten testnet committee above by default.
+# Prefer SEAL_SERVER_CONFIGS for committee key servers because committee entries
+# require an aggregatorUrl. Example Mysten testnet committee override:
+# SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
 #
 # Legacy independent key server object IDs remain supported as fallback:
 SEAL_KEY_SERVERS=0x...,0x...

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -38,12 +38,12 @@ MEMWAL_REGISTRY_ID=0x...
 # SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
 #
 # Legacy independent key server object IDs remain supported as fallback:
-SEAL_KEY_SERVERS=0x...,0x...
+# SEAL_KEY_SERVERS=0x...,0x...
 
 # SEAL threshold - minimum configured server weight that must respond for
 # encrypt/decrypt to succeed. Must be <= total configured server weight.
 # Default: min(2, total configured weight); a single committee config defaults to 1.
-SEAL_THRESHOLD=2
+# SEAL_THRESHOLD=2
 
 # Walrus on-chain package ID (auto-detected from SUI_NETWORK if not set)
 # WALRUS_PACKAGE_ID=0x...

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -28,13 +28,20 @@ SERVER_SUI_PRIVATE_KEYS=suiprivkey1...,suiprivkey1...
 MEMWAL_PACKAGE_ID=0x...
 MEMWAL_REGISTRY_ID=0x...
 
-# SEAL key servers (comma-separated object IDs)
-# Required for SEAL encrypt/decrypt in sidecar scripts
+# SEAL server configs for sidecar encrypt/decrypt.
+# Prefer SEAL_SERVER_CONFIGS for committee key servers because committee entries
+# require an aggregatorUrl. Example Mysten testnet committee:
+# SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
+#
+# If SUI_NETWORK=testnet and neither SEAL_SERVER_CONFIGS nor SEAL_KEY_SERVERS is
+# set, the sidecar uses the Mysten testnet committee above by default.
+#
+# Legacy independent key server object IDs remain supported as fallback:
 SEAL_KEY_SERVERS=0x...,0x...
 
-# SEAL threshold — minimum number of key servers that must respond for
-# encrypt/decrypt to succeed. Must be ≤ number of entries in SEAL_KEY_SERVERS.
-# Default: 2 (requires at least 2 key servers configured above)
+# SEAL threshold - minimum configured server weight that must respond for
+# encrypt/decrypt to succeed. Must be <= total configured server weight.
+# Default: min(2, total configured weight); a single committee config defaults to 1.
 SEAL_THRESHOLD=2
 SEAL_DECRYPT_THRESHOLD=2
 

--- a/services/server/scripts/seal-config.ts
+++ b/services/server/scripts/seal-config.ts
@@ -105,7 +105,7 @@ function parseLegacyKeyServers(value: string | undefined): SealServerConfig[] {
 }
 
 function getDefaultSealServerConfigs(network: string | undefined): SealServerConfig[] {
-    return DEFAULT_SEAL_SERVER_CONFIGS[network || ""] ?? [];
+    return DEFAULT_SEAL_SERVER_CONFIGS[network || "mainnet"] ?? [];
 }
 
 export function getSealServerConfigsFromEnv(env: Env = process.env): SealServerConfig[] {
@@ -120,4 +120,28 @@ export function getSealServerConfigsFromEnv(env: Env = process.env): SealServerC
     }
 
     return getDefaultSealServerConfigs(env.SUI_NETWORK);
+}
+
+export function getSealThresholdFromEnv(
+    configs: SealServerConfig[],
+    env: Env = process.env,
+): number {
+    const totalWeight = configs.reduce((sum, config) => sum + config.weight, 0);
+    const defaultThreshold = totalWeight > 0 ? Math.min(2, totalWeight) : 2;
+    const rawThreshold = env.SEAL_THRESHOLD?.trim();
+
+    if (!rawThreshold) {
+        return defaultThreshold;
+    }
+
+    const threshold = Number(rawThreshold);
+    if (!Number.isInteger(threshold) || threshold < 1) {
+        throw new Error("SEAL_THRESHOLD must be a positive integer");
+    }
+
+    if (totalWeight > 0 && threshold > totalWeight) {
+        throw new Error("SEAL_THRESHOLD must be less than or equal to total configured SEAL server weight");
+    }
+
+    return threshold;
 }

--- a/services/server/scripts/seal-config.ts
+++ b/services/server/scripts/seal-config.ts
@@ -8,14 +8,27 @@ export type SealServerConfig = {
 
 type Env = Record<string, string | undefined>;
 
-const MYSTEN_TESTNET_COMMITTEE_CONFIG: SealServerConfig = {
-    objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
-    weight: 1,
-    aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
-};
-
 const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, SealServerConfig[]> = {
-    testnet: [MYSTEN_TESTNET_COMMITTEE_CONFIG],
+    mainnet: [
+        {
+            objectId: "0x145540d931f182fef76467dd8074c9839aea126852d90d18e1556fcbbd1208b6",
+            weight: 1,
+        },
+        {
+            objectId: "0xe0eb52eba9261b96e895bbb4deca10dcd64fbc626a1133017adcd5131353fd10",
+            weight: 1,
+        },
+    ],
+    testnet: [
+        {
+            objectId: "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
+            weight: 1,
+        },
+        {
+            objectId: "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
+            weight: 1,
+        },
+    ],
 };
 
 function requireObject(value: unknown, index: number): Record<string, unknown> {

--- a/services/server/scripts/seal-config.ts
+++ b/services/server/scripts/seal-config.ts
@@ -1,0 +1,110 @@
+export type SealServerConfig = {
+    objectId: string;
+    weight: number;
+    aggregatorUrl?: string;
+    apiKeyName?: string;
+    apiKey?: string;
+};
+
+type Env = Record<string, string | undefined>;
+
+const MYSTEN_TESTNET_COMMITTEE_CONFIG: SealServerConfig = {
+    objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
+    weight: 1,
+    aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
+};
+
+const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, SealServerConfig[]> = {
+    testnet: [MYSTEN_TESTNET_COMMITTEE_CONFIG],
+};
+
+function requireObject(value: unknown, index: number): Record<string, unknown> {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error(`SEAL_SERVER_CONFIGS[${index}] must be an object`);
+    }
+    return value as Record<string, unknown>;
+}
+
+function requireNonEmptyString(value: unknown, field: string, index: number): string {
+    if (typeof value !== "string" || value.trim().length === 0) {
+        throw new Error(`SEAL_SERVER_CONFIGS[${index}].${field} must be a non-empty string`);
+    }
+    return value.trim();
+}
+
+function optionalNonEmptyString(value: unknown, field: string, index: number): string | undefined {
+    if (value === undefined) return undefined;
+    return requireNonEmptyString(value, field, index);
+}
+
+function normalizeWeight(value: unknown, index: number): number {
+    if (value === undefined) return 1;
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+        throw new Error(`SEAL_SERVER_CONFIGS[${index}].weight must be a positive integer`);
+    }
+    return value;
+}
+
+function normalizeSealServerConfig(value: unknown, index: number): SealServerConfig {
+    const raw = requireObject(value, index);
+    const objectId = requireNonEmptyString(raw.objectId, "objectId", index);
+    const weight = normalizeWeight(raw.weight, index);
+    const aggregatorUrl = optionalNonEmptyString(raw.aggregatorUrl, "aggregatorUrl", index);
+    const apiKeyName = optionalNonEmptyString(raw.apiKeyName, "apiKeyName", index);
+    const apiKey = optionalNonEmptyString(raw.apiKey, "apiKey", index);
+
+    if ((apiKeyName && !apiKey) || (!apiKeyName && apiKey)) {
+        throw new Error(
+            `SEAL_SERVER_CONFIGS[${index}] must provide both apiKeyName and apiKey, or neither`,
+        );
+    }
+
+    return {
+        objectId,
+        weight,
+        ...(aggregatorUrl ? { aggregatorUrl } : {}),
+        ...(apiKeyName && apiKey ? { apiKeyName, apiKey } : {}),
+    };
+}
+
+function parseSealServerConfigsJson(value: string): SealServerConfig[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(value);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`SEAL_SERVER_CONFIGS must be valid JSON: ${message}`);
+    }
+
+    if (!Array.isArray(parsed)) {
+        throw new Error("SEAL_SERVER_CONFIGS must be a JSON array");
+    }
+
+    return parsed.map(normalizeSealServerConfig);
+}
+
+function parseLegacyKeyServers(value: string | undefined): SealServerConfig[] {
+    return (value || "")
+        .split(",")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0)
+        .map((objectId) => ({ objectId, weight: 1 }));
+}
+
+function getDefaultSealServerConfigs(network: string | undefined): SealServerConfig[] {
+    return DEFAULT_SEAL_SERVER_CONFIGS[network || ""] ?? [];
+}
+
+export function getSealServerConfigsFromEnv(env: Env = process.env): SealServerConfig[] {
+    const rawServerConfigs = env.SEAL_SERVER_CONFIGS?.trim();
+    if (rawServerConfigs) {
+        return parseSealServerConfigsJson(rawServerConfigs);
+    }
+
+    const legacyConfigs = parseLegacyKeyServers(env.SEAL_KEY_SERVERS);
+    if (legacyConfigs.length > 0) {
+        return legacyConfigs;
+    }
+
+    return getDefaultSealServerConfigs(env.SUI_NETWORK);
+}

--- a/services/server/scripts/seal-decrypt.ts
+++ b/services/server/scripts/seal-decrypt.ts
@@ -29,7 +29,7 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Transaction } from "@mysten/sui/transactions";
 import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
-import { getSealServerConfigsFromEnv } from "./seal-config.ts";
+import { getSealServerConfigsFromEnv } from "./seal-config.js";
 
 // Network config from env vars
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";

--- a/services/server/scripts/seal-decrypt.ts
+++ b/services/server/scripts/seal-decrypt.ts
@@ -29,11 +29,12 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Transaction } from "@mysten/sui/transactions";
 import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
-import { getSealServerConfigsFromEnv } from "./seal-config.js";
+import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-config.js";
 
 // Network config from env vars
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
 const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
+const SEAL_THRESHOLD = getSealThresholdFromEnv(SEAL_SERVER_CONFIGS);
 
 // ============================================================
 // Parse CLI arguments
@@ -149,7 +150,7 @@ async function main() {
         ids: [fullId],
         txBytes,
         sessionKey,
-        threshold: 1,
+        threshold: SEAL_THRESHOLD,
     });
 
     // Step 5: Decrypt locally using fetched keys

--- a/services/server/scripts/seal-decrypt.ts
+++ b/services/server/scripts/seal-decrypt.ts
@@ -29,13 +29,11 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Transaction } from "@mysten/sui/transactions";
 import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
+import { getSealServerConfigsFromEnv } from "./seal-config.ts";
 
 // Network config from env vars
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
-const SEAL_KEY_SERVERS = (process.env.SEAL_KEY_SERVERS || "")
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
 
 // ============================================================
 // Parse CLI arguments
@@ -110,10 +108,7 @@ async function main() {
     // Initialize SEAL client
     const sealClient = new SealClient({
         suiClient: suiClient as any,
-        serverConfigs: SEAL_KEY_SERVERS.map((id) => ({
-            objectId: id,
-            weight: 1,
-        })),
+        serverConfigs: SEAL_SERVER_CONFIGS,
         verifyKeyServers: true,
     });
 

--- a/services/server/scripts/seal-encrypt.ts
+++ b/services/server/scripts/seal-encrypt.ts
@@ -20,13 +20,11 @@
 
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { SealClient } from "@mysten/seal";
+import { getSealServerConfigsFromEnv } from "./seal-config.ts";
 
 // Network config from env vars
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
-const SEAL_KEY_SERVERS = (process.env.SEAL_KEY_SERVERS || "")
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
 
 // ============================================================
 // Parse CLI arguments
@@ -89,10 +87,7 @@ async function main() {
 
     const sealClient = new SealClient({
         suiClient: suiClient as any,
-        serverConfigs: SEAL_KEY_SERVERS.map((id) => ({
-            objectId: id,
-            weight: 1,
-        })),
+        serverConfigs: SEAL_SERVER_CONFIGS,
         verifyKeyServers: true,
     });
 

--- a/services/server/scripts/seal-encrypt.ts
+++ b/services/server/scripts/seal-encrypt.ts
@@ -20,7 +20,7 @@
 
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { SealClient } from "@mysten/seal";
-import { getSealServerConfigsFromEnv } from "./seal-config.ts";
+import { getSealServerConfigsFromEnv } from "./seal-config.js";
 
 // Network config from env vars
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";

--- a/services/server/scripts/seal-encrypt.ts
+++ b/services/server/scripts/seal-encrypt.ts
@@ -20,11 +20,12 @@
 
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { SealClient } from "@mysten/seal";
-import { getSealServerConfigsFromEnv } from "./seal-config.js";
+import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-config.js";
 
 // Network config from env vars
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
 const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
+const SEAL_THRESHOLD = getSealThresholdFromEnv(SEAL_SERVER_CONFIGS);
 
 // ============================================================
 // Parse CLI arguments
@@ -91,10 +92,10 @@ async function main() {
         verifyKeyServers: true,
     });
 
-    // Encrypt with threshold 1 (need 1 of N key servers to decrypt)
+    // The default threshold is capped to configured server weight.
     // The SEAL SDK uses packageId + id to derive the encryption key
     const result = await sealClient.encrypt({
-        threshold: 1,
+        threshold: SEAL_THRESHOLD,
         packageId,
         id: owner,
         data: new Uint8Array(data),

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -19,7 +19,7 @@ import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Transaction } from "@mysten/sui/transactions";
 import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
 import { WalrusClient } from "@mysten/walrus";
-import { getSealServerConfigsFromEnv } from "./seal-config.js";
+import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-config.js";
 
 // ============================================================
 // Shared clients (initialized once at boot — the whole point!)
@@ -31,16 +31,13 @@ import { getSealServerConfigsFromEnv } from "./seal-config.js";
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
 
 const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
-const SEAL_CONFIG_TOTAL_WEIGHT = SEAL_SERVER_CONFIGS.reduce((sum, config) => sum + config.weight, 0);
-const DEFAULT_SEAL_THRESHOLD = SEAL_CONFIG_TOTAL_WEIGHT > 0 ? Math.min(2, SEAL_CONFIG_TOTAL_WEIGHT) : 2;
+const SEAL_THRESHOLD = getSealThresholdFromEnv(SEAL_SERVER_CONFIGS);
 
 if (SEAL_SERVER_CONFIGS.length === 0) {
     console.error(
         "[sidecar] WARNING: SEAL_SERVER_CONFIGS/SEAL_KEY_SERVERS env vars are empty and no network default exists — SEAL encrypt/decrypt will fail",
     );
 }
-
-const SEAL_THRESHOLD = parseInt(process.env.SEAL_THRESHOLD || String(DEFAULT_SEAL_THRESHOLD), 10);
 
 // Server Sui Private Keys for Walrus uploads
 const SERVER_SUI_PRIVATE_KEYS = (process.env.SERVER_SUI_PRIVATE_KEYS || "")

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -19,7 +19,7 @@ import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Transaction } from "@mysten/sui/transactions";
 import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
 import { WalrusClient } from "@mysten/walrus";
-import { getSealServerConfigsFromEnv } from "./seal-config.ts";
+import { getSealServerConfigsFromEnv } from "./seal-config.js";
 
 // ============================================================
 // Shared clients (initialized once at boot — the whole point!)

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -19,6 +19,7 @@ import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Transaction } from "@mysten/sui/transactions";
 import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
 import { WalrusClient } from "@mysten/walrus";
+import { getSealServerConfigsFromEnv } from "./seal-config.ts";
 
 // ============================================================
 // Shared clients (initialized once at boot — the whole point!)
@@ -29,17 +30,17 @@ import { WalrusClient } from "@mysten/walrus";
 
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
 
-// SEAL key server object IDs (comma-separated via env var)
-const SEAL_KEY_SERVERS = (process.env.SEAL_KEY_SERVERS || "")
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
+const SEAL_CONFIG_TOTAL_WEIGHT = SEAL_SERVER_CONFIGS.reduce((sum, config) => sum + config.weight, 0);
+const DEFAULT_SEAL_THRESHOLD = SEAL_CONFIG_TOTAL_WEIGHT > 0 ? Math.min(2, SEAL_CONFIG_TOTAL_WEIGHT) : 2;
 
-if (SEAL_KEY_SERVERS.length === 0) {
-    console.error("[sidecar] WARNING: SEAL_KEY_SERVERS env var is empty — SEAL encrypt/decrypt will fail");
+if (SEAL_SERVER_CONFIGS.length === 0) {
+    console.error(
+        "[sidecar] WARNING: SEAL_SERVER_CONFIGS/SEAL_KEY_SERVERS env vars are empty and no network default exists — SEAL encrypt/decrypt will fail",
+    );
 }
 
-const SEAL_THRESHOLD = parseInt(process.env.SEAL_THRESHOLD || "2", 10);
+const SEAL_THRESHOLD = parseInt(process.env.SEAL_THRESHOLD || String(DEFAULT_SEAL_THRESHOLD), 10);
 
 // Server Sui Private Keys for Walrus uploads
 const SERVER_SUI_PRIVATE_KEYS = (process.env.SERVER_SUI_PRIVATE_KEYS || "")
@@ -77,10 +78,7 @@ const suiClient = new SuiJsonRpcClient({
 
 const sealClient = new SealClient({
     suiClient: suiClient as any,
-    serverConfigs: SEAL_KEY_SERVERS.map((id) => ({
-        objectId: id,
-        weight: 1,
-    })),
+    serverConfigs: SEAL_SERVER_CONFIGS,
     verifyKeyServers: true,
 });
 


### PR DESCRIPTION
## Summary
- add SEAL server config parsing with committee aggregator support
- keep legacy independent key server configs working
- add Mysten testnet committee defaults for SDK/manual and sidecar testnet fallback

## Verification
- pnpm --filter @mysten-incubation/memwal typecheck
- pnpm --filter @mysten-incubation/memwal build
- npx tsc --noEmit for sidecar scripts
- smoke tested SEAL config precedence