### PR TITLE
Clean up ENG-1405 follow-ups

### DIFF
--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -86,6 +86,7 @@ body,
 
 body {
   background-image: none;
+  overflow-x: hidden;
 }
 
 h1, h2, h3 {
@@ -442,26 +443,37 @@ h1, h2, h3 {
 }
 
 .lp-nav-inner {
+  position: relative;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 20px;
+  min-width: 0;
 }
 
 .lp-nav-brand {
   display: flex;
   align-items: center;
   text-decoration: none;
+  min-width: 0;
 }
 
 .lp-nav-brand img {
   height: 28px;
+  max-width: min(280px, 46vw);
 }
 
 .lp-nav-links {
   display: flex;
   align-items: center;
   gap: 32px;
+  min-width: 0;
+  flex-shrink: 0;
+}
+
+.lp-nav-links > :only-child {
+  grid-column: 1 / -1;
 }
 
 .lp-nav-links a:not(.lp-nav-cta) {
@@ -503,6 +515,13 @@ h1, h2, h3 {
   cursor: pointer;
   transition: transform 0.15s, box-shadow 0.15s;
   box-shadow: 3px 3px 0 #000000;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  line-height: 1.05;
+  text-align: center;
+  white-space: nowrap;
 }
 
 .lp-nav-cta:hover {
@@ -524,6 +543,7 @@ h1, h2, h3 {
 .lp-demo-trigger {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
   background: none;
   border: 2px solid #000000;
@@ -780,6 +800,21 @@ h1, h2, h3 {
   width: 100%;
 }
 
+.lp-login-menu {
+  width: min(360px, calc(100vw - 48px));
+  max-width: calc(100vw - 48px);
+}
+
+.lp-login-provider-btn {
+  min-width: 0;
+  overflow: hidden;
+  white-space: normal;
+}
+
+.lp-login-provider-btn svg {
+  flex: 0 0 auto;
+}
+
 .lp-login-wallet-btn [class*="ConnectButton"],
 .lp-login-wallet-btn div {
   width: 100% !important;
@@ -814,6 +849,19 @@ h1, h2, h3 {
     padding: 0 24px;
   }
 
+  .lp-nav-inner {
+    gap: 16px;
+  }
+
+  .lp-nav-links {
+    gap: 14px;
+  }
+
+  .lp-nav-cta,
+  .lp-demo-trigger {
+    padding: 10px 14px;
+  }
+
   .lp-hero {
     padding: 0 24px;
   }
@@ -842,7 +890,78 @@ h1, h2, h3 {
   }
 }
 
+@media (max-width: 640px) {
+  .lp-nav {
+    height: auto;
+    min-height: 72px;
+    padding: 12px 18px;
+  }
+
+  .lp-nav-inner {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .lp-nav-brand img {
+    max-width: 220px;
+  }
+
+  .lp-nav-links {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr);
+    gap: 12px;
+  }
+
+  .lp-demo-dropdown,
+  .lp-demo-trigger,
+  .lp-nav-links .lp-nav-cta {
+    width: 100%;
+  }
+
+  .lp-demo-menu {
+    left: 0;
+    right: auto;
+    width: min(280px, calc(100vw - 36px));
+  }
+
+  .lp-login-dropdown {
+    position: static;
+  }
+
+  .lp-login-menu {
+    left: 0;
+    right: 0;
+    width: 100% !important;
+    max-width: none;
+    min-width: 0 !important;
+  }
+}
+
 @media (max-width: 480px) {
+  .lp-nav {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .lp-nav-brand img {
+    max-width: 200px;
+  }
+
+  .lp-nav-links {
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+
+  .lp-nav-cta,
+  .lp-demo-trigger {
+    min-height: 52px;
+    padding: 9px 10px;
+    font-size: 0.86rem;
+    white-space: normal;
+  }
+
   .lp-hero-copy h1 {
     font-size: 2rem;
   }
@@ -890,6 +1009,17 @@ h1, h2, h3 {
   font-size: 0.9rem;
 }
 
+.dashboard-cta-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.dashboard-cta-row > :only-child {
+  grid-column: 1 / -1;
+}
+
 .dashboard-cta {
   display: flex;
   align-items: center;
@@ -904,6 +1034,13 @@ h1, h2, h3 {
   box-shadow: var(--neo-shadow);
   cursor: pointer;
   transition: transform 0.1s ease, box-shadow 0.1s ease;
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+.dashboard-cta--disabled {
+  cursor: default;
+  opacity: 0.75;
 }
 
 .dashboard-cta:hover {
@@ -920,12 +1057,14 @@ h1, h2, h3 {
   font-size: 1.15rem;
   font-weight: 800;
   color: #0d0e16;
+  overflow-wrap: anywhere;
 }
 
 .dashboard-cta-subtitle {
   font-size: 0.88rem;
   font-weight: 500;
   color: #3a3b48;
+  overflow-wrap: anywhere;
 }
 
 .dashboard-cta-arrow {
@@ -1006,6 +1145,14 @@ h1, h2, h3 {
   display: flex;
   gap: 8px;
   margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.card-header-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .key-display .btn-secondary {
@@ -1442,20 +1589,131 @@ h1, h2, h3 {
 @media (max-width: 640px) {
   .nav {
     padding: 0 14px;
+    height: auto;
+    min-height: 64px;
   }
 
   .nav-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
     height: auto;
     min-height: 64px;
-    padding: 12px 0;
-    flex-wrap: wrap;
-    gap: 10px;
+    padding: 14px 0;
+    gap: 10px 14px;
+  }
+
+  .nav-brand {
+    min-width: 0;
+  }
+
+  .nav-brand img {
+    max-width: min(220px, 58vw);
   }
 
   .nav-user {
+    display: contents;
+  }
+
+  .nav-address {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-self: start;
+    max-width: 100%;
+  }
+
+  .nav-user .demo-nav-back {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-self: start;
+  }
+
+  .nav-user .demo-nav-back + .nav-address {
+    grid-row: 3;
+  }
+
+  .nav-user .lp-nav-cta {
+    grid-column: 2;
+    grid-row: 1;
+    min-height: 48px;
+    padding: 9px 16px;
+  }
+
+  .dashboard {
+    padding: 32px 18px;
+  }
+
+  .dashboard-header {
+    margin-bottom: 24px;
+  }
+
+  .dashboard-cta-row {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .dashboard-cta {
+    min-height: 116px;
+    padding: 18px 20px;
+  }
+
+  .dashboard-cta-title {
+    font-size: 1.05rem;
+  }
+
+  .card {
+    padding: 18px;
+  }
+
+  .card-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .card-header-actions {
     width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .card-header-actions .btn,
+  .card-header-actions .lp-nav-cta {
+    width: 100%;
+    min-height: 52px;
+  }
+
+  .key-display {
+    padding: 16px;
+  }
+
+  .key-display .key-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .key-display .key-actions .btn {
+    width: 100%;
+  }
+
+  .install-tabs {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 6px;
+    margin-bottom: 8px;
+    overflow: visible;
+  }
+
+  .install-tab,
+  .install-tab:last-child {
+    border: 2px solid #000000;
+    border-radius: 10px;
+    min-height: 54px;
+    padding: 10px 12px;
+  }
+
+  .install-tabs + .demo-code-block {
+    border-top-left-radius: 12px;
   }
 
   .dashboard-cta-arrow {

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -391,9 +391,9 @@ const result = await generateText({
                 )}
 
                 {/* Action CTAs */}
-                <div style={{ display: 'flex', gap: 16, marginBottom: 24 }}>
+                <div className="dashboard-cta-row">
                     {delegateKey ? (
-                        <Link to="/playground" className="dashboard-cta" style={{ flex: 1, marginBottom: 0 }}>
+                        <Link to="/playground" className="dashboard-cta">
                             <div>
                                 <div className="dashboard-cta-title">
                                     try interactive demo
@@ -405,7 +405,7 @@ const result = await generateText({
                             <div className="dashboard-cta-arrow">→</div>
                         </Link>
                     ) : hasMaxDelegateKeys ? (
-                        <div className="dashboard-cta" style={{ flex: 1, marginBottom: 0, cursor: 'default', opacity: 0.75 }}>
+                        <div className="dashboard-cta dashboard-cta--disabled">
                             <div>
                                 <div className="dashboard-cta-title">
                                     remove a key first
@@ -417,7 +417,7 @@ const result = await generateText({
                             <div className="dashboard-cta-arrow">↓</div>
                         </div>
                     ) : (
-                        <Link to="/setup" className="dashboard-cta" style={{ flex: 1, marginBottom: 0 }}>
+                        <Link to="/setup" className="dashboard-cta">
                             <div>
                                 <div className="dashboard-cta-title">
                                     create delegate key
@@ -430,7 +430,7 @@ const result = await generateText({
                         </Link>
                     )}
                     {config.docsUrl && (
-                        <a href={config.docsUrl} target="_blank" rel="noopener noreferrer" className="dashboard-cta" style={{ flex: 1, marginBottom: 0 }}>
+                        <a href={config.docsUrl} target="_blank" rel="noopener noreferrer" className="dashboard-cta">
                             <div>
                                 <div className="dashboard-cta-title">
                                     documentation
@@ -532,7 +532,7 @@ const result = await generateText({
                                 all Ed25519 keys registered on your MemWalAccount
                             </div>
                         </div>
-                        <div style={{ display: 'flex', gap: 8 }}>
+                        <div className="card-header-actions">
                             <button
                                 className="btn btn-secondary btn-sm"
                                 onClick={fetchOnChainKeys}

--- a/apps/app/src/pages/LandingPage.tsx
+++ b/apps/app/src/pages/LandingPage.tsx
@@ -155,7 +155,7 @@ export default function LandingPage() {
                                 SDK Playground <span className="lp-arrow">↗</span>
                             </button>
                         ) : (
-                            <div className="lp-demo-dropdown" ref={loginRef}>
+                            <div className="lp-demo-dropdown lp-login-dropdown" ref={loginRef}>
                                 <button
                                     className="lp-nav-cta"
                                     onClick={() => setLoginOpen(o => !o)}
@@ -163,9 +163,10 @@ export default function LandingPage() {
                                     SDK Playground <span className="lp-arrow">↗</span>
                                 </button>
                                 {loginOpen && (
-                                    <div className="lp-demo-menu" style={{ minWidth: 240, padding: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                                    <div className="lp-demo-menu lp-login-menu" style={{ minWidth: 240, padding: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
                                         {hasEnokiConfig && googleWallet && (
                                             <button
+                                                className="lp-login-provider-btn"
                                                 onClick={handleEnokiConnect}
                                                 style={{
                                                     display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10,

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -43,6 +43,7 @@ These are not all enforced at boot, but most real deployments need them.
 | `SEAL_THRESHOLD` | `min(2, total configured weight)` | Required configured server weight for SEAL encrypt/decrypt |
 | `ENOKI_API_KEY` | none | Optional Enoki key for sponsored sidecar transactions |
 | `ENOKI_NETWORK` | `mainnet` | Network used for Enoki-sponsored flows |
+| `ENOKI_FALLBACK_TO_DIRECT_SIGN` | `false` | If true, sidecar pays gas directly with the server wallet when Enoki sponsorship fails or is not configured |
 | `MEMWAL_RELAYER_URL` | `http://127.0.0.1:$PORT` | Relayer URL passed from the Rust server to the sidecar for MCP tool calls |
 | `MCP_MAX_TOTAL_SESSIONS` | `1000` | Maximum active MCP sessions across SSE and Streamable HTTP transports |
 | `MCP_MAX_SESSIONS_PER_IP` | `16` | Maximum active MCP sessions from one source IP |
@@ -50,7 +51,8 @@ These are not all enforced at boot, but most real deployments need them.
 
 ## Notes
 
-- If both `SERVER_SUI_PRIVATE_KEYS` and `SERVER_SUI_PRIVATE_KEY` are set, the key pool takes priority for uploads.
+- If both `SERVER_SUI_PRIVATE_KEYS` and `SERVER_SUI_PRIVATE_KEY` are set, the key pool takes priority for uploads. Upload jobs use the pool in round-robin order.
+- Keep `ENOKI_FALLBACK_TO_DIRECT_SIGN=false` in production if the server wallet should not pay gas when sponsorship is missing, expired, or rejected.
 - `OPENAI_API_KEY` and `OPENAI_API_BASE` control the embedding and fact-extraction provider used by `remember`, `recall`, `analyze`, `ask`, and restore re-indexing.
 - Without `OPENAI_API_KEY`, the server can fall back to mock embeddings. That is useful for local testing, not for normal production behavior.
 - `SUI_NETWORK` drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -59,6 +59,9 @@ MEMWAL_REGISTRY_ID=0x...
 # Enoki Sponsored Transactions (sidecar)
 ENOKI_API_KEY=
 ENOKI_NETWORK=mainnet
+# Keep false in production so missing/expired/rejected sponsorship retries
+# through Apalis instead of making the server wallet pay gas directly.
+ENOKI_FALLBACK_TO_DIRECT_SIGN=false
 
 # Sponsor endpoint rate limiting (per IP + per sender, sliding window)
 SPONSOR_RATE_LIMIT_PER_MINUTE=10

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -139,7 +139,7 @@ const enokiNetwork = (process.env.ENOKI_NETWORK || process.env.SUI_NETWORK || "m
     | "testnet"
     | "devnet";
 const ENOKI_FALLBACK_TO_DIRECT_SIGN = (() => {
-    const raw = (process.env.ENOKI_FALLBACK_TO_DIRECT_SIGN || "true").trim().toLowerCase();
+    const raw = (process.env.ENOKI_FALLBACK_TO_DIRECT_SIGN || "false").trim().toLowerCase();
     return raw !== "0" && raw !== "false" && raw !== "no";
 })();
 
@@ -219,6 +219,11 @@ async function callEnoki<T>(path: string, payload: unknown): Promise<T> {
 
 async function executeWithEnokiSponsor(tx: Transaction, signer: Ed25519Keypair, allowedAddresses?: string[]): Promise<string> {
     if (!enokiApiKey) {
+        if (!ENOKI_FALLBACK_TO_DIRECT_SIGN) {
+            throw new Error("ENOKI_API_KEY is not configured and ENOKI_FALLBACK_TO_DIRECT_SIGN=false");
+        }
+
+        console.warn("[enoki-sponsor] ENOKI_API_KEY not configured, falling back to direct signing");
         const direct = await suiClient.signAndExecuteTransaction({
             signer,
             transaction: tx,

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1,10 +1,10 @@
 /// Wallet signing job queue.
 ///
 /// Every operation that requires a Sui wallet signature is modelled as a
-/// `WalletJob` jobs are signed by the configured server wallet.
+/// `WalletJob` jobs are signed by the configured server wallet pool.
 /// This guarantees that:
 ///   - upload → metadata+transfer use the same key for a given job
-///   - signing operations can run concurrently on the same wallet
+///   - signing operations can run concurrently across the configured wallets
 ///   - jobs survive server restarts (persisted in Postgres via Apalis)
 ///
 /// Retry policy: up to MAX_ATTEMPTS attempts with exponential back-off.
@@ -103,12 +103,13 @@ pub(crate) async fn warm_blob_cache_after_upload(
     }
 }
 
-/// A wallet job. `wallet_index` is retained for legacy/audit payloads; new
-/// jobs use `0` and all routing goes through the single shared wallet queue.
+/// A wallet job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletJob {
     /// Index into `config.sui_private_keys` used by the sidecar for signing.
-    /// New jobs use 0 after the single-wallet simplification.
+    /// For `UploadAndTransfer`, this is the enqueue-time assignment used for
+    /// logging only; the worker selects a fresh round-robin wallet at execution
+    /// time so retries can move to another wallet.
     pub wallet_index: usize,
     pub operation: WalletOperation,
 }
@@ -209,13 +210,13 @@ pub fn backoff_duration(attempt: u32) -> std::time::Duration {
 
 /// Apalis worker handler for WalletJob.
 ///
-/// Multiple concurrent invocations of this handler share the single signing
-/// wallet (Apalis `WALLET_JOB_CONCURRENCY` controls fan-out, default 8). The
-/// `wallet_index` field in the job payload is retained for audit only —
-/// routing dimension was removed per MEM-35.
+/// Multiple concurrent invocations of this handler share the `wallet_jobs`
+/// queue. Upload jobs select a fresh wallet index at execution time; legacy
+/// metadata-transfer jobs keep their pinned wallet because the blob object is
+/// owned by the wallet that registered/certified it.
 pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Result<(), Error> {
     let state: &AppState = &ctx;
-    let wallet_index = job.wallet_index;
+    let enqueued_wallet_index = job.wallet_index;
 
     let result = match job.operation {
         WalletOperation::UploadAndTransfer {
@@ -228,6 +229,20 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
             remember_job_id,
             epochs,
         } => {
+            let wallet_index = state.key_pool.next_index().ok_or_else(|| {
+                WalletJobError::Permanent(
+                    "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)"
+                        .into(),
+                )
+                .into_apalis_error()
+            })?;
+            if wallet_index != enqueued_wallet_index {
+                tracing::info!(
+                    "[wallet-job:upload] reassigned wallet at execution: enqueued={} executing={}",
+                    enqueued_wallet_index,
+                    wallet_index,
+                );
+            }
             execute_upload_and_transfer(
                 state,
                 wallet_index,
@@ -251,7 +266,7 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
         } => {
             execute_set_metadata_and_transfer(
                 state,
-                wallet_index,
+                enqueued_wallet_index,
                 blob_object_id,
                 owner,
                 namespace,
@@ -267,7 +282,7 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
             tracing::warn!(
                 target: "wallet_job.permanent",
                 "permanent failure for wallet_index={} (will mark Dead): {}",
-                wallet_index,
+                enqueued_wallet_index,
                 msg
             );
         }
@@ -480,8 +495,8 @@ async fn execute_upload_and_transfer(
 ///
 /// Mapping rules (enforced at the point of error origination):
 /// - `MoveAbort(_)` → `Permanent` (deterministic Move-level failure)
-/// - `ObjectLockedAtVersion(_)` → `Transient` (the single-wallet model relies
-///   on retrying any remaining concurrency/race failures)
+/// - `ObjectLockedAtVersion(_)` → `Transient` (retry can rebuild with a fresh
+///   wallet assignment)
 /// - `InsufficientGas` / `ObjectNotFound` /
 ///   `ObjectVersionUnavailableForConsumption` → `Transient` (refill wallet,
 ///   refresh local state, retry)
@@ -509,6 +524,9 @@ impl WalletJobError {
             || lower.contains("object_locked")
             || lower.contains("object is locked")
             || lower.contains("locked at version")
+            || lower.contains("sponsor failed")
+            || lower.contains("enoki api error")
+            || lower.contains("sponsored transaction has expired")
         {
             return WalletJobError::Transient(msg.to_string());
         }
@@ -713,7 +731,7 @@ pub struct BulkRememberItem {
     /// Pre-computed embedding vector (1536-dim).
     pub vector: Vec<f32>,
     pub namespace: String,
-    /// Wallet index assigned at enqueue time. New jobs use 0.
+    /// Wallet index assigned at enqueue time.
     pub wallet_index: usize,
 }
 

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -155,27 +155,14 @@ async fn main() {
     let bulk_job_storage: PostgresStorage<BulkRememberJob> =
         PostgresStorage::new(apalis_pool.clone());
 
-    // Single Apalis queue for all WalletJob signing operations.
-    //
-    // Was previously a Vec of per-wallet queues to avoid Sui coin-object
-    // equivocation locks. Per Will Bradley (Mysten, 2026-05-12 Slack callout):
-    // Sui no longer permanently locks coin objects on equivocation, so a single
-    // wallet + concurrent workers + retry handling is sufficient. Multi-wallet
-    // is only justified for raw throughput, which is not a bottleneck for
-    // background Walrus uploads.
+    // Single Apalis queue for all WalletJob signing operations. Workers select
+    // a key from the configured pool when they execute an upload job, so
+    // retries can rotate away from a wallet whose sponsored tx expired.
     const WALLET_QUEUE_NAME: &str = "wallet_jobs";
     let wallet_storage: WalletJobStorage = PostgresStorage::new_with_config(
         apalis_pool.clone(),
         apalis_sql::Config::new(WALLET_QUEUE_NAME),
     );
-    let pool_size = config.sui_private_keys.len();
-    if pool_size > 1 {
-        tracing::warn!(
-            "  SERVER_SUI_PRIVATE_KEYS has {} entries; only the first is used. \
-             Multi-wallet routing was retired — see plans/simplify-walrus-wallet-queues/.",
-            pool_size,
-        );
-    }
     tracing::info!(
         "  Apalis: job queue ready (table=apalis_jobs, queue={})",
         WALLET_QUEUE_NAME
@@ -193,7 +180,7 @@ async fn main() {
     let pool_size = config.sui_private_keys.len();
     if pool_size > 0 {
         tracing::info!(
-            "  Walrus upload: {} key(s) configured; using first key for wallet jobs",
+            "  Walrus upload: {} key(s) configured; using round-robin wallet jobs",
             pool_size,
         );
     } else {
@@ -202,7 +189,6 @@ async fn main() {
 
     // Build wallet key holder.
     // `Arc` so the MemoryEngine impl's store_blob draws from the same pool.
-    // Wraps dev's single-wallet KeyPool (MEM-35); the engine takes an Arc
     // clone so handlers + the engine share one holder.
     let key_pool = Arc::new(KeyPool::new(config.sui_private_keys.clone()));
 

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -41,13 +41,11 @@ use apalis::prelude::Storage as _;
 // Wallet-job enqueue (used by remember + analyze)
 // ============================================================
 
-/// Enqueue a WalletJob to the (now single) Apalis queue.
+/// Enqueue a WalletJob to the single Apalis wallet queue.
 ///
-/// `wallet_index` is preserved in the job payload for audit / sidecar parity
-/// but no longer drives queue routing — MEM-35 collapsed the per-wallet
-/// queues into a single `wallet_jobs` queue (see plans/simplify-walrus-
-/// wallet-queues/ + KeyPool::next_index). Returns the wallet_index for
-/// caller tracking.
+/// `wallet_index` is preserved in the job payload for audit/logging. Upload
+/// workers select a fresh round-robin key at execution time so Apalis retries
+/// can move to another wallet.
 pub async fn enqueue_wallet_job(
     state: &AppState,
     wallet_index: usize,

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -6,6 +6,7 @@ use crate::jobs::{BulkRememberJobStorage, RememberJobStorage, WalletJobStorage};
 use crate::rate_limit::RateLimitConfig;
 use crate::services::{Embedder, Extractor};
 use crate::storage::db::VectorDb;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// ENG-1408: Max items in a single POST /api/remember/bulk request.
 pub const MAX_BULK_ITEMS: usize = 20;
@@ -85,41 +86,40 @@ pub struct AppState {
 }
 
 // ============================================================
-// Key Pool — single-wallet wrapper
+// Key Pool — round-robin wallet selection
 // ============================================================
 
-/// Wallet key holder. Historically a round-robin pool of N keys used to
-/// horizontally side-step Sui coin-object equivocation locks. Per Will Bradley
-/// (Mysten, 2026-05-12): coin-object locking is no longer a practical concern
-/// on Sui, so a single key with concurrent workers + retry handling is
-/// sufficient. `next_index()` always returns `Some(0)` when a key is
-/// configured (the API is kept so callers can still distinguish "no keys"
-/// from "key available").
+/// Wallet key holder for distributing Walrus uploads across configured server
+/// keys. Apalis retries call `next_index()` again at execution time, so a
+/// transient sponsor/RPC failure can move to the next wallet in the pool.
 pub struct KeyPool {
     keys: Vec<String>,
+    cursor: AtomicUsize,
 }
 
 impl KeyPool {
     pub fn new(keys: Vec<String>) -> Self {
-        // Only the first key is used. Additional keys (if any) are ignored —
-        // surfaced via a warning at boot in main.rs.
-        Self { keys }
+        Self {
+            keys,
+            cursor: AtomicUsize::new(0),
+        }
     }
 
-    /// Returns the first configured key, or `None` if no keys are configured.
+    /// Returns the next configured key in round-robin order.
     #[allow(dead_code)]
     pub fn next(&self) -> Option<&str> {
-        self.keys.first().map(|s| s.as_str())
+        let idx = self.next_index()?;
+        self.keys.get(idx).map(|s| s.as_str())
     }
 
-    /// Returns `Some(0)` when a key is configured, `None` otherwise.
-    /// `wallet_index` is retained in job payloads for audit / sidecar parity
-    /// but no longer drives queue routing.
+    /// Returns the next key index in round-robin order, or `None` if no keys
+    /// are configured.
     pub fn next_index(&self) -> Option<usize> {
-        if self.keys.is_empty() {
+        let len = self.keys.len();
+        if len == 0 {
             None
         } else {
-            Some(0)
+            Some(self.cursor.fetch_add(1, Ordering::Relaxed) % len)
         }
     }
 
@@ -899,14 +899,15 @@ mod tests {
         assert_eq!(resp.status(), axum::http::StatusCode::PAYMENT_REQUIRED);
     }
 
-    // ── KeyPool: single-wallet selection ─────────────────────────────────
+    // ── KeyPool: round-robin selection ─────────────────────────────────
 
     #[test]
-    fn key_pool_returns_first_key() {
+    fn key_pool_returns_keys_round_robin() {
         let pool = KeyPool::new(vec!["key_a".into(), "key_b".into(), "key_c".into()]);
 
         assert_eq!(pool.next(), Some("key_a"));
-        assert_eq!(pool.next(), Some("key_a"));
+        assert_eq!(pool.next(), Some("key_b"));
+        assert_eq!(pool.next(), Some("key_c"));
         assert_eq!(pool.next(), Some("key_a"));
     }
 
@@ -927,10 +928,10 @@ mod tests {
     }
 
     #[test]
-    fn key_pool_next_index_always_zero() {
+    fn key_pool_next_index_round_robin() {
         let pool = KeyPool::new(vec!["a".into(), "b".into()]);
         assert_eq!(pool.next_index(), Some(0));
-        assert_eq!(pool.next_index(), Some(0));
+        assert_eq!(pool.next_index(), Some(1));
         assert_eq!(pool.next_index(), Some(0));
     }
 


### PR DESCRIPTION
## Summary
- Restore round-robin wallet key selection for upload retries and make Enoki direct-sign fallback opt-in.
- Improve responsive landing/dashboard navigation and CTA layouts for mobile and optional single-button states.
- Document the Enoki fallback behavior and server key pool routing.

## Tests
- cargo test
- npm test (services/server/scripts)
- npm run build (apps/app)