### PR TITLE
chore(release): bump SDK package metadata

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @mysten-incubation/memwal-mcp
+
+## 0.0.1
+
+### Initial Release
+
+- Stdio MCP server for MemWal with browser-based wallet login.
+- Inline `memwal_login` and `memwal_logout` session tools.
+- Memory tools for remember, recall, analyze, and restore through the MemWal relayer.
+- Environment presets for production, dev, staging, and local relayers.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @mysten-incubation/memwal
 
+## 0.0.4
+
+### Added
+
+- Added `getRememberStatus(jobId)` so clients can poll and display the full async remember state machine.
+- Added `SealServerConfig` and `sealServerConfigs` for manual-mode SEAL committee aggregator configuration.
+
+### Changed
+
+- Manual mode now normalizes full SEAL server configs, validates optional API key pairs, and caps the default threshold to configured server weight.
+- Manual mode keeps testnet defaults on the legacy independent key servers for compatibility with hosted testnet relayer data.
+
 ## 0.0.3
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "MemWal — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump @mysten-incubation/memwal from 0.0.3 to 0.0.4 for the new public SDK APIs in PR #153
- Add SDK changelog notes for getRememberStatus and manual-mode SEAL server configs
- Add initial MCP changelog for the new @mysten-incubation/memwal-mcp package

## Testing
- pnpm --filter @mysten-incubation/memwal typecheck
- pnpm --filter @mysten-incubation/memwal-mcp typecheck (fails locally because MCP package deps are not installed in node_modules after lockfile-only install; change is changelog-only for MCP)