### PR TITLE
feat(relayer): add k6 stress tests and Neon TLS support

### DIFF
--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/benchmark-live.yml'
       - '.github/workflows/benchmark-smoke.yml'
       - 'docs/relayer/benchmark-ci-setup.md'
+      - 'docs/relayer/k6-stress-tests.md'
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - '.github/workflows/benchmark-live.yml'
       - '.github/workflows/benchmark-smoke.yml'
       - 'docs/relayer/benchmark-ci-setup.md'
+      - 'docs/relayer/k6-stress-tests.md'
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -66,3 +68,7 @@ jobs:
         working-directory: services/server/scripts
         run: |
           ./node_modules/.bin/tsx bench-recall-latency.ts --help
+
+      - name: Build k6 relayer bundle
+        working-directory: services/server/scripts
+        run: npm run k6:build

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -99,7 +99,8 @@
               "relayer/overview",
               "relayer/public-relayer",
               "relayer/self-hosting",
-              "relayer/api-reference"
+              "relayer/api-reference",
+              "relayer/k6-stress-tests"
             ]
           }
         ]

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -20,19 +20,21 @@ All `/api/*` routes require signed headers. The SDK handles this automatically.
 | `x-public-key` | Hex-encoded Ed25519 public key (32 bytes) |
 | `x-signature` | Hex-encoded Ed25519 signature (64 bytes) |
 | `x-timestamp` | Unix timestamp in seconds (5-minute validity window) |
+| `x-nonce` | UUID nonce, unique per request, used for replay protection |
+| `x-account-id` | MemWalAccount object ID; included in the signed message |
 
 ### Optional Headers
 
 | Header | Description |
 |--------|-------------|
-| `x-account-id` | MemWalAccount object ID hint — speeds up account resolution when not cached |
-| `x-delegate-key` | Delegate private key (hex) — used by the default SDK for SEAL decrypt flows |
+| `x-seal-session` | Client-built SEAL SessionKey for server-side decrypt flows |
+| `x-delegate-key` | Legacy delegate private key (hex or `suiprivkey`) fallback for SEAL decrypt flows |
 
 ### Signature Format
 
-The signed message is: `{timestamp}.{method}.{path}.{body_sha256}`
+The signed message is: `{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}`
 
-The relayer verifies the Ed25519 signature, then resolves the owner by looking up the public key in onchain `MemWalAccount.delegate_keys`.
+The relayer verifies the Ed25519 signature, checks the nonce, then resolves the owner by looking up the public key in onchain `MemWalAccount.delegate_keys`.
 
 ## Public Routes
 

--- a/docs/relayer/benchmark-ci-setup.md
+++ b/docs/relayer/benchmark-ci-setup.md
@@ -14,6 +14,7 @@ deployment.
   - Runs `cargo check`.
   - Typechecks `bench-recall-latency.ts`.
   - Runs a `--help` smoke check for the recall benchmark CLI.
+  - Builds the k6 relayer bundle from `services/server/scripts/k6/relayer.ts`.
   - Does not need secrets and does not call Sui, Walrus, SEAL, or OpenAI.
 
 - `.github/workflows/benchmark-live.yml`
@@ -84,3 +85,19 @@ cd services/server/scripts
   --remember-text "benchmark memory" \
   --query "benchmark memory"
 ```
+
+k6 smoke against staging:
+
+```bash
+cd services/server/scripts
+npm run k6:build
+
+BENCH_SERVER_URL=https://relayer.staging.memwal.ai \
+BENCH_ACCOUNT_ID="$BENCH_ACCOUNT_ID" \
+BENCH_DELEGATE_KEY="$BENCH_DELEGATE_KEY" \
+MEMWAL_NAMESPACE=benchmark \
+K6_PROFILE=smoke \
+k6 run dist/k6/relayer.js
+```
+
+For load, stress, and spike profiles, see [k6 Stress Tests](/relayer/k6-stress-tests).

--- a/docs/relayer/k6-stress-tests.md
+++ b/docs/relayer/k6-stress-tests.md
@@ -1,0 +1,159 @@
+---
+title: "k6 Stress Tests"
+---
+
+The relayer k6 harness lives in `services/server/scripts/k6/relayer.ts`.
+It signs protected requests with the same canonical message as the Rust auth
+middleware:
+
+```text
+{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
+```
+
+The bundle sends `x-nonce`, `x-account-id`, and the legacy `x-delegate-key`
+header so relayer-mode `recall`, `ask`, and `restore` can decrypt through SEAL
+without needing SDK SessionKey construction inside k6.
+
+## Build
+
+```bash
+cd services/server/scripts
+npm ci
+npm run k6:build
+```
+
+This writes `dist/k6/relayer.js`, which is the file k6 runs.
+
+## Required Environment
+
+| Variable | Notes |
+| --- | --- |
+| `MEMWAL_SERVER_URL` | Relayer base URL, for example `http://localhost:8000` |
+| `MEMWAL_ACCOUNT_ID` | MemWal account object ID used by `x-account-id` |
+| `MEMWAL_DELEGATE_KEY` | Ed25519 delegate key, as `suiprivkey`, 64-char hex, or `0x` hex |
+| `MEMWAL_NAMESPACE` | Namespace to read/write. Defaults to `k6` |
+
+The harness also accepts the existing benchmark variable names:
+`BENCH_SERVER_URL`, `BENCH_ACCOUNT_ID`, and `BENCH_DELEGATE_KEY`.
+
+## Profiles
+
+Run from `services/server/scripts` after building:
+
+```bash
+# Health only, no auth required
+K6_PROFILE=health k6 run dist/k6/relayer.js
+
+# One end-to-end remember -> poll -> recall pass
+K6_PROFILE=smoke \
+MEMWAL_SERVER_URL=http://localhost:8000 \
+MEMWAL_ACCOUNT_ID=0x... \
+MEMWAL_DELEGATE_KEY=suiprivkey1... \
+k6 run dist/k6/relayer.js
+
+# Steady load. Defaults to 1 iteration/sec for 5 minutes.
+K6_PROFILE=load K6_RATE=2 K6_DURATION=10m k6 run dist/k6/relayer.js
+
+# Gradual ramp. Override stage rates/durations as needed.
+K6_PROFILE=stress \
+K6_STRESS_STAGE_1_RATE=2 \
+K6_STRESS_STAGE_2_RATE=5 \
+K6_STRESS_STAGE_3_RATE=10 \
+k6 run dist/k6/relayer.js
+
+# Sudden traffic burst.
+K6_PROFILE=spike K6_SPIKE_RATE=30 k6 run dist/k6/relayer.js
+```
+
+The default `mixedFlow` is conservative:
+
+| Flow | Default weight | Main bottlenecks exercised |
+| --- | ---: | --- |
+| `POST /api/recall` | `0.75` | query embedding, pgvector search, Walrus download/cache, SEAL decrypt |
+| `POST /api/remember` + status polling | `0.25` | enqueue latency, background embedding, SEAL encrypt, Walrus upload, DB insert |
+| `POST /api/ask` | `0` | recall path plus LLM completion |
+| `POST /api/restore` | `0` | onchain blob query, Walrus download, SEAL decrypt, re-embedding, DB insert |
+
+Enable expensive flows explicitly:
+
+```bash
+MEMWAL_ASK_WEIGHT=0.05 MEMWAL_RESTORE_WEIGHT=0.01 K6_PROFILE=load k6 run dist/k6/relayer.js
+```
+
+To isolate one endpoint family, set `K6_EXEC`:
+
+```bash
+K6_PROFILE=load K6_EXEC=recallOnly k6 run dist/k6/relayer.js
+K6_PROFILE=load K6_EXEC=rememberOnly k6 run dist/k6/relayer.js
+K6_PROFILE=load K6_EXEC=askOnly k6 run dist/k6/relayer.js
+K6_PROFILE=load K6_EXEC=restoreOnly k6 run dist/k6/relayer.js
+```
+
+## Metrics
+
+k6 already reports `http_req_duration`, `http_reqs`, `http_req_failed`, and
+request throughput. The harness adds:
+
+| Metric | Meaning |
+| --- | --- |
+| `memwal_remember_enqueue_duration` | Time for `POST /api/remember` to return `202` |
+| `memwal_remember_worker_duration` | Time from enqueue to terminal remember job status |
+| `memwal_recall_duration` | End-to-end `POST /api/recall` latency |
+| `memwal_ask_duration` | End-to-end `POST /api/ask` latency |
+| `memwal_restore_duration` | End-to-end `POST /api/restore` latency |
+| `memwal_timeout_rate` | Requests or worker polls that timed out |
+| `memwal_remember_job_failed_rate` | Remember jobs that ended failed or timed out |
+| `memwal_http_errors` | HTTP status `0` or `>=400`, tagged by endpoint |
+
+Thresholds include p95/p99 latency checks for health, remember enqueue, recall,
+timeout rate, and remember job failure rate.
+
+## Local Runs
+
+For local capacity testing, start the relayer with the benchmark rate-limit
+escape hatch so polling does not dominate the results:
+
+```bash
+RATE_LIMIT_DISABLED=1 cargo run --release
+```
+
+Use this only on local benchmark instances. Keep normal rate limits enabled for
+shared staging unless the environment is isolated for a run.
+
+## Staging Runs
+
+Use the existing benchmark secrets:
+
+```bash
+cd services/server/scripts
+npm run k6:build
+
+BENCH_SERVER_URL=https://relayer.staging.memwal.ai \
+BENCH_ACCOUNT_ID="$BENCH_ACCOUNT_ID" \
+BENCH_DELEGATE_KEY="$BENCH_DELEGATE_KEY" \
+MEMWAL_NAMESPACE=benchmark \
+K6_PROFILE=smoke \
+k6 run dist/k6/relayer.js
+```
+
+Before running load, stress, or spike against staging, seed the namespace with
+several memories and agree on rate limits for OpenAI, SEAL, Walrus, and Sui RPC.
+For recall-only tests, a namespace with no memories still exercises query
+embedding and pgvector search, but it does not exercise Walrus download or SEAL
+decrypt.
+
+## RPC Self-Hosting
+
+The Rust relayer honors `SUI_RPC_URL`; the sidecar now uses the same env var
+before falling back to `getJsonRpcFullnodeUrl(SUI_NETWORK)`. If public Sui RPC is
+blocked or rate-limited, self-hosting is viable as long as the relayer and
+sidecar are both configured with the same private or paid RPC endpoint:
+
+```bash
+SUI_NETWORK=testnet
+SUI_RPC_URL=https://your-sui-fullnode.example.com
+```
+
+Walrus publisher, aggregator, and upload relay are separate from Sui RPC. If
+those endpoints are blocked too, override `WALRUS_PUBLISHER_URL`,
+`WALRUS_AGGREGATOR_URL`, and `WALRUS_UPLOAD_RELAY_URL` separately.

--- a/services/indexer/Cargo.lock
+++ b/services/indexer/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "indexmap",
  "log",
  "memchr",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "serde",

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 
 # Database (PostgreSQL)
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "chrono"] }
 
 # HTTP client (for Sui RPC)
 reqwest = { version = "0.12", features = ["json"] }

--- a/services/server/Cargo.lock
+++ b/services/server/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "indexmap",
  "log",
  "memchr",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "serde",

--- a/services/server/Cargo.toml
+++ b/services/server/Cargo.toml
@@ -11,7 +11,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # Database (PostgreSQL + pgvector)
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "chrono", "uuid"] }
 pgvector = { version = "0.4", features = ["sqlx"] }
 
 # Auth

--- a/services/server/scripts/k6/k6.d.ts
+++ b/services/server/scripts/k6/k6.d.ts
@@ -1,0 +1,62 @@
+declare module "k6/http" {
+    export type Response = {
+        status: number;
+        body: unknown;
+        timings: { duration: number };
+        json: () => unknown;
+    };
+
+    type Params = {
+        headers?: Record<string, string>;
+        tags?: Record<string, string>;
+        timeout?: string;
+    };
+
+    const http: {
+        get: (url: string, params?: Params) => Response;
+        request: (
+            method: string,
+            url: string,
+            body?: string | null,
+            params?: Params,
+        ) => Response;
+    };
+
+    export default http;
+}
+
+declare module "k6/execution" {
+    const exec: {
+        vu: { idInTest: number };
+        scenario: { iterationInTest: number };
+    };
+    export default exec;
+}
+
+declare module "k6" {
+    import type { Response } from "k6/http";
+
+    export function check<T = Response>(
+        value: T,
+        sets: Record<string, (value: T) => boolean>,
+    ): boolean;
+    export function fail(message: string): never;
+    export function sleep(seconds: number): void;
+}
+
+declare module "k6/metrics" {
+    export class Counter {
+        constructor(name: string);
+        add(value: number, tags?: Record<string, string>): void;
+    }
+
+    export class Rate {
+        constructor(name: string);
+        add(value: boolean, tags?: Record<string, string>): void;
+    }
+
+    export class Trend {
+        constructor(name: string, isTime?: boolean);
+        add(value: number, tags?: Record<string, string>): void;
+    }
+}

--- a/services/server/scripts/k6/relayer.ts
+++ b/services/server/scripts/k6/relayer.ts
@@ -1,0 +1,479 @@
+/// <reference path="./k6.d.ts" />
+
+import http from "k6/http";
+import exec from "k6/execution";
+import { check, fail, sleep } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+import * as ed from "@noble/ed25519";
+import { sha256, sha512 } from "@noble/hashes/sha2.js";
+import { bech32 } from "bech32";
+
+declare const __ENV: Record<string, string | undefined>;
+
+ed.hashes.sha512 = sha512;
+
+type Json = Record<string, unknown>;
+type Profile = "smoke" | "load" | "stress" | "spike" | "health";
+
+const serverUrl = trimTrailingSlash(
+    env("MEMWAL_SERVER_URL", "SERVER_URL", "BENCH_SERVER_URL") ?? "http://localhost:8000",
+);
+const accountId = env("MEMWAL_ACCOUNT_ID", "BENCH_ACCOUNT_ID") ?? "";
+const delegateKeyRaw = env("MEMWAL_DELEGATE_KEY", "BENCH_DELEGATE_KEY") ?? "";
+const namespace = __ENV.MEMWAL_NAMESPACE ?? __ENV.NAMESPACE ?? "k6";
+const query = __ENV.MEMWAL_QUERY ?? __ENV.QUERY ?? "benchmark memory";
+const rememberText = __ENV.MEMWAL_REMEMBER_TEXT ?? __ENV.REMEMBER_TEXT ?? "benchmark memory";
+const limit = intEnv("MEMWAL_LIMIT", 5);
+const requestTimeout = __ENV.MEMWAL_REQUEST_TIMEOUT ?? "60s";
+const rememberPollTimeoutMs = intEnv("MEMWAL_REMEMBER_POLL_TIMEOUT_MS", 180_000);
+const rememberPollIntervalMs = intEnv("MEMWAL_REMEMBER_POLL_INTERVAL_MS", 1_000);
+const healthSampleRate = numberEnv("MEMWAL_HEALTH_SAMPLE_RATE", 0.05);
+const recallWeight = numberEnv("MEMWAL_RECALL_WEIGHT", 0.75);
+const rememberWeight = numberEnv("MEMWAL_REMEMBER_WEIGHT", 0.25);
+const askWeight = numberEnv("MEMWAL_ASK_WEIGHT", 0);
+const restoreWeight = numberEnv("MEMWAL_RESTORE_WEIGHT", 0);
+const profile = (env("K6_PROFILE", "MEMWAL_K6_PROFILE") ?? "smoke") as Profile;
+
+let secretKey: Uint8Array | null = null;
+let publicKeyHex = "";
+if (profile !== "health") {
+    if (!accountId) fail("MEMWAL_ACCOUNT_ID or BENCH_ACCOUNT_ID is required");
+    if (!delegateKeyRaw) fail("MEMWAL_DELEGATE_KEY or BENCH_DELEGATE_KEY is required");
+    secretKey = decodeDelegateKey(delegateKeyRaw);
+    publicKeyHex = bytesToHex(ed.getPublicKey(secretKey));
+}
+
+export const options = buildOptions(profile);
+
+const httpErrors = new Counter("memwal_http_errors");
+const requestTimeouts = new Rate("memwal_timeout_rate");
+const rememberEnqueueDuration = new Trend("memwal_remember_enqueue_duration", true);
+const rememberWorkerDuration = new Trend("memwal_remember_worker_duration", true);
+const recallDuration = new Trend("memwal_recall_duration", true);
+const askDuration = new Trend("memwal_ask_duration", true);
+const restoreDuration = new Trend("memwal_restore_duration", true);
+const jobFailures = new Rate("memwal_remember_job_failed_rate");
+
+export function setup() {
+    const health = http.get(`${serverUrl}/health`, {
+        tags: { endpoint: "health", flow: "setup" },
+        timeout: "10s",
+    });
+    check(health, { "setup health is 200": (r) => r.status === 200 });
+    if (health.status !== 200) {
+        fail(`GET /health returned ${health.status}`);
+    }
+    return { baseUrl: serverUrl, namespace };
+}
+
+export function healthOnly() {
+    const res = http.get(`${serverUrl}/health`, {
+        tags: { endpoint: "health", flow: "health" },
+        timeout: "10s",
+    });
+    recordHttpResult(res.status, "health");
+    check(res, { "health is 200": (r) => r.status === 200 });
+}
+
+export function smoke() {
+    healthOnly();
+    const job = remember();
+    if (job) {
+        pollRememberJob(job.jobId, job.startedAt);
+    }
+    recall();
+}
+
+export function mixedFlow() {
+    sampleHealth("mixed");
+    const total = recallWeight + rememberWeight + askWeight + restoreWeight;
+    if (total <= 0) {
+        recall();
+        return;
+    }
+
+    const r = Math.random() * total;
+    if (r < recallWeight) {
+        recall();
+    } else if (r < recallWeight + rememberWeight) {
+        const job = remember();
+        if (job && shouldPollRemember()) {
+            pollRememberJob(job.jobId, job.startedAt);
+        }
+    } else if (r < recallWeight + rememberWeight + askWeight) {
+        ask();
+    } else {
+        restore();
+    }
+}
+
+export function recallOnly() {
+    sampleHealth("recall");
+    recall();
+}
+
+export function rememberOnly() {
+    sampleHealth("remember");
+    const job = remember();
+    if (job && shouldPollRemember()) {
+        pollRememberJob(job.jobId, job.startedAt);
+    }
+}
+
+export function askOnly() {
+    sampleHealth("ask");
+    ask();
+}
+
+export function restoreOnly() {
+    sampleHealth("restore");
+    restore();
+}
+
+function remember(): { jobId: string; startedAt: number } | null {
+    const startedAt = Date.now();
+    const body = {
+        text: `${rememberText} vu=${exec.vu.idInTest} iter=${exec.scenario.iterationInTest} ts=${startedAt}`,
+        namespace,
+    };
+    const res = signedRequest("POST", "/api/remember", body, "remember_enqueue");
+    rememberEnqueueDuration.add(res.durationMs);
+
+    const ok = check(res, {
+        "remember accepted": (r) => r.status === 202,
+        "remember returned job_id": (r) => typeof r.json?.job_id === "string",
+    });
+    if (!ok) return null;
+
+    return { jobId: res.json!.job_id as string, startedAt };
+}
+
+function pollRememberJob(jobId: string, startedAt: number): boolean {
+    const path = `/api/remember/${jobId}`;
+    while (Date.now() - startedAt < rememberPollTimeoutMs) {
+        const res = signedRequest("GET", path, undefined, "remember_status");
+        if (res.status !== 200) {
+            sleep(rememberPollIntervalMs / 1000);
+            continue;
+        }
+
+        const status = res.json?.status;
+        if (status === "done") {
+            rememberWorkerDuration.add(Date.now() - startedAt);
+            jobFailures.add(false);
+            return true;
+        }
+        if (status === "failed") {
+            rememberWorkerDuration.add(Date.now() - startedAt);
+            jobFailures.add(true);
+            return false;
+        }
+        sleep(rememberPollIntervalMs / 1000);
+    }
+
+    requestTimeouts.add(true, { endpoint: "remember_worker" });
+    jobFailures.add(true);
+    return false;
+}
+
+function recall() {
+    const res = signedRequest("POST", "/api/recall", { query, namespace, limit }, "recall");
+    recallDuration.add(res.durationMs);
+    check(res, {
+        "recall is 200": (r) => r.status === 200,
+        "recall has results array": (r) => Array.isArray(r.json?.results),
+    });
+}
+
+function ask() {
+    const res = signedRequest(
+        "POST",
+        "/api/ask",
+        { question: query, namespace, limit },
+        "ask",
+    );
+    askDuration.add(res.durationMs);
+    check(res, {
+        "ask is 200": (r) => r.status === 200,
+        "ask has answer": (r) => typeof r.json?.answer === "string",
+    });
+}
+
+function restore() {
+    const res = signedRequest("POST", "/api/restore", { namespace, limit }, "restore");
+    restoreDuration.add(res.durationMs);
+    check(res, {
+        "restore is 200": (r) => r.status === 200,
+        "restore reports totals": (r) => typeof r.json?.total === "number",
+    });
+}
+
+function signedRequest(
+    method: "GET" | "POST",
+    path: string,
+    body: Json | undefined,
+    endpoint: string,
+): { status: number; durationMs: number; json?: Json } {
+    if (!secretKey) fail("signedRequest called without a delegate key");
+
+    const bodyStr = method === "GET" ? "" : JSON.stringify(body ?? {});
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const nonce = randomUuid();
+    const bodyHash = bytesToHex(sha256(utf8(bodyStr)));
+    const message = `${timestamp}.${method}.${path}.${bodyHash}.${nonce}.${accountId}`;
+    const signature = ed.sign(utf8(message), secretKey);
+
+    try {
+        const res = http.request(method, `${serverUrl}${path}`, method === "GET" ? null : bodyStr, {
+            headers: {
+                "Content-Type": "application/json",
+                "x-public-key": publicKeyHex,
+                "x-signature": bytesToHex(signature),
+                "x-timestamp": timestamp,
+                "x-nonce": nonce,
+                "x-account-id": accountId,
+                "x-delegate-key": normalizeDelegateKeyForHeader(delegateKeyRaw),
+            },
+            tags: { endpoint },
+            timeout: requestTimeout,
+        });
+
+        recordHttpResult(res.status, endpoint);
+        return {
+            status: res.status,
+            durationMs: res.timings.duration,
+            json: parseJson(res.body),
+        };
+    } catch (err) {
+        httpErrors.add(1, { endpoint });
+        requestTimeouts.add(String(err).toLowerCase().includes("timeout"), { endpoint });
+        return { status: 0, durationMs: 0 };
+    }
+}
+
+function sampleHealth(flow: string) {
+    if (healthSampleRate <= 0 || Math.random() > healthSampleRate) return;
+    const res = http.get(`${serverUrl}/health`, {
+        tags: { endpoint: "health", flow },
+        timeout: "10s",
+    });
+    recordHttpResult(res.status, "health");
+}
+
+function shouldPollRemember(): boolean {
+    const raw = __ENV.MEMWAL_POLL_REMEMBER ?? "true";
+    return raw !== "0" && raw.toLowerCase() !== "false";
+}
+
+function recordHttpResult(status: number, endpoint: string) {
+    if (status === 0 || status >= 400) {
+        httpErrors.add(1, { endpoint });
+    }
+    requestTimeouts.add(status === 0, { endpoint });
+}
+
+function parseJson(body: unknown): Json | undefined {
+    if (typeof body !== "string" || body.length === 0) return undefined;
+    try {
+        return JSON.parse(body) as Json;
+    } catch {
+        return undefined;
+    }
+}
+
+function buildOptions(selectedProfile: Profile) {
+    const thresholds = {
+        http_req_failed: ["rate<0.05"],
+        "http_req_duration{endpoint:health}": ["p(95)<500", "p(99)<1000"],
+        memwal_timeout_rate: ["rate<0.02"],
+        memwal_remember_job_failed_rate: ["rate<0.05"],
+        memwal_recall_duration: ["p(95)<5000", "p(99)<10000"],
+        memwal_remember_enqueue_duration: ["p(95)<2000", "p(99)<5000"],
+    };
+
+    if (selectedProfile === "health") {
+        return {
+            scenarios: {
+                health: {
+                    executor: "constant-arrival-rate",
+                    rate: intEnv("K6_HEALTH_RATE", 10),
+                    timeUnit: "1s",
+                    duration: __ENV.K6_DURATION ?? "2m",
+                    preAllocatedVUs: intEnv("K6_PRE_ALLOCATED_VUS", 20),
+                    exec: "healthOnly",
+                },
+            },
+            thresholds,
+        };
+    }
+
+    if (selectedProfile === "load") {
+        return {
+            scenarios: {
+                load: {
+                    executor: "constant-arrival-rate",
+                    rate: intEnv("K6_RATE", 1),
+                    timeUnit: "1s",
+                    duration: __ENV.K6_DURATION ?? "5m",
+                    preAllocatedVUs: intEnv("K6_PRE_ALLOCATED_VUS", 20),
+                    maxVUs: intEnv("K6_MAX_VUS", 100),
+                    exec: __ENV.K6_EXEC ?? "mixedFlow",
+                },
+            },
+            thresholds,
+        };
+    }
+
+    if (selectedProfile === "stress") {
+        return {
+            scenarios: {
+                stress: {
+                    executor: "ramping-arrival-rate",
+                    startRate: 1,
+                    timeUnit: "1s",
+                    preAllocatedVUs: intEnv("K6_PRE_ALLOCATED_VUS", 30),
+                    maxVUs: intEnv("K6_MAX_VUS", 200),
+                    exec: __ENV.K6_EXEC ?? "mixedFlow",
+                    stages: [
+                        { target: intEnv("K6_STRESS_STAGE_1_RATE", 2), duration: __ENV.K6_STRESS_STAGE_1_DURATION ?? "2m" },
+                        { target: intEnv("K6_STRESS_STAGE_2_RATE", 5), duration: __ENV.K6_STRESS_STAGE_2_DURATION ?? "5m" },
+                        { target: intEnv("K6_STRESS_STAGE_3_RATE", 10), duration: __ENV.K6_STRESS_STAGE_3_DURATION ?? "5m" },
+                        { target: 0, duration: __ENV.K6_STRESS_COOLDOWN ?? "1m" },
+                    ],
+                },
+            },
+            thresholds,
+        };
+    }
+
+    if (selectedProfile === "spike") {
+        return {
+            scenarios: {
+                spike: {
+                    executor: "ramping-arrival-rate",
+                    startRate: intEnv("K6_SPIKE_BASE_RATE", 1),
+                    timeUnit: "1s",
+                    preAllocatedVUs: intEnv("K6_PRE_ALLOCATED_VUS", 50),
+                    maxVUs: intEnv("K6_MAX_VUS", 300),
+                    exec: __ENV.K6_EXEC ?? "mixedFlow",
+                    stages: [
+                        { target: intEnv("K6_SPIKE_BASE_RATE", 1), duration: "30s" },
+                        { target: intEnv("K6_SPIKE_RATE", 30), duration: "15s" },
+                        { target: intEnv("K6_SPIKE_RATE", 30), duration: "45s" },
+                        { target: intEnv("K6_SPIKE_BASE_RATE", 1), duration: "1m" },
+                    ],
+                },
+            },
+            thresholds,
+        };
+    }
+
+    return {
+        scenarios: {
+            smoke: {
+                executor: "shared-iterations",
+                vus: 1,
+                iterations: 1,
+                maxDuration: "5m",
+                exec: "smoke",
+            },
+        },
+        thresholds,
+    };
+}
+
+function decodeDelegateKey(key: string): Uint8Array {
+    if (key.startsWith("suiprivkey")) {
+        const decoded = bech32.decode(key, 1_000);
+        if (decoded.prefix !== "suiprivkey") {
+            throw new Error(`unexpected Sui private key prefix: ${decoded.prefix}`);
+        }
+        const bytes = Uint8Array.from(bech32.fromWords(decoded.words));
+        if (bytes[0] !== 0) {
+            throw new Error("k6 relayer tests require an Ed25519 Sui delegate key");
+        }
+        if (bytes.length !== 33) {
+            throw new Error(`expected 33 Sui private key bytes, got ${bytes.length}`);
+        }
+        return bytes.slice(1);
+    }
+
+    const hex = stripHexPrefix(key);
+    if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+        throw new Error("delegate key must be 64-char hex, 0x-prefixed hex, or suiprivkey");
+    }
+    return hexToBytes(hex);
+}
+
+function normalizeDelegateKeyForHeader(key: string): string {
+    return key.startsWith("0x") && key.length === 66 ? key.slice(2) : key;
+}
+
+function randomUuid(): string {
+    const hex = `${randomHex(8)}${randomHex(8)}${randomHex(8)}${randomHex(8)}`.split("");
+    hex[12] = "4";
+    hex[16] = ((parseInt(hex[16], 16) & 0x3) | 0x8).toString(16);
+    return `${hex.slice(0, 8).join("")}-${hex.slice(8, 12).join("")}-${hex
+        .slice(12, 16)
+        .join("")}-${hex.slice(16, 20).join("")}-${hex.slice(20, 32).join("")}`;
+}
+
+function randomHex(chars: number): string {
+    let out = "";
+    while (out.length < chars) {
+        out += Math.floor(Math.random() * 0xffffffff)
+            .toString(16)
+            .padStart(8, "0");
+    }
+    return out.slice(0, chars);
+}
+
+function utf8(input: string): Uint8Array {
+    return new TextEncoder().encode(input);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    let out = "";
+    for (const b of bytes) {
+        out += b.toString(16).padStart(2, "0");
+    }
+    return out;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i += 1) {
+        bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes;
+}
+
+function stripHexPrefix(value: string): string {
+    return value.startsWith("0x") ? value.slice(2) : value;
+}
+
+function trimTrailingSlash(value: string): string {
+    return value.replace(/\/+$/, "");
+}
+
+function env(...names: string[]): string | undefined {
+    for (const name of names) {
+        const value = __ENV[name];
+        if (value !== undefined && value !== "") return value;
+    }
+    return undefined;
+}
+
+function intEnv(name: string, fallback: number): number {
+    const value = __ENV[name];
+    if (!value) return fallback;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function numberEnv(name: string, fallback: number): number {
+    const value = __ENV[name];
+    if (!value) return fallback;
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+}

--- a/services/server/scripts/package-lock.json
+++ b/services/server/scripts/package-lock.json
@@ -13,13 +13,16 @@
                 "@mysten/seal": "1.1.0",
                 "@mysten/sui": "2.5.0",
                 "@mysten/walrus": "1.0.3",
-                "@noble/ed25519": "2.3.0",
+                "@noble/ed25519": "^3.1.0",
                 "express": "5.1.0",
                 "tsx": "4.21.0",
                 "zod": "^3.25.0"
             },
             "devDependencies": {
+                "@noble/hashes": "^2.2.0",
                 "@types/express": "5.0.0",
+                "bech32": "^2.0.0",
+                "esbuild": "^0.28.0",
                 "typescript": "5.6.3"
             }
         },
@@ -52,12 +55,13 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -68,12 +72,13 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -84,12 +89,13 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -100,12 +106,13 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -116,12 +123,13 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -132,12 +140,13 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -148,12 +157,13 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -164,12 +174,13 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -180,12 +191,13 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -196,12 +208,13 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -212,12 +225,13 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -228,12 +242,13 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -244,12 +259,13 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -260,12 +276,13 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -276,12 +293,13 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -292,12 +310,13 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -308,12 +327,13 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -340,12 +360,13 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -356,12 +377,13 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -372,12 +394,13 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -404,12 +427,13 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -420,12 +444,13 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -436,12 +461,13 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -452,12 +478,13 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -610,15 +637,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
-            "version": "3.25.2",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-            "license": "ISC",
-            "peerDependencies": {
-                "zod": "^3.25.28 || ^4"
-            }
-        },
         "node_modules/@mysten-incubation/memwal": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@mysten-incubation/memwal/-/memwal-0.0.3.tgz",
@@ -647,13 +665,22 @@
                 }
             }
         },
+        "node_modules/@mysten-incubation/memwal/node_modules/@noble/ed25519": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+            "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@mysten/bcs": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.0.5.tgz",
-            "integrity": "sha512-Dop9Xq36DPLlsmIDQZvUg4uJeBBxIGirgp2OXGaEff+mtLKFBoW2HnE3aSTSSpiMQH9XRhjwtiM16zFJhFqz0Q==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.0.2.tgz",
+            "integrity": "sha512-c/nVRPJEV1fRZdKXhysVsy/yCPdiFt7jn6A4/7W2LH1ZPSVPzRkxtLY362D0zaLuBnyT5Y9d9nFLm3ixI8Goug==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@mysten/utils": "^0.3.3",
+                "@mysten/utils": "^0.3.1",
                 "@scure/base": "^2.0.0"
             }
         },
@@ -698,9 +725,9 @@
             }
         },
         "node_modules/@mysten/utils": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.3.3.tgz",
-            "integrity": "sha512-gVHn5toh24eXXLEyBknwwM2F/tbDgqPX0yj77KtHjuoYUallcQ9vSwGfGsAy39IcTB259Yprt/ZOEwdup+zrpA==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.3.1.tgz",
+            "integrity": "sha512-36KhxG284uhDdSnlkyNaS6fzKTX9FpP2WQWOwUKIRsqQFFIm2ooCf2TP1IuqrtMpkairwpiWkAS0eg7cpemVzg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scure/base": "^2.0.0"
@@ -722,9 +749,9 @@
             }
         },
         "node_modules/@mysten/walrus-wasm": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@mysten/walrus-wasm/-/walrus-wasm-0.2.2.tgz",
-            "integrity": "sha512-MbI1OAYvnlcdYo3hhSPgMra4Loiox32gI13aP+EpC1pjVxkIRnINzM2FcUgu1PIrl/L49O6f+latQm0vcCGXiQ=="
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@mysten/walrus-wasm/-/walrus-wasm-0.2.0.tgz",
+            "integrity": "sha512-QYZoS6CIoFnVxqYClXkwgeoUjnNUyPdXwoD1Re4Xo/TVdXXmpH46akodNJ+e6egUSrjzHgeiRgfAuq57sDXGNA=="
         },
         "node_modules/@noble/curves": {
             "version": "2.0.1",
@@ -741,19 +768,31 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@noble/curves/node_modules/@noble/hashes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@noble/ed25519": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
-            "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+            "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
             "license": "MIT",
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@noble/hashes": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -810,6 +849,18 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@scure/bip39": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
@@ -818,6 +869,18 @@
             "dependencies": {
                 "@noble/hashes": "2.0.1",
                 "@scure/base": "2.0.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -967,6 +1030,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/bech32": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+            "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "2.2.2",
@@ -1193,9 +1263,10 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -1205,32 +1276,66 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.7",
-                "@esbuild/android-arm": "0.27.7",
-                "@esbuild/android-arm64": "0.27.7",
-                "@esbuild/android-x64": "0.27.7",
-                "@esbuild/darwin-arm64": "0.27.7",
-                "@esbuild/darwin-x64": "0.27.7",
-                "@esbuild/freebsd-arm64": "0.27.7",
-                "@esbuild/freebsd-x64": "0.27.7",
-                "@esbuild/linux-arm": "0.27.7",
-                "@esbuild/linux-arm64": "0.27.7",
-                "@esbuild/linux-ia32": "0.27.7",
-                "@esbuild/linux-loong64": "0.27.7",
-                "@esbuild/linux-mips64el": "0.27.7",
-                "@esbuild/linux-ppc64": "0.27.7",
-                "@esbuild/linux-riscv64": "0.27.7",
-                "@esbuild/linux-s390x": "0.27.7",
-                "@esbuild/linux-x64": "0.27.7",
-                "@esbuild/netbsd-arm64": "0.27.7",
-                "@esbuild/netbsd-x64": "0.27.7",
-                "@esbuild/openbsd-arm64": "0.27.7",
-                "@esbuild/openbsd-x64": "0.27.7",
-                "@esbuild/openharmony-arm64": "0.27.7",
-                "@esbuild/sunos-x64": "0.27.7",
-                "@esbuild/win32-arm64": "0.27.7",
-                "@esbuild/win32-ia32": "0.27.7",
-                "@esbuild/win32-x64": "0.27.7"
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
+            }
+        },
+        "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/escape-html": {
@@ -2056,6 +2161,431 @@
                 "fsevents": "~2.3.3"
             }
         },
+        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
         "node_modules/type-is": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -2150,6 +2680,15 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25.28 || ^4"
             }
         }
     }

--- a/services/server/scripts/package.json
+++ b/services/server/scripts/package.json
@@ -5,7 +5,13 @@
     "type": "module",
     "scripts": {
         "sidecar": "tsx sidecar-server.ts",
-        "test": "node --test --import tsx './mcp/__tests__/*.test.ts'"
+        "test": "node --test --import tsx './mcp/__tests__/*.test.ts'",
+        "k6:build": "esbuild k6/relayer.ts --bundle --platform=browser --format=esm --target=es2020 --external:k6 --external:k6/* --outfile=dist/k6/relayer.js",
+        "k6:health": "npm run k6:build && K6_PROFILE=health k6 run dist/k6/relayer.js",
+        "k6:smoke": "npm run k6:build && K6_PROFILE=smoke k6 run dist/k6/relayer.js",
+        "k6:load": "npm run k6:build && K6_PROFILE=load k6 run dist/k6/relayer.js",
+        "k6:stress": "npm run k6:build && K6_PROFILE=stress k6 run dist/k6/relayer.js",
+        "k6:spike": "npm run k6:build && K6_PROFILE=spike k6 run dist/k6/relayer.js"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -13,13 +19,16 @@
         "@mysten/seal": "1.1.0",
         "@mysten/sui": "2.5.0",
         "@mysten/walrus": "1.0.3",
-        "@noble/ed25519": "2.3.0",
+        "@noble/ed25519": "^3.1.0",
         "express": "5.1.0",
         "tsx": "4.21.0",
         "zod": "^3.25.0"
     },
     "devDependencies": {
+        "@noble/hashes": "^2.2.0",
         "@types/express": "5.0.0",
+        "bech32": "^2.0.0",
+        "esbuild": "^0.28.0",
         "typescript": "5.6.3"
     }
 }

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -30,6 +30,7 @@ import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-con
 // ============================================================
 
 const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
+const SUI_RPC_URL = process.env.SUI_RPC_URL || getJsonRpcFullnodeUrl(SUI_NETWORK);
 
 const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
 const SEAL_THRESHOLD = getSealThresholdFromEnv(SEAL_SERVER_CONFIGS);
@@ -70,7 +71,7 @@ const WALRUS_UPLOAD_RELAY_URL = process.env.WALRUS_UPLOAD_RELAY_URL || (
 const DEFAULT_WALRUS_EPOCHS = SUI_NETWORK === "testnet" ? 50 : 3;
 
 const suiClient = new SuiJsonRpcClient({
-    url: getJsonRpcFullnodeUrl(SUI_NETWORK),
+    url: SUI_RPC_URL,
     network: SUI_NETWORK,
 });
 


### PR DESCRIPTION
## Summary
- add k6 stress test harness for the relayer
- enable native TLS support for sqlx so the Rust services can connect to Neon Postgres with sslmode=require

## Verification
- cargo check in services/server
- cargo check in services/indexer