### PR TITLE
feat(mcp): configurable default memory namespace

### DIFF
--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -88,6 +88,46 @@ See [How It Works](/mcp/how-it-works) for the full flow and security model.
 - The package can open the browser flow, save credentials, and recover from missing auth inline.
 - It keeps bearer credentials out of the MCP client config in the common stdio path.
 
+## Default memory namespace
+
+Memory tools take an optional `namespace` so you can keep, say, `work` and
+`personal` memories separate. Instead of having the agent pass it on every
+call, pin a default once in your client config — the package fills it in
+whenever the agent omits one.
+
+**Cursor** (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "memwal": {
+      "command": "npx",
+      "args": ["-y", "@mysten-incubation/memwal-mcp", "--namespace", "work"]
+    }
+  }
+}
+```
+
+**Claude Desktop** (`claude_desktop_config.json`) — via env var:
+
+```json
+{
+  "mcpServers": {
+    "memwal": {
+      "command": "npx",
+      "args": ["-y", "@mysten-incubation/memwal-mcp"],
+      "env": { "MEMWAL_NAMESPACE": "work" }
+    }
+  }
+}
+```
+
+An explicit per-call `namespace` from the agent always wins over the
+configured default. If neither a flag/env default nor a per-call value is
+set, the relayer applies its own `"default"` namespace. See
+[Reference](/mcp/reference#default-namespace) for the full precedence rules
+and `memwal_restore` behavior.
+
 ## What the MCP package adds
 
 Compared with wiring a raw HTTP MCP endpoint by hand, the package adds a few important runtime behaviors:

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -85,11 +85,50 @@ The stdio package accepts CLI flags and environment variables. **CLI takes prece
 | `--relayer <url>` | `MEMWAL_SERVER_URL` | Override the relayer base URL. |
 | `--web-url <url>` | `MEMWAL_WEB_URL` | Override the dashboard URL used during login. |
 | `--label <text>` | `MEMWAL_CLIENT_LABEL` | Friendly delegate-key label shown in the MemWal dashboard. |
+| `--namespace <name>` (alias `--ns`) | `MEMWAL_NAMESPACE` | Default memory namespace injected into memory tool calls that omit one. See [Default namespace](#default-namespace). |
 | `--login` (or `login` subcommand) | — | Force a re-login even when credentials exist. |
 | `--logout` | — | Wipe `~/.memwal/credentials.json` and exit. |
 | `--help`, `-h` | — | Print usage and exit. |
 
 Set `MEMWAL_MCP_DEBUG=1` to enable verbose stderr logging.
+
+## Default namespace
+
+Set a default memory namespace once in your client config instead of having
+the agent pass `namespace` on every call. The package injects it into
+`memwal_remember`, `memwal_recall`, `memwal_analyze`, and `memwal_restore`
+calls that don't already carry one.
+
+Precedence, highest first:
+
+1. **Explicit per-call `namespace`** — a non-empty `namespace` in the tool
+   call is used as-is. The configured default never overrides it.
+2. **`--namespace` CLI flag** (alias `--ns`).
+3. **`MEMWAL_NAMESPACE` environment variable**.
+4. **Unset** — the call is forwarded without a `namespace` and the relayer
+   applies its own `"default"` namespace.
+
+CLI wins over the environment variable when both are set, matching every other
+flag in the table above.
+
+<Note>
+`memwal_restore` still lists `namespace` as **required** in its tool schema,
+so agents normally pass one explicitly. A configured default is only used as a
+fallback if the agent calls `memwal_restore` without a namespace.
+</Note>
+
+Example — pin every memory call to a `work` namespace:
+
+```json
+{
+  "mcpServers": {
+    "memwal": {
+      "command": "npx",
+      "args": ["-y", "@mysten-incubation/memwal-mcp", "--namespace", "work"]
+    }
+  }
+}
+```
 
 ## Credential file
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -47,8 +47,72 @@ Use CLI flags or environment variables to override the default MemWal endpoints.
 | `--relayer <url>` | `MEMWAL_SERVER_URL` | Override the relayer base URL. |
 | `--web-url <url>` | `MEMWAL_WEB_URL` | Override the web app URL used during login. |
 | `--label <text>` | `MEMWAL_CLIENT_LABEL` | Friendly delegate-key label shown in MemWal. |
+| `--namespace <name>` (alias `--ns`) | `MEMWAL_NAMESPACE` | Default memory namespace applied when the agent omits one. |
 
 Enable verbose stderr logging with `MEMWAL_MCP_DEBUG=1`.
+
+## Default Namespace
+
+By default the MCP tool schemas expose an optional `namespace` argument and the
+agent has to pass it on every `memwal_remember` / `memwal_recall` /
+`memwal_analyze` call (and `memwal_restore` requires it). Set a default once in
+your client config instead:
+
+```json
+{
+  "mcpServers": {
+    "memwal": {
+      "command": "npx",
+      "args": ["-y", "@mysten-incubation/memwal-mcp", "--namespace", "work"]
+    }
+  }
+}
+```
+
+Or with an environment variable (e.g. Claude Desktop / Codex `env` blocks):
+
+```json
+{
+  "mcpServers": {
+    "memwal": {
+      "command": "npx",
+      "args": ["-y", "@mysten-incubation/memwal-mcp"],
+      "env": { "MEMWAL_NAMESPACE": "work" }
+    }
+  }
+}
+```
+
+Resolution and precedence:
+
+- **Per-call wins**: an explicit, non-empty `namespace` in a tool call is
+  always used as-is — the configured default never overrides it.
+- **Configured default**: when the agent omits `namespace`, the package
+  injects `--namespace` (CLI) or `MEMWAL_NAMESPACE` (env); CLI wins over env.
+- **Unset**: if neither is configured, the call is forwarded without a
+  `namespace` and the relayer applies its own `"default"` namespace.
+
+`memwal_restore` still advertises `namespace` as **required** in its schema, so
+agents normally pass one explicitly. If a default is configured and the agent
+calls `memwal_restore` without a namespace, the configured default is filled
+in the same way.
+
+### Verifying namespace injection
+
+No automated test runner ships with this package (consistent with the rest of
+the monorepo). To verify manually:
+
+1. Start the server pinned to a namespace and with debug logging:
+   `MEMWAL_MCP_DEBUG=1 npx -y @mysten-incubation/memwal-mcp --namespace demo-ns`
+2. From your MCP client, ask the agent to remember a fact **without**
+   specifying a namespace, then recall it **without** a namespace — the recall
+   should return that fact (both landed in `demo-ns`).
+3. Ask the agent to recall with an explicit different namespace
+   (e.g. `other`) — it should **not** return the fact, proving the per-call
+   value overrode the default.
+
+The injection itself is the pure, exported `applyDefaultNamespace(msg, ns)`
+function in `src/bridge.ts` if you want to assert it directly.
 
 ## Environment Presets
 

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -158,6 +158,12 @@ export interface AuthRequiredConfig {
     relayerUrl: string;
     webUrl: string;
     label: string;
+    /** Default memory namespace resolved at boot. Accepted here so the entry
+     * point can pass one config shape to both server modes — but auth-required
+     * mode never forwards a memory tool call (every non-login tool returns the
+     * login instruction), so there is nothing to namespace yet. It takes
+     * effect once credentials exist and the bridge runs. */
+    namespace?: string;
 }
 
 /** Send a `notifications/message` (MCP logging notification). Some clients

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -26,6 +26,51 @@ export interface BridgeConfig {
     relayerUrl: string;
     webUrl: string;
     label: string;
+    /** Default memory namespace resolved at boot (`--namespace` /
+     * `MEMWAL_NAMESPACE`). Injected into memory tool calls that omit a
+     * namespace. Undefined → don't inject; the relayer applies its own
+     * "default" namespace. */
+    namespace?: string;
+}
+
+/** Memory tools that take a `namespace` argument. `memwal_remember`,
+ * `memwal_recall`, and `memwal_analyze` treat it as optional; `memwal_restore`
+ * requires it (its upstream schema still lists `namespace` as required, so
+ * agents normally pass one — but a configured default is filled in if the
+ * agent calls it without). */
+const NAMESPACE_TOOLS = new Set([
+    "memwal_remember",
+    "memwal_recall",
+    "memwal_analyze",
+    "memwal_restore",
+]);
+
+/**
+ * Inject the configured default namespace into an outbound `tools/call`
+ * message when the agent omitted one. Mutates `msg.params.arguments` in place
+ * and returns `msg` (so it works inline before tracking/forwarding).
+ *
+ * No-op when:
+ *   - no default namespace is configured (`namespace` falsy), or
+ *   - the message is not a `tools/call` for a namespace-aware memory tool, or
+ *   - the caller already supplied a non-empty `namespace` — an explicit
+ *     per-call namespace always wins over the configured default.
+ */
+export function applyDefaultNamespace(msg: RpcMessage, namespace?: string): RpcMessage {
+    if (!namespace) return msg;
+    if (msg.method !== "tools/call") return msg;
+    const params = msg.params as
+        | { name?: string; arguments?: Record<string, unknown> }
+        | undefined;
+    if (!params || typeof params.name !== "string" || !NAMESPACE_TOOLS.has(params.name)) {
+        return msg;
+    }
+    const args = (params.arguments ??= {});
+    const current = args.namespace;
+    // Explicit, non-empty per-call namespace wins.
+    if (typeof current === "string" && current.trim() !== "") return msg;
+    args.namespace = namespace;
+    return msg;
 }
 
 /** Tools we serve LOCALLY (not forwarded to the relayer) so the user can
@@ -549,6 +594,11 @@ export async function runBridge(creds: MemWalCredentials, config: BridgeConfig):
                         return;
                     }
                 }
+
+                // Fill in the configured default namespace for memory tool
+                // calls that didn't pass one. Mutates msg in place so the
+                // forwarded — and any replayed-on-reconnect — copy carries it.
+                applyDefaultNamespace(msg, config.namespace);
 
                 // Track `tools/list` requests so the SSE pump can splice
                 // our local tools into the upstream response.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -27,6 +27,7 @@ interface ParsedArgs {
     relayerUrl?: string;
     webUrl?: string;
     label?: string;
+    namespace?: string;
 }
 
 /** Per-environment URL shortcuts. `--dev`/`--staging`/`--local` set both
@@ -77,11 +78,17 @@ function parseArgs(argv: string[]): ParsedArgs {
             case "--label":
                 out.label = next();
                 break;
+            case "--namespace":
+            case "--ns":
+                out.namespace = next();
+                break;
             default:
                 // Allow `--relayer=URL` and `--web-url=URL` forms too.
                 if (a?.startsWith("--relayer=")) out.relayerUrl = a.split("=", 2)[1];
                 else if (a?.startsWith("--web-url=")) out.webUrl = a.split("=", 2)[1];
                 else if (a?.startsWith("--label=")) out.label = a.split("=", 2)[1];
+                else if (a?.startsWith("--namespace=")) out.namespace = a.split("=", 2)[1];
+                else if (a?.startsWith("--ns=")) out.namespace = a.split("=", 2)[1];
                 // Unknown flag: ignore silently.
                 break;
         }
@@ -116,6 +123,13 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     // "Antigravity", ...) after the first MCP `initialize` request. User
     // can rename anytime from the dashboard.
     const label = args.label ?? process.env.MEMWAL_CLIENT_LABEL ?? "MCP Client";
+    // Default memory namespace applied to memory tool calls when the agent
+    // omits one. CLI > env, then UNSET — we deliberately do NOT hardcode a
+    // fallback here: if neither is set, the namespace argument is left off
+    // the forwarded call and the relayer applies its own "default" namespace.
+    // An explicit per-call `namespace` from the agent always wins (see
+    // applyDefaultNamespace in bridge.ts).
+    const namespace = args.namespace ?? process.env.MEMWAL_NAMESPACE;
 
     let creds = loadCreds();
     if (creds && args.relayerUrl && creds.relayerUrl !== args.relayerUrl) {
@@ -163,7 +177,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
             // tool from the MCP client) opens the correct dashboard. Before
             // this fix `--dev` was silently dropped here and the flow always
             // routed to prod (https://memwal.ai).
-            await runAuthRequiredServer({ relayerUrl, webUrl, label });
+            await runAuthRequiredServer({ relayerUrl, webUrl, label, namespace });
             return;
         }
         // TTY = manual invocation. Block on the browser flow as before.
@@ -201,7 +215,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
         return;
     }
 
-    await runBridge(creds, { relayerUrl, webUrl, label });
+    await runBridge(creds, { relayerUrl, webUrl, label, namespace });
 }
 
 function printHelp(): void {
@@ -230,11 +244,19 @@ function printHelp(): void {
         "  --label <text>                   Friendly delegate-key label",
         "                                   registered on-chain. Default:",
         '                                   "MemWal MCP"',
+        "  --namespace <name>               Default memory namespace applied",
+        "                                   to memwal_remember / recall /",
+        "                                   analyze / restore when the agent",
+        "                                   omits one. An explicit per-call",
+        "                                   namespace always wins. Unset →",
+        '                                   relayer uses its "default".',
+        "                                   Alias: --ns",
         "",
         "Environment (equivalent to options):",
         "  MEMWAL_SERVER_URL                same as --relayer",
         "  MEMWAL_WEB_URL                   same as --web-url",
         "  MEMWAL_CLIENT_LABEL              same as --label",
+        "  MEMWAL_NAMESPACE                 same as --namespace",
         "  MEMWAL_MCP_DEBUG=1               Verbose stderr logging.",
         "",
         "Minimal MCP client config (Cursor, Claude Desktop, etc.):",
@@ -255,6 +277,19 @@ function printHelp(): void {
         '        "args": [',
         '          "-y", "@mysten-incubation/memwal-mcp",',
         '          "--relayer", "https://relayer.dev.memwal.ai"',
+        "        ]",
+        "      }",
+        "    }",
+        "  }",
+        "",
+        "Pinned to a memory namespace (set once, no per-call namespace needed):",
+        "  {",
+        '    "mcpServers": {',
+        '      "memwal": {',
+        '        "command": "npx",',
+        '        "args": [',
+        '          "-y", "@mysten-incubation/memwal-mcp",',
+        '          "--namespace", "work"',
         "        ]",
         "      }",
         "    }",


### PR DESCRIPTION
## Summary

Adds a server-level default memory namespace to the MemWal MCP package so users set it once in their MCP client config instead of passing `namespace` on every tool call.

> **Stacked on #162** (`docs/restructure-mcp-page`) so this diff is exactly the one feature commit. Retarget to `dev` once #162 merges.

## Changes

- New `--namespace <name>` CLI flag (alias `--ns`, plus `--namespace=` form)
- New `MEMWAL_NAMESPACE` env var
- Precedence: explicit per-call namespace > CLI > env > unset (unset = forwarded without namespace; relayer applies its own `"default"`)
- Resolved namespace threaded through `BridgeConfig` + `AuthRequiredConfig`
- Pure `applyDefaultNamespace()` injects the default into `memwal_remember`, `memwal_recall`, `memwal_analyze`, `memwal_restore` calls when the agent omits it; explicit per-call value always wins
- `memwal_restore` keeps `namespace` required in its schema; the configured default is only a fallback if the agent calls it without one
- Help text + config snippet; README "Default Namespace" section with Cursor and Claude Desktop examples + manual verification note
- `docs/mcp` overview + reference: default-namespace behavior and examples

## Test plan

- `pnpm typecheck` / `pnpm build` pass
- 8-case unit check of `applyDefaultNamespace` (inject when omitted, per-call override wins, blank treated as omitted, no-default no-op, restore fallback, non-namespace tool untouched, non-tools/call untouched, missing arguments object created)
- Real run: built `memwal-mcp` driven via stdin through the real bridge path; forwarded bytes confirmed `"namespace"` injected when omitted and preserved when explicitly passed