### PR TITLE
fix(relayer): enable TLS for Neon Postgres

### DIFF
--- a/services/indexer/Cargo.lock
+++ b/services/indexer/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "indexmap",
  "log",
  "memchr",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "serde",

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 
 # Database (PostgreSQL)
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "chrono"] }
 
 # HTTP client (for Sui RPC)
 reqwest = { version = "0.12", features = ["json"] }

--- a/services/server/Cargo.lock
+++ b/services/server/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "indexmap",
  "log",
  "memchr",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "serde",

--- a/services/server/Cargo.toml
+++ b/services/server/Cargo.toml
@@ -11,7 +11,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # Database (PostgreSQL + pgvector)
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "chrono", "uuid"] }
 pgvector = { version = "0.4", features = ["sqlx"] }
 
 # Auth


### PR DESCRIPTION
## Summary
- enable native TLS support for sqlx in the relayer server and indexer
- allow Neon Postgres URLs with sslmode=require to connect successfully

## Verification
- cargo check in services/server
- cargo check in services/indexer