### PR TITLE
docs(mcp): restructure as landing + quick-start + reference

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,7 +110,9 @@
           {
             "group": "Model Context Protocol",
             "pages": [
-              "mcp/overview"
+              "mcp/overview",
+              "mcp/quick-start",
+              "mcp/reference"
             ]
           }
         ]

--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -1,192 +1,53 @@
 ---
 title: "MCP"
+description: "Give MCP-aware AI clients access to your encrypted Walrus-backed MemWal memory."
 ---
 
-MemWal exposes a Model Context Protocol (MCP) server so MCP-aware clients can read from and write to a user's encrypted Walrus-backed memory.
+MemWal exposes a **Model Context Protocol (MCP) server** so MCP-aware clients can read from and write to your encrypted memory. Use it when you want Cursor, Claude Desktop, Claude Code, Codex, Antigravity, or any other MCP client to call MemWal directly from an agent workflow — without writing custom integration code.
 
-Use MCP when you want tools like Cursor, Claude Desktop, Claude Code, or Antigravity to call MemWal directly from an agent workflow.
+## Features
 
-## Tools
+<CardGroup cols={2}>
+  <Card title="Six Built-In Tools" icon="wrench">
+    `memwal_remember`, `memwal_recall`, `memwal_analyze`, `memwal_restore`, `memwal_login`, `memwal_logout`
+  </Card>
+  <Card title="Inline Browser Login" icon="globe">
+    Agents call `memwal_login` to open a browser sign-in — no separate CLI step, no client restart
+  </Card>
+  <Card title="Two Transports" icon="arrows-left-right">
+    Streamable HTTP for remote MCP clients, or stdio package (`npx`) for local-command clients
+  </Card>
+  <Card title="Encrypted & User-Owned" icon="lock">
+    SEAL-encrypted, stored on Walrus, tied to your delegate key — you own the data
+  </Card>
+  <Card title="Cross-Client Memory" icon="arrows-rotate">
+    Memories saved from Cursor surface in Claude Desktop, Codex, and vice versa — one MemWal account, every client
+  </Card>
+  <Card title="Environment Presets" icon="server">
+    `--prod` / `--staging` / `--dev` / `--local` flags switch networks without editing client configs
+  </Card>
+</CardGroup>
 
-The MCP server exposes six tools — four memory tools that round-trip to the relayer, and two session tools served locally by the stdio package.
+## When to use this
 
-**Memory tools** (forwarded to the relayer):
+- You want an AI client to **call MemWal directly** — no custom SDK integration code in your app
+- You need the agent to **remember across conversations and sessions**
+- You're running **multiple MCP clients** and want all of them to share one memory store
+- You need **encrypted, user-owned memory** instead of platform-managed storage
 
-| Tool | Purpose |
-| --- | --- |
-| `memwal_remember` | Save a memory to MemWal |
-| `memwal_recall` | Search saved memories by query |
-| `memwal_analyze` | Extract and save durable facts from longer text |
-| `memwal_restore` | Re-index memories from onchain Walrus blob records |
+## Get started
 
-**Session tools** (handled locally by `@mysten-incubation/memwal-mcp`):
-
-| Tool | Purpose |
-| --- | --- |
-| `memwal_login` | Open the browser, approve the wallet, and write credentials to `~/.memwal/credentials.json`. Use for first-time sign-in or to switch accounts. |
-| `memwal_logout` | Remove the saved credentials from this machine. The on-chain delegate key is not revoked — visit the dashboard to remove it from the account. |
-
-The two session tools mean a user can sign in from inside their MCP client (Cursor, Claude Desktop, Claude Code, Antigravity, …) without leaving the chat to run a separate CLI command.
-
-## Transport Options
-
-MemWal supports two MCP connection modes.
-
-| Mode | Best for | Client config shape |
-| --- | --- | --- |
-| Streamable HTTP | Clients that support remote HTTP MCP servers | `url: "https://relayer.memwal.ai/api/mcp"` |
-| stdio package | Clients that run local MCP commands | `npx -y @mysten-incubation/memwal-mcp` |
-
-For the hosted production relayer, the Streamable HTTP endpoint is:
-
-```text
-https://relayer.memwal.ai/api/mcp
-```
-
-The stdio package opens a browser-based wallet login the first time it runs, then stores credentials in `~/.memwal/credentials.json`.
-
-<Warning>
-The MCP bearer token is the delegate private key created for the MCP client. Treat it like a long-lived API token. Do not commit MCP configs that contain a real `Authorization` header.
-</Warning>
-
-## Streamable HTTP Setup
-
-Use this when your MCP client supports HTTP transport.
-
-The HTTP transport authenticates every request with a bearer token (the delegate private key) and account ID. To get those values, run the stdio package once to generate them:
-
-```bash
-npx -y @mysten-incubation/memwal-mcp login
-```
-
-This opens the dashboard, registers a delegate key, and writes credentials to `~/.memwal/credentials.json`. Copy `delegatePrivateKey` into the bearer token placeholder and `accountId` into `x-memwal-account-id`:
-
-```json
-{
-  "mcpServers": {
-    "memwal": {
-      "url": "https://relayer.memwal.ai/api/mcp",
-      "headers": {
-        "Authorization": "Bearer <YOUR_DELEGATE_PRIVATE_KEY>",
-        "x-memwal-account-id": "<YOUR_ACCOUNT_ID>"
-      }
-    }
-  }
-}
-```
-
-The relayer authenticates every request with the bearer key and account ID, then proxies the MCP protocol to the TypeScript sidecar.
-
-For Claude Code, the equivalent command is:
-
-```bash
-claude mcp add --transport http memwal https://relayer.memwal.ai/api/mcp
-```
-
-If your client cannot attach headers from the command, add the headers in the generated MCP config file.
-
-## stdio Package Setup
-
-Use this when your MCP client supports command-based MCP servers. Add the entry to your client config:
-
-```json
-{
-  "mcpServers": {
-    "memwal": {
-      "command": "npx",
-      "args": ["-y", "@mysten-incubation/memwal-mcp"]
-    }
-  }
-}
-```
-
-**First run.** When `~/.memwal/credentials.json` is missing, the package starts in a sign-in-required mode and advertises a `memwal_login` tool to the client. Ask your agent to call `memwal_login` — it returns a one-time URL. Open the URL, approve the connection in your Sui wallet, and the next `memwal_*` call works without restarting the client.
-
-The login URL stays valid for **5 minutes**. If it expires, ask the agent to call `memwal_login` again to get a fresh one.
-
-**Manual fallback.** You can also pre-authorize from the terminal:
-
-```bash
-npx -y @mysten-incubation/memwal-mcp login
-```
-
-**Switching accounts or signing out.** Ask the agent to call `memwal_logout` (clears local credentials) followed by `memwal_login`. The CLI equivalent is:
-
-```bash
-npx -y @mysten-incubation/memwal-mcp --logout
-```
-
-After login, MCP clients can use the saved credentials without prompting again.
-
-## CLI Flags and Environment Variables
-
-The stdio package reads flags from `args` in the client config. Environment variables work too — flags win when both are set.
-
-| CLI flag | Environment variable | Description |
-| --- | --- | --- |
-| `--relayer <url>` | `MEMWAL_SERVER_URL` | Override the relayer base URL. |
-| `--web-url <url>` | `MEMWAL_WEB_URL` | Override the dashboard URL used during login. |
-| `--label <text>` | `MEMWAL_CLIENT_LABEL` | Friendly delegate-key label shown in the MemWal dashboard. |
-| `--login` | — | Force a re-login even when credentials already exist. |
-| `--logout` | — | Wipe `~/.memwal/credentials.json` and exit. |
-| `--help`, `-h` | — | Print usage and exit. |
-
-Set `MEMWAL_MCP_DEBUG=1` to enable verbose stderr logging.
-
-## Environment Presets
-
-The stdio package accepts environment shortcuts that set both the relayer and the dashboard URL in one flag:
-
-| Flag | Relayer | Dashboard |
-| --- | --- | --- |
-| `--prod` | `https://relayer.memwal.ai` | `https://memwal.ai` |
-| `--dev` | `https://relayer.dev.memwal.ai` | `https://dev.memwal.ai` |
-| `--staging` | `https://relayer.staging.memwal.ai` | `https://staging.memwal.ai` |
-| `--local` | `http://127.0.0.1:8000` | `http://localhost:5173` |
-
-Explicit `--relayer` and `--web-url` override the preset. You can also pass explicit URLs without a preset:
-
-```json
-{
-  "mcpServers": {
-    "memwal": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@mysten-incubation/memwal-mcp",
-        "--relayer",
-        "https://relayer.dev.memwal.ai"
-      ]
-    }
-  }
-}
-```
-
-## Client Config
-
-Use the snippets above for Cursor, Claude Desktop, Claude Code, Antigravity, or any other MCP client that accepts either command-based stdio servers or Streamable HTTP servers.
-
-## Self-Hosting Notes
-
-Self-hosted relayers expose the same public MCP routes:
-
-| Route | Purpose |
-| --- | --- |
-| `GET /api/mcp/sse` | Legacy SSE session for the stdio bridge |
-| `POST /api/mcp/messages` | JSON-RPC messages for the legacy SSE transport |
-| `GET /api/mcp` | Streamable HTTP server-to-client stream |
-| `POST /api/mcp` | Streamable HTTP JSON-RPC messages |
-| `DELETE /api/mcp` | Close a Streamable HTTP session |
-
-The Rust relayer starts the TypeScript sidecar automatically and forwards MCP traffic to the sidecar over loopback. The sidecar resolves MCP bearer credentials into normal MemWal SDK sessions, so tool calls still use the same relayer, SEAL, Walrus, and pgvector paths as SDK calls.
-
-The MCP session limits that operators most often need to tune:
-
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `SIDECAR_URL` | `http://localhost:9000` | Loopback endpoint the Rust relayer uses to reach the sidecar. |
-| `MCP_MAX_TOTAL_SESSIONS` | `1000` | Cap on concurrent MCP sessions across SSE and Streamable HTTP. |
-| `MCP_MAX_SESSIONS_PER_IP` | `16` | Cap on concurrent sessions from one source IP. |
-| `MCP_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | Rate cap on new sessions per source IP per minute. |
-
-See [Environment Variables](/reference/environment-variables) for the full list, including SEAL and Walrus settings.
+<CardGroup cols={2}>
+  <Card title="Quick Start" icon="rocket" href="/mcp/quick-start">
+    Install the package, sign in with your wallet, wire your client, and run your first tool call
+  </Card>
+  <Card title="Reference" icon="book" href="/mcp/reference">
+    All six tools, CLI flags, environment presets, transport routes, and self-hosting notes
+  </Card>
+  <Card title="Source Code" icon="github" href="https://github.com/MystenLabs/MemWal/tree/main/packages/mcp">
+    Browse the `@mysten-incubation/memwal-mcp` package on GitHub
+  </Card>
+  <Card title="MemWal Dashboard" icon="window" href="https://memwal.ai">
+    Manage delegate keys, view storage, and revoke connected clients
+  </Card>
+</CardGroup>

--- a/docs/mcp/quick-start.md
+++ b/docs/mcp/quick-start.md
@@ -1,0 +1,168 @@
+---
+title: "Quick Start"
+description: "Install the MemWal MCP package, sign in with your wallet, and wire it into an MCP client in under five minutes."
+---
+
+This page gets you from zero to a working MemWal MCP server inside Cursor, Claude Desktop, Claude Code, or Codex.
+
+## Prerequisites
+
+- **Node.js 20** or newer (`node -v` to check)
+- A **Sui wallet** with the MemWal app authorized — Sui Wallet, Suiet, Phantom, or any [Sui-compatible wallet](https://memwal.ai)
+- An **MCP-aware client**: Cursor, Claude Desktop, Claude Code, Codex, Antigravity, or another MCP host
+
+No npm install needed — `npx` fetches the `@mysten-incubation/memwal-mcp` package on demand.
+
+## Installation
+
+<Steps>
+  <Step>
+    ### Sign in with your Sui wallet
+
+    Run the login flow once from your terminal. Your browser opens to `https://memwal.ai/connect/mcp` — approve the connection in your Sui wallet.
+
+    ```bash
+    npx -y @mysten-incubation/memwal-mcp login --prod
+    ```
+
+    The package writes credentials to `~/.memwal/credentials.json`. For other environments use `--staging`, `--dev`, or `--local`.
+
+    <Warning>
+    Run this in a real terminal (with a TTY). The login command opens a browser and waits for your wallet approval. If you wrap it in a non-interactive shell, the browser won't pop and the flow exits silently.
+    </Warning>
+  </Step>
+
+  <Step>
+    ### Add MemWal to your MCP client
+
+    Pick the snippet for your client. Drop it into the client's MCP config file.
+
+    <Tabs>
+      <Tab title="Cursor">
+      ```json
+      // ~/.cursor/mcp.json
+      {
+        "mcpServers": {
+          "memwal": {
+            "command": "npx",
+            "args": ["-y", "@mysten-incubation/memwal-mcp"]
+          }
+        }
+      }
+      ```
+      </Tab>
+      <Tab title="Claude Desktop">
+      ```json
+      // macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json
+      // Windows: %APPDATA%\Claude\claude_desktop_config.json
+      {
+        "mcpServers": {
+          "memwal": {
+            "command": "npx",
+            "args": ["-y", "@mysten-incubation/memwal-mcp"]
+          }
+        }
+      }
+      ```
+      </Tab>
+      <Tab title="Claude Code">
+      ```bash
+      claude mcp add --scope user memwal -- npx -y @mysten-incubation/memwal-mcp
+      ```
+      </Tab>
+      <Tab title="Codex">
+      ```toml
+      # ~/.codex/config.toml
+      [mcp_servers.memwal]
+      command = "npx"
+      args = ["-y", "@mysten-incubation/memwal-mcp"]
+      ```
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step>
+    ### Restart the client
+
+    MCP servers load at client startup. Quit and reopen your MCP client (`Cmd+Q` on macOS — closing the window is not enough). On first start, `npx` fetches the package — expect a 5–10 second delay the first time.
+  </Step>
+</Steps>
+
+## Verify
+
+### Check connectivity
+
+Ask the agent in any conversation:
+
+> What MCP tools do you have available?
+
+You should see six tools:
+
+- `memwal_remember`
+- `memwal_recall`
+- `memwal_analyze`
+- `memwal_restore`
+- `memwal_login`
+- `memwal_logout`
+
+If you only see five — or only `memwal_login` — credentials are missing. Run the login command from step 1 again or ask the agent to call `memwal_login`.
+
+### Save and recall a memory
+
+```text
+Use memwal_remember to save: "My favorite programming language is Rust and I drink black coffee in the mornings."
+```
+
+Wait a few seconds for the async upload to land on Walrus, then:
+
+```text
+Use memwal_recall to search for: "what is my favorite language?"
+```
+
+The agent should retrieve the memory you just saved.
+
+### Extract multiple facts from a passage
+
+```text
+Use memwal_analyze on this paragraph: "I live in Saigon, work as a software engineer at MystenLabs, exercise at 6am, and am allergic to shellfish."
+```
+
+The tool extracts each distinct fact and saves them as separate memories. Follow up with `memwal_recall` to verify any one of them came back.
+
+## Switching environments
+
+Need to hop between prod, staging, dev, or a local relayer without re-editing your client config?
+
+```bash
+npx -y @mysten-incubation/memwal-mcp --logout
+npx -y @mysten-incubation/memwal-mcp login --staging
+```
+
+Your client config doesn't change — the package reads the saved environment from `~/.memwal/credentials.json` on each run. See [Environment presets](/mcp/reference#environment-presets) for all four shortcuts.
+
+## Signing out
+
+Ask the agent to call `memwal_logout`, or run from your terminal:
+
+```bash
+npx -y @mysten-incubation/memwal-mcp --logout
+```
+
+This deletes the local credentials file. The on-chain delegate key is **not** revoked — visit the [MemWal dashboard](https://memwal.ai) to remove it from your account if needed.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Reference" icon="book" href="/mcp/reference">
+    All six tools with parameters, CLI flags, and transport routes
+  </Card>
+  <Card title="Streamable HTTP transport" icon="globe" href="/mcp/reference#streamable-http">
+    Skip `npx` — point your client at the relayer URL directly
+  </Card>
+  <Card title="Self-Hosting" icon="server" href="/mcp/reference#self-hosting">
+    Run your own relayer and route MCP traffic through it
+  </Card>
+  <Card title="Environment Variables" icon="gear" href="/reference/environment-variables">
+    Full list of relayer + sidecar settings (SEAL, Walrus, sessions)
+  </Card>
+</CardGroup>

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -1,0 +1,187 @@
+---
+title: "Reference"
+description: "Complete reference for MemWal MCP tools, CLI flags, environment presets, transport routes, and self-hosting."
+---
+
+This page documents every tool, flag, environment variable, and transport route the MemWal MCP package exposes. For a guided walkthrough, start with the [Quick Start](/mcp/quick-start).
+
+## Tools
+
+The MCP server exposes **six tools** — four **memory tools** that round-trip to the relayer, and two **session tools** served locally by the stdio package.
+
+### memwal_remember
+
+Save a fact to the user's MemWal personal memory. Call only when the user explicitly asks to remember or save something. Pass the full statement — do not summarize.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `text` | string | yes | The complete fact to save. |
+| `namespace` | string | no | Namespace bucket. Defaults to the session namespace. |
+
+### memwal_recall
+
+Search the user's MemWal memory for facts relevant to a query. Returns matches ranked by relevance.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `query` | string | yes | Natural-language query to match against stored memories. |
+| `limit` | integer (1–100) | no | Max memories to return. Default `10`. |
+| `namespace` | string | no | Namespace bucket to search. |
+
+### memwal_analyze
+
+Extract memorable facts from a longer passage of text (preferences, habits, biographical info, constraints) and save each as a separate memory.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `text` | string | yes | Conversation transcript, note, or arbitrary text to extract from. |
+| `namespace` | string | no | Namespace for the extracted facts. |
+
+### memwal_restore
+
+Re-index a namespace from Walrus blobs back into the relayer's search index. Returns counts only (`restored` / `skipped` / `total`) — does **not** return memory texts. Call `memwal_recall` afterwards to query the rebuilt index.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `namespace` | string | yes | Namespace bucket to restore. |
+| `limit` | integer (1–500) | no | Max memories to re-index. Default `10`. |
+
+### memwal_login
+
+Open a browser to sign in (or re-sign in) with your Sui wallet. Use to switch wallets, refresh credentials, or sign in for the first time inline. Takes no parameters.
+
+Returns a one-time URL valid for **5 minutes**. If it expires, call the tool again to mint a fresh URL.
+
+### memwal_logout
+
+Remove the saved credentials from this machine (`~/.memwal/credentials.json`). Takes no parameters.
+
+<Warning>
+The on-chain delegate key registration is **not** revoked by `memwal_logout` — only the local file is wiped. Visit the [MemWal dashboard](https://memwal.ai) to remove the delegate key from your account.
+</Warning>
+
+<Note>
+Both session tools (`memwal_login`, `memwal_logout`) are intercepted locally by the stdio package and never reach the relayer. They read and write files on the client machine only.
+</Note>
+
+## CLI
+
+The stdio package accepts CLI flags and environment variables. **CLI takes precedence** when both are set.
+
+| CLI flag | Environment variable | Description |
+| --- | --- | --- |
+| `--relayer <url>` | `MEMWAL_SERVER_URL` | Override the relayer base URL. |
+| `--web-url <url>` | `MEMWAL_WEB_URL` | Override the dashboard URL used during login. |
+| `--label <text>` | `MEMWAL_CLIENT_LABEL` | Friendly delegate-key label shown in the MemWal dashboard. |
+| `--login` (or `login` subcommand) | — | Force a re-login even when credentials exist. |
+| `--logout` | — | Wipe `~/.memwal/credentials.json` and exit. |
+| `--help`, `-h` | — | Print usage and exit. |
+
+Set `MEMWAL_MCP_DEBUG=1` to enable verbose stderr logging.
+
+### Environment presets
+
+Shortcut flags that set both the relayer and the dashboard URL in one switch:
+
+| Flag | Relayer | Dashboard |
+| --- | --- | --- |
+| `--prod` | `https://relayer.memwal.ai` | `https://memwal.ai` |
+| `--dev` | `https://relayer.dev.memwal.ai` | `https://dev.memwal.ai` |
+| `--staging` | `https://relayer.staging.memwal.ai` | `https://staging.memwal.ai` |
+| `--local` | `http://127.0.0.1:8000` | `http://localhost:5173` |
+
+Explicit `--relayer` and `--web-url` override the preset. You can also pass either flag without a preset to point at a custom URL.
+
+## Transports
+
+MemWal supports two MCP connection modes.
+
+| Mode | Best for | Configured via |
+| --- | --- | --- |
+| **stdio package** | Clients that run local MCP commands (most clients today) | `npx -y @mysten-incubation/memwal-mcp` in the client config |
+| **Streamable HTTP** | Clients that support remote HTTP MCP servers | `url: "https://relayer.memwal.ai/api/mcp"` + auth headers |
+
+### Streamable HTTP
+
+Use HTTP transport when your client supports remote MCP servers natively. Authentication is bearer-token + account ID per request:
+
+```json
+{
+  "mcpServers": {
+    "memwal": {
+      "url": "https://relayer.memwal.ai/api/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_DELEGATE_PRIVATE_KEY>",
+        "x-memwal-account-id": "<YOUR_ACCOUNT_ID>"
+      }
+    }
+  }
+}
+```
+
+The bearer token is the `delegatePrivateKey` from `~/.memwal/credentials.json`. The account ID is the `accountId` field in that same file. Run `npx -y @mysten-incubation/memwal-mcp login --prod` once to populate it.
+
+<Warning>
+The bearer token is a long-lived credential equivalent to an API key. **Never commit MCP configs with a real `Authorization` header to source control.** Treat it like any other secret.
+</Warning>
+
+For Claude Code, the equivalent registration command is:
+
+```bash
+claude mcp add --transport http memwal https://relayer.memwal.ai/api/mcp
+```
+
+If your client cannot attach headers from the CLI, edit the generated MCP config file to add them manually.
+
+### Public routes
+
+The hosted relayer (and any self-hosted relayer) exposes the same MCP routes:
+
+| Route | Purpose |
+| --- | --- |
+| `GET /api/mcp/sse` | Legacy SSE session for the stdio bridge |
+| `POST /api/mcp/messages` | JSON-RPC messages for the legacy SSE transport |
+| `GET /api/mcp` | Streamable HTTP server-to-client stream |
+| `POST /api/mcp` | Streamable HTTP JSON-RPC messages |
+| `DELETE /api/mcp` | Close a Streamable HTTP session |
+
+The Rust relayer auto-starts a TypeScript sidecar and forwards MCP traffic to it over loopback. The sidecar resolves MCP bearer credentials into normal MemWal SDK sessions, so MCP tool calls go through the **same SEAL, Walrus, and pgvector paths** as direct SDK calls.
+
+## Self-Hosting
+
+Self-hosted relayers expose the same public MCP routes as the hosted relayer. The most common operator-tunable settings:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SIDECAR_URL` | `http://localhost:9000` | Loopback endpoint the Rust relayer uses to reach the sidecar |
+| `MCP_MAX_TOTAL_SESSIONS` | `1000` | Cap on concurrent MCP sessions across SSE and Streamable HTTP |
+| `MCP_MAX_SESSIONS_PER_IP` | `16` | Cap on concurrent sessions from one source IP |
+| `MCP_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | Rate cap on new sessions per source IP per minute |
+
+See [Environment Variables](/reference/environment-variables) for the full list including SEAL, Walrus, embeddings, and database settings.
+
+## Troubleshooting
+
+### Tools aren't visible to the agent
+
+Quit and relaunch your MCP client — MCP servers only load at startup. If you used `claude mcp add`, run `claude mcp list` to confirm `memwal` is registered before restarting Claude Code.
+
+### Only `memwal_login` shows up
+
+Credentials are missing. Ask the agent to call `memwal_login`, or run `npx -y @mysten-incubation/memwal-mcp login --prod` from your terminal.
+
+### `memwal_login` URL expires before approval
+
+The URL is valid for **5 minutes**. Call the tool again to mint a fresh one. Make sure your browser is logged into the wallet you intend to use before clicking.
+
+### Recall returns "No matching memories found" right after a remember
+
+`memwal_remember` enqueues an async upload to Walrus. Embedding generation, SEAL encryption, blob upload, and DB indexing typically take 5–15 seconds. Wait, then retry the recall.
+
+### 401 Unauthorized from the relayer
+
+Your delegate key was revoked from the dashboard, or your saved credentials point at the wrong environment. Run `--logout` then `login --<env>` for the env you want.
+
+### Verbose logs for debugging
+
+Set `MEMWAL_MCP_DEBUG=1` in the client's MCP server config `env` block (or in your terminal) to dump structured stderr logs covering credential loading, bridge connection, and per-request flow.


### PR DESCRIPTION
## Summary

Reviewer feedback flagged the MCP overview as too rough to use — 193 lines mixed overview, setup, CLI flags, transport details, and self-hosting into a single page.

This PR mirrors the `docs/openclaw/` structure (overview hub → focused sub-pages) so users land on the page that matches their intent.

## Changes

- **`docs/mcp/overview.md`** (193 → 53 lines): landing page with `<CardGroup>` features, "When to use this" bullets, and Get Started cards linking to sub-pages.
- **`docs/mcp/quick-start.md`** (new, 168 lines): Prerequisites + `<Steps>` for login, client wiring (`<Tabs>` for Cursor / Claude Desktop / Claude Code / Codex), restart, plus Verify section with three test prompts, environment switching, and sign-out.
- **`docs/mcp/reference.md`** (new, 187 lines): per-tool parameter tables for all six tools (`memwal_remember`, `memwal_recall`, `memwal_analyze`, `memwal_restore`, `memwal_login`, `memwal_logout`), CLI flags + env vars, environment presets, Streamable HTTP setup, public route table, self-hosting tunables, and troubleshooting.
- **`docs/docs.json`**: add `mcp/quick-start` and `mcp/reference` to the MCP tab group.

## Notes

No new content invented — every fact in quick-start and reference comes from the original overview, just redistributed so each page has a single focus. The Mintlify components used (`<CardGroup>`, `<Card>`, `<Steps>`, `<Step>`, `<Tabs>`, `<Tab>`, `<Warning>`, `<Note>`) match what's already in `docs/openclaw/` and `docs/getting-started/`.

## Test plan

- [ ] Open the Mintlify preview and verify the three pages render: tables, CardGroups, Steps, and Tabs.
- [ ] Check the internal links resolve (`/mcp/quick-start`, `/mcp/reference`, `/reference/environment-variables`).
- [ ] Confirm the sidebar shows all three pages under the MCP tab.