### PR TITLE
feat: add relayer observability and metrics

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -99,6 +99,7 @@
               "relayer/overview",
               "relayer/public-relayer",
               "relayer/self-hosting",
+              "relayer/observability",
               "relayer/api-reference"
             ]
           }

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -28,6 +28,8 @@ These are not all enforced at boot, but most real deployments need them.
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `PORT` | `8000` | Relayer port |
+| `RUST_LOG` | `memwal_server=info,tower_http=info` | Rust tracing filter for relayer logs |
+| `LOG_FORMAT` | pretty text | Set to `json` for machine-parseable structured logs |
 | `SIDECAR_URL` | `http://localhost:9000` | Sidecar HTTP endpoint |
 | `OPENAI_API_BASE` | `https://api.openai.com/v1` | OpenAI-compatible base URL |
 | `SUI_NETWORK` | `mainnet` | Picks the fallback RPC URL and network-driven service defaults |

--- a/docs/relayer/observability.md
+++ b/docs/relayer/observability.md
@@ -1,0 +1,126 @@
+---
+title: "Observability"
+---
+
+Production relayers should emit structured logs, scrape Prometheus metrics, and send alerts for the external systems MemWal depends on: PostgreSQL, Redis, Sui RPC, OpenAI-compatible embedding/LLM APIs, SEAL, Walrus, and the TypeScript sidecar.
+
+## Request Correlation
+
+Every relayer request gets an `x-request-id`.
+
+- If the client sends `x-request-id`, the relayer reuses it.
+- If the client sends only `x-correlation-id`, the relayer uses that value.
+- If neither is present, the relayer generates a UUID.
+- The response includes `x-request-id`.
+- Rust logs, internal error `traceId` values, outbound sidecar requests, and sidecar error responses use the same ID.
+
+Use this ID when searching logs across the Rust relayer and TypeScript sidecar.
+
+## Logs
+
+For production, run with JSON logs:
+
+```bash
+RUST_LOG=memwal_server=info,tower_http=info
+LOG_FORMAT=json
+```
+
+Useful fields include:
+
+| Field | Meaning |
+| --- | --- |
+| `request_id` | Request/correlation ID shared across relayer and sidecar |
+| `route` | Low-cardinality route label such as `/api/recall` |
+| `method` | HTTP method |
+| `status` | HTTP status code |
+| `latency_ms` | Request latency in milliseconds |
+| `owner`, `namespace` | User and namespace fields on selected route logs |
+
+The relayer avoids logging memory text, recall queries, and ask/analyze prompts. It logs byte or character lengths instead.
+
+## Prometheus Metrics
+
+The Rust relayer exposes Prometheus metrics at:
+
+```text
+GET /metrics
+```
+
+The TypeScript sidecar also exposes wallet-specific counters at:
+
+```text
+GET <SIDECAR_URL>/metrics/wallet
+```
+
+Core relayer metrics:
+
+| Metric | Labels | Notes |
+| --- | --- | --- |
+| `memwal_http_requests_total` | `method`, `route`, `status` | Request volume and status mix |
+| `memwal_http_request_duration_seconds` | `method`, `route`, `status` | HTTP latency histogram |
+| `memwal_http_requests_in_flight` | none | Current in-flight request count |
+| `memwal_errors_total` | `kind`, `route` | Application error counts |
+| `memwal_rate_limit_denials_total` | `bucket`, `route` | Rate-limit denials |
+| `memwal_rate_limit_fallbacks_total` | `scope` | Redis fallback usage |
+| `memwal_external_request_duration_seconds` | `service`, `operation`, `status` | OpenAI, Sui RPC, SEAL sidecar, Walrus latency |
+| `memwal_sidecar_failures_total` | `operation`, `reason` | Sidecar transport and HTTP failures |
+| `memwal_db_query_duration_seconds` | `operation`, `status` | PostgreSQL and pgvector query latency |
+| `memwal_db_pool_connections` | `state` | PostgreSQL pool `open` and `idle` gauges |
+
+Example Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: memwal-relayer
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["relayer.example.com"]
+```
+
+## Recommended Dashboards
+
+Create panels for:
+
+- HTTP request rate by route and status.
+- p50/p95/p99 HTTP latency by route.
+- Error rate from `memwal_errors_total` and 5xx statuses.
+- Rate-limit denials by bucket.
+- External service p95 latency by `service` and `operation`.
+- Sidecar failures by operation.
+- PostgreSQL query latency and pool open/idle connections.
+- Sidecar wallet counters: `walletSubmittedTotal`, `walletLockErrorsTotal`, `walletPermanentFailuresTotal`.
+
+## Recommended Alerts
+
+| Alert | Suggested Condition |
+| --- | --- |
+| High 5xx rate | 5xx responses exceed 1% for 5 minutes |
+| Route latency regression | p95 `/api/recall` or `/api/remember` latency exceeds the normal SLO for 10 minutes |
+| Redis degraded | `memwal_rate_limit_fallbacks_total` increases in production |
+| Sidecar unhealthy | `memwal_sidecar_failures_total` increases for SEAL or Walrus operations |
+| OpenAI latency/errors | External `service="openai"` p95 latency or non-2xx status rate spikes |
+| Walrus download/upload failures | External `service="walrus"` or sidecar Walrus failures increase |
+| Sui RPC failures | `service="sui_rpc"` transport errors or non-2xx statuses increase |
+| DB saturation | PostgreSQL pool open connections near configured max, or idle connections stay at 0 |
+| Wallet lock canary | Sidecar `walletLockErrorsTotal` is greater than 0 |
+| Permanent wallet failures | Sidecar `walletPermanentFailuresTotal` increases |
+
+## APM Integration
+
+MemWal emits structured logs and Prometheus metrics in vendor-neutral formats. For Datadog, New Relic, Grafana Cloud, or OpenTelemetry Collector based setups:
+
+1. Scrape `/metrics` from the Rust relayer.
+2. Collect stdout/stderr logs from both the Rust process and sidecar.
+3. Parse JSON logs when `LOG_FORMAT=json`.
+4. Treat `request_id` and `traceId` as the correlation key.
+5. Scrape or poll sidecar `/metrics/wallet` when the sidecar is reachable from the monitoring agent.
+
+If your APM supports custom spans, map `memwal_external_request_duration_seconds` operations to dependencies:
+
+- `openai / embeddings`
+- `openai / chat_completions`
+- `sui_rpc / sui_getObject`
+- `sidecar / seal_encrypt`
+- `sidecar / seal_decrypt_batch`
+- `sidecar / walrus_upload`
+- `walrus / download_blob`

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -157,9 +157,10 @@ See [Database Sync](/indexer/database-sync) for the full schema.
 - The server starts the sidecar automatically on boot — if sidecar startup fails, the relayer will exit
 - DB migrations run automatically on boot (`pgvector` must already be installed as a PostgreSQL extension)
 - Connection pool: 10 max connections (relayer), 3 max connections (indexer)
-- `/health` is the basic service check, API routes live under `/api/*`
+- `/health` is the basic service check, `/metrics` exposes Prometheus metrics, API routes live under `/api/*`
 - The indexer is recommended for fast account lookup in production — without it, the relayer falls back to onchain registry scans
 - Without `OPENAI_API_KEY`, the server uses deterministic mock embeddings (hash-based) — useful for local testing but not production
+- Use `LOG_FORMAT=json` in production and see [Observability](/relayer/observability) for dashboards and alerts
 
 ## Docker
 

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -1,6 +1,12 @@
 # Server
 PORT=8000
 
+# Observability
+# RUST_LOG controls Rust tracing filters. Set LOG_FORMAT=json in production
+# so request_id, route, status, and latency fields are machine-parseable.
+RUST_LOG=memwal_server=info,tower_http=info
+LOG_FORMAT=pretty
+
 # Database (PostgreSQL + pgvector)
 DATABASE_URL=postgresql://memwal:memwal_secret@localhost:5432/memwal
 

--- a/services/server/Cargo.lock
+++ b/services/server/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
  "hex",
  "percent-encoding",
  "pgvector",
+ "prometheus",
  "redis",
  "reqwest",
  "serde",
@@ -1593,6 +1594,27 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
@@ -2637,6 +2659,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,12 +2678,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/services/server/Cargo.toml
+++ b/services/server/Cargo.toml
@@ -35,7 +35,8 @@ dotenvy = "0.15"
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+prometheus = "0.13"
 
 # HTTP client (for Sui RPC onchain verification)
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -317,6 +317,56 @@ const JSON_LIMIT_SEAL_ENCRYPT = "2mb"; // matches PROTECTED_BODY_LIMIT_BYTES (au
 const JSON_LIMIT_SEAL_DECRYPT = "2mb"; // single encrypted blob, same size class as encrypt
 const JSON_LIMIT_SEAL_DECRYPT_BATCH = "8mb"; // up to 25 × ~320 KiB items
 const JSON_LIMIT_WALRUS_UPLOAD = "10mb"; // base64-encoded encrypted blob
+type RequestWithId = Request & { requestId?: string };
+
+function sanitizeRequestId(value: unknown): string | null {
+    const raw = Array.isArray(value) ? value[0] : value;
+    if (typeof raw !== "string") return null;
+    const trimmed = raw.trim();
+    if (!/^[A-Za-z0-9_.:-]{1,128}$/.test(trimmed)) return null;
+    return trimmed;
+}
+
+function requestIdFor(req: Request): string {
+    return (req as RequestWithId).requestId
+        ?? sanitizeRequestId(req.headers["x-request-id"])
+        ?? randomUUID();
+}
+
+function errorMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    return String(err);
+}
+
+function sidecarLog(
+    level: "info" | "warn" | "error",
+    event: string,
+    fields: Record<string, unknown> = {},
+): void {
+    const line = JSON.stringify({
+        ts: new Date().toISOString(),
+        level,
+        scope: "memwal-sidecar",
+        event,
+        ...fields,
+    });
+    if (level === "error") {
+        console.error(line);
+    } else if (level === "warn") {
+        console.warn(line);
+    } else {
+        console.log(line);
+    }
+}
+
+app.use((req: RequestWithId, res: Response, next: NextFunction) => {
+    const requestId = sanitizeRequestId(req.headers["x-request-id"])
+        ?? sanitizeRequestId(req.headers["x-correlation-id"])
+        ?? randomUUID();
+    req.requestId = requestId;
+    res.setHeader("x-request-id", requestId);
+    next();
+});
 
 // CORS — sidecar is called only by the co-located Rust server, never by browsers.
 // Remove all CORS headers so no cross-origin access is granted.
@@ -410,8 +460,11 @@ app.post("/seal/encrypt", express.json({ limit: JSON_LIMIT_SEAL_ENCRYPT }), asyn
         const encryptedBase64 = Buffer.from(result.encryptedObject).toString("base64");
         res.json({ encryptedData: encryptedBase64 });
     } catch (err: any) {
-        const traceId = randomUUID();
-        console.error(`[seal/encrypt] [${traceId}] error:`, err);
+        const traceId = requestIdFor(req);
+        sidecarLog("error", "seal_encrypt_failed", {
+            requestId: traceId,
+            error: errorMessage(err),
+        });
         res.status(500).json({ error: "Internal server error", traceId });
     }
 });
@@ -526,8 +579,11 @@ app.post("/seal/decrypt", express.json({ limit: JSON_LIMIT_SEAL_DECRYPT }), asyn
         const decryptedBase64 = Buffer.from(decrypted).toString("base64");
         res.json({ decryptedData: decryptedBase64 });
     } catch (err: any) {
-        const traceId = randomUUID();
-        console.error(`[seal/decrypt] [${traceId}] error:`, err);
+        const traceId = requestIdFor(req);
+        sidecarLog("error", "seal_decrypt_failed", {
+            requestId: traceId,
+            error: errorMessage(err),
+        });
         res.status(500).json({ error: "Internal server error", traceId });
     }
 });
@@ -630,8 +686,11 @@ app.post("/seal/decrypt-batch", express.json({ limit: JSON_LIMIT_SEAL_DECRYPT_BA
         console.log(`[seal/decrypt-batch] ${results.length}/${items.length} decrypted ok, ${errors.length} errors`);
         res.json({ results, errors });
     } catch (err: any) {
-        const traceId = randomUUID();
-        console.error(`[seal/decrypt-batch] [${traceId}] error:`, err);
+        const traceId = requestIdFor(req);
+        sidecarLog("error", "seal_decrypt_batch_failed", {
+            requestId: traceId,
+            error: errorMessage(err),
+        });
         res.status(500).json({ error: "Internal server error", traceId });
     }
 });
@@ -853,9 +912,12 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
             transferStatus: deferTransfer ? "deferred" : "ok",
         });
     } catch (err: any) {
-        const traceId = randomUUID();
-        const message = err?.message || String(err);
-        console.error(`[walrus/upload] [${traceId}] error:`, err);
+        const traceId = requestIdFor(req);
+        const message = errorMessage(err);
+        sidecarLog("error", "walrus_upload_failed", {
+            requestId: traceId,
+            error: message,
+        });
         res.status(500).json({ error: message, traceId });
     }
 });
@@ -901,9 +963,12 @@ app.post("/walrus/set-metadata-batch", express.json({ limit: "1mb" }), async (re
         console.log(`[walrus/set-metadata-batch] transferred ${normalized.length} blobs to owner`);
         res.json({ transferred: normalized.length, digest });
     } catch (err: any) {
-        const traceId = randomUUID();
-        const message = err?.message || String(err);
-        console.error(`[walrus/set-metadata-batch] [${traceId}] error:`, err);
+        const traceId = requestIdFor(req);
+        const message = errorMessage(err);
+        sidecarLog("error", "walrus_set_metadata_batch_failed", {
+            requestId: traceId,
+            error: message,
+        });
         res.status(500).json({ error: message, traceId });
     }
 });
@@ -932,9 +997,12 @@ app.post("/walrus/set-metadata", express.json({ limit: "128kb" }), async (req, r
         );
         res.json({ transferred: 1, digest });
     } catch (err: any) {
-        const traceId = randomUUID();
-        const message = err?.message || String(err);
-        console.error(`[walrus/set-metadata] [${traceId}] error:`, err);
+        const traceId = requestIdFor(req);
+        const message = errorMessage(err);
+        sidecarLog("error", "walrus_set_metadata_failed", {
+            requestId: traceId,
+            error: message,
+        });
         res.status(500).json({ error: message, traceId });
     }
 });
@@ -1324,8 +1392,13 @@ app.post("/walrus/query-blobs", express.json({ limit: JSON_LIMIT_METADATA }), as
         console.log(`[query-blobs] returning ${blobs.length} blobs (filtered from ${rawObjs.length}) for owner=${owner} ns=${namespace || '*'}`);
         res.json({ blobs, total: blobs.length });
     } catch (err: any) {
-        console.error(`[walrus/query-blobs] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const traceId = requestIdFor(req);
+        const message = errorMessage(err);
+        sidecarLog("error", "walrus_query_blobs_failed", {
+            requestId: traceId,
+            error: message,
+        });
+        res.status(500).json({ error: message, traceId });
     }
 });
 
@@ -1356,8 +1429,13 @@ app.post("/sponsor", express.json({ limit: JSON_LIMIT_METADATA }), async (req, r
         console.log(`[sponsor] sponsored tx created (digest_len=${sponsored.digest.length})`);
         res.json(sponsored); // { bytes, digest }
     } catch (err: any) {
-        console.error(`[sponsor] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const traceId = requestIdFor(req);
+        const message = errorMessage(err);
+        sidecarLog("error", "sponsor_failed", {
+            requestId: traceId,
+            error: message,
+        });
+        res.status(500).json({ error: message, traceId });
     }
 });
 
@@ -1393,8 +1471,13 @@ app.post("/sponsor/execute", express.json({ limit: JSON_LIMIT_METADATA }), async
         console.log(`[sponsor/execute] executed sponsored tx (digest_len=${digest.length})`);
         res.json(executed); // { digest }
     } catch (err: any) {
-        console.error(`[sponsor/execute] error: ${err.message || err}`);
-        res.status(500).json({ error: err.message || String(err) });
+        const traceId = requestIdFor(req);
+        const message = errorMessage(err);
+        sidecarLog("error", "sponsor_execute_failed", {
+            requestId: traceId,
+            error: message,
+        });
+        res.status(500).json({ error: message, traceId });
     }
 });
 

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -47,6 +47,7 @@ fn unsupported_legacy_sdk() -> StatusCode {
     StatusCode::UPGRADE_REQUIRED
 }
 
+#[tracing::instrument(name = "auth.verify_signature", skip_all)]
 pub async fn verify_signature(
     State(state): State<Arc<AppState>>,
     request: Request,
@@ -277,6 +278,7 @@ pub async fn verify_signature(
 /// 3. On-chain registry scan (slower, auto-discovery fallback)
 ///
 /// After successful resolution, the mapping is cached for future requests.
+#[tracing::instrument(name = "auth.resolve_account", skip_all)]
 async fn resolve_account(
     state: &AppState,
     public_key_hex: &str,

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -2,6 +2,7 @@ mod auth;
 mod engine;
 mod jobs;
 mod mcp_proxy;
+mod observability;
 mod rate_limit;
 mod routes;
 mod services;
@@ -18,7 +19,6 @@ use axum::{
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tower_http::trace::TraceLayer;
 
 use apalis::prelude::*;
 use apalis_sql::postgres::PostgresStorage;
@@ -43,13 +43,7 @@ async fn main() {
     // Load .env file (optional, won't error if missing)
     dotenvy::dotenv().ok();
 
-    // Initialize tracing
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "memwal_server=info,tower_http=info".into()),
-        )
-        .init();
+    observability::init_tracing();
 
     // Load config
     let config = Config::from_env();
@@ -524,6 +518,10 @@ async fn main() {
             "/config",
             get(routes::get_config).layer(DefaultBodyLimit::max(16 * 1024)),
         )
+        .route(
+            "/metrics",
+            get(observability::metrics).layer(DefaultBodyLimit::max(16 * 1024)),
+        )
         .merge(sponsor_routes)
         .merge(mcp_routes);
 
@@ -562,6 +560,8 @@ async fn main() {
                     "x-nonce".parse::<header::HeaderName>().unwrap(),
                     "x-account-id".parse::<header::HeaderName>().unwrap(),
                     "x-delegate-key".parse::<header::HeaderName>().unwrap(),
+                    "x-request-id".parse::<header::HeaderName>().unwrap(),
+                    "x-correlation-id".parse::<header::HeaderName>().unwrap(),
                     // ENG-1697: SessionKey envelope replacing x-delegate-key
                     "x-seal-session".parse::<header::HeaderName>().unwrap(),
                     // MCP headers — caller's MemWalAccount id + optional default namespace.
@@ -576,7 +576,9 @@ async fn main() {
         .merge(public_routes)
         .with_state(state)
         .layer(cors)
-        .layer(TraceLayer::new_for_http());
+        .layer(middleware::from_fn(
+            observability::request_context_middleware,
+        ));
 
     // Start server
     let addr = format!("0.0.0.0:{}", config.port);
@@ -586,6 +588,7 @@ async fn main() {
 
     tracing::info!("memwal server listening on {}", addr);
     tracing::info!("  health: http://localhost:{}/health", config.port);
+    tracing::info!("  metrics: http://localhost:{}/metrics", config.port);
     tracing::info!(
         "  api:    http://localhost:{}/api/{{remember,recall,analyze}}",
         config.port

--- a/services/server/src/mcp_proxy.rs
+++ b/services/server/src/mcp_proxy.rs
@@ -44,6 +44,8 @@ const FORWARD_HEADER_EXACT: &[&str] = &[
     "authorization",
     "content-type",
     "accept",
+    "x-request-id",
+    "x-correlation-id",
     // MCP 2025-06 streamable HTTP transport headers — the SDK on both
     // sides reads these to route requests to the right session.
     "mcp-session-id",

--- a/services/server/src/observability.rs
+++ b/services/server/src/observability.rs
@@ -1,0 +1,390 @@
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::{header, HeaderName, HeaderValue, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use prometheus::{Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+use tracing::Instrument;
+use tracing_subscriber::EnvFilter;
+
+use crate::types::AppState;
+
+const X_REQUEST_ID: &str = "x-request-id";
+const X_CORRELATION_ID: &str = "x-correlation-id";
+
+#[derive(Clone, Debug)]
+pub struct RequestContext {
+    request_id: String,
+    route: String,
+}
+
+tokio::task_local! {
+    static REQUEST_CONTEXT: RequestContext;
+}
+
+static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    prometheus::register_int_counter_vec!(
+        "memwal_http_requests_total",
+        "Total HTTP requests handled by the MemWal relayer.",
+        &["method", "route", "status"]
+    )
+    .expect("register memwal_http_requests_total")
+});
+
+static HTTP_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus::register_histogram_vec!(
+        HistogramOpts::new(
+            "memwal_http_request_duration_seconds",
+            "HTTP request latency in seconds."
+        )
+        .buckets(vec![
+            0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+        ]),
+        &["method", "route", "status"]
+    )
+    .expect("register memwal_http_request_duration_seconds")
+});
+
+static HTTP_REQUESTS_IN_FLIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
+    prometheus::register_int_gauge!(
+        "memwal_http_requests_in_flight",
+        "HTTP requests currently being handled by the MemWal relayer."
+    )
+    .expect("register memwal_http_requests_in_flight")
+});
+
+static ERRORS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    prometheus::register_int_counter_vec!(
+        "memwal_errors_total",
+        "Application errors returned by the MemWal relayer.",
+        &["kind", "route"]
+    )
+    .expect("register memwal_errors_total")
+});
+
+static RATE_LIMIT_DENIALS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    prometheus::register_int_counter_vec!(
+        "memwal_rate_limit_denials_total",
+        "Rate-limit denials by limiter bucket.",
+        &["bucket", "route"]
+    )
+    .expect("register memwal_rate_limit_denials_total")
+});
+
+static RATE_LIMIT_FALLBACKS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    prometheus::register_int_counter_vec!(
+        "memwal_rate_limit_fallbacks_total",
+        "Times the relayer used in-memory rate limiting because Redis was unavailable.",
+        &["scope"]
+    )
+    .expect("register memwal_rate_limit_fallbacks_total")
+});
+
+static EXTERNAL_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus::register_histogram_vec!(
+        HistogramOpts::new(
+            "memwal_external_request_duration_seconds",
+            "External service request latency in seconds."
+        )
+        .buckets(vec![
+            0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 180.0,
+        ]),
+        &["service", "operation", "status"]
+    )
+    .expect("register memwal_external_request_duration_seconds")
+});
+
+static SIDECAR_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    prometheus::register_int_counter_vec!(
+        "memwal_sidecar_failures_total",
+        "Sidecar failures seen by the Rust relayer.",
+        &["operation", "reason"]
+    )
+    .expect("register memwal_sidecar_failures_total")
+});
+
+static DB_QUERY_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus::register_histogram_vec!(
+        HistogramOpts::new(
+            "memwal_db_query_duration_seconds",
+            "Database query latency in seconds."
+        )
+        .buckets(vec![
+            0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+        ]),
+        &["operation", "status"]
+    )
+    .expect("register memwal_db_query_duration_seconds")
+});
+
+static DB_POOL: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    prometheus::register_int_gauge_vec!(
+        "memwal_db_pool_connections",
+        "PostgreSQL pool connections by state.",
+        &["state"]
+    )
+    .expect("register memwal_db_pool_connections")
+});
+
+pub fn init_tracing() {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "memwal_server=info,tower_http=info".into());
+    let json_logs = std::env::var("LOG_FORMAT")
+        .map(|value| value.eq_ignore_ascii_case("json"))
+        .unwrap_or(false);
+
+    if json_logs {
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_target(true)
+            .init();
+    }
+}
+
+pub async fn request_context_middleware(mut request: Request, next: Next) -> Response {
+    let request_id = resolve_request_id(request.headers());
+    let route = route_label(request.uri().path());
+    let method = request.method().as_str().to_string();
+    let path = request.uri().path().to_string();
+    let started = Instant::now();
+
+    request.extensions_mut().insert(RequestContext {
+        request_id: request_id.clone(),
+        route: route.clone(),
+    });
+    if let Ok(value) = HeaderValue::from_str(&request_id) {
+        request
+            .headers_mut()
+            .insert(request_id_header_name(), value);
+    }
+
+    let span = tracing::info_span!(
+        "http.request",
+        request_id = %request_id,
+        method = %method,
+        route = %route,
+        path = %path,
+    );
+    HTTP_REQUESTS_IN_FLIGHT.inc();
+
+    let context = RequestContext {
+        request_id: request_id.clone(),
+        route: route.clone(),
+    };
+
+    REQUEST_CONTEXT
+        .scope(context, async move {
+            let mut response = next.run(request).instrument(span).await;
+            let status = response.status();
+            let elapsed = started.elapsed();
+
+            if let Ok(value) = HeaderValue::from_str(&request_id) {
+                response
+                    .headers_mut()
+                    .insert(request_id_header_name(), value);
+            }
+
+            record_http_request(&method, &route, status, elapsed);
+            HTTP_REQUESTS_IN_FLIGHT.dec();
+            tracing::info!(
+                request_id = %request_id,
+                method = %method,
+                route = %route,
+                status = status.as_u16(),
+                latency_ms = elapsed.as_millis(),
+                "http request complete"
+            );
+            response
+        })
+        .await
+}
+
+pub async fn metrics(State(state): State<Arc<AppState>>) -> Response {
+    update_db_pool_metrics(state.db.pool());
+
+    let encoder = prometheus::TextEncoder::new();
+    let mut buffer = Vec::new();
+    match encoder.encode(&prometheus::gather(), &mut buffer) {
+        Ok(()) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, encoder.format_type())
+            .body(Body::from(buffer))
+            .expect("build metrics response"),
+        Err(err) => Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+            .body(Body::from(format!("failed to encode metrics: {}", err)))
+            .expect("build metrics error response"),
+    }
+}
+
+pub fn current_request_id() -> Option<String> {
+    REQUEST_CONTEXT.try_with(|ctx| ctx.request_id.clone()).ok()
+}
+
+pub fn current_context() -> Option<RequestContext> {
+    REQUEST_CONTEXT.try_with(Clone::clone).ok()
+}
+
+pub async fn with_request_context<F>(context: RequestContext, future: F) -> F::Output
+where
+    F: Future,
+{
+    REQUEST_CONTEXT.scope(context, future).await
+}
+
+pub fn current_route() -> String {
+    REQUEST_CONTEXT
+        .try_with(|ctx| ctx.route.clone())
+        .unwrap_or_else(|_| "background".to_string())
+}
+
+pub fn request_id_header_name() -> HeaderName {
+    HeaderName::from_static(X_REQUEST_ID)
+}
+
+pub fn apply_request_id_header(req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    match current_request_id() {
+        Some(request_id) => req.header(X_REQUEST_ID, request_id),
+        None => req,
+    }
+}
+
+pub fn record_app_error(kind: &'static str) {
+    let route = current_route();
+    ERRORS_TOTAL.with_label_values(&[kind, &route]).inc();
+}
+
+pub fn record_rate_limit_denial(bucket: &str) {
+    let route = current_route();
+    RATE_LIMIT_DENIALS_TOTAL
+        .with_label_values(&[bucket, &route])
+        .inc();
+}
+
+pub fn record_rate_limit_fallback(scope: &'static str) {
+    RATE_LIMIT_FALLBACKS_TOTAL.with_label_values(&[scope]).inc();
+}
+
+pub fn observe_external(
+    service: &'static str,
+    operation: &'static str,
+    status: &str,
+    elapsed: Duration,
+) {
+    EXTERNAL_REQUEST_DURATION_SECONDS
+        .with_label_values(&[service, operation, status])
+        .observe(elapsed.as_secs_f64());
+}
+
+pub fn record_sidecar_failure(operation: &'static str, reason: &'static str) {
+    SIDECAR_FAILURES_TOTAL
+        .with_label_values(&[operation, reason])
+        .inc();
+}
+
+pub fn observe_db(operation: &'static str, status: &'static str, elapsed: Duration) {
+    DB_QUERY_DURATION_SECONDS
+        .with_label_values(&[operation, status])
+        .observe(elapsed.as_secs_f64());
+}
+
+pub fn update_db_pool_metrics(pool: &sqlx::PgPool) {
+    DB_POOL
+        .with_label_values(&["open"])
+        .set(i64::from(pool.size()));
+    DB_POOL
+        .with_label_values(&["idle"])
+        .set(pool.num_idle() as i64);
+}
+
+fn record_http_request(method: &str, route: &str, status: StatusCode, elapsed: Duration) {
+    let status = status.as_u16().to_string();
+    HTTP_REQUESTS_TOTAL
+        .with_label_values(&[method, route, &status])
+        .inc();
+    HTTP_REQUEST_DURATION_SECONDS
+        .with_label_values(&[method, route, &status])
+        .observe(elapsed.as_secs_f64());
+}
+
+fn resolve_request_id(headers: &axum::http::HeaderMap) -> String {
+    [X_REQUEST_ID, X_CORRELATION_ID]
+        .iter()
+        .find_map(|name| {
+            headers
+                .get(*name)
+                .and_then(|value| value.to_str().ok())
+                .map(str::trim)
+                .filter(|value| is_safe_request_id(value))
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+}
+
+fn is_safe_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+}
+
+fn route_label(path: &str) -> String {
+    match path {
+        "/health" => "/health".to_string(),
+        "/config" => "/config".to_string(),
+        "/metrics" => "/metrics".to_string(),
+        "/sponsor" => "/sponsor".to_string(),
+        "/sponsor/execute" => "/sponsor/execute".to_string(),
+        "/api/remember" => "/api/remember".to_string(),
+        "/api/remember/bulk" => "/api/remember/bulk".to_string(),
+        "/api/remember/bulk/status" => "/api/remember/bulk/status".to_string(),
+        "/api/remember/manual" => "/api/remember/manual".to_string(),
+        "/api/recall" => "/api/recall".to_string(),
+        "/api/recall/manual" => "/api/recall/manual".to_string(),
+        "/api/analyze" => "/api/analyze".to_string(),
+        "/api/ask" => "/api/ask".to_string(),
+        "/api/restore" => "/api/restore".to_string(),
+        "/api/forget" => "/api/forget".to_string(),
+        "/api/stats" => "/api/stats".to_string(),
+        "/api/mcp/sse" => "/api/mcp/sse".to_string(),
+        "/api/mcp/messages" => "/api/mcp/messages".to_string(),
+        "/api/mcp" => "/api/mcp".to_string(),
+        _ if path.starts_with("/api/remember/") => "/api/remember/{job_id}".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_safe_request_id, route_label};
+
+    #[test]
+    fn request_id_validation_rejects_header_injection() {
+        assert!(is_safe_request_id("req-123_ok.test:1"));
+        assert!(!is_safe_request_id(""));
+        assert!(!is_safe_request_id("bad\nid"));
+        assert!(!is_safe_request_id(&"x".repeat(129)));
+    }
+
+    #[test]
+    fn route_label_normalizes_remember_status_ids() {
+        assert_eq!(route_label("/api/remember/abc"), "/api/remember/{job_id}");
+        assert_eq!(route_label("/api/recall"), "/api/recall");
+        assert_eq!(route_label("/unexpected"), "unknown");
+    }
+}

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -326,6 +326,7 @@ impl TokenBucket {
 
 /// Build a 429 response with JSON body and Retry-After header.
 fn rate_limit_response(layer: &str, limit: i64, window: &str, retry_after: u64) -> Response {
+    crate::observability::record_rate_limit_denial(layer);
     let body = serde_json::json!({
         "error": "Rate limit exceeded",
         "layer": layer,
@@ -347,6 +348,7 @@ fn rate_limit_response(layer: &str, limit: i64, window: &str, retry_after: u64) 
 /// in-memory fallback also cannot be used (e.g., lock poisoned).
 /// HIGH-2 fix: previously Redis errors silently allowed requests through.
 fn rate_limiter_unavailable_response() -> Response {
+    crate::observability::record_app_error("rate_limiter_unavailable");
     let body = serde_json::json!({
         "error": "Rate limiter temporarily unavailable",
         "retry_after_seconds": 30,
@@ -533,6 +535,7 @@ pub async fn rate_limit_middleware(
     // --- Fallback path: Redis unreachable — use in-memory token buckets ---
     if redis_down {
         tracing::warn!("rate limit: Redis is unreachable, using in-memory fallback");
+        crate::observability::record_rate_limit_fallback("authenticated");
         let mut fallback = state.fallback_rate_limit.lock().await;
 
         if !fallback.can_consume(
@@ -705,7 +708,10 @@ pub async fn check_sender_rate_limit(
     )
     .await
     {
-        Ok(WindowCheckResult::Denied) => return Ok(SponsorRlResult::MinuteLimitExceeded),
+        Ok(WindowCheckResult::Denied) => {
+            crate::observability::record_rate_limit_denial("sponsor_sender_burst");
+            return Ok(SponsorRlResult::MinuteLimitExceeded);
+        }
         Err(e) => {
             tracing::warn!("check_sender_rate_limit: Redis error (minute): {} — switching to in-memory fallback", e);
             redis_down = true;
@@ -726,7 +732,10 @@ pub async fn check_sender_rate_limit(
         )
         .await
         {
-            Ok(WindowCheckResult::Denied) => return Ok(SponsorRlResult::HourLimitExceeded),
+            Ok(WindowCheckResult::Denied) => {
+                crate::observability::record_rate_limit_denial("sponsor_sender_sustained");
+                return Ok(SponsorRlResult::HourLimitExceeded);
+            }
             Err(e) => {
                 tracing::warn!("check_sender_rate_limit: Redis error (hour): {} — switching to in-memory fallback", e);
                 redis_down = true;
@@ -737,11 +746,14 @@ pub async fn check_sender_rate_limit(
 
     // --- In-memory fallback when Redis is down (HIGH-2 fix) ---
     if redis_down {
+        crate::observability::record_rate_limit_fallback("sponsor_sender");
         let mut fallback = state.fallback_rate_limit.lock().await;
         if !fallback.can_consume(&min_key, 1.0, per_minute as f64, 60.0) {
+            crate::observability::record_rate_limit_denial("sponsor_sender_burst");
             return Ok(SponsorRlResult::MinuteLimitExceeded);
         }
         if !fallback.can_consume(&hr_key, 1.0, per_hour as f64, 3600.0) {
+            crate::observability::record_rate_limit_denial("sponsor_sender_sustained");
             return Ok(SponsorRlResult::HourLimitExceeded);
         }
         fallback.consume(&min_key, 1.0, per_minute as f64, 60.0);
@@ -942,6 +954,7 @@ pub async fn sponsor_rate_limit_middleware(
     // --- In-memory fallback when Redis is down (HIGH-2 fix) ---
     if redis_down {
         tracing::warn!("sponsor_rate_limit_middleware: Redis is unreachable, using in-memory fallback for ip={}", ip);
+        crate::observability::record_rate_limit_fallback("sponsor_ip");
         let mut fallback = state.fallback_rate_limit.lock().await;
 
         if !fallback.can_consume(&min_key, 1.0, config.per_minute as f64, 60.0) {

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -18,7 +18,7 @@ use crate::services::llm_chat::{ChatCompletionRequest, ChatCompletionResponse, C
 use crate::storage::{seal, walrus};
 use crate::types::*;
 
-use super::{cleanup_expired_blob, truncate_str};
+use super::cleanup_expired_blob;
 
 /// ENG-1747: the `/api/ask` system prompt — a versioned text asset with a
 /// `{MEMORY_CONTEXT}` placeholder (substituted with the `<memory>`-tag-
@@ -171,10 +171,10 @@ pub async fn ask(
     // `recall` already enforces (MED-3) — see routes/recall.rs.
     let limit = body.limit.unwrap_or(5).min(100);
     tracing::info!(
-        "ask: question=\"{}...\" owner={} ns={}",
-        truncate_str(&body.question, 50),
-        owner,
-        namespace
+        question_len = body.question.len(),
+        owner = %owner,
+        namespace = %namespace,
+        "ask request"
     );
 
     // F3 (structure-review): probe the SEAL credential up front. If the
@@ -261,7 +261,7 @@ pub async fn ask(
         .ok_or_else(|| AppError::Internal("OPENAI_API_KEY required for /api/ask".into()))?;
     let url = format!("{}/chat/completions", state.config.openai_api_base);
 
-    let resp = state
+    let req = state
         .http_client
         .post(&url)
         .header("Authorization", format!("Bearer {}", api_key))
@@ -280,10 +280,25 @@ pub async fn ask(
             ],
             temperature: 0.7,
             max_tokens: 512,
-        })
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("LLM request failed: {}", e)))?;
+        });
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
+    let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "openai",
+            "ask_chat_completions",
+            "transport_error",
+            started.elapsed(),
+        );
+        AppError::Internal(format!("LLM request failed: {}", e))
+    })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "openai",
+        "ask_chat_completions",
+        &status_label,
+        started.elapsed(),
+    );
 
     if !resp.status().is_success() {
         let status = resp.status();

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -24,7 +24,7 @@ use crate::rate_limit;
 use crate::services::extractor::MAX_ANALYZE_FACTS;
 use crate::types::*;
 
-use super::{collect_bounded_results, enqueue_wallet_job, truncate_str};
+use super::{collect_bounded_results, enqueue_wallet_job};
 
 const ANALYZE_CONCURRENCY: usize = 5;
 
@@ -60,10 +60,10 @@ pub async fn analyze(
     let owner = &auth.owner;
     let namespace = &body.namespace;
     tracing::info!(
-        "analyze: text=\"{}...\" owner={} ns={}",
-        truncate_str(&body.text, 50),
-        owner,
-        namespace
+        text_len = body.text.len(),
+        owner = %owner,
+        namespace = %namespace,
+        "analyze request"
     );
 
     // Step 1: Extract facts using the Extractor service (sync — fast, ~1-2s)
@@ -257,10 +257,10 @@ pub async fn analyze(
         .map_err(|e| AppError::Internal(format!("Failed to enqueue analyze job: {}", e)))?;
 
         tracing::info!(
-            "analyze: fact enqueued job_id={} wallet={} fact=\"{}...\"",
-            job_id,
+            job_id = %job_id,
             wallet_index,
-            truncate_str(&fact_text, 40)
+            fact_len = fact_text.len(),
+            "analyze fact enqueued"
         );
         accepted_facts.push(AnalyzeAcceptedFact {
             text: fact_text,

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -69,6 +69,7 @@ pub async fn enqueue_wallet_job(
 /// Truncate a string to at most `max_bytes` bytes without splitting a UTF-8
 /// character.  Falls back to the nearest char boundary when `max_bytes` lands
 /// inside a multi-byte sequence (e.g. emoji).
+#[cfg(test)]
 pub(super) fn truncate_str(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
         return s;

--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -15,8 +15,6 @@ use std::sync::Arc;
 
 use crate::types::*;
 
-use super::truncate_str;
-
 // ============================================================
 // Recall query-embedding cache (Redis) — wraps the Embedder service
 // ============================================================
@@ -94,10 +92,10 @@ pub async fn recall(
     let owner = &auth.owner;
     let namespace = &body.namespace;
     tracing::info!(
-        "recall: query=\"{}...\" owner={} ns={}",
-        truncate_str(&body.query, 50),
-        owner,
-        namespace
+        query_len = body.query.len(),
+        owner = %owner,
+        namespace = %namespace,
+        "recall request"
     );
 
     let t0 = std::time::Instant::now();

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -102,83 +102,92 @@ fn spawn_prepare_remember_job(
     namespace: String,
     agent_public_key: String,
 ) {
+    let request_context = crate::observability::current_context();
     tokio::spawn(async move {
-        let result: Result<(), AppError> = async {
-            // ENG-1407: texts beyond the embedder's context window must be
-            // summarized first. Summarization runs sequentially before the
-            // embed/encrypt fan-out because the summary is the embedder's
-            // input — encrypt still uses the original `text`.
-            let needs_summary =
-                text.len() > SUMMARIZE_THRESHOLD_BYTES && state.config.openai_api_key.is_some();
-            let embed_input: std::borrow::Cow<'_, str> = if needs_summary {
-                let summary =
-                    summarize_for_embedding(&state.http_client, &state.config, &text).await?;
-                tracing::info!(
-                    "remember prep: summarized {} bytes → {} bytes for embedding (job_id={})",
-                    text.len(),
-                    summary.len(),
-                    job_id,
+        let work = async move {
+            let result: Result<(), AppError> = async {
+                // ENG-1407: texts beyond the embedder's context window must be
+                // summarized first. Summarization runs sequentially before the
+                // embed/encrypt fan-out because the summary is the embedder's
+                // input — encrypt still uses the original `text`.
+                let needs_summary =
+                    text.len() > SUMMARIZE_THRESHOLD_BYTES && state.config.openai_api_key.is_some();
+                let embed_input: std::borrow::Cow<'_, str> = if needs_summary {
+                    let summary =
+                        summarize_for_embedding(&state.http_client, &state.config, &text).await?;
+                    tracing::info!(
+                        "remember prep: summarized {} bytes → {} bytes for embedding (job_id={})",
+                        text.len(),
+                        summary.len(),
+                        job_id,
+                    );
+                    std::borrow::Cow::Owned(summary)
+                } else {
+                    std::borrow::Cow::Borrowed(text.as_str())
+                };
+
+                let embed_fut = state.embedder.embed(&embed_input);
+                let encrypt_fut = crate::storage::seal::seal_encrypt(
+                    &state.http_client,
+                    &state.config.sidecar_url,
+                    state.config.sidecar_secret.as_deref(),
+                    text.as_bytes(),
+                    &owner,
+                    &state.config.package_id,
                 );
-                std::borrow::Cow::Owned(summary)
-            } else {
-                std::borrow::Cow::Borrowed(text.as_str())
-            };
+                let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
+                let vector = vector_result?;
+                let encrypted = encrypted_result?;
 
-            let embed_fut = state.embedder.embed(&embed_input);
-            let encrypt_fut = crate::storage::seal::seal_encrypt(
-                &state.http_client,
-                &state.config.sidecar_url,
-                state.config.sidecar_secret.as_deref(),
-                text.as_bytes(),
-                &owner,
-                &state.config.package_id,
-            );
-            let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
-            let vector = vector_result?;
-            let encrypted = encrypted_result?;
+                rate_limit::check_storage_quota(&state, &owner, encrypted.len() as i64).await?;
 
-            rate_limit::check_storage_quota(&state, &owner, encrypted.len() as i64).await?;
+                let wallet_index = state.key_pool.next_index().ok_or_else(|| {
+                    AppError::Internal(
+                        "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)"
+                            .into(),
+                    )
+                })?;
+                let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
 
-            let wallet_index = state.key_pool.next_index().ok_or_else(|| {
-                AppError::Internal(
-                    "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)"
-                        .into(),
+                enqueue_wallet_job(
+                    &state,
+                    wallet_index,
+                    WalletOperation::UploadAndTransfer {
+                        encrypted_b64,
+                        vector,
+                        owner: owner.clone(),
+                        namespace: namespace.clone(),
+                        package_id: state.config.package_id.clone(),
+                        agent_public_key: Some(agent_public_key.clone()),
+                        remember_job_id: Some(job_id.clone()),
+                        epochs: 50,
+                    },
                 )
-            })?;
-            let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+                .await?;
 
-            enqueue_wallet_job(
-                &state,
-                wallet_index,
-                WalletOperation::UploadAndTransfer {
-                    encrypted_b64,
-                    vector,
-                    owner: owner.clone(),
-                    namespace: namespace.clone(),
-                    package_id: state.config.package_id.clone(),
-                    agent_public_key: Some(agent_public_key.clone()),
-                    remember_job_id: Some(job_id.clone()),
-                    epochs: 50,
-                },
-            )
-            .await?;
+                tracing::info!(
+                    "remember prepared: job_id={} owner={} ns={} encrypted_bytes={} wallet={}",
+                    job_id,
+                    owner,
+                    namespace,
+                    encrypted.len(),
+                    wallet_index,
+                );
+                Ok(())
+            }
+            .await;
 
-            tracing::info!(
-                "remember prepared: job_id={} owner={} ns={} encrypted_bytes={} wallet={}",
-                job_id,
-                owner,
-                namespace,
-                encrypted.len(),
-                wallet_index,
-            );
-            Ok(())
-        }
-        .await;
+            if let Err(e) = result {
+                let msg = e.to_string();
+                tracing::error!("remember preparation failed: job_id={} {}", job_id, msg);
+                mark_remember_job_failed(&state, &job_id, &msg).await;
+            }
+        };
 
-        if let Err(e) = result {
-            let msg = e.to_string();
-            tracing::error!("remember preparation failed: job_id={} {}", job_id, msg);
-            mark_remember_job_failed(&state, &job_id, &msg).await;
+        if let Some(request_context) = request_context {
+            crate::observability::with_request_context(request_context, work).await;
+        } else {
+            work.await;
         }
     });
 }
@@ -189,118 +198,129 @@ fn spawn_prepare_bulk_remember_job(
     agent_public_key: String,
     pending_items: Vec<PendingBulkRememberItem>,
 ) {
+    let request_context = crate::observability::current_context();
     tokio::spawn(async move {
-        let job_ids: Vec<String> = pending_items
-            .iter()
-            .map(|item| item.job_id.clone())
-            .collect();
-        let result: Result<(), AppError> = async {
-            let prep_tasks: Vec<_> = pending_items
-                .into_iter()
-                .map(|item| {
-                    let state = Arc::clone(&state);
-                    let owner = owner.clone();
-                    async move {
-                        // ENG-1407: bulk items can carry up to MAX_REMEMBER_TEXT_BYTES
-                        // each, so the same summarize-before-embed rule applies here.
-                        let needs_summary = item.text.len() > SUMMARIZE_THRESHOLD_BYTES
-                            && state.config.openai_api_key.is_some();
-                        let embed_input: std::borrow::Cow<'_, str> = if needs_summary {
-                            let summary = summarize_for_embedding(
-                                &state.http_client,
-                                &state.config,
-                                &item.text,
-                            )
-                            .await?;
-                            tracing::info!(
-                                "bulk prep: summarized {} bytes → {} bytes for embedding (job_id={})",
-                                item.text.len(),
-                                summary.len(),
-                                item.job_id,
-                            );
-                            std::borrow::Cow::Owned(summary)
-                        } else {
-                            std::borrow::Cow::Borrowed(item.text.as_str())
-                        };
-
-                        let embed_fut = state.embedder.embed(&embed_input);
-                        let encrypt_fut = crate::storage::seal::seal_encrypt(
-                            &state.http_client,
-                            &state.config.sidecar_url,
-                            state.config.sidecar_secret.as_deref(),
-                            item.text.as_bytes(),
-                            &owner,
-                            &state.config.package_id,
-                        );
-                        let (vector_result, encrypted_result) =
-                            tokio::join!(embed_fut, encrypt_fut);
-                        Ok::<_, AppError>((
-                            item.job_id,
-                            item.namespace,
-                            vector_result?,
-                            encrypted_result?,
-                        ))
-                    }
-                })
+        let work = async move {
+            let job_ids: Vec<String> = pending_items
+                .iter()
+                .map(|item| item.job_id.clone())
                 .collect();
+            let result: Result<(), AppError> = async {
+                let prep_tasks: Vec<_> = pending_items
+                    .into_iter()
+                    .map(|item| {
+                        let state = Arc::clone(&state);
+                        let owner = owner.clone();
+                        async move {
+                            // ENG-1407: bulk items can carry up to MAX_REMEMBER_TEXT_BYTES
+                            // each, so the same summarize-before-embed rule applies here.
+                            let needs_summary = item.text.len() > SUMMARIZE_THRESHOLD_BYTES
+                                && state.config.openai_api_key.is_some();
+                            let embed_input: std::borrow::Cow<'_, str> = if needs_summary {
+                                let summary = summarize_for_embedding(
+                                    &state.http_client,
+                                    &state.config,
+                                    &item.text,
+                                )
+                                .await?;
+                                tracing::info!(
+                                    "bulk prep: summarized {} bytes → {} bytes for embedding (job_id={})",
+                                    item.text.len(),
+                                    summary.len(),
+                                    item.job_id,
+                                );
+                                std::borrow::Cow::Owned(summary)
+                            } else {
+                                std::borrow::Cow::Borrowed(item.text.as_str())
+                            };
 
-            let prep_results = collect_bounded_results(prep_tasks, BULK_EMBED_CONCURRENCY).await;
+                            let embed_fut = state.embedder.embed(&embed_input);
+                            let encrypt_fut = crate::storage::seal::seal_encrypt(
+                                &state.http_client,
+                                &state.config.sidecar_url,
+                                state.config.sidecar_secret.as_deref(),
+                                item.text.as_bytes(),
+                                &owner,
+                                &state.config.package_id,
+                            );
+                            let (vector_result, encrypted_result) =
+                                tokio::join!(embed_fut, encrypt_fut);
+                            Ok::<_, AppError>((
+                                item.job_id,
+                                item.namespace,
+                                vector_result?,
+                                encrypted_result?,
+                            ))
+                        }
+                    })
+                    .collect();
 
-            let mut prepared: Vec<(String, String, Vec<f32>, Vec<u8>)> =
-                Vec::with_capacity(prep_results.len());
-            let mut total_encrypted_bytes: i64 = 0;
-            for result in prep_results {
-                let (job_id, namespace, vector, encrypted) = result?;
-                total_encrypted_bytes += encrypted.len() as i64;
-                prepared.push((job_id, namespace, vector, encrypted));
+                let prep_results =
+                    collect_bounded_results(prep_tasks, BULK_EMBED_CONCURRENCY).await;
+
+                let mut prepared: Vec<(String, String, Vec<f32>, Vec<u8>)> =
+                    Vec::with_capacity(prep_results.len());
+                let mut total_encrypted_bytes: i64 = 0;
+                for result in prep_results {
+                    let (job_id, namespace, vector, encrypted) = result?;
+                    total_encrypted_bytes += encrypted.len() as i64;
+                    prepared.push((job_id, namespace, vector, encrypted));
+                }
+
+                rate_limit::check_storage_quota(&state, &owner, total_encrypted_bytes).await?;
+
+                let mut bulk_items: Vec<BulkRememberItem> = Vec::with_capacity(prepared.len());
+                for (job_id, namespace, vector, encrypted) in prepared {
+                    let wallet_index = state
+                        .key_pool
+                        .next_index()
+                        .ok_or_else(|| AppError::Internal("No Sui keys configured".into()))?;
+                    let encrypted_b64 =
+                        base64::engine::general_purpose::STANDARD.encode(&encrypted);
+                    bulk_items.push(BulkRememberItem {
+                        job_id,
+                        encrypted_b64,
+                        vector,
+                        namespace,
+                        wallet_index,
+                    });
+                }
+
+                let mut storage = state.bulk_job_storage.clone();
+                storage
+                    .push(crate::jobs::BulkRememberJob {
+                        owner: owner.clone(),
+                        package_id: state.config.package_id.clone(),
+                        agent_public_key: Some(agent_public_key.clone()),
+                        items: bulk_items,
+                        epochs: 50,
+                    })
+                    .await
+                    .map_err(|e| {
+                        AppError::Internal(format!("Failed to enqueue bulk remember job: {}", e))
+                    })?;
+
+                tracing::info!(
+                    "remember_bulk prepared: {} items owner={} total_encrypted_bytes={}",
+                    job_ids.len(),
+                    owner,
+                    total_encrypted_bytes
+                );
+                Ok(())
             }
+            .await;
 
-            rate_limit::check_storage_quota(&state, &owner, total_encrypted_bytes).await?;
-
-            let mut bulk_items: Vec<BulkRememberItem> = Vec::with_capacity(prepared.len());
-            for (job_id, namespace, vector, encrypted) in prepared {
-                let wallet_index = state
-                    .key_pool
-                    .next_index()
-                    .ok_or_else(|| AppError::Internal("No Sui keys configured".into()))?;
-                let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
-                bulk_items.push(BulkRememberItem {
-                    job_id,
-                    encrypted_b64,
-                    vector,
-                    namespace,
-                    wallet_index,
-                });
+            if let Err(e) = result {
+                let msg = e.to_string();
+                tracing::error!("remember_bulk preparation failed: {}", msg);
+                mark_remember_jobs_failed(&state, &job_ids, &msg).await;
             }
+        };
 
-            let mut storage = state.bulk_job_storage.clone();
-            storage
-                .push(crate::jobs::BulkRememberJob {
-                    owner: owner.clone(),
-                    package_id: state.config.package_id.clone(),
-                    agent_public_key: Some(agent_public_key.clone()),
-                    items: bulk_items,
-                    epochs: 50,
-                })
-                .await
-                .map_err(|e| {
-                    AppError::Internal(format!("Failed to enqueue bulk remember job: {}", e))
-                })?;
-
-            tracing::info!(
-                "remember_bulk prepared: {} items owner={} total_encrypted_bytes={}",
-                job_ids.len(),
-                owner,
-                total_encrypted_bytes
-            );
-            Ok(())
-        }
-        .await;
-
-        if let Err(e) = result {
-            let msg = e.to_string();
-            tracing::error!("remember_bulk preparation failed: {}", msg);
-            mark_remember_jobs_failed(&state, &job_ids, &msg).await;
+        if let Some(request_context) = request_context {
+            crate::observability::with_request_context(request_context, work).await;
+        } else {
+            work.await;
         }
     });
 }
@@ -384,7 +404,7 @@ async fn summarize_with_prompt(
 
     let url = format!("{}/chat/completions", config.openai_api_base);
 
-    let resp = client
+    let req = client
         .post(&url)
         .header("Authorization", format!("Bearer {}", api_key))
         .header("Content-Type", "application/json")
@@ -402,10 +422,25 @@ async fn summarize_with_prompt(
             ],
             temperature: 0.1,
             max_tokens,
-        })
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Summarization API request failed: {}", e)))?;
+        });
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
+    let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "openai",
+            "summarize_for_embedding",
+            "transport_error",
+            started.elapsed(),
+        );
+        AppError::Internal(format!("Summarization API request failed: {}", e))
+    })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "openai",
+        "summarize_for_embedding",
+        &status_label,
+        started.elapsed(),
+    );
 
     if !resp.status().is_success() {
         let status = resp.status();

--- a/services/server/src/routes/sponsor.rs
+++ b/services/server/src/routes/sponsor.rs
@@ -159,10 +159,20 @@ pub async fn sponsor_proxy(
     if let Some(secret) = state.config.sidecar_secret.as_deref() {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Sponsor proxy failed: {}", e)))?;
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
+    let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sidecar",
+            "sponsor",
+            "transport_error",
+            started.elapsed(),
+        );
+        crate::observability::record_sidecar_failure("sponsor", "transport_error");
+        AppError::Internal(format!("Sponsor proxy failed: {}", e))
+    })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external("sidecar", "sponsor", &status_label, started.elapsed());
 
     let upstream_status = resp.status();
     let resp_body = resp
@@ -177,6 +187,7 @@ pub async fn sponsor_proxy(
             .body(Body::from(resp_body))
             .unwrap())
     } else {
+        crate::observability::record_sidecar_failure("sponsor", "http_error");
         tracing::error!(
             "sponsor upstream error {}: {}",
             upstream_status,
@@ -268,10 +279,25 @@ pub async fn sponsor_execute_proxy(
     if let Some(secret) = state.config.sidecar_secret.as_deref() {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Sponsor execute proxy failed: {}", e)))?;
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
+    let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sidecar",
+            "sponsor_execute",
+            "transport_error",
+            started.elapsed(),
+        );
+        crate::observability::record_sidecar_failure("sponsor_execute", "transport_error");
+        AppError::Internal(format!("Sponsor execute proxy failed: {}", e))
+    })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "sponsor_execute",
+        &status_label,
+        started.elapsed(),
+    );
 
     let upstream_status = resp.status();
     let resp_body = resp
@@ -286,6 +312,7 @@ pub async fn sponsor_execute_proxy(
             .body(Body::from(resp_body))
             .unwrap())
     } else {
+        crate::observability::record_sidecar_failure("sponsor_execute", "http_error");
         tracing::error!(
             "sponsor/execute upstream error {}: {}",
             upstream_status,

--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -58,6 +58,7 @@ impl Embedder for OpenAiEmbedder {
                 // Real embedding via OpenRouter/OpenAI-compatible API
                 let url = format!("{}/embeddings", self.config.openai_api_base);
 
+                let started = std::time::Instant::now();
                 let resp = self
                     .http_client
                     .post(&url)
@@ -70,8 +71,21 @@ impl Embedder for OpenAiEmbedder {
                     .send()
                     .await
                     .map_err(|e| {
+                        crate::observability::observe_external(
+                            "openai",
+                            "embeddings",
+                            "transport_error",
+                            started.elapsed(),
+                        );
                         AppError::Internal(format!("Embedding API request failed: {}", e))
                     })?;
+                let status_label = resp.status().as_u16().to_string();
+                crate::observability::observe_external(
+                    "openai",
+                    "embeddings",
+                    &status_label,
+                    started.elapsed(),
+                );
 
                 if !resp.status().is_success() {
                     let status = resp.status();

--- a/services/server/src/services/extractor.rs
+++ b/services/server/src/services/extractor.rs
@@ -90,6 +90,7 @@ impl Extractor for LlmExtractor {
 
         let url = format!("{}/chat/completions", self.config.openai_api_base);
 
+        let started = std::time::Instant::now();
         let resp = self
             .http_client
             .post(&url)
@@ -112,7 +113,22 @@ impl Extractor for LlmExtractor {
             })
             .send()
             .await
-            .map_err(|e| AppError::Internal(format!("LLM API request failed: {}", e)))?;
+            .map_err(|e| {
+                crate::observability::observe_external(
+                    "openai",
+                    "chat_completions",
+                    "transport_error",
+                    started.elapsed(),
+                );
+                AppError::Internal(format!("LLM API request failed: {}", e))
+            })?;
+        let status_label = resp.status().as_u16().to_string();
+        crate::observability::observe_external(
+            "openai",
+            "chat_completions",
+            &status_label,
+            started.elapsed(),
+        );
 
         if !resp.status().is_success() {
             let status = resp.status();

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -8,6 +8,14 @@ pub struct VectorDb {
     pool: PgPool,
 }
 
+fn db_status<T>(result: &Result<T, AppError>) -> &'static str {
+    if result.is_ok() {
+        "ok"
+    } else {
+        "error"
+    }
+}
+
 impl VectorDb {
     /// Initialize database connection pool and run migrations
     pub async fn new(database_url: &str) -> Result<Self, AppError> {
@@ -98,7 +106,8 @@ impl VectorDb {
     ) -> Result<(), AppError> {
         let embedding = Vector::from(vector.to_vec());
 
-        sqlx::query(
+        let started = std::time::Instant::now();
+        let result = sqlx::query(
             "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes)
              VALUES ($1, $2, $3, $4, $5, $6)
              ON CONFLICT (id) DO UPDATE SET
@@ -116,7 +125,9 @@ impl VectorDb {
         .bind(blob_size_bytes)
         .execute(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)));
+        crate::observability::observe_db("vector.insert", db_status(&result), started.elapsed());
+        result?;
 
         tracing::debug!(
             "inserted vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
@@ -147,7 +158,8 @@ impl VectorDb {
     ) -> Result<(), AppError> {
         let embedding = Vector::from(vector.to_vec());
 
-        sqlx::query(
+        let started = std::time::Instant::now();
+        let result = sqlx::query(
             "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, plaintext)
              VALUES ($1, $2, $3, $4, $5, $6, $7)
              ON CONFLICT (id) DO UPDATE SET
@@ -167,7 +179,13 @@ impl VectorDb {
         .bind(plaintext)
         .execute(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to insert plaintext vector: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to insert plaintext vector: {}", e)));
+        crate::observability::observe_db(
+            "vector.insert_plaintext",
+            db_status(&result),
+            started.elapsed(),
+        );
+        result?;
 
         tracing::debug!(
             "inserted plaintext vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
@@ -195,14 +213,21 @@ impl VectorDb {
         blob_id: &str,
         owner: &str,
     ) -> Result<Option<String>, AppError> {
-        let row: Option<(Option<String>,)> = sqlx::query_as(
+        let started = std::time::Instant::now();
+        let result: Result<Option<(Option<String>,)>, AppError> = sqlx::query_as(
             "SELECT plaintext FROM vector_entries WHERE blob_id = $1 AND owner = $2 LIMIT 1",
         )
         .bind(blob_id)
         .bind(owner)
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to fetch plaintext: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to fetch plaintext: {}", e)));
+        crate::observability::observe_db(
+            "vector.fetch_plaintext",
+            db_status(&result),
+            started.elapsed(),
+        );
+        let row = result?;
 
         Ok(row.and_then(|(plaintext,)| plaintext))
     }
@@ -218,7 +243,8 @@ impl VectorDb {
     ) -> Result<Vec<SearchHit>, AppError> {
         let embedding = Vector::from(query_vector.to_vec());
 
-        let rows: Vec<(String, f64)> = sqlx::query_as(
+        let started = std::time::Instant::now();
+        let result: Result<Vec<(String, f64)>, AppError> = sqlx::query_as(
             "SELECT blob_id, (embedding <=> $1)::float8 AS distance
              FROM vector_entries
              WHERE owner = $2 AND namespace = $3
@@ -231,7 +257,13 @@ impl VectorDb {
         .bind(limit as i64)
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to search vectors: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to search vectors: {}", e)));
+        crate::observability::observe_db(
+            "vector.search_similar",
+            db_status(&result),
+            started.elapsed(),
+        );
+        let rows = result?;
 
         let results = rows
             .into_iter()
@@ -247,7 +279,8 @@ impl VectorDb {
         owner: &str,
         namespace: &str,
     ) -> Result<Vec<String>, AppError> {
-        let rows: Vec<(String,)> = sqlx::query_as(
+        let started = std::time::Instant::now();
+        let result: Result<Vec<(String,)>, AppError> = sqlx::query_as(
             "SELECT DISTINCT blob_id FROM vector_entries
              WHERE owner = $1 AND namespace = $2",
         )
@@ -255,7 +288,13 @@ impl VectorDb {
         .bind(namespace)
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to get blobs by namespace: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to get blobs by namespace: {}", e)));
+        crate::observability::observe_db(
+            "vector.get_blobs_by_namespace",
+            db_status(&result),
+            started.elapsed(),
+        );
+        let rows = result?;
 
         Ok(rows.into_iter().map(|(blob_id,)| blob_id).collect())
     }
@@ -268,7 +307,8 @@ impl VectorDb {
         owner: &str,
         namespace: &str,
     ) -> Result<(i64, i64), AppError> {
-        let row: (i64, i64) = sqlx::query_as(
+        let started = std::time::Instant::now();
+        let result: Result<(i64, i64), AppError> = sqlx::query_as(
             "SELECT COUNT(*)::BIGINT, COALESCE(SUM(blob_size_bytes)::BIGINT, 0)
              FROM vector_entries WHERE owner = $1 AND namespace = $2",
         )
@@ -276,7 +316,13 @@ impl VectorDb {
         .bind(namespace)
         .fetch_one(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to get namespace stats: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to get namespace stats: {}", e)));
+        crate::observability::observe_db(
+            "vector.namespace_stats",
+            db_status(&result),
+            started.elapsed(),
+        );
+        let row = result?;
 
         Ok(row)
     }
@@ -287,12 +333,19 @@ impl VectorDb {
     /// retrievable and stop counting toward storage quota.) Reachable via
     /// `POST /api/forget` — authed, owner-scoped.
     pub async fn delete_by_namespace(&self, owner: &str, namespace: &str) -> Result<u64, AppError> {
+        let started = std::time::Instant::now();
         let result = sqlx::query("DELETE FROM vector_entries WHERE owner = $1 AND namespace = $2")
             .bind(owner)
             .bind(namespace)
             .execute(&self.pool)
             .await
-            .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)))?;
+            .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)));
+        crate::observability::observe_db(
+            "vector.delete_by_namespace",
+            db_status(&result),
+            started.elapsed(),
+        );
+        let result = result?;
 
         let rows = result.rows_affected();
         tracing::info!(
@@ -308,14 +361,19 @@ impl VectorDb {
     /// Called reactively when Walrus returns 404 during blob download.
     /// LOW-10: Requires owner to prevent cross-user blob deletion.
     pub async fn delete_by_blob_id(&self, blob_id: &str, owner: &str) -> Result<u64, AppError> {
+        let started = std::time::Instant::now();
         let result = sqlx::query("DELETE FROM vector_entries WHERE blob_id = $1 AND owner = $2")
             .bind(blob_id)
             .bind(owner)
             .execute(&self.pool)
             .await
-            .map_err(|e| {
-                AppError::Internal(format!("Failed to delete vector by blob_id: {}", e))
-            })?;
+            .map_err(|e| AppError::Internal(format!("Failed to delete vector by blob_id: {}", e)));
+        crate::observability::observe_db(
+            "vector.delete_by_blob_id",
+            db_status(&result),
+            started.elapsed(),
+        );
+        let result = result?;
 
         let rows = result.rows_affected();
         if rows > 0 {
@@ -339,15 +397,21 @@ impl VectorDb {
         &self,
         public_key_hex: &str,
     ) -> Result<Option<(String, String)>, AppError> {
-        let result: Option<(String, String)> = sqlx::query_as(
+        let started = std::time::Instant::now();
+        let result: Result<Option<(String, String)>, AppError> = sqlx::query_as(
             "SELECT account_id, owner FROM delegate_key_cache WHERE public_key = $1 AND expires_at > NOW()",
         )
         .bind(public_key_hex)
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to query cache: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to query cache: {}", e)));
+        crate::observability::observe_db(
+            "delegate_cache.get",
+            db_status(&result),
+            started.elapsed(),
+        );
 
-        Ok(result)
+        result
     }
 
     /// Cache a verified delegate key → account mapping.
@@ -357,7 +421,8 @@ impl VectorDb {
         account_id: &str,
         owner: &str,
     ) -> Result<(), AppError> {
-        sqlx::query(
+        let started = std::time::Instant::now();
+        let result = sqlx::query(
             "INSERT INTO delegate_key_cache (public_key, account_id, owner, expires_at)
              VALUES ($1, $2, $3, NOW() + INTERVAL '24 hours')
              ON CONFLICT (public_key)
@@ -368,7 +433,13 @@ impl VectorDb {
         .bind(owner)
         .execute(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to cache delegate key: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("Failed to cache delegate key: {}", e)));
+        crate::observability::observe_db(
+            "delegate_cache.set",
+            db_status(&result),
+            started.elapsed(),
+        );
+        result?;
 
         tracing::debug!(
             "cached delegate key: {} -> account {}",
@@ -459,6 +530,7 @@ impl VectorDb {
         owner: &str,
         lock_key: i64,
     ) -> Result<i64, AppError> {
+        let started = std::time::Instant::now();
         let mut tx = self
             .pool
             .begin()
@@ -483,6 +555,7 @@ impl VectorDb {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to commit tx: {}", e)))?;
 
+        crate::observability::observe_db("quota.storage_used_with_lock", "ok", started.elapsed());
         Ok(row.0)
     }
 

--- a/services/server/src/storage/seal.rs
+++ b/services/server/src/storage/seal.rs
@@ -107,14 +107,31 @@ pub async fn seal_encrypt(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
     let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sidecar",
+            "seal_encrypt",
+            "transport_error",
+            started.elapsed(),
+        );
+        crate::observability::record_sidecar_failure("seal_encrypt", "transport_error");
         AppError::Internal(format!(
             "Sidecar seal/encrypt request failed: {}. Is the sidecar running?",
             e
         ))
     })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "seal_encrypt",
+        &status_label,
+        started.elapsed(),
+    );
 
     if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("seal_encrypt", "http_error");
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
             return Err(AppError::Internal(format!(
@@ -175,14 +192,31 @@ pub async fn seal_decrypt(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
     let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sidecar",
+            "seal_decrypt",
+            "transport_error",
+            started.elapsed(),
+        );
+        crate::observability::record_sidecar_failure("seal_decrypt", "transport_error");
         AppError::Internal(format!(
             "Sidecar seal/decrypt request failed: {}. Is the sidecar running?",
             e
         ))
     })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "seal_decrypt",
+        &status_label,
+        started.elapsed(),
+    );
 
     if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("seal_decrypt", "http_error");
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
             return Err(AppError::Internal(format!(
@@ -261,15 +295,32 @@ pub async fn seal_decrypt_batch(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
+    let req = crate::observability::apply_request_id_header(req);
 
+    let started = std::time::Instant::now();
     let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sidecar",
+            "seal_decrypt_batch",
+            "transport_error",
+            started.elapsed(),
+        );
+        crate::observability::record_sidecar_failure("seal_decrypt_batch", "transport_error");
         AppError::Internal(format!(
             "Sidecar seal/decrypt-batch request failed: {}. Is the sidecar running?",
             e
         ))
     })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "seal_decrypt_batch",
+        &status_label,
+        started.elapsed(),
+    );
 
     if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("seal_decrypt_batch", "http_error");
         let body_text = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body_text) {
             return Err(AppError::Internal(format!(

--- a/services/server/src/storage/sui.rs
+++ b/services/server/src/storage/sui.rs
@@ -24,13 +24,28 @@ pub async fn verify_delegate_key_onchain(
         ]
     });
 
-    let response = http_client
+    let request = http_client
         .post(rpc_url)
         .header(reqwest::header::ACCEPT_ENCODING, "identity")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| OnchainVerifyError::RpcError(format!("HTTP request failed: {}", e)))?;
+        .json(&body);
+    let request = crate::observability::apply_request_id_header(request);
+    let started = std::time::Instant::now();
+    let response = request.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sui_rpc",
+            "sui_getObject",
+            "transport_error",
+            started.elapsed(),
+        );
+        OnchainVerifyError::RpcError(format!("HTTP request failed: {}", e))
+    })?;
+    let status_label = response.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sui_rpc",
+        "sui_getObject",
+        &status_label,
+        started.elapsed(),
+    );
 
     let rpc_response: RpcResponse = parse_json_rpc_response(response, "sui_getObject").await?;
 
@@ -137,13 +152,28 @@ pub async fn find_account_by_delegate_key(
         "params": [registry_id, { "showContent": true }]
     });
 
-    let registry_resp = http_client
+    let request = http_client
         .post(rpc_url)
         .header(reqwest::header::ACCEPT_ENCODING, "identity")
-        .json(&registry_body)
-        .send()
-        .await
-        .map_err(|e| OnchainVerifyError::RpcError(format!("Failed to fetch registry: {}", e)))?;
+        .json(&registry_body);
+    let request = crate::observability::apply_request_id_header(request);
+    let started = std::time::Instant::now();
+    let registry_resp = request.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sui_rpc",
+            "sui_getObject_registry",
+            "transport_error",
+            started.elapsed(),
+        );
+        OnchainVerifyError::RpcError(format!("Failed to fetch registry: {}", e))
+    })?;
+    let status_label = registry_resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sui_rpc",
+        "sui_getObject_registry",
+        &status_label,
+        started.elapsed(),
+    );
 
     let registry_json: serde_json::Value =
         parse_json_rpc_response(registry_resp, "sui_getObject registry").await?;
@@ -170,13 +200,28 @@ pub async fn find_account_by_delegate_key(
             "params": [table_id, cursor, 50]
         });
 
-        let response = http_client
+        let request = http_client
             .post(rpc_url)
             .header(reqwest::header::ACCEPT_ENCODING, "identity")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| OnchainVerifyError::RpcError(format!("HTTP request failed: {}", e)))?;
+            .json(&body);
+        let request = crate::observability::apply_request_id_header(request);
+        let started = std::time::Instant::now();
+        let response = request.send().await.map_err(|e| {
+            crate::observability::observe_external(
+                "sui_rpc",
+                "suix_getDynamicFields",
+                "transport_error",
+                started.elapsed(),
+            );
+            OnchainVerifyError::RpcError(format!("HTTP request failed: {}", e))
+        })?;
+        let status_label = response.status().as_u16().to_string();
+        crate::observability::observe_external(
+            "sui_rpc",
+            "suix_getDynamicFields",
+            &status_label,
+            started.elapsed(),
+        );
 
         let resp_json: serde_json::Value =
             parse_json_rpc_response(response, "suix_getDynamicFields").await?;
@@ -214,15 +259,28 @@ pub async fn find_account_by_delegate_key(
                 "params": [field_obj_id, { "showContent": true }]
             });
 
-            let field_resp = http_client
+            let request = http_client
                 .post(rpc_url)
                 .header(reqwest::header::ACCEPT_ENCODING, "identity")
-                .json(&field_body)
-                .send()
-                .await
-                .map_err(|e| {
-                    OnchainVerifyError::RpcError(format!("Failed to fetch field: {}", e))
-                })?;
+                .json(&field_body);
+            let request = crate::observability::apply_request_id_header(request);
+            let started = std::time::Instant::now();
+            let field_resp = request.send().await.map_err(|e| {
+                crate::observability::observe_external(
+                    "sui_rpc",
+                    "sui_getObject_dynamic_field",
+                    "transport_error",
+                    started.elapsed(),
+                );
+                OnchainVerifyError::RpcError(format!("Failed to fetch field: {}", e))
+            })?;
+            let status_label = field_resp.status().as_u16().to_string();
+            crate::observability::observe_external(
+                "sui_rpc",
+                "sui_getObject_dynamic_field",
+                &status_label,
+                started.elapsed(),
+            );
 
             let field_json: serde_json::Value =
                 parse_json_rpc_response(field_resp, "sui_getObject dynamic field").await?;

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -152,13 +152,32 @@ async fn upload_blob_inner(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
     let resp = req
         .timeout(SIDECAR_WALRUS_TIMEOUT)
         .send()
         .await
-        .map_err(|e| AppError::Internal(format!("Sidecar walrus/upload request failed: {}", e)))?;
+        .map_err(|e| {
+            crate::observability::observe_external(
+                "sidecar",
+                "walrus_upload",
+                "transport_error",
+                started.elapsed(),
+            );
+            crate::observability::record_sidecar_failure("walrus_upload", "transport_error");
+            AppError::Internal(format!("Sidecar walrus/upload request failed: {}", e))
+        })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "walrus_upload",
+        &status_label,
+        started.elapsed(),
+    );
 
     if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("walrus_upload", "http_error");
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
             return Err(AppError::Internal(format!(
@@ -222,18 +241,38 @@ pub async fn set_metadata_batch(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
+    let req = crate::observability::apply_request_id_header(req);
 
+    let started = std::time::Instant::now();
     let resp = req
         .timeout(SIDECAR_WALRUS_TIMEOUT)
         .send()
         .await
         .map_err(|e| {
+            crate::observability::observe_external(
+                "sidecar",
+                "walrus_set_metadata_batch",
+                "transport_error",
+                started.elapsed(),
+            );
+            crate::observability::record_sidecar_failure(
+                "walrus_set_metadata_batch",
+                "transport_error",
+            );
             AppError::Internal(format!(
                 "Sidecar walrus/set-metadata-batch request failed: {}",
                 e
             ))
         })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "walrus_set_metadata_batch",
+        &status_label,
+        started.elapsed(),
+    );
     if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("walrus_set_metadata_batch", "http_error");
         let body = resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<SidecarError>(&body) {
             return Err(AppError::Internal(format!(
@@ -287,12 +326,28 @@ pub async fn query_blobs_by_owner(
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
     }
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Sidecar walrus/query-blobs failed: {}", e)))?;
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
+    let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sidecar",
+            "walrus_query_blobs",
+            "transport_error",
+            started.elapsed(),
+        );
+        crate::observability::record_sidecar_failure("walrus_query_blobs", "transport_error");
+        AppError::Internal(format!("Sidecar walrus/query-blobs failed: {}", e))
+    })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "walrus_query_blobs",
+        &status_label,
+        started.elapsed(),
+    );
 
     if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("walrus_query_blobs", "http_error");
         let body = resp.text().await.unwrap_or_default();
         return Err(AppError::Internal(format!(
             "walrus query-blobs failed: {}",
@@ -325,20 +380,41 @@ pub async fn download_blob(
     blob_id: &str,
 ) -> Result<Vec<u8>, AppError> {
     // Timeout to avoid hanging on broken/slow blobs (Walrus 500s can take 60s+)
+    let started = std::time::Instant::now();
     let download_fut = walrus_client.read_blob_by_id(blob_id);
     let bytes = match tokio::time::timeout(std::time::Duration::from_secs(15), download_fut).await {
-        Ok(Ok(data)) => data,
+        Ok(Ok(data)) => {
+            crate::observability::observe_external(
+                "walrus",
+                "download_blob",
+                "ok",
+                started.elapsed(),
+            );
+            data
+        }
         Ok(Err(e)) => {
             let err_str = e.to_string();
             let is_not_found = err_str.contains("404")
                 || err_str.to_lowercase().contains("not found")
                 || err_str.to_lowercase().contains("blob not found");
             if is_not_found {
+                crate::observability::observe_external(
+                    "walrus",
+                    "download_blob",
+                    "not_found",
+                    started.elapsed(),
+                );
                 return Err(AppError::BlobNotFound(format!(
                     "Blob {} expired or not found: {}",
                     blob_id, err_str
                 )));
             } else {
+                crate::observability::observe_external(
+                    "walrus",
+                    "download_blob",
+                    "error",
+                    started.elapsed(),
+                );
                 return Err(AppError::Internal(format!(
                     "Walrus download failed: {}",
                     err_str
@@ -346,8 +422,14 @@ pub async fn download_blob(
             }
         }
         Err(_) => {
+            crate::observability::observe_external(
+                "walrus",
+                "download_blob",
+                "timeout",
+                started.elapsed(),
+            );
             return Err(AppError::Internal(format!(
-                "Walrus download timed out after 10s for blob {}",
+                "Walrus download timed out after 15s for blob {}",
                 blob_id
             )));
         }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -710,16 +710,18 @@ impl std::fmt::Display for AppError {
 
 impl axum::response::IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
+        crate::observability::record_app_error(self.kind());
         let (status, message) = match &self {
             AppError::BadRequest(msg) => (axum::http::StatusCode::BAD_REQUEST, msg.clone()),
             AppError::Unauthorized(msg) => (axum::http::StatusCode::UNAUTHORIZED, msg.clone()),
             AppError::Internal(msg) => {
                 // SEC: Never leak internal error details to the client.
-                // Log the full message server-side with a trace ID so
+                // Log the full message server-side with a request ID so
                 // operators can correlate, then return a generic message.
-                let trace_id = uuid::Uuid::new_v4().to_string();
+                let trace_id = crate::observability::current_request_id()
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
                 tracing::error!(
-                    trace_id = %trace_id,
+                    request_id = %trace_id,
                     "Internal server error: {}",
                     msg,
                 );
@@ -735,6 +737,19 @@ impl axum::response::IntoResponse for AppError {
 
         let body = serde_json::json!({ "error": message });
         (status, axum::Json(body)).into_response()
+    }
+}
+
+impl AppError {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            AppError::BadRequest(_) => "bad_request",
+            AppError::Unauthorized(_) => "unauthorized",
+            AppError::Internal(_) => "internal",
+            AppError::BlobNotFound(_) => "blob_not_found",
+            AppError::RateLimited(_) => "rate_limited",
+            AppError::QuotaExceeded(_) => "quota_exceeded",
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add relayer request IDs, structured tracing setup, Prometheus metrics, and route normalization
- instrument auth, rate limiting, API handlers, DB, embedding/LLM, Walrus, SEAL sidecar, and Sui RPC operations
- propagate request IDs through sidecar/proxy calls and document observability/env configuration

## Test plan
- cargo test
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck sidecar-server.ts
- npm test

Linear: MEM-31