### PR TITLE
chore(sdk): bump version to 0.0.3

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @mysten-incubation/memwal
 
+## 0.0.3
+
+### Changed
+
+- Updated `remember()` for the relayer's async `/api/remember` flow. It now returns the accepted job payload immediately.
+- Added `rememberAsync()`, `waitForRememberJob()`, and `rememberAndWait()` for callers that need the final `blob_id`.
+- Added bulk remember helpers: `rememberBulk()`, `rememberBulkAsync()`, `waitForRememberJobs()`, and `rememberBulkAndWait()`.
+- Updated `analyze()` for async fact storage and added `analyzeAndWait()`.
+
+### Compatibility
+
+- `recall()` and `restore()` remain wire-compatible with the existing relayer responses.
+- The SDK continues to use `x-seal-session` for relayer-mode decrypt credentials.
+
 ## 0.0.2
 
 ### Security

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "MemWal — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump @mysten-incubation/memwal from 0.0.2 to 0.0.3
- add changelog entry for async remember/analyze helpers and compatibility notes
## Verification
- pnpm --filter @mysten-incubation/memwal typecheck
- pnpm build:sdk