### PR TITLE
MEM-37: Cache SEAL ciphertext in Redis

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -34,6 +34,8 @@ These are not all enforced at boot, but most real deployments need them.
 | `SUI_RPC_URL` | network default | Override the Sui fullnode URL |
 | `WALRUS_PUBLISHER_URL` | Walrus mainnet publisher | Override upload endpoint |
 | `WALRUS_AGGREGATOR_URL` | Walrus mainnet aggregator | Override download endpoint |
+| `BLOB_CACHE_TTL_SECS` | `1209600` | Redis TTL for cached SEAL ciphertext by `blob_id`. `0` disables blob cache use |
+| `BLOB_CACHE_MAX_BYTES` | `524288` | Maximum SEAL ciphertext bytes cached in Redis. Larger blobs stay Walrus-only; `0` disables blob cache use |
 | `SERVER_SUI_PRIVATE_KEYS` | none | Comma-separated upload key pool. Takes priority over `SERVER_SUI_PRIVATE_KEY` for uploads |
 | `MEMWAL_ACCOUNT_ID` | none | Optional account ID in server config |
 | `WALRUS_PACKAGE_ID` | network default | Override the Walrus on-chain package used by the sidecar |

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -17,6 +17,11 @@ SUI_RPC_URL=https://fullnode.mainnet.sui.io:443
 WALRUS_PUBLISHER_URL=https://publisher.walrus-mainnet.walrus.space
 WALRUS_AGGREGATOR_URL=https://aggregator.walrus-mainnet.walrus.space
 
+# Redis blob cache (SEAL ciphertext, keyed by Walrus blob ID)
+# 14 days by default; set TTL or max bytes to 0 to disable blob cache use.
+BLOB_CACHE_TTL_SECS=1209600
+BLOB_CACHE_MAX_BYTES=524288
+
 # Server wallet (deployer = TEE admin) — required for SEAL decrypt
 SERVER_SUI_PRIVATE_KEY=suiprivkey1...
 

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -16,10 +16,11 @@ use apalis::prelude::*;
 use apalis_sql::postgres::PostgresStorage;
 use base64::Engine as _;
 use futures::stream::{self, StreamExt as _};
+use redis::AsyncCommands;
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{AppState, BULK_UPLOAD_CONCURRENCY};
+use crate::types::{AppState, BLOB_CACHE_KEY_PREFIX, BULK_UPLOAD_CONCURRENCY};
 use crate::walrus::SetMetadataBatchEntry;
 
 // ============================================================
@@ -72,6 +73,35 @@ pub enum WalletOperation {
 
 fn default_epochs() -> u32 {
     50
+}
+
+pub(crate) async fn warm_blob_cache_after_upload(
+    state: &AppState,
+    blob_id: &str,
+    ciphertext: &[u8],
+) {
+    let ttl_secs = state.blob_cache_ttl.as_secs();
+    if ttl_secs == 0 || state.blob_cache_max_bytes == 0 {
+        return;
+    }
+
+    if ciphertext.len() > state.blob_cache_max_bytes {
+        tracing::info!(
+            "blob cache warm skipped for {}: {} bytes exceeds max {}",
+            blob_id,
+            ciphertext.len(),
+            state.blob_cache_max_bytes
+        );
+        return;
+    }
+
+    let cache_key = format!("{}{}", BLOB_CACHE_KEY_PREFIX, blob_id);
+    let mut redis = state.redis.clone();
+    let result: redis::RedisResult<()> =
+        redis.set_ex(cache_key, ciphertext.to_vec(), ttl_secs).await;
+    if let Err(e) = result {
+        tracing::warn!("blob cache warm failed for {}: {}", blob_id, e);
+    }
 }
 
 /// A wallet-pinned job. `wallet_index` determines which per-wallet worker
@@ -361,6 +391,8 @@ async fn execute_upload_and_transfer(
     };
     let blob_id = upload.blob_id.clone();
 
+    warm_blob_cache_after_upload(state, &blob_id, &encrypted).await;
+
     if let Some(ref jid) = remember_job_id {
         let _ = sqlx::query(
             "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
@@ -556,6 +588,8 @@ pub async fn execute_remember(
         Err(e) => fail!(format!("walrus upload failed: {}", e)),
     };
     let blob_id = upload.blob_id.clone();
+
+    warm_blob_cache_after_upload(state, &blob_id, &encrypted).await;
 
     // ── Step 4: insert_vector ────────────────────────────────────
     let blob_size = encrypted.len() as i64;
@@ -779,6 +813,8 @@ pub async fn execute_bulk_remember(
                 .bind(&item.job_id)
                 .execute(state.db.pool())
                 .await;
+
+                warm_blob_cache_after_upload(&state, &upload.blob_id, &encrypted).await;
 
                 Ok(UploadOk {
                     job_id: item.job_id,

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -29,7 +29,8 @@ use jobs::{
     WalletJobStorage,
 };
 use types::{
-    AppState, Config, KeyPool, DEFAULT_BLOB_CACHE_TTL_SECS, DEFAULT_EMBEDDING_CACHE_TTL_SECS,
+    AppState, Config, KeyPool, DEFAULT_BLOB_CACHE_MAX_BYTES, DEFAULT_BLOB_CACHE_TTL_SECS,
+    DEFAULT_EMBEDDING_CACHE_TTL_SECS,
 };
 
 const STALE_REMEMBER_JOB_AFTER: std::time::Duration = std::time::Duration::from_secs(10 * 60);
@@ -192,14 +193,20 @@ async fn main() {
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(DEFAULT_BLOB_CACHE_TTL_SECS);
+    let blob_cache_max_bytes = std::env::var("BLOB_CACHE_MAX_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_BLOB_CACHE_MAX_BYTES);
     let embedding_cache_ttl_secs = std::env::var("EMBEDDING_CACHE_TTL_SECS")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(DEFAULT_EMBEDDING_CACHE_TTL_SECS);
     tracing::info!(
-        "  blob cache: redis ttl={}s (BLOB_CACHE_TTL_SECS={}); embedding cache: redis ttl={}s (EMBEDDING_CACHE_TTL_SECS={})",
+        "  blob cache: redis ttl={}s max={} bytes (BLOB_CACHE_TTL_SECS={}, BLOB_CACHE_MAX_BYTES={}); embedding cache: redis ttl={}s (EMBEDDING_CACHE_TTL_SECS={})",
         blob_cache_ttl_secs,
+        blob_cache_max_bytes,
         blob_cache_ttl_secs,
+        blob_cache_max_bytes,
         embedding_cache_ttl_secs,
         embedding_cache_ttl_secs
     );
@@ -210,6 +217,9 @@ async fn main() {
         tracing::warn!(
             "  blob cache: BLOB_CACHE_TTL_SECS=0 disables cache hits and forces Walrus revalidation"
         );
+    }
+    if blob_cache_max_bytes == 0 {
+        tracing::warn!("  blob cache: BLOB_CACHE_MAX_BYTES=0 disables blob cache reads and writes");
     }
     if embedding_cache_ttl.is_zero() {
         tracing::warn!(
@@ -230,6 +240,7 @@ async fn main() {
         wallet_storages: wallet_storages.clone(),
         bulk_job_storage: bulk_job_storage.clone(),
         blob_cache_ttl,
+        blob_cache_max_bytes,
         embedding_cache_ttl,
     });
 

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -129,8 +129,8 @@ fn spawn_prepare_remember_job(
             // summarized first. Summarization runs sequentially before the
             // embed/encrypt fan-out because the summary is the embedder's
             // input — encrypt still uses the original `text`.
-            let needs_summary = text.len() > SUMMARIZE_THRESHOLD_BYTES
-                && state.config.openai_api_key.is_some();
+            let needs_summary =
+                text.len() > SUMMARIZE_THRESHOLD_BYTES && state.config.openai_api_key.is_some();
             let embed_input: std::borrow::Cow<'_, str> = if needs_summary {
                 let summary =
                     summarize_for_embedding(&state.http_client, &state.config, &text).await?;
@@ -575,10 +575,9 @@ async fn summarize_with_prompt(
         )));
     }
 
-    let api_resp: ChatCompletionResponse = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to parse summarization response: {}", e)))?;
+    let api_resp: ChatCompletionResponse = resp.json().await.map_err(|e| {
+        AppError::Internal(format!("Failed to parse summarization response: {}", e))
+    })?;
 
     let summary = api_resp
         .choices
@@ -587,7 +586,9 @@ async fn summarize_with_prompt(
         .unwrap_or_default();
 
     if summary.is_empty() {
-        return Err(AppError::Internal("Summarization returned empty result".into()));
+        return Err(AppError::Internal(
+            "Summarization returned empty result".into(),
+        ));
     }
 
     Ok(summary)
@@ -1050,8 +1051,6 @@ pub async fn recall(
         }));
     }
 
-    const BLOB_CACHE_KEY_PREFIX: &str = "memwal:blob:v1:";
-
     struct FetchedBlob {
         blob_id: String,
         distance: f64,
@@ -1061,6 +1060,8 @@ pub async fn recall(
 
     let t2 = std::time::Instant::now();
     let db = &state.db;
+    let blob_cache_enabled = state.blob_cache_ttl.as_secs() > 0 && state.blob_cache_max_bytes > 0;
+    let blob_cache_max_bytes = state.blob_cache_max_bytes;
     let download_tasks: Vec<_> = hits
         .iter()
         .map(|hit| {
@@ -1072,18 +1073,28 @@ pub async fn recall(
 
             async move {
                 let cache_key = format!("{}{}", BLOB_CACHE_KEY_PREFIX, blob_id);
-                match redis.get::<_, Option<Vec<u8>>>(&cache_key).await {
-                    Ok(Some(ciphertext)) => {
-                        return Some(FetchedBlob {
-                            blob_id,
-                            distance,
-                            ciphertext,
-                            was_cached: true,
-                        });
-                    }
-                    Ok(None) => {}
-                    Err(e) => {
-                        tracing::warn!("blob cache get failed for {}: {}", blob_id, e);
+                if blob_cache_enabled {
+                    match redis.get::<_, Option<Vec<u8>>>(&cache_key).await {
+                        Ok(Some(ciphertext)) => {
+                            if ciphertext.len() <= blob_cache_max_bytes {
+                                return Some(FetchedBlob {
+                                    blob_id,
+                                    distance,
+                                    ciphertext,
+                                    was_cached: true,
+                                });
+                            }
+                            tracing::info!(
+                                "blob cache ignored for {}: {} bytes exceeds max {}",
+                                blob_id,
+                                ciphertext.len(),
+                                blob_cache_max_bytes
+                            );
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            tracing::warn!("blob cache get failed for {}: {}", blob_id, e);
+                        }
                     }
                 }
 
@@ -1138,10 +1149,19 @@ pub async fn recall(
     );
 
     let blob_cache_ttl_secs = state.blob_cache_ttl.as_secs();
-    if blob_cache_ttl_secs > 0 {
+    if blob_cache_ttl_secs > 0 && state.blob_cache_max_bytes > 0 {
         let mut redis = state.redis.clone();
         for fetched in &fetched_blobs {
             if fetched.was_cached {
+                continue;
+            }
+            if fetched.ciphertext.len() > state.blob_cache_max_bytes {
+                tracing::info!(
+                    "blob cache skip for {}: {} bytes exceeds max {}",
+                    fetched.blob_id,
+                    fetched.ciphertext.len(),
+                    state.blob_cache_max_bytes
+                );
                 continue;
             }
             let cache_key = format!("{}{}", BLOB_CACHE_KEY_PREFIX, fetched.blob_id);
@@ -1320,6 +1340,7 @@ pub async fn remember_manual(
 
     let blob_id = upload.blob_id;
     tracing::info!("remember_manual: walrus upload ok blob_id={}", blob_id);
+    crate::jobs::warm_blob_cache_after_upload(&state, &blob_id, &encrypted_bytes).await;
 
     // Store {vector, blobId, namespace} in Vector DB
     let blob_size = encrypted_bytes.len() as i64;
@@ -1894,7 +1915,9 @@ mod tests {
         let chunks = split_text_chunks(&text, SUMMARIZE_CHUNK_BYTES);
 
         assert!(chunks.len() > 1);
-        assert!(chunks.iter().all(|chunk| chunk.len() <= SUMMARIZE_CHUNK_BYTES));
+        assert!(chunks
+            .iter()
+            .all(|chunk| chunk.len() <= SUMMARIZE_CHUNK_BYTES));
         assert_eq!(chunks.concat(), text);
     }
 
@@ -1947,33 +1970,30 @@ mod tests {
     #[tokio::test]
     async fn summarize_for_embedding_bounds_each_llm_request() {
         let seen_input_lengths = Arc::new(std::sync::Mutex::new(Vec::<usize>::new()));
-        let app = axum::Router::new()
-            .route(
-                "/chat/completions",
-                axum::routing::post({
+        let app = axum::Router::new().route(
+            "/chat/completions",
+            axum::routing::post({
+                let seen_input_lengths = Arc::clone(&seen_input_lengths);
+                move |axum::Json(body): axum::Json<serde_json::Value>| {
                     let seen_input_lengths = Arc::clone(&seen_input_lengths);
-                    move |axum::Json(body): axum::Json<serde_json::Value>| {
-                        let seen_input_lengths = Arc::clone(&seen_input_lengths);
-                        async move {
-                            let input_len = body["messages"][1]["content"]
-                                .as_str()
-                                .expect("user message content")
-                                .len();
-                            seen_input_lengths.lock().unwrap().push(input_len);
-                            axum::Json(serde_json::json!({
-                                "choices": [{
-                                    "message": {
-                                        "content": "mock summary"
-                                    }
-                                }]
-                            }))
-                        }
+                    async move {
+                        let input_len = body["messages"][1]["content"]
+                            .as_str()
+                            .expect("user message content")
+                            .len();
+                        seen_input_lengths.lock().unwrap().push(input_len);
+                        axum::Json(serde_json::json!({
+                            "choices": [{
+                                "message": {
+                                    "content": "mock summary"
+                                }
+                            }]
+                        }))
                     }
-                }),
-            );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .unwrap();
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
@@ -1990,9 +2010,7 @@ mod tests {
         assert_eq!(summary, "mock summary");
         let seen = seen_input_lengths.lock().unwrap();
         assert!(seen.len() > 1);
-        assert!(seen
-            .iter()
-            .all(|len| *len <= SUMMARIZE_CHUNK_BYTES + 1024));
+        assert!(seen.iter().all(|len| *len <= SUMMARIZE_CHUNK_BYTES + 1024));
         assert!(seen.iter().all(|len| *len < MAX_REMEMBER_TEXT_BYTES / 4));
     }
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -14,8 +14,14 @@ pub const BULK_EMBED_CONCURRENCY: usize = 5;
 /// ENG-1408: Bounded concurrency for Walrus uploads inside one bulk job.
 pub const BULK_UPLOAD_CONCURRENCY: usize = 5;
 
+/// Redis key prefix for Walrus ciphertext cache entries.
+pub const BLOB_CACHE_KEY_PREFIX: &str = "memwal:blob:v1:";
+
 /// Default max age for Redis-cached Walrus ciphertext before revalidating via Walrus.
-pub const DEFAULT_BLOB_CACHE_TTL_SECS: u64 = 5 * 60;
+pub const DEFAULT_BLOB_CACHE_TTL_SECS: u64 = 14 * 24 * 60 * 60;
+
+/// Default maximum ciphertext size stored in Redis.
+pub const DEFAULT_BLOB_CACHE_MAX_BYTES: usize = 512 * 1024;
 
 /// Default max age for Redis-cached recall query embeddings.
 pub const DEFAULT_EMBEDDING_CACHE_TTL_SECS: u64 = 10 * 60;
@@ -50,6 +56,9 @@ pub struct AppState {
     /// ENG-1405: Redis TTL for Walrus blob ciphertext cache entries.
     /// Expiry forces Walrus revalidation so BlobNotFound still triggers cleanup.
     pub blob_cache_ttl: std::time::Duration,
+    /// MEM-37: Maximum SEAL ciphertext bytes to cache in Redis.
+    /// Zero disables blob ciphertext reads and writes in Redis.
+    pub blob_cache_max_bytes: usize,
     /// ENG-1405: Redis TTL for recall query embedding cache entries.
     pub embedding_cache_ttl: std::time::Duration,
 }
@@ -677,6 +686,13 @@ mod tests {
     use super::*;
 
     // ── LOW-5: AuthInfo Debug redacts delegate_key ───────────────────────
+
+    #[test]
+    fn blob_cache_defaults_match_mem_37_policy() {
+        assert_eq!(BLOB_CACHE_KEY_PREFIX, "memwal:blob:v1:");
+        assert_eq!(DEFAULT_BLOB_CACHE_TTL_SECS, 14 * 24 * 60 * 60);
+        assert_eq!(DEFAULT_BLOB_CACHE_MAX_BYTES, 512 * 1024);
+    }
 
     #[test]
     fn auth_info_debug_redacts_delegate_key() {


### PR DESCRIPTION
## Summary
- Add Redis-backed SEAL ciphertext blob cache keyed by Walrus blob ID with TTL and max-size controls.
- Warm the blob cache after successful uploads and use it during recall before falling back to Walrus.
- Document `BLOB_CACHE_TTL_SECS` and `BLOB_CACHE_MAX_BYTES` in env reference and server example env.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `git diff --check`