### PR TITLE
feat(server): collapse multi-wallet Apalis queues to single wallet

### DIFF
--- a/services/server/migrations/007_collapse_wallet_queues.sql
+++ b/services/server/migrations/007_collapse_wallet_queues.sql
@@ -10,8 +10,8 @@
 -- Retryable rows from old per-wallet queues need their `job_type` (Apalis
 -- namespace = queue name) rewritten so the new single worker can pick them up.
 -- Terminal rows (Done / Killed) keep their old name as historical record.
--- Running rows may be re-enqueued after an interrupted deploy, so migrate them
--- too instead of stranding them on a queue with no worker.
+-- Running rows can otherwise remain locked by old `wallet-{i}` workers after
+-- an interrupted deploy. Requeue them explicitly on the new namespace.
 --
 -- The DO block guards against the case where this migration is applied
 -- before the Apalis `setup()` runs and the `apalis.jobs` table doesn't exist
@@ -22,6 +22,15 @@ BEGIN
     IF to_regclass('apalis.jobs') IS NOT NULL THEN
         UPDATE apalis.jobs
         SET job_type = 'wallet_jobs'
-        WHERE job_type LIKE 'wallet-%' AND status IN ('Pending', 'Failed', 'Running');
+        WHERE job_type LIKE 'wallet-%' AND status IN ('Pending', 'Failed');
+
+        UPDATE apalis.jobs
+        SET job_type = 'wallet_jobs',
+            status = 'Pending',
+            lock_by = NULL,
+            lock_at = NULL,
+            done_at = NULL,
+            last_error = COALESCE(last_error, 'Requeued during wallet queue migration')
+        WHERE job_type LIKE 'wallet-%' AND status = 'Running';
     END IF;
 END $$;

--- a/services/server/migrations/007_collapse_wallet_queues.sql
+++ b/services/server/migrations/007_collapse_wallet_queues.sql
@@ -1,0 +1,26 @@
+-- MEM-35: Collapse per-wallet Apalis queues into a single `wallet_jobs` queue.
+--
+-- Background: the server used to create N queues named `wallet-{i}` (one per
+-- pool key) to side-step Sui coin-object equivocation locks. Per Will Bradley
+-- (Mysten, 2026-05-12 Slack callout): coin-object locking is no longer a
+-- practical concern on Sui. A single queue + concurrent workers + retry
+-- handling at the Apalis layer (Transient/Permanent classification) is
+-- sufficient.
+--
+-- Pending rows from old per-wallet queues need their `job_type` (Apalis
+-- namespace = queue name) rewritten so the new single worker can pick them up.
+-- Non-Pending rows (Done / Dead / Killed) keep their old name as historical
+-- record — they will never be polled again.
+--
+-- The DO block guards against the case where this migration is applied
+-- before the Apalis `setup()` runs and the `apalis.jobs` table doesn't exist
+-- yet (e.g., on a brand-new database). In that case there's nothing to
+-- migrate; Apalis will create the table later with the new queue name.
+DO $$
+BEGIN
+    IF to_regclass('apalis.jobs') IS NOT NULL THEN
+        UPDATE apalis.jobs
+        SET job_type = 'wallet_jobs'
+        WHERE job_type LIKE 'wallet-%' AND status = 'Pending';
+    END IF;
+END $$;

--- a/services/server/migrations/007_collapse_wallet_queues.sql
+++ b/services/server/migrations/007_collapse_wallet_queues.sql
@@ -7,10 +7,11 @@
 -- handling at the Apalis layer (Transient/Permanent classification) is
 -- sufficient.
 --
--- Pending rows from old per-wallet queues need their `job_type` (Apalis
+-- Retryable rows from old per-wallet queues need their `job_type` (Apalis
 -- namespace = queue name) rewritten so the new single worker can pick them up.
--- Non-Pending rows (Done / Dead / Killed) keep their old name as historical
--- record — they will never be polled again.
+-- Terminal rows (Done / Killed) keep their old name as historical record.
+-- Running rows may be re-enqueued after an interrupted deploy, so migrate them
+-- too instead of stranding them on a queue with no worker.
 --
 -- The DO block guards against the case where this migration is applied
 -- before the Apalis `setup()` runs and the `apalis.jobs` table doesn't exist
@@ -21,6 +22,6 @@ BEGIN
     IF to_regclass('apalis.jobs') IS NOT NULL THEN
         UPDATE apalis.jobs
         SET job_type = 'wallet_jobs'
-        WHERE job_type LIKE 'wallet-%' AND status = 'Pending';
+        WHERE job_type LIKE 'wallet-%' AND status IN ('Pending', 'Failed', 'Running');
     END IF;
 END $$;

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -149,10 +149,8 @@ type EnokiExecuteResponse = { digest: string };
 // MEM-35: in-memory counters surfaced via /metrics/wallet.
 // Per Will Bradley (Mysten, 2026-05-12 Slack): Sui no longer permanently
 // locks coin objects on equivocation, so the original multi-wallet routing
-// is unnecessary. We collapsed to a single wallet; the per-signer mutex
-// below still serializes concurrent submissions because Enoki sponsored
-// transactions and SDK default gas-coin selection both race on a single
-// wallet — separate concerns from equivocation locking.
+// is unnecessary. We use a single wallet concurrently and rely on Apalis
+// retries for transient Sui/RPC/coin-selection races.
 //
 // `walletLockErrorsTotal` should stay at 0 under load and is the canary
 // for re-evaluating the simplification if the Sui guarantee changes.
@@ -161,23 +159,6 @@ const sidecarMetrics = {
     walletLockErrorsTotal: 0,
     walletPermanentFailuresTotal: 0,
 };
-
-// Per-signer FIFO serialization. Originally added to side-step Sui coin-
-// object equivocation locks. Per MEM-35 testing on testnet (2026-05-12):
-// equivocation locks are no longer an issue (Will Bradley's callout
-// confirmed empirically — `walletLockErrorsTotal: 0` across all tests).
-// We keep the mutex because of TWO other concurrent-tx hazards that the
-// mutex incidentally also fixes:
-//   1. Enoki sponsor returns time-bounded signatures; concurrent requests
-//      from the same sender race and earlier ones expire ("Sponsored
-//      transaction has expired") before submission.
-//   2. SDK default gas-coin picker selects the same coin for concurrent
-//      transactions; whichever lands second sees a stale ObjectRef and
-//      errors with "No valid gas coins found for the transaction."
-// Removing this mutex caused a ~75% failure rate at concurrency=4 in
-// testnet validation. Apalis retries recover, but the latency cost is
-// large. The mutex is cheap (one Map<address, Promise<void>>).
-const signerUploadQueues = new Map<string, Promise<void>>();
 
 let uploadRelayTipAddressCache: string | null | undefined = undefined;
 
@@ -285,36 +266,6 @@ async function executeWithEnokiSponsor(tx: Transaction, signer: Ed25519Keypair, 
             transaction: tx,
         });
         return direct.digest;
-    }
-}
-
-/**
- * Acquire the per-signer FIFO mutex for the duration of `task`.
- *
- * Sub-100-line workaround for two concurrent-tx hazards that surface when
- * multiple Walrus uploads run on the same signing wallet (see comment
- * above `signerUploadQueues` for the full rationale).
- */
-async function runExclusiveBySigner<T>(
-    signerAddress: string,
-    task: () => Promise<T>,
-): Promise<T> {
-    const previous = signerUploadQueues.get(signerAddress) ?? Promise.resolve();
-    let release!: () => void;
-    const current = new Promise<void>((resolve) => {
-        release = resolve;
-    });
-    const queued = previous.then(() => current);
-    signerUploadQueues.set(signerAddress, queued);
-
-    await previous;
-    try {
-        return await task();
-    } finally {
-        release();
-        if (signerUploadQueues.get(signerAddress) === queued) {
-            signerUploadQueues.delete(signerAddress);
-        }
     }
 }
 
@@ -753,15 +704,13 @@ async function setMetadataAndTransferBlobs(
     }
 
     metaTx.transferObjects(blobArgs, owner);
-    return runExclusiveBySigner(signerAddress, async () => {
-        const digest = await submitWalletTransaction(
-            metaTx,
-            signer,
-            dedupeAddresses([signerAddress, owner]),
-        );
-        await suiClient.waitForTransaction({ digest });
-        return digest;
-    });
+    const digest = await submitWalletTransaction(
+        metaTx,
+        signer,
+        dedupeAddresses([signerAddress, owner]),
+    );
+    await suiClient.waitForTransaction({ digest });
+    return digest;
 }
 
 // HIGH-13: /walrus/upload receives a base64-encoded SEAL ciphertext which can
@@ -808,49 +757,45 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         const signerAddress = signer.toSuiAddress();
         const blobData = new Uint8Array(Buffer.from(data, "base64"));
 
-        // writeBlobFlow (stateful: encode → register → upload → certify).
-        // Serialized per-signer to avoid Enoki sponsor race / SDK gas-coin
-        // contention on concurrent uploads (MEM-35: Sui no longer locks
-        // objects, but Enoki + gas selection still race — see comment above
-        // signerUploadQueues).
-        const blob = await runExclusiveBySigner(signerAddress, async () => {
-            const flow = walrusClient.writeBlobFlow({ blob: blobData });
-            await flow.encode();
+        // writeBlobFlow is intentionally not serialized by signer. Current Sui
+        // no longer permanently locks coin objects for concurrent submissions;
+        // transient gas/RPC races are retried by the Apalis wallet job layer.
+        const flow = walrusClient.writeBlobFlow({ blob: blobData });
+        await flow.encode();
 
-            const registerTx = flow.register({
-                epochs,
-                // Server owns the blob initially (needed for certify step)
-                owner: signerAddress,
-                deletable: true,
-                // Store namespace + owner as on-chain metadata (queryable for restore)
-                attributes: {
-                    ...(namespace ? { memwal_namespace: namespace } : {}),
-                    ...(owner ? { memwal_owner: owner } : {}),
-                    ...(packageId ? { memwal_package_id: packageId } : {}),
-                },
-            });
-
-            // Patch: convert GasCoin intents → sender's SUI coins.
-            // Enoki rejects GasCoin as tx argument, but relay requires the tip.
-            // After patching, signer pays tip from own SUI; Enoki sponsors gas.
-            patchGasCoinIntents(registerTx);
-            const tipRecipient = await getUploadRelayTipAddress();
-            const registerAllowedAddresses = dedupeAddresses([signerAddress, tipRecipient]);
-            const registerDigest = await submitWalletTransaction(
-                registerTx,
-                signer,
-                registerAllowedAddresses,
-            );
-            await suiClient.waitForTransaction({ digest: registerDigest });
-
-            await flow.upload({ digest: registerDigest });
-
-            const certifyTx = flow.certify();
-            const certifyDigest = await submitWalletTransaction(certifyTx, signer);
-            await suiClient.waitForTransaction({ digest: certifyDigest });
-
-            return flow.getBlob();
+        const registerTx = flow.register({
+            epochs,
+            // Server owns the blob initially (needed for certify step)
+            owner: signerAddress,
+            deletable: true,
+            // Store namespace + owner as on-chain metadata (queryable for restore)
+            attributes: {
+                ...(namespace ? { memwal_namespace: namespace } : {}),
+                ...(owner ? { memwal_owner: owner } : {}),
+                ...(packageId ? { memwal_package_id: packageId } : {}),
+            },
         });
+
+        // Patch: convert GasCoin intents → sender's SUI coins.
+        // Enoki rejects GasCoin as tx argument, but relay requires the tip.
+        // After patching, signer pays tip from own SUI; Enoki sponsors gas.
+        patchGasCoinIntents(registerTx);
+        const tipRecipient = await getUploadRelayTipAddress();
+        const registerAllowedAddresses = dedupeAddresses([signerAddress, tipRecipient]);
+        const registerDigest = await submitWalletTransaction(
+            registerTx,
+            signer,
+            registerAllowedAddresses,
+        );
+        await suiClient.waitForTransaction({ digest: registerDigest });
+
+        await flow.upload({ digest: registerDigest });
+
+        const certifyTx = flow.certify();
+        const certifyDigest = await submitWalletTransaction(certifyTx, signer);
+        await suiClient.waitForTransaction({ digest: certifyDigest });
+
+        const blob = flow.getBlob();
 
         const blobObjectId = extractBlobObjectId(blob);
 

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -795,7 +795,7 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         const certifyDigest = await submitWalletTransaction(certifyTx, signer);
         await suiClient.waitForTransaction({ digest: certifyDigest });
 
-        const blob = flow.getBlob();
+        const blob = await flow.getBlob();
 
         const blobObjectId = extractBlobObjectId(blob);
 
@@ -837,8 +837,9 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         });
     } catch (err: any) {
         const traceId = randomUUID();
+        const message = err?.message || String(err);
         console.error(`[walrus/upload] [${traceId}] error:`, err);
-        res.status(500).json({ error: "Internal server error", traceId });
+        res.status(500).json({ error: message, traceId });
     }
 });
 
@@ -884,8 +885,9 @@ app.post("/walrus/set-metadata-batch", express.json({ limit: "1mb" }), async (re
         res.json({ transferred: normalized.length, digest });
     } catch (err: any) {
         const traceId = randomUUID();
+        const message = err?.message || String(err);
         console.error(`[walrus/set-metadata-batch] [${traceId}] error:`, err);
-        res.status(500).json({ error: "Internal server error", traceId });
+        res.status(500).json({ error: message, traceId });
     }
 });
 
@@ -914,8 +916,9 @@ app.post("/walrus/set-metadata", express.json({ limit: "128kb" }), async (req, r
         res.json({ transferred: 1, digest });
     } catch (err: any) {
         const traceId = randomUUID();
+        const message = err?.message || String(err);
         console.error(`[walrus/set-metadata] [${traceId}] error:`, err);
-        res.status(500).json({ error: "Internal server error", traceId });
+        res.status(500).json({ error: message, traceId });
     }
 });
 

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -145,7 +145,40 @@ const ENOKI_FALLBACK_TO_DIRECT_SIGN = (() => {
 type EnokiDataWrapper<T> = { data: T };
 type EnokiSponsorResponse = { bytes: string; digest: string };
 type EnokiExecuteResponse = { digest: string };
+
+// MEM-35: in-memory counters surfaced via /metrics/wallet.
+// Per Will Bradley (Mysten, 2026-05-12 Slack): Sui no longer permanently
+// locks coin objects on equivocation, so the original multi-wallet routing
+// is unnecessary. We collapsed to a single wallet; the per-signer mutex
+// below still serializes concurrent submissions because Enoki sponsored
+// transactions and SDK default gas-coin selection both race on a single
+// wallet — separate concerns from equivocation locking.
+//
+// `walletLockErrorsTotal` should stay at 0 under load and is the canary
+// for re-evaluating the simplification if the Sui guarantee changes.
+const sidecarMetrics = {
+    walletSubmittedTotal: 0,
+    walletLockErrorsTotal: 0,
+    walletPermanentFailuresTotal: 0,
+};
+
+// Per-signer FIFO serialization. Originally added to side-step Sui coin-
+// object equivocation locks. Per MEM-35 testing on testnet (2026-05-12):
+// equivocation locks are no longer an issue (Will Bradley's callout
+// confirmed empirically — `walletLockErrorsTotal: 0` across all tests).
+// We keep the mutex because of TWO other concurrent-tx hazards that the
+// mutex incidentally also fixes:
+//   1. Enoki sponsor returns time-bounded signatures; concurrent requests
+//      from the same sender race and earlier ones expire ("Sponsored
+//      transaction has expired") before submission.
+//   2. SDK default gas-coin picker selects the same coin for concurrent
+//      transactions; whichever lands second sees a stale ObjectRef and
+//      errors with "No valid gas coins found for the transaction."
+// Removing this mutex caused a ~75% failure rate at concurrency=4 in
+// testnet validation. Apalis retries recover, but the latency cost is
+// large. The mutex is cheap (one Map<address, Promise<void>>).
 const signerUploadQueues = new Map<string, Promise<void>>();
+
 let uploadRelayTipAddressCache: string | null | undefined = undefined;
 
 function dedupeAddresses(addresses: (string | null | undefined)[]): string[] {
@@ -256,10 +289,16 @@ async function executeWithEnokiSponsor(tx: Transaction, signer: Ed25519Keypair, 
 }
 
 /**
- * Queue tasks by signer to avoid coin-object lock conflicts when multiple
- * Walrus uploads are triggered concurrently for the same signing key.
+ * Acquire the per-signer FIFO mutex for the duration of `task`.
+ *
+ * Sub-100-line workaround for two concurrent-tx hazards that surface when
+ * multiple Walrus uploads run on the same signing wallet (see comment
+ * above `signerUploadQueues` for the full rationale).
  */
-async function runExclusiveBySigner<T>(signerAddress: string, task: () => Promise<T>): Promise<T> {
+async function runExclusiveBySigner<T>(
+    signerAddress: string,
+    task: () => Promise<T>,
+): Promise<T> {
     const previous = signerUploadQueues.get(signerAddress) ?? Promise.resolve();
     let release!: () => void;
     const current = new Promise<void>((resolve) => {
@@ -273,10 +312,35 @@ async function runExclusiveBySigner<T>(signerAddress: string, task: () => Promis
         return await task();
     } finally {
         release();
-        // Cleanup queue map entry once this task is done and no newer task replaced it.
         if (signerUploadQueues.get(signerAddress) === queued) {
             signerUploadQueues.delete(signerAddress);
         }
+    }
+}
+
+/**
+ * Submit a Sui transaction via the Enoki sponsor path (or direct sign as
+ * fallback). Wraps `executeWithEnokiSponsor` with metrics + lock-error
+ * detection for the validation canary.
+ */
+async function submitWalletTransaction(
+    tx: Transaction,
+    signer: Ed25519Keypair,
+    allowedAddresses?: string[],
+): Promise<string> {
+    try {
+        const digest = await executeWithEnokiSponsor(tx, signer, allowedAddresses);
+        sidecarMetrics.walletSubmittedTotal += 1;
+        return digest;
+    } catch (err: any) {
+        const msg = err?.message || String(err);
+        if (/objectlocked|locked at version|object is locked/i.test(msg)) {
+            sidecarMetrics.walletLockErrorsTotal += 1;
+            console.error(`[wallet] coin-object lock error: ${msg}`);
+        } else if (/moveabort|move abort/i.test(msg)) {
+            sidecarMetrics.walletPermanentFailuresTotal += 1;
+        }
+        throw err;
     }
 }
 
@@ -311,6 +375,24 @@ app.use((_req: Request, res: Response, next: NextFunction) => {
 // Health check — placed before auth middleware so it is always reachable.
 app.get("/health", (_req: Request, res: Response) => {
     res.json({ status: "ok" });
+});
+
+// Wallet-execution metrics (MEM-35 observability). Placed before auth so
+// operators / scrapers don't need a token.
+//
+// `walletLockErrorsTotal` is the canary for the simplification: it should
+// stay at 0 because Sui no longer permanently locks coin objects on
+// equivocation. If it ever climbs, the original multi-wallet rationale
+// would need re-evaluating.
+//
+// Values are integer counters that monotonically increase; clients compute
+// deltas.
+app.get("/metrics/wallet", (_req: Request, res: Response) => {
+    res.json({
+        ...sidecarMetrics,
+        enokiEnabled: !!enokiApiKey,
+        suiNetwork: SUI_NETWORK,
+    });
 });
 
 // Shared-secret authentication — protects all routes registered after this point.
@@ -618,61 +700,65 @@ async function setMetadataAndTransferBlobs(
     }
 
     const signerAddress = signer.toSuiAddress();
-    return runExclusiveBySigner(signerAddress, async () => {
-        const metaTx = new Transaction();
-        const blobArgs = [];
+    const metaTx = new Transaction();
+    const blobArgs = [];
 
-        for (const blob of blobs) {
-            const blobArg = metaTx.object(blob.blobObjectId);
-            blobArgs.push(blobArg);
+    for (const blob of blobs) {
+        const blobArg = metaTx.object(blob.blobObjectId);
+        blobArgs.push(blobArg);
 
+        metaTx.moveCall({
+            target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+            arguments: [
+                blobArg,
+                metaTx.pure.string("memwal_namespace"),
+                metaTx.pure.string(blob.namespace || "default"),
+            ],
+            typeArguments: [],
+        });
+
+        metaTx.moveCall({
+            target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+            arguments: [
+                blobArg,
+                metaTx.pure.string("memwal_owner"),
+                metaTx.pure.string(owner),
+            ],
+            typeArguments: [],
+        });
+
+        if (packageId) {
             metaTx.moveCall({
                 target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
                 arguments: [
                     blobArg,
-                    metaTx.pure.string("memwal_namespace"),
-                    metaTx.pure.string(blob.namespace || "default"),
+                    metaTx.pure.string("memwal_package_id"),
+                    metaTx.pure.string(packageId),
                 ],
                 typeArguments: [],
             });
-
-            metaTx.moveCall({
-                target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
-                arguments: [
-                    blobArg,
-                    metaTx.pure.string("memwal_owner"),
-                    metaTx.pure.string(owner),
-                ],
-                typeArguments: [],
-            });
-
-            if (packageId) {
-                metaTx.moveCall({
-                    target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
-                    arguments: [
-                        blobArg,
-                        metaTx.pure.string("memwal_package_id"),
-                        metaTx.pure.string(packageId),
-                    ],
-                    typeArguments: [],
-                });
-            }
-
-            if (agentId) {
-                metaTx.moveCall({
-                    target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
-                    arguments: [
-                        blobArg,
-                        metaTx.pure.string("memwal_agent_id"),
-                        metaTx.pure.string(agentId),
-                    ],
-                    typeArguments: [],
-                });
-            }
         }
 
-        metaTx.transferObjects(blobArgs, owner);
-        const digest = await executeWithEnokiSponsor(metaTx, signer, dedupeAddresses([signerAddress, owner]));
+        if (agentId) {
+            metaTx.moveCall({
+                target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+                arguments: [
+                    blobArg,
+                    metaTx.pure.string("memwal_agent_id"),
+                    metaTx.pure.string(agentId),
+                ],
+                typeArguments: [],
+            });
+        }
+    }
+
+    metaTx.transferObjects(blobArgs, owner);
+    return runExclusiveBySigner(signerAddress, async () => {
+        const digest = await submitWalletTransaction(
+            metaTx,
+            signer,
+            dedupeAddresses([signerAddress, owner]),
+        );
         await suiClient.waitForTransaction({ digest });
         return digest;
     });
@@ -720,10 +806,14 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         const signer = Ed25519Keypair.fromSecretKey(secretKey);
 
         const signerAddress = signer.toSuiAddress();
-        const blob = await runExclusiveBySigner(signerAddress, async () => {
-            const blobData = new Uint8Array(Buffer.from(data, "base64"));
+        const blobData = new Uint8Array(Buffer.from(data, "base64"));
 
-            // writeBlobFlow (stateful: encode → register → upload → certify)
+        // writeBlobFlow (stateful: encode → register → upload → certify).
+        // Serialized per-signer to avoid Enoki sponsor race / SDK gas-coin
+        // contention on concurrent uploads (MEM-35: Sui no longer locks
+        // objects, but Enoki + gas selection still race — see comment above
+        // signerUploadQueues).
+        const blob = await runExclusiveBySigner(signerAddress, async () => {
             const flow = walrusClient.writeBlobFlow({ blob: blobData });
             await flow.encode();
 
@@ -746,14 +836,17 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
             patchGasCoinIntents(registerTx);
             const tipRecipient = await getUploadRelayTipAddress();
             const registerAllowedAddresses = dedupeAddresses([signerAddress, tipRecipient]);
-            const registerDigest = await executeWithEnokiSponsor(registerTx, signer, registerAllowedAddresses);
+            const registerDigest = await submitWalletTransaction(
+                registerTx,
+                signer,
+                registerAllowedAddresses,
+            );
             await suiClient.waitForTransaction({ digest: registerDigest });
 
             await flow.upload({ digest: registerDigest });
 
             const certifyTx = flow.certify();
-            // Wait until certify tx is confirmed before returning this upload.
-            const certifyDigest = await executeWithEnokiSponsor(certifyTx, signer);
+            const certifyDigest = await submitWalletTransaction(certifyTx, signer);
             await suiClient.waitForTransaction({ digest: certifyDigest });
 
             return flow.getBlob();

--- a/services/server/src/db.rs
+++ b/services/server/src/db.rs
@@ -55,6 +55,16 @@ impl VectorDb {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 006: {}", e)))?;
 
+        // MEM-35: collapse per-wallet Apalis queues to a single `wallet_jobs`
+        // queue. Equivocation locks are no longer a practical concern on Sui
+        // (per Will Bradley, Mysten, 2026-05-12); concurrent workers on one
+        // wallet + retry handling is sufficient.
+        let migration_007 = include_str!("../migrations/007_collapse_wallet_queues.sql");
+        sqlx::raw_sql(migration_007)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 007: {}", e)))?;
+
         tracing::info!("database connected and migrations applied");
 
         Ok(Self { pool })

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1,15 +1,16 @@
-/// Per-wallet Apalis job queue.
+/// Wallet signing job queue.
 ///
 /// Every operation that requires a Sui wallet signature is modelled as a
-/// `WalletJob` and routed to the queue that is **pinned to that wallet index**.
+/// `WalletJob` jobs are signed by the configured server wallet.
 /// This guarantees that:
-///   - upload → metadata+transfer always use the SAME key (no wrong-signer retries)
-///   - each wallet queue processes jobs serially (no coin-object lock conflicts)
+///   - upload → metadata+transfer use the same key for a given job
+///   - signing operations can run concurrently on the same wallet
 ///   - jobs survive server restarts (persisted in Postgres via Apalis)
 ///
 /// Retry policy: up to MAX_ATTEMPTS attempts with exponential back-off.
-/// Failed jobs are visible in the `apalis_jobs` table (status = 'Dead').
+/// Failed jobs are visible in the `apalis_jobs` table.
 use std::collections::HashMap;
+use std::io;
 use std::sync::Arc;
 
 use apalis::prelude::*;
@@ -218,7 +219,7 @@ pub fn backoff_duration(attempt: u32) -> std::time::Duration {
 pub async fn execute_wallet_job(
     job: WalletJob,
     ctx: Data<Arc<AppState>>,
-) -> Result<(), WalletJobError> {
+) -> Result<(), Error> {
     let state: &AppState = &ctx;
     let wallet_index = job.wallet_index;
 
@@ -267,18 +268,17 @@ pub async fn execute_wallet_job(
         }
     };
 
-    // Observability hook: surface permanent failures (Move abort / object
-    // lock) as a structured warn-level log. Operators alert on these.
-    if let Err(WalletJobError::Permanent(ref msg)) = result {
-        tracing::warn!(
-            target: "wallet_job.permanent",
-            "permanent failure for wallet_index={} (will mark Dead): {}",
-            wallet_index,
-            msg
-        );
-    }
-
-    result
+    result.map_err(|err| {
+        if let WalletJobError::Permanent(ref msg) = err {
+            tracing::warn!(
+                target: "wallet_job.permanent",
+                "permanent failure for wallet_index={} (will mark Dead): {}",
+                wallet_index,
+                msg
+            );
+        }
+        err.into_apalis_error()
+    })
 }
 
 // ────────────────────────────────────────────────────────────
@@ -524,6 +524,14 @@ impl WalletJobError {
             return WalletJobError::Permanent(msg.to_string());
         }
         WalletJobError::Transient(msg.to_string())
+    }
+
+    pub fn into_apalis_error(self) -> Error {
+        let error = io::Error::other(self.to_string());
+        match self {
+            WalletJobError::Transient(_) => Error::Failed(Arc::new(Box::new(error))),
+            WalletJobError::Permanent(_) => Error::Abort(Arc::new(Box::new(error))),
+        }
     }
 }
 
@@ -1070,5 +1078,17 @@ mod tests {
         let trans = WalletJobError::Transient("network".to_string());
         assert!(perm.to_string().contains("permanent"));
         assert!(trans.to_string().contains("transient"));
+    }
+
+    #[test]
+    fn permanent_errors_abort_apalis_retries() {
+        let error = WalletJobError::Permanent("move abort".to_string()).into_apalis_error();
+        assert!(matches!(error, apalis::prelude::Error::Abort(_)));
+    }
+
+    #[test]
+    fn transient_errors_remain_retryable() {
+        let error = WalletJobError::Transient("timeout".to_string()).into_apalis_error();
+        assert!(matches!(error, apalis::prelude::Error::Failed(_)));
     }
 }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -9,19 +9,17 @@
 ///
 /// Retry policy: up to MAX_ATTEMPTS attempts with exponential back-off.
 /// Failed jobs are visible in the `apalis_jobs` table.
-use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 
 use apalis::prelude::*;
 use apalis_sql::postgres::PostgresStorage;
 use base64::Engine as _;
-use futures::stream::{self, StreamExt as _};
 use redis::AsyncCommands;
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{AppState, BLOB_CACHE_KEY_PREFIX, BULK_UPLOAD_CONCURRENCY};
+use crate::types::{AppState, BLOB_CACHE_KEY_PREFIX};
 use crate::walrus::SetMetadataBatchEntry;
 
 // ============================================================
@@ -105,13 +103,12 @@ pub(crate) async fn warm_blob_cache_after_upload(
     }
 }
 
-/// A wallet-pinned job. `wallet_index` determines which per-wallet worker
-/// picks up and executes this job.
+/// A wallet job. `wallet_index` is retained for legacy/audit payloads; new
+/// jobs use `0` and all routing goes through the single shared wallet queue.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletJob {
-    /// Index into `config.sui_private_keys` — both for routing (queue name)
-    /// and for signing within the worker. Set once at enqueue time and never
-    /// changed, so upload and transfer always use the identical key.
+    /// Index into `config.sui_private_keys` used by the sidecar for signing.
+    /// New jobs use 0 after the single-wallet simplification.
     pub wallet_index: usize,
     pub operation: WalletOperation,
 }
@@ -216,10 +213,7 @@ pub fn backoff_duration(attempt: u32) -> std::time::Duration {
 /// wallet (Apalis `WALLET_JOB_CONCURRENCY` controls fan-out, default 8). The
 /// `wallet_index` field in the job payload is retained for audit only —
 /// routing dimension was removed per MEM-35.
-pub async fn execute_wallet_job(
-    job: WalletJob,
-    ctx: Data<Arc<AppState>>,
-) -> Result<(), Error> {
+pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Result<(), Error> {
     let state: &AppState = &ctx;
     let wallet_index = job.wallet_index;
 
@@ -350,8 +344,7 @@ async fn execute_upload_and_transfer(
     }
 
     // Helper: mark failed and return Err. Classifies sidecar errors so Apalis
-    // can mark deterministic failures (Move abort, object lock) Dead without
-    // burning retries.
+    // retries transient wallet/RPC conflicts and aborts deterministic failures.
     let fail = |msg: String| -> WalletJobError {
         tracing::error!("[wallet-job:upload] {}", msg);
         WalletJobError::classify_sidecar_error(&msg)
@@ -487,9 +480,8 @@ async fn execute_upload_and_transfer(
 ///
 /// Mapping rules (enforced at the point of error origination):
 /// - `MoveAbort(_)` → `Permanent` (deterministic Move-level failure)
-/// - `ObjectLockedAtVersion(_)` → `Permanent` (per-Sui-2026 behavior, locks
-///   should be rare; if one surfaces, alert ops via `wallet_job.permanent`
-///   tracing target rather than burning retries)
+/// - `ObjectLockedAtVersion(_)` → `Transient` (the single-wallet model relies
+///   on retrying any remaining concurrency/race failures)
 /// - `InsufficientGas` / `ObjectNotFound` /
 ///   `ObjectVersionUnavailableForConsumption` → `Transient` (refill wallet,
 ///   refresh local state, retry)
@@ -518,7 +510,7 @@ impl WalletJobError {
             || lower.contains("object is locked")
             || lower.contains("locked at version")
         {
-            return WalletJobError::Permanent(msg.to_string());
+            return WalletJobError::Transient(msg.to_string());
         }
         if lower.contains("moveabort") || lower.contains("move abort") {
             return WalletJobError::Permanent(msg.to_string());
@@ -708,7 +700,7 @@ pub async fn execute_remember(
 // ============================================================
 // BulkRememberJob — ENG-1408
 //
-// Fans a preprocessed bulk request out into N wallet-pinned jobs.
+// Fans a preprocessed bulk request out into per-item wallet jobs.
 // ============================================================
 
 /// One pre-processed item (embed + encrypt already done in route handler).
@@ -721,7 +713,7 @@ pub struct BulkRememberItem {
     /// Pre-computed embedding vector (1536-dim).
     pub vector: Vec<f32>,
     pub namespace: String,
-    /// Wallet pool index assigned at enqueue time (round-robin).
+    /// Wallet index assigned at enqueue time. New jobs use 0.
     pub wallet_index: usize,
 }
 
@@ -765,11 +757,9 @@ impl std::error::Error for BulkRememberError {}
 
 /// Apalis worker handler for BulkRememberJob (ENG-1408).
 ///
-/// Steps:
-///   1. Upload each encrypted item with `deferTransfer=true`.
-///   2. Insert vectors once each blob is certified.
-///   3. Group certified Blob object IDs by wallet and transfer each group in
-///      one set-metadata PTB.
+/// The bulk worker intentionally does not perform wallet work itself. It fans
+/// out already-prepared items into the shared WalletJob queue so single-item
+/// and bulk requests share the same retry/error-classification path.
 pub async fn execute_bulk_remember(
     job: BulkRememberJob,
     ctx: Data<Arc<AppState>>,
@@ -789,234 +779,41 @@ pub async fn execute_bulk_remember(
         job.epochs,
     );
 
-    for item in &job.items {
-        let _ = sqlx::query(
-            "UPDATE remember_jobs SET status = 'running', updated_at = NOW() WHERE id = $1",
-        )
-        .bind(&item.job_id)
-        .execute(state.db.pool())
-        .await;
-    }
-
-    struct UploadOk {
-        job_id: String,
-        blob_id: String,
-        object_id: String,
-        wallet_index: usize,
-        namespace: String,
-        vector: Vec<f32>,
-        blob_size: i64,
-    }
-
-    let owner = job.owner.clone();
-    let package_id = job.package_id.clone();
-    let agent_public_key = job.agent_public_key.clone();
-    let epochs = job.epochs as u64;
-
-    let upload_results: Vec<Result<UploadOk, ()>> = stream::iter(job.items)
-        .map(|item| {
-            let state = Arc::clone(&state);
-            let owner = owner.clone();
-            let package_id = package_id.clone();
-            let agent_public_key = agent_public_key.clone();
-            async move {
-                let encrypted = match base64::engine::general_purpose::STANDARD
-                    .decode(&item.encrypted_b64)
-                {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        let msg = format!("base64 decode failed: {}", e);
-                        tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
-                        let _ = sqlx::query(
-                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-                        )
-                        .bind(&msg)
-                        .bind(&item.job_id)
-                        .execute(state.db.pool())
-                        .await;
-                        return Err(());
-                    }
-                };
-
-                let upload = match crate::walrus::upload_blob_deferred(
-                    &state.http_client,
-                    &state.config.sidecar_url,
-                    state.config.sidecar_secret.as_deref(),
-                    &encrypted,
-                    epochs,
-                    &owner,
-                    item.wallet_index,
-                    &item.namespace,
-                    &package_id,
-                    agent_public_key.as_deref(),
-                )
-                .await
-                {
-                    Ok(upload) => upload,
-                    Err(e) => {
-                        let msg = format!("walrus upload failed: {}", e);
-                        tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
-                        let _ = sqlx::query(
-                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-                        )
-                        .bind(&msg)
-                        .bind(&item.job_id)
-                        .execute(state.db.pool())
-                        .await;
-                        return Err(());
-                    }
-                };
-
-                let object_id = match upload.object_id {
-                    Some(object_id) if !object_id.is_empty() => object_id,
-                    _ => {
-                        let msg = "walrus deferred upload returned no object_id".to_string();
-                        tracing::error!("[bulk-remember] job_id={} {}", item.job_id, msg);
-                        let _ = sqlx::query(
-                            "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-                        )
-                        .bind(&msg)
-                        .bind(&item.job_id)
-                        .execute(state.db.pool())
-                        .await;
-                        return Err(());
-                    }
-                };
-
-                let _ = sqlx::query(
-                    "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, updated_at = NOW() WHERE id = $2",
-                )
-                .bind(&upload.blob_id)
-                .bind(&item.job_id)
-                .execute(state.db.pool())
-                .await;
-
-                warm_blob_cache_after_upload(&state, &upload.blob_id, &encrypted).await;
-
-                Ok(UploadOk {
-                    job_id: item.job_id,
-                    blob_id: upload.blob_id,
-                    object_id,
-                    wallet_index: item.wallet_index,
-                    namespace: item.namespace,
+    let mut storage = state.wallet_storage.clone();
+    let mut enqueued_count = 0usize;
+    for item in job.items {
+        let job_id = item.job_id.clone();
+        let namespace = item.namespace.clone();
+        let wallet_index = item.wallet_index;
+        storage
+            .push(WalletJob {
+                wallet_index,
+                operation: WalletOperation::UploadAndTransfer {
+                    encrypted_b64: item.encrypted_b64,
                     vector: item.vector,
-                    blob_size: encrypted.len() as i64,
-                })
-            }
-        })
-        .buffer_unordered(BULK_UPLOAD_CONCURRENCY)
-        .collect()
-        .await;
-
-    let mut groups: HashMap<usize, Vec<UploadOk>> = HashMap::new();
-    let mut fail_count = 0usize;
-    let mut uploaded_count = 0usize;
-
-    for result in upload_results {
-        match result {
-            Ok(upload) => {
-                uploaded_count += 1;
-                let vector_id = upload.job_id.clone();
-                if let Err(e) = state
-                    .db
-                    .insert_vector(
-                        &vector_id,
-                        &job.owner,
-                        &upload.namespace,
-                        &upload.blob_id,
-                        &upload.vector,
-                        upload.blob_size,
-                    )
-                    .await
-                {
-                    fail_count += 1;
-                    let msg = format!("insert_vector failed: {}", e);
-                    tracing::error!("[bulk-remember] job_id={} {}", upload.job_id, msg);
-                    let _ = sqlx::query(
-                        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
-                    )
-                    .bind(&msg)
-                    .bind(&upload.job_id)
-                    .execute(state.db.pool())
-                    .await;
-                    continue;
-                }
-                groups.entry(upload.wallet_index).or_default().push(upload);
-            }
-            Err(()) => {
-                fail_count += 1;
-            }
-        }
-    }
-
-    let mut success_count = 0usize;
-    for (wallet_index, uploads) in groups {
-        let entries: Vec<SetMetadataBatchEntry> = uploads
-            .iter()
-            .map(|upload| SetMetadataBatchEntry {
-                blob_object_id: upload.object_id.clone(),
-                namespace: upload.namespace.clone(),
+                    owner: job.owner.clone(),
+                    namespace,
+                    package_id: job.package_id.clone(),
+                    agent_public_key: job.agent_public_key.clone(),
+                    remember_job_id: Some(job_id.clone()),
+                    epochs: job.epochs,
+                },
             })
-            .collect();
-
-        match crate::walrus::set_metadata_batch(
-            &state.http_client,
-            &state.config.sidecar_url,
-            state.config.sidecar_secret.as_deref(),
-            wallet_index,
-            &job.owner,
-            &job.package_id,
-            job.agent_public_key.as_deref(),
-            entries,
-        )
-        .await
-        {
-            Ok(transferred) => {
-                tracing::info!(
-                    "[bulk-remember] metadata batch transferred {} blobs wallet={}",
-                    transferred,
-                    wallet_index
-                );
-                for upload in uploads {
-                    let _ = sqlx::query(
-                        "UPDATE remember_jobs SET status = 'done', blob_id = $1, updated_at = NOW() WHERE id = $2",
-                    )
-                    .bind(&upload.blob_id)
-                    .bind(&upload.job_id)
-                    .execute(state.db.pool())
-                    .await;
-                    success_count += 1;
-                }
-            }
-            Err(e) => {
-                fail_count += uploads.len();
-                let msg = format!("metadata batch failed: {}", e);
-                tracing::warn!(
-                    "[bulk-remember] wallet={} {} ({} blobs)",
-                    wallet_index,
-                    msg,
-                    uploads.len()
-                );
-                let failed_job_ids: Vec<String> =
-                    uploads.iter().map(|upload| upload.job_id.clone()).collect();
-                let _ = sqlx::query(
-                    "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = ANY($2)",
-                )
-                .bind(&msg)
-                .bind(&failed_job_ids)
-                .execute(state.db.pool())
-                .await;
-            }
-        }
+            .await
+            .map_err(|e| {
+                BulkRememberError::Internal(format!(
+                    "failed to enqueue wallet job for {}: {}",
+                    job_id, e
+                ))
+            })?;
+        enqueued_count += 1;
     }
 
     tracing::info!(
-        "[bulk-remember] complete: owner={} total={} uploaded={} done={} fail={}",
+        "[bulk-remember] fanout complete: owner={} total={} enqueued={}",
         &job.owner[..10.min(job.owner.len())],
         items_total,
-        uploaded_count,
-        success_count,
-        fail_count,
+        enqueued_count,
     );
 
     Ok(())
@@ -1027,7 +824,7 @@ mod tests {
     use super::WalletJobError;
 
     #[test]
-    fn classify_object_lock_as_permanent() {
+    fn classify_object_lock_as_transient() {
         let cases = [
             "ObjectLockedAtVersion { object_id: 0xabc, version: 42 }",
             "object is locked at version 17",
@@ -1035,8 +832,8 @@ mod tests {
         ];
         for msg in cases {
             assert!(
-                WalletJobError::classify_sidecar_error(msg).is_permanent(),
-                "expected permanent for: {}",
+                !WalletJobError::classify_sidecar_error(msg).is_permanent(),
+                "expected transient for: {}",
                 msg
             );
         }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -181,18 +181,18 @@ pub fn backoff_duration(attempt: u32) -> std::time::Duration {
 
 /// Apalis worker handler for WalletJob.
 ///
-/// The worker is pinned to a specific `wallet_index` via `Data<(Arc<AppState>, usize)>`.
-/// Every operation inside uses that fixed index — never round-robin.
+/// Multiple concurrent invocations of this handler share the single signing
+/// wallet (Apalis `WALLET_JOB_CONCURRENCY` controls fan-out, default 8). The
+/// `wallet_index` field in the job payload is retained for audit only —
+/// routing dimension was removed per MEM-35.
 pub async fn execute_wallet_job(
     job: WalletJob,
     ctx: Data<Arc<AppState>>,
 ) -> Result<(), WalletJobError> {
     let state: &AppState = &ctx;
-    // The wallet_index stored in the job is authoritative.
-    // The worker queue name is just for routing; actual signing uses job.wallet_index.
     let wallet_index = job.wallet_index;
 
-    match job.operation {
+    let result = match job.operation {
         WalletOperation::UploadAndTransfer {
             encrypted_b64,
             vector,
@@ -235,7 +235,20 @@ pub async fn execute_wallet_job(
             )
             .await
         }
+    };
+
+    // Observability hook: surface permanent failures (Move abort / object
+    // lock) as a structured warn-level log. Operators alert on these.
+    if let Err(WalletJobError::Permanent(ref msg)) = result {
+        tracing::warn!(
+            target: "wallet_job.permanent",
+            "permanent failure for wallet_index={} (will mark Dead): {}",
+            wallet_index,
+            msg
+        );
     }
+
+    result
 }
 
 // ────────────────────────────────────────────────────────────
@@ -266,7 +279,17 @@ async fn execute_set_metadata_and_transfer(
     )
     .await
     .map(|_| ())
-    .map_err(|e| WalletJobError::Internal(e.to_string()))
+    .map_err(|e| {
+        let msg = e.to_string();
+        let classified = WalletJobError::classify_sidecar_error(&msg);
+        if classified.is_permanent() {
+            tracing::error!(
+                "[wallet-job:set-metadata] permanent failure (will mark Dead): {}",
+                msg
+            );
+        }
+        classified
+    })
 }
 
 // ────────────────────────────────────────────────────────────
@@ -296,10 +319,12 @@ async fn execute_upload_and_transfer(
         .await;
     }
 
-    // Helper: mark failed and return Err
+    // Helper: mark failed and return Err. Classifies sidecar errors so Apalis
+    // can mark deterministic failures (Move abort, object lock) Dead without
+    // burning retries.
     let fail = |msg: String| -> WalletJobError {
         tracing::error!("[wallet-job:upload] {}", msg);
-        WalletJobError::Internal(msg)
+        WalletJobError::classify_sidecar_error(&msg)
     };
 
     // ── Decode encrypted bytes ─────────────────────────────────
@@ -422,15 +447,59 @@ async fn execute_upload_and_transfer(
 // WalletJobError
 // ============================================================
 
+/// Failure classification for `WalletJob` handlers.
+///
+/// Apalis re-queues with exponential backoff on `Transient`. `Permanent`
+/// errors are returned as-is so the job is marked Dead immediately and we
+/// don't burn retry budget on inputs that can never succeed.
+///
+/// Mapping rules (enforced at the point of error origination):
+/// - `MoveAbort(_)` → `Permanent` (deterministic Move-level failure)
+/// - `ObjectLockedAtVersion(_)` → `Permanent` (per-Sui-2026 behavior, locks
+///   should be rare; if one surfaces, alert ops via `wallet_job.permanent`
+///   tracing target rather than burning retries)
+/// - `InsufficientGas` / `ObjectNotFound` /
+///   `ObjectVersionUnavailableForConsumption` → `Transient` (refill wallet,
+///   refresh local state, retry)
+/// - Network 429 / 5xx / timeout → `Transient`
 #[derive(Debug)]
 pub enum WalletJobError {
-    Internal(String),
+    /// Transient failure — Apalis should retry with backoff.
+    Transient(String),
+    /// Permanent failure — Apalis should mark Dead immediately (no retry).
+    Permanent(String),
+}
+
+impl WalletJobError {
+    /// True if the error is `Permanent` — caller should NOT retry.
+    pub fn is_permanent(&self) -> bool {
+        matches!(self, WalletJobError::Permanent(_))
+    }
+
+    /// Heuristic classification from the sidecar's error string. The sidecar
+    /// surfaces Sui execution errors verbatim (Move abort codes, lock errors).
+    /// Until the sidecar emits structured error codes, we match on substrings.
+    pub fn classify_sidecar_error(msg: &str) -> Self {
+        let lower = msg.to_ascii_lowercase();
+        if lower.contains("objectlocked")
+            || lower.contains("object_locked")
+            || lower.contains("object is locked")
+            || lower.contains("locked at version")
+        {
+            return WalletJobError::Permanent(msg.to_string());
+        }
+        if lower.contains("moveabort") || lower.contains("move abort") {
+            return WalletJobError::Permanent(msg.to_string());
+        }
+        WalletJobError::Transient(msg.to_string())
+    }
 }
 
 impl std::fmt::Display for WalletJobError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WalletJobError::Internal(msg) => write!(f, "wallet job error: {}", msg),
+            WalletJobError::Transient(msg) => write!(f, "wallet job error (transient): {}", msg),
+            WalletJobError::Permanent(msg) => write!(f, "wallet job error (permanent): {}", msg),
         }
     }
 }
@@ -907,4 +976,63 @@ pub async fn execute_bulk_remember(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WalletJobError;
+
+    #[test]
+    fn classify_object_lock_as_permanent() {
+        let cases = [
+            "ObjectLockedAtVersion { object_id: 0xabc, version: 42 }",
+            "object is locked at version 17",
+            "ObjectLocked: 0x1234",
+        ];
+        for msg in cases {
+            assert!(
+                WalletJobError::classify_sidecar_error(msg).is_permanent(),
+                "expected permanent for: {}",
+                msg
+            );
+        }
+    }
+
+    #[test]
+    fn classify_move_abort_as_permanent() {
+        for msg in [
+            "MoveAbort(MoveLocation { module: ... }, 1)",
+            "Move abort at code 7",
+        ] {
+            assert!(
+                WalletJobError::classify_sidecar_error(msg).is_permanent(),
+                "expected permanent for: {}",
+                msg
+            );
+        }
+    }
+
+    #[test]
+    fn classify_network_errors_as_transient() {
+        for msg in [
+            "sidecar timeout",
+            "503 service unavailable",
+            "ECONNRESET",
+            "insufficient gas",
+        ] {
+            assert!(
+                !WalletJobError::classify_sidecar_error(msg).is_permanent(),
+                "expected transient for: {}",
+                msg
+            );
+        }
+    }
+
+    #[test]
+    fn display_includes_classification_tag() {
+        let perm = WalletJobError::Permanent("locked".to_string());
+        let trans = WalletJobError::Transient("network".to_string());
+        assert!(perm.to_string().contains("permanent"));
+        assert!(trans.to_string().contains("transient"));
+    }
 }

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -146,19 +146,28 @@ async fn main() {
     let bulk_job_storage: PostgresStorage<BulkRememberJob> =
         PostgresStorage::new(apalis_pool.clone());
 
-    // Create N per-wallet queues (one per pool key) for WalletJob.
-    // Each queue name is "wallet-{i}" and has a single dedicated worker.
+    // Single Apalis queue for all WalletJob signing operations.
+    //
+    // Was previously a Vec of per-wallet queues to avoid Sui coin-object
+    // equivocation locks. Per Will Bradley (Mysten, 2026-05-12 Slack callout):
+    // Sui no longer permanently locks coin objects on equivocation, so a single
+    // wallet + concurrent workers + retry handling is sufficient. Multi-wallet
+    // is only justified for raw throughput, which is not a bottleneck for
+    // background Walrus uploads.
+    const WALLET_QUEUE_NAME: &str = "wallet_jobs";
+    let wallet_storage: WalletJobStorage = PostgresStorage::new_with_config(
+        apalis_pool.clone(),
+        apalis_sql::Config::new(WALLET_QUEUE_NAME),
+    );
     let pool_size = config.sui_private_keys.len();
-    let mut wallet_storages: Vec<WalletJobStorage> = Vec::with_capacity(pool_size.max(1));
-    for i in 0..pool_size.max(1) {
-        let config_name = format!("wallet-{}", i);
-        let storage: WalletJobStorage = PostgresStorage::new_with_config(
-            apalis_pool.clone(),
-            apalis_sql::Config::new(&config_name),
+    if pool_size > 1 {
+        tracing::warn!(
+            "  SERVER_SUI_PRIVATE_KEYS has {} entries; only the first is used. \
+             Multi-wallet routing was retired — see plans/simplify-walrus-wallet-queues/.",
+            pool_size,
         );
-        wallet_storages.push(storage);
     }
-    tracing::info!("  Apalis: job queue ready (table=apalis_jobs)");
+    tracing::info!("  Apalis: job queue ready (table=apalis_jobs, queue={})", WALLET_QUEUE_NAME);
 
     // Initialize Walrus client (SDK wraps Publisher + Aggregator HTTP APIs)
     let walrus_client =
@@ -227,7 +236,7 @@ async fn main() {
         redis,
         fallback_rate_limit: tokio::sync::Mutex::new(crate::rate_limit::InMemoryFallback::default()),
         remember_job_storage: remember_job_storage.clone(),
-        wallet_storages: wallet_storages.clone(),
+        wallet_storage: wallet_storage.clone(),
         bulk_job_storage: bulk_job_storage.clone(),
         blob_cache_ttl,
         embedding_cache_ttl,
@@ -296,30 +305,43 @@ async fn main() {
         tracing::info!("  Apalis: worker 'bulk-remember' spawned (concurrency=2)");
     }
 
-    // Workers 3..N: Per-wallet WalletJob workers (one per pool key).
-    // Each worker is pinned to wallet_index i and processes jobs from queue "wallet-{i}".
-    // This guarantees upload and set-metadata+transfer always use the same signing key.
-    for (i, storage) in wallet_storages.into_iter().enumerate() {
+    // Worker 4: WalletJob — single worker, single queue.
+    //
+    // Concurrency = WALLET_JOB_CONCURRENCY (default 8). Multiple jobs can be
+    // dispatched simultaneously; the sidecar's per-signer mutex serializes
+    // them at the signing boundary (see sidecar-server.ts → signerUploadQueues
+    // for rationale: Enoki sponsor race + SDK gas-coin contention, NOT
+    // equivocation locking — that one is solved). Apalis-level retry
+    // (Transient vs Permanent classified in `WalletJobError`) handles
+    // transient RPC / Sui errors.
+    let wallet_concurrency: usize = std::env::var("WALLET_JOB_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8);
+    {
         let worker_state = state.clone();
-        let queue_name = format!("wallet-{}", i);
-        let queue_label = queue_name.clone();
+        let storage = wallet_storage.clone();
         tokio::spawn(async move {
             loop {
-                let worker = WorkerBuilder::new(&queue_name)
+                let worker = WorkerBuilder::new("wallet_jobs")
                     .data(worker_state.clone())
                     .backend(storage.clone())
                     .build_fn(execute_wallet_job);
 
                 #[allow(deprecated)]
-                if let Err(e) = Monitor::new().register_with_count(1, worker).run().await {
-                    tracing::error!("Apalis wallet worker {} exited: {}", queue_label, e);
+                if let Err(e) = Monitor::new()
+                    .register_with_count(wallet_concurrency, worker)
+                    .run()
+                    .await
+                {
+                    tracing::error!("Apalis wallet worker exited: {}", e);
                 }
                 tokio::time::sleep(APALIS_MONITOR_RESTART_DELAY).await;
             }
         });
         tracing::info!(
-            "  Apalis: wallet worker '{}' spawned (serial)",
-            format!("wallet-{}", i)
+            "  Apalis: worker 'wallet_jobs' spawned (concurrency={})",
+            wallet_concurrency
         );
     }
 

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -168,7 +168,10 @@ async fn main() {
             pool_size,
         );
     }
-    tracing::info!("  Apalis: job queue ready (table=apalis_jobs, queue={})", WALLET_QUEUE_NAME);
+    tracing::info!(
+        "  Apalis: job queue ready (table=apalis_jobs, queue={})",
+        WALLET_QUEUE_NAME
+    );
 
     // Initialize Walrus client (SDK wraps Publisher + Aggregator HTTP APIs)
     let walrus_client =

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -176,19 +176,18 @@ async fn main() {
             .expect("Failed to initialize Walrus client (invalid URL?)");
     tracing::info!("  Walrus publisher: {}", config.walrus_publisher_url);
     tracing::info!("  Walrus aggregator: {}", config.walrus_aggregator_url);
-    // Log upload key pool status
+    // Log upload key status
     let pool_size = config.sui_private_keys.len();
     if pool_size > 0 {
         tracing::info!(
-            "  Walrus upload: {} key(s) in pool (parallel uploads up to {}x)",
+            "  Walrus upload: {} key(s) configured; using first key for wallet jobs",
             pool_size,
-            pool_size
         );
     } else {
         tracing::warn!("  Walrus upload: no Sui private keys configured, uploads will fail");
     }
 
-    // Build key pool for parallel Walrus uploads
+    // Build wallet key holder
     let key_pool = KeyPool::new(config.sui_private_keys.clone());
 
     // Initialize Redis for rate limiting
@@ -319,12 +318,8 @@ async fn main() {
     // Worker 4: WalletJob — single worker, single queue.
     //
     // Concurrency = WALLET_JOB_CONCURRENCY (default 8). Multiple jobs can be
-    // dispatched simultaneously; the sidecar's per-signer mutex serializes
-    // them at the signing boundary (see sidecar-server.ts → signerUploadQueues
-    // for rationale: Enoki sponsor race + SDK gas-coin contention, NOT
-    // equivocation locking — that one is solved). Apalis-level retry
-    // (Transient vs Permanent classified in `WalletJobError`) handles
-    // transient RPC / Sui errors.
+    // dispatched simultaneously against the same wallet; transient Sui/RPC
+    // conflicts are classified by `WalletJobError` and retried by Apalis.
     let wallet_concurrency: usize = std::env::var("WALLET_JOB_CONCURRENCY")
         .ok()
         .and_then(|v| v.parse().ok())

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -823,8 +823,9 @@ pub async fn remember_status(
 /// POST /api/remember/bulk  (ENG-1408)
 ///
 /// Accepts up to MAX_BULK_ITEMS memories and returns HTTP 202 after creating
-/// status rows. Embed/encrypt runs in the background; the bulk worker batches
-/// metadata+transfer by wallet after deferred Walrus uploads.
+/// status rows. Embed/encrypt runs in the background; the bulk worker fans
+/// prepared items into the shared wallet queue so each item uses the same
+/// retry/error-classification path as single-memory uploads.
 pub async fn remember_bulk(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthInfo>,

--- a/services/server/src/routes.rs
+++ b/services/server/src/routes.rs
@@ -18,25 +18,19 @@ use crate::seal;
 use crate::types::*;
 use crate::walrus;
 
-/// Enqueue a WalletJob to the correct per-wallet Apalis queue.
+/// Enqueue a WalletJob to the single shared Apalis queue.
 ///
-/// `wallet_index` must match the index used (or to be used) for the Walrus
-/// upload so that upload and set-metadata+transfer always sign with the
-/// same key. Returns the wallet_index for caller tracking.
+/// `wallet_index` is retained in the payload for audit/legacy parity but no
+/// longer drives queue routing — all jobs flow through one queue and the
+/// Apalis worker handles `WALLET_JOB_CONCURRENCY` requests in parallel.
+/// See MEM-35: multi-wallet was an equivocation workaround that's no longer
+/// needed on current Sui.
 pub async fn enqueue_wallet_job(
     state: &AppState,
     wallet_index: usize,
     operation: WalletOperation,
 ) -> Result<usize, AppError> {
-    let storages = &state.wallet_storages;
-    if wallet_index >= storages.len() {
-        return Err(AppError::Internal(format!(
-            "wallet_index {} out of range (pool size={})",
-            wallet_index,
-            storages.len()
-        )));
-    }
-    let mut storage = storages[wallet_index].clone();
+    let mut storage = state.wallet_storage.clone();
     storage
         .push(WalletJob {
             wallet_index,

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -10,9 +10,6 @@ pub const MAX_BULK_ITEMS: usize = 20;
 /// ENG-1408: Bounded concurrency for concurrent embed+encrypt in bulk route handler.
 pub const BULK_EMBED_CONCURRENCY: usize = 5;
 
-/// ENG-1408: Bounded concurrency for Walrus uploads inside one bulk job.
-pub const BULK_UPLOAD_CONCURRENCY: usize = 5;
-
 /// Redis key prefix for Walrus ciphertext cache entries.
 pub const BLOB_CACHE_KEY_PREFIX: &str = "memwal:blob:v1:";
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::db::VectorDb;
 use crate::jobs::{BulkRememberJobStorage, RememberJobStorage, WalletJobStorage};
@@ -41,10 +40,13 @@ pub struct AppState {
     /// migration to WalletJob::UploadAndTransfer; new requests do NOT use this.
     #[allow(dead_code)]
     pub remember_job_storage: RememberJobStorage,
-    /// Per-wallet Apalis storages — wallet_storages[i] maps to pool key[i].
-    /// New code should enqueue WalletJob here instead of using
-    /// MetaTransferJob/RememberJob directly.
-    pub wallet_storages: Vec<WalletJobStorage>,
+    /// Single Apalis storage for WalletJob. Routing dimension was previously a
+    /// Vec<WalletJobStorage> keyed by wallet_index; that existed to side-step
+    /// Sui coin-object equivocation locks. Per Will Bradley (Mysten, 2026-05-12
+    /// Slack callout): Sui no longer permanently locks coin objects on
+    /// equivocation, so one wallet + concurrent workers + retry handler is
+    /// sufficient. See `plans/simplify-walrus-wallet-queues/reports/` for context.
+    pub wallet_storage: WalletJobStorage,
     /// ENG-1408: Apalis storage for BulkRememberJob.
     pub bulk_job_storage: BulkRememberJobStorage,
     /// ENG-1405: Redis TTL for Walrus blob ciphertext cache entries.
@@ -55,46 +57,52 @@ pub struct AppState {
 }
 
 // ============================================================
-// Key Pool (round-robin selection for parallel uploads)
+// Key Pool — single-wallet wrapper
 // ============================================================
 
-/// A thread-safe round-robin pool of Sui private keys.
-/// Each call to `next()` returns the next key in the pool,
-/// allowing concurrent uploads to use different signer addresses.
+/// Wallet key holder. Historically a round-robin pool of N keys used to
+/// horizontally side-step Sui coin-object equivocation locks. Per Will Bradley
+/// (Mysten, 2026-05-12): coin-object locking is no longer a practical concern
+/// on Sui, so a single key with concurrent workers + retry handling is
+/// sufficient. `next_index()` always returns `Some(0)` when a key is
+/// configured (the API is kept so callers can still distinguish "no keys"
+/// from "key available").
 pub struct KeyPool {
     keys: Vec<String>,
-    counter: AtomicUsize,
 }
 
 impl KeyPool {
     pub fn new(keys: Vec<String>) -> Self {
-        Self {
-            keys,
-            counter: AtomicUsize::new(0),
-        }
+        // Only the first key is used. Additional keys (if any) are ignored —
+        // surfaced via a warning at boot in main.rs.
+        Self { keys }
     }
 
-    /// Returns the next key in round-robin order, or `None` if the pool is empty.
+    /// Returns the first configured key, or `None` if no keys are configured.
     #[allow(dead_code)]
     pub fn next(&self) -> Option<&str> {
-        if self.keys.is_empty() {
-            return None;
-        }
-        let idx = self.counter.fetch_add(1, Ordering::Relaxed) % self.keys.len();
-        Some(&self.keys[idx])
+        self.keys.first().map(|s| s.as_str())
     }
 
-    /// Returns the pool index for the next key in round-robin order.
+    /// Returns `Some(0)` when a key is configured, `None` otherwise.
+    /// `wallet_index` is retained in job payloads for audit / sidecar parity
+    /// but no longer drives queue routing.
     pub fn next_index(&self) -> Option<usize> {
         if self.keys.is_empty() {
-            return None;
+            None
+        } else {
+            Some(0)
         }
-        Some(self.counter.fetch_add(1, Ordering::Relaxed) % self.keys.len())
     }
 
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
+    }
+
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.keys.len()
     }
 }
 
@@ -812,16 +820,15 @@ mod tests {
         assert_eq!(resp.status(), axum::http::StatusCode::PAYMENT_REQUIRED);
     }
 
-    // ── KeyPool: round-robin selection ───────────────────────────────────
+    // ── KeyPool: single-wallet selection ─────────────────────────────────
 
     #[test]
-    fn key_pool_round_robin() {
+    fn key_pool_returns_first_key() {
         let pool = KeyPool::new(vec!["key_a".into(), "key_b".into(), "key_c".into()]);
 
         assert_eq!(pool.next(), Some("key_a"));
-        assert_eq!(pool.next(), Some("key_b"));
-        assert_eq!(pool.next(), Some("key_c"));
-        assert_eq!(pool.next(), Some("key_a")); // wraps around
+        assert_eq!(pool.next(), Some("key_a"));
+        assert_eq!(pool.next(), Some("key_a"));
     }
 
     #[test]
@@ -841,10 +848,10 @@ mod tests {
     }
 
     #[test]
-    fn key_pool_next_index_wraps() {
+    fn key_pool_next_index_always_zero() {
         let pool = KeyPool::new(vec!["a".into(), "b".into()]);
         assert_eq!(pool.next_index(), Some(0));
-        assert_eq!(pool.next_index(), Some(1));
+        assert_eq!(pool.next_index(), Some(0));
         assert_eq!(pool.next_index(), Some(0));
     }
 

--- a/services/server/src/walrus.rs
+++ b/services/server/src/walrus.rs
@@ -122,38 +122,6 @@ pub async fn upload_blob(
     .await
 }
 
-/// Upload an encrypted blob but leave the certified Blob object owned by the
-/// server wallet. Bulk remember uses this so one later PTB can transfer many
-/// blobs together.
-#[allow(clippy::too_many_arguments)]
-pub async fn upload_blob_deferred(
-    client: &reqwest::Client,
-    sidecar_url: &str,
-    sidecar_secret: Option<&str>,
-    data: &[u8],
-    epochs: u64,
-    owner_address: &str,
-    key_index: usize,
-    namespace: &str,
-    package_id: &str,
-    agent_id: Option<&str>,
-) -> Result<UploadResult, AppError> {
-    upload_blob_inner(
-        client,
-        sidecar_url,
-        sidecar_secret,
-        data,
-        epochs,
-        owner_address,
-        key_index,
-        namespace,
-        package_id,
-        agent_id,
-        true,
-    )
-    .await
-}
-
 #[allow(clippy::too_many_arguments)]
 async fn upload_blob_inner(
     client: &reqwest::Client,
@@ -184,12 +152,11 @@ async fn upload_blob_inner(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req.timeout(SIDECAR_WALRUS_TIMEOUT).send().await.map_err(|e| {
-        AppError::Internal(format!(
-            "Sidecar walrus/upload request failed: {}",
-            e
-        ))
-    })?;
+    let resp = req
+        .timeout(SIDECAR_WALRUS_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Sidecar walrus/upload request failed: {}", e)))?;
 
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
@@ -256,12 +223,16 @@ pub async fn set_metadata_batch(
         req = req.header("authorization", format!("Bearer {}", secret));
     }
 
-    let resp = req.timeout(SIDECAR_WALRUS_TIMEOUT).send().await.map_err(|e| {
-        AppError::Internal(format!(
-            "Sidecar walrus/set-metadata-batch request failed: {}",
-            e
-        ))
-    })?;
+    let resp = req
+        .timeout(SIDECAR_WALRUS_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!(
+                "Sidecar walrus/set-metadata-batch request failed: {}",
+                e
+            ))
+        })?;
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {

--- a/services/server/src/walrus.rs
+++ b/services/server/src/walrus.rs
@@ -1,5 +1,8 @@
 use crate::types::{AppError, SidecarError};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use std::time::Duration;
+
+const SIDECAR_WALRUS_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// Result of a Walrus blob upload
 pub struct UploadResult {
@@ -181,9 +184,9 @@ async fn upload_blob_inner(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req.send().await.map_err(|e| {
+    let resp = req.timeout(SIDECAR_WALRUS_TIMEOUT).send().await.map_err(|e| {
         AppError::Internal(format!(
-            "Sidecar walrus/upload request failed: {}. Is the sidecar running?",
+            "Sidecar walrus/upload request failed: {}",
             e
         ))
     })?;
@@ -253,7 +256,7 @@ pub async fn set_metadata_batch(
         req = req.header("authorization", format!("Bearer {}", secret));
     }
 
-    let resp = req.send().await.map_err(|e| {
+    let resp = req.timeout(SIDECAR_WALRUS_TIMEOUT).send().await.map_err(|e| {
         AppError::Internal(format!(
             "Sidecar walrus/set-metadata-batch request failed: {}",
             e


### PR DESCRIPTION
 # Collapse multi-wallet Apalis queues to single wallet (MEM-35)

 ## Why

  The server currently routes Apalis wallet jobs across **N wallet-specific queues** mainly to side-step Sui coin-object equivocation locks. Each queue is serial on its own wallet, which prevents  two concurrent transactions from locking the same coin object until end-of-epoch (~24h on mainnet).

  > I believe object locks such as this are no longer possible. So, it's safe to use the same wallet+coin across workers concurrently. You may be forced to retry and need to handle those retries  but you could theoretically now eliminate the multiple-wallet complexity.

This PR collapses the architecture to **single wallet + single queue + retry classification** and adds `/metrics/wallet` so the simplification can be validated empirically post-deploy (the canary   metric is `walletLockErrorsTotal`).


## What changes

  ### Rust server (`services/server/src/`)

  - **`types.rs`** — `AppState.wallet_storages: Vec<WalletJobStorage>` → singular `wallet_storage: WalletJobStorage`. `KeyPool::next_index()` always returns `Some(0)` when at least one key is configured. Extra `SERVER_SUI_PRIVATE_KEYS` entries are ignored with a boot-time warning so we don't have to drop them from config immediately.
  - **`main.rs`** — dropped the per-wallet `for (i, storage) in wallet_storages` spawn loop. Single Apalis worker on queue `wallet_jobs` with `WALLET_JOB_CONCURRENCY` env knob (default `8`). Boot  logs `Multi-wallet routing was retired` so the change is visible in production logs.
  - **`routes.rs`** — `enqueue_wallet_job` uses the single storage. `wallet_index` stays in the job payload for audit/sidecar parity but no longer drives routing.
  - **`jobs.rs`** — new `WalletJobError::{Transient, Permanent}` + `classify_sidecar_error()` heuristic. Substring match: `objectlocked` / `move abort` → `Permanent`, everything else → `Transient`.
   Apalis exponential backoff retries on `Transient`, marks `Dead` immediately on `Permanent`. Permanent failures emit `tracing::warn!(target: "wallet_job.permanent")` so ops can alert on them via  existing tracing pipeline. 3 new unit tests cover classification.
  - **`db.rs`** + **`migrations/007_collapse_wallet_queues.sql`** — idempotent SQL migration that renames`apalis.jobs.job_type` from `wallet-%` → `wallet_jobs` **for Pending rows only**. `DO $$ ... END $$` block guarded by `to_regclass('apalis.jobs') IS NOT NULL` so brand-new databases don't fail when the Apalis schema hasn't been created yet. Done / Killed / Dead rows keep their  historical name as audit trail.


 ### TS sidecar (`services/server/scripts/sidecar-server.ts`)

  - **New `submitWalletTransaction(tx, signer, allowed?)`** wrapper around `executeWithEnokiSponsor` that increments three in-memory counters (`walletSubmittedTotal`, `walletLockErrorsTotal`,  `walletPermanentFailuresTotal`) and uses regex on the error message to detect lock errors for the canary metric.
  - **New `GET /metrics/wallet`** — no auth, before the shared-secret middleware (same posture as `/health`). Returns `{walletSubmittedTotal, walletLockErrorsTotal, walletPermanentFailuresTotal,  enokiEnabled, suiNetwork}`. Operators scrape this from staging and prod to validate the simplification.
  - **`patchGasCoinIntents` kept** — Enoki sponsor requires explicit SUI coin types instead of `GasCoin` intent for the upload-relay tip, unchanged from before.



## Operational impact
  - **Wallet count: 5 → 1** (5× reduction in funding, monitoring, rotation surface)
  - **Throughput: 5× parallel → 1× serial via mutex.** Acceptable per Daniel's "Walrus uploading is happening on the background" guidance — current peak load is <10 jobs/s and  `WALLET_JOB_CONCURRENCY=8` has headroom for queue depth
  - **Apalis queues: N → 1** — smaller `apalis.jobs` table fragmentation, easier debug
  - **Failure mode** — if Sui regresses on equivocation, the single wallet bricks instead of `1/N`. Defense: `WalletJobError::Permanent` classifier marks `Dead` immediately (no retry storm on
  inputs that can never succeed) + `wallet_job.permanent` tracing target for alerting






