### PR TITLE
Feat: Pin prompt versions in benchmark run artifacts

### DIFF
--- a/services/server/benchmarks/core/report.py
+++ b/services/server/benchmarks/core/report.py
@@ -181,6 +181,20 @@ def generate_comparison_table(
         overall_row.append(f"**{score:.2f}**" if score is not None else "-")
     rows.append(overall_row)
 
+    # MEM-56: prompt-version provenance row. Renders `extract.vN/ask.vM`
+    # per preset so a future "score jumped" delta is attributable to the
+    # prompt change vs the weights change. Empty cells when an artifact
+    # predates MEM-56 (legacy comparisons stay readable).
+    pv_row = ["_prompt versions_"]
+    for r in results:
+        pv = r.get("prompt_versions", {}) or {}
+        extract = pv.get("extract", "-")
+        ask = pv.get("ask", "-")
+        pv_row.append(f"{extract}/{ask}" if extract != "-" or ask != "-" else "-")
+    for _ in baselines:
+        pv_row.append("-")
+    rows.append(pv_row)
+
     return tabulate(rows, headers=headers, tablefmt="github")
 
 

--- a/services/server/benchmarks/core/types.py
+++ b/services/server/benchmarks/core/types.py
@@ -172,6 +172,14 @@ class RunArtifact:
     benchmark: str
     preset: str
 
+    # MEM-56: the `extract.v*` / `ask.v*` versions the server was running
+    # at the moment the run started. Captured from GET /health.
+    # Empty-dict default only for legacy artifacts loaded by `compare`;
+    # fresh runs always populate this — the harness fails fast at startup
+    # if the server doesn't expose `prompt_versions` so no fresh artifact
+    # can land with an empty dict.
+    prompt_versions: dict[str, str] = field(default_factory=dict)
+
     config: dict = field(default_factory=dict)
     ingestion: IngestionStats = field(default_factory=IngestionStats)
     metrics_overall: CategoryMetrics = field(default_factory=CategoryMetrics)

--- a/services/server/benchmarks/run.py
+++ b/services/server/benchmarks/run.py
@@ -407,6 +407,13 @@ def stage_eval(
         overall = {}
         by_category = {}
 
+    # MEM-56: pin the server's prompt versions into the run artifact.
+    # The harness fails fast at startup if these are missing, so by the
+    # time we get here `_server_prompt_versions` is guaranteed present
+    # for any run kicked off via `main()`. The `or {}` guard is just for
+    # the rare case where `stage_eval` is invoked directly from tests.
+    prompt_versions = config.get("_server_prompt_versions") or {}
+
     # Build artifact
     artifact = RunArtifact(
         run_id=run_id,
@@ -414,6 +421,7 @@ def stage_eval(
         git_commit=get_git_commit(),
         benchmark=benchmark_name,
         preset=preset_name,
+        prompt_versions=prompt_versions,
         config={
             "server_url": config.get("server", {}).get("url", ""),
             "scoring_weights": weights.to_dict(),
@@ -641,6 +649,11 @@ def main():
     # servers don't return it. We treat missing-mode as "unknown — proceed
     # with warning" rather than abort, so this check works against both
     # refactored and pre-refactor servers.
+    #
+    # MEM-56: `prompt_versions` is the newer field. It's NOT optional — a
+    # server that doesn't expose it can't produce attributable run
+    # artifacts, so we abort rather than silently recording empty
+    # versions. See the validation gate on MEM-56.
     try:
         health = client.health()
         version = health.get("version", "?")
@@ -659,6 +672,21 @@ def main():
             sys.exit(1)
         else:
             print(f"Server: {server_cfg['url']} ({version}) [mode=benchmark]")
+
+        prompt_versions = health.get("prompt_versions")
+        if not isinstance(prompt_versions, dict) or "extract" not in prompt_versions or "ask" not in prompt_versions:
+            print(
+                "ERROR: Server /health response missing `prompt_versions.extract` "
+                "and/or `prompt_versions.ask`. MEM-56 requires every run artifact "
+                "to pin the prompt versions; aborting rather than recording empty "
+                "metadata. Upgrade the server to a build that exposes these fields."
+            )
+            sys.exit(1)
+        print(f"  prompt versions: extract={prompt_versions['extract']} ask={prompt_versions['ask']}")
+        # Stash on `config` so stage_eval picks it up without a signature change.
+        config["_server_prompt_versions"] = prompt_versions
+    except SystemExit:
+        raise
     except Exception as e:
         print(f"ERROR: Cannot reach server at {server_cfg['url']}: {e}")
         sys.exit(1)

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -26,7 +26,9 @@ use super::cleanup_expired_blob;
 /// guard. Bundled at compile time.
 const ASK_SYSTEM_PROMPT: &str = include_str!("../services/prompts/ask.txt");
 /// Version ID for the ask prompt. Bump on every meaningful prompt change.
-#[allow(dead_code)]
+/// Exposed on `GET /health` via `HealthResponse.prompt_versions.ask` so
+/// the benchmark harness can pin it into the result-artifact metadata
+/// (MEM-56).
 const ASK_SYSTEM_PROMPT_VERSION: &str = "ask.v1";
 
 // ============================================================
@@ -119,6 +121,14 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> 
             "benchmark".to_string()
         } else {
             "production".to_string()
+        },
+        // MEM-56: surface the prompt-version constants so benchmark
+        // run-artifacts can pin them at run start. Read from the same
+        // consts the running binary uses for extraction (`/api/analyze`)
+        // and ask (`/api/ask`) — no separate config to drift.
+        prompt_versions: PromptVersions {
+            extract: crate::services::extractor::FACT_EXTRACTION_PROMPT_VERSION.to_string(),
+            ask: ASK_SYSTEM_PROMPT_VERSION.to_string(),
         },
     })
 }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -734,6 +734,26 @@ pub struct HealthResponse {
     /// at startup that they're hitting a benchmark-mode server before
     /// ingesting plaintext memories. Mirrors `Config::benchmark_mode`.
     pub mode: String,
+    /// MEM-56: the prompt version constants the running binary is using.
+    /// The benchmark harness reads this at run start and pins the
+    /// versions into the result-artifact JSON so a future "score jumped"
+    /// delta is attributable to the prompt change rather than guessed
+    /// at from git history. Both fields are always populated — there is
+    /// no "version unknown" state for a running server.
+    pub prompt_versions: PromptVersions,
+}
+
+/// MEM-56: prompt version constants surfaced on `/health`. See the
+/// `*_PROMPT_VERSION` consts in `services::extractor` and `routes::admin`.
+#[derive(Debug, Serialize)]
+pub struct PromptVersions {
+    /// `FACT_EXTRACTION_PROMPT_VERSION` from `services::extractor` — the
+    /// extractor system prompt used by `/api/analyze` and the
+    /// summarise-long-text path in `/api/remember`.
+    pub extract: String,
+    /// `ASK_SYSTEM_PROMPT_VERSION` from `routes::admin` — the LLM
+    /// system prompt that wraps recalled memories on `/api/ask`.
+    pub ask: String,
 }
 
 /// GET /config response (ENG-1697).
@@ -1268,5 +1288,26 @@ mod tests {
         // recall response). Failing this test = ack the change.
         assert_eq!(ScoringWeights::default().recency, 0.0);
         assert!(!ScoringWeights::default().is_ranker_active());
+    }
+
+    // ── MEM-56: HealthResponse.prompt_versions wire shape ────────────────
+
+    #[test]
+    fn health_response_serializes_prompt_versions_block() {
+        // The benchmark harness reads exactly these field names — pin the
+        // wire shape so a rename can't silently break the run-artifact
+        // pipeline.
+        let resp = HealthResponse {
+            status: "ok".to_string(),
+            version: "0.1.0".to_string(),
+            mode: "benchmark".to_string(),
+            prompt_versions: PromptVersions {
+                extract: "extract.v1".to_string(),
+                ask: "ask.v1".to_string(),
+            },
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["prompt_versions"]["extract"], "extract.v1");
+        assert_eq!(json["prompt_versions"]["ask"], "ask.v1");
     }
 }


### PR DESCRIPTION
## Summary

### Why

Two benchmark runs with different extractor prompts currently produce **indistinguishable** result JSONs on disk — both just say "LOCOMO 54.3 J overall". When we go back in a month and ask "why did the score jump in week N?", we have to grep commit history to figure out which prompt version was live. That's attribution debt that compounds, and it lands hard on MEM-54 (extract prompt v2 for the importance signal) and MEM-55 (extract prompt revision for assistant-side fact scope), both of which are about to change the extractor.

### What

- Server's `GET /health` response gains a `prompt_versions: { extract, ask }` block sourced from the existing `FACT_EXTRACTION_PROMPT_VERSION` (`services/extractor.rs`) and `ASK_SYSTEM_PROMPT_VERSION` (`routes/admin.rs`) constants.
- Benchmark harness reads `prompt_versions` at run start. **Fails fast** if the server doesn't expose both fields (no silent fallback to empty metadata).
- `RunArtifact` gains a `prompt_versions: dict[str, str]` field that's serialised into every result JSON.
- `generate_comparison_table` renders a `prompt versions` row showing `extract.vN/ask.vM` per preset.

### Solution

**Server-side** (commit `da85894`): minimal — just add a `PromptVersions` struct and populate it in the `health()` handler from the existing version constants. The constants already lived in the right places from Phase 3 of ENG-1747 (with documentation explicitly anticipating this exposure); `ASK_SYSTEM_PROMPT_VERSION` loses its `#[allow(dead_code)]` because it's now load-bearing.

**Harness-side** (commit `ba2d945`): the `mode == "benchmark"` check already happens at server boot validation, and `prompt_versions` is checked in the same block. On success, the dict is stashed on `config["_server_prompt_versions"]` so `stage_eval` picks it up without a signature change. The dataclass default of `field(default_factory=dict)` is for backward-compat with legacy artifacts that `compare` might still load — fresh runs always populate because the boot check aborts otherwise.

**Manually verified end-to-end** against the running server:
- `/health` returns `{"extract":"extract.v1","ask":"ask.v1"}`
- Harness fail-fast triggered against a pre-MEM-56 server with the documented error message
- Stand-alone Python script confirmed: server → harness → artifact JSON contains the `prompt_versions` block
- Comparison table renders the row with synthetic data

## Types of Changes

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [x] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

- [x] I have tested this code locally
- [x] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

**Unit tests**: 188/188 pass (was 187 — one new test pins the wire shape).

- `health_response_serializes_prompt_versions_block` (`types.rs`) — pins the JSON keys (`prompt_versions.extract` / `prompt_versions.ask`) so a future rename can't silently break the harness pipeline.

**Manual integration verification**:

| Check | Result |
|---|---|
| `curl localhost:3001/health` returns `prompt_versions` block | ✅ `{"extract":"extract.v1","ask":"ask.v1"}` |
| Harness fail-fast against pre-MEM-56 server (no field) | ✅ Aborts with the documented error message |
| `run.py` startup logs `prompt versions: extract=extract.v1 ask=ask.v1` | ✅ Visible in boot output |
| `RunArtifact` serializes the field via `dataclasses.asdict` | ✅ Confirmed in stand-alone Python smoke |
| `generate_comparison_table` renders the `prompt versions` row | ✅ Hand-tested with synthetic data |

**Not benchmarked end-to-end** because this PR doesn't touch scoring, extraction, or retrieval — pure metadata plumbing. A full LOCOMO + LongMemEval re-run would reproduce yesterday's ranker numbers within judge noise at ~$8 spend. Saving that budget for MEM-54 / MEM-55 / MEM-57 where benchmarks actually buy signal.

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Related Issues

- Closes MEM-56
- Part of MEM-52 (RAG quality, cycle 13)
- Unblocks MEM-54, MEM-55, MEM-57 (all change the extract prompt and need their J-Score deltas to be attributable)

## Additional Notes

This is the infrastructure prerequisite for the next three sub-issues. Without it, MEM-54's importance-signal benchmark and MEM-55's scope-fix benchmark would produce result JSONs indistinguishable from each other or from MEM-53's baseline — making the cycle's J-Score deltas non-attributable a month from now.

Two logical commits to keep the server-side change reviewable separately from the harness-side change:

1. `da85894` — `feat(server): expose prompt versions on /health (MEM-56)` — types + handler wiring + one wire-shape test
2. `ba2d945` — `feat(benchmarks): pin prompt_versions into run artifacts (MEM-56)` — RunArtifact field, harness fail-fast, comparison table row
