### PR TITLE
ci: update Walrus site package

### DIFF
--- a/.github/workflows/deploy-app-walrus.yml
+++ b/.github/workflows/deploy-app-walrus.yml
@@ -99,6 +99,6 @@ jobs:
                 general:
                   wallet_env: mainnet
                   walrus_context: mainnet
-                  walrus_package: 0xfa65cb2d62f4d39e60346fb7d501c12538ca2bbc646eaa37ece2aec5f897814e
+                  walrus_package: 0x98da433aa0139512c210597b1c5e3df6cd121d8d77f8652691bb66fadfc8aa1b
                   gas_budget: 500000000
             default_context: mainnet


### PR DESCRIPTION
## Summary
- update the Walrus Sites deploy workflow to use the current mainnet Walrus package
- fixes site-builder deploy aborting with `EWrongVersion` during `system::extend_blob`

## Verification
- local mainnet deploy succeeded with site-builder v2.9.1
- deployed site object: `0xf2e1de6b5f0d413a3f4b92521881aabe1c52d9f30c4bd27af7d8ed7d56fc8a32`
- deploy tx: `F4doeA6MRRsZAXXh7A98GY8eUsyicqYJBRGnPzhMDzzP`