### PR TITLE
fix(restore): lower default restore limit

### DIFF
--- a/docs/fundamentals/architecture/how-storage-works.md
+++ b/docs/fundamentals/architecture/how-storage-works.md
@@ -111,7 +111,7 @@ sequenceDiagram
 1. The relayer queries on-chain Walrus blob objects owned by the user, filtered by namespace metadata
 2. It compares against the local database to find which blobs are already indexed
 3. Only missing blobs are downloaded, decrypted, re-embedded, and re-indexed
-4. The restore supports a configurable `limit` (default: 50) to control how many blobs are processed per call
+4. The restore supports a configurable `limit` (default: 10) to control how many blobs are processed per call
 
 Restore is incremental and idempotent — you can call it multiple times safely.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -143,7 +143,7 @@ Use `analyzeAndWait(text, namespace?, opts?)` to wait for every extracted fact j
 
 Rebuild missing indexed entries for one namespace from Walrus. Incremental — only re-indexes blobs that aren't already in the local database.
 
-- `limit` defaults to `50`
+- `limit` defaults to `10`
 
 Returns:
 ```ts

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -300,11 +300,11 @@ Rebuild missing vector entries for one namespace. Queries onchain blobs by owner
 ```json
 {
   "namespace": "demo",
-  "limit": 50
+  "limit": 10
 }
 ```
 
-`limit` defaults to `50`.
+`limit` defaults to `10`.
 
 **Response:**
 

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -122,7 +122,7 @@ Use `analyzeAndWait(text, namespace?, opts?)` to wait for every extracted fact j
 
 Rebuild missing indexed entries for one namespace from Walrus. Incremental — only re-indexes blobs that aren't already in the local database.
 
-- `limit` defaults to `50`
+- `limit` defaults to `10`
 
 **Returns:**
 

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -49,7 +49,7 @@ for (const memory of result.results) {
 }
 
 // Same relayer restore endpoint
-await manual.restore("chatbot-prod", 50);
+await manual.restore("chatbot-prod", 10);
 
 // Check if using a connected wallet signer
 console.log(manual.isWalletMode);

--- a/docs/sdk/usage/memwal.md
+++ b/docs/sdk/usage/memwal.md
@@ -49,7 +49,7 @@ Rebuild missing indexed entries for one namespace. Incremental, namespace-scoped
 repair PostgreSQL vector state from Walrus-backed memory.
 
 ```ts
-const result = await memwal.restore("chatbot-prod", 50);
+const result = await memwal.restore("chatbot-prod", 10);
 ```
 
 ## Lower-Level Methods

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -85,7 +85,7 @@ const TOOL_DEFINITIONS = [
             type: "object",
             properties: {
                 namespace: { type: "string", minLength: 1 },
-                limit: { type: "integer", minimum: 1, maximum: 500, default: 50 },
+                limit: { type: "integer", minimum: 1, maximum: 500, default: 10 },
             },
             required: ["namespace"],
             additionalProperties: false,

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -733,7 +733,7 @@ export class MemWalManual {
      * @param namespace - Namespace to restore
      * @returns RestoreResult with count of restored entries
      */
-    async restore(namespace: string, limit: number = 50): Promise<RestoreResult> {
+    async restore(namespace: string, limit: number = 10): Promise<RestoreResult> {
         return this.signedRequest<RestoreResult>("POST", "/api/restore", {
             namespace,
             limit,

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -626,7 +626,7 @@ export class MemWal {
      * console.log(`Restored ${result.restored} memories`)
      * ```
      */
-    async restore(namespace: string, limit: number = 50): Promise<RestoreResult> {
+    async restore(namespace: string, limit: number = 10): Promise<RestoreResult> {
         return this.signedRequest<RestoreResult>("POST", "/api/restore", {
             namespace,
             limit,

--- a/services/server/scripts/mcp/tools/restore.ts
+++ b/services/server/scripts/mcp/tools/restore.ts
@@ -13,7 +13,7 @@ const RESTORE_INPUT = {
         .int()
         .min(1)
         .max(500)
-        .default(50)
+        .default(10)
         .describe("Max number of memories to re-index (1-500)."),
 } as const;
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -527,13 +527,13 @@ pub struct AskResponse {
 /// POST /api/restore
 /// Restore a namespace: download blobs from Walrus, decrypt, re-embed, re-index
 fn default_restore_limit() -> usize {
-    50
+    10
 }
 
 #[derive(Debug, Deserialize)]
 pub struct RestoreRequest {
     pub namespace: String,
-    /// Max blobs to restore (default: 50)
+    /// Max blobs to restore (default: 10)
     #[serde(default = "default_restore_limit")]
     pub limit: usize,
 }


### PR DESCRIPTION
## Summary
- Lower default restore limit from 50 to 10 in server, SDK, and MCP schemas
- Update restore docs and examples to match the new default

## Testing
- Not run; default literal and docs-only change