### PR TITLE
test(python-sdk): update signing tests to canonical 6-part message fo…

### DIFF
--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -16,7 +16,7 @@ import respx
 
 from memwal.client import MemWal, MemWalError
 from memwal.types import RecallManualOptions, RememberManualOptions
-from memwal.utils import bytes_to_hex, sha256_hex
+from memwal.utils import build_signature_message, bytes_to_hex, sha256_hex
 
 # ============================================================
 # Fixtures
@@ -94,6 +94,7 @@ class TestRemember:
         assert len(headers["x-signature"]) == 128  # 64 bytes = 128 hex chars
         assert "x-timestamp" in headers
         assert headers["x-timestamp"].isdigit()
+        assert "x-nonce" in headers
         assert headers["x-delegate-key"] == _TEST_KEY_HEX
         assert headers["x-account-id"] == _TEST_ACCOUNT_ID
         assert headers["content-type"] == "application/json"
@@ -120,7 +121,15 @@ class TestRemember:
         # Reconstruct the signing message
         timestamp = headers["x-timestamp"]
         body_hash = sha256_hex(body_str)
-        message = f"{timestamp}.POST./api/remember.{body_hash}"
+        nonce = headers["x-nonce"]
+        message = build_signature_message(
+            timestamp=timestamp,
+            method="POST",
+            path="/api/remember",
+            body_sha256=body_hash,
+            nonce=nonce,
+            account_id=headers["x-account-id"],
+        )
 
         # Verify signature
         verify_key = nacl.signing.VerifyKey(bytes.fromhex(headers["x-public-key"]))

--- a/packages/python-sdk-memwal/tests/test_integration.py
+++ b/packages/python-sdk-memwal/tests/test_integration.py
@@ -40,13 +40,14 @@ import hashlib
 import json
 import os
 import time
+import uuid
 
 import httpx
 import nacl.signing
 import pytest
 
 from memwal.client import MemWal, MemWalError, MemWalSync
-from memwal.utils import bytes_to_hex
+from memwal.utils import build_signature_message, bytes_to_hex
 
 # ── Config ───────────────────────────────────────────────────────────────────
 
@@ -78,7 +79,15 @@ def _raw_signed_request(
     body_bytes = json.dumps(body, separators=(",", ":")).encode()
     body_hash = hashlib.sha256(body_bytes).hexdigest()
     timestamp = timestamp_override or str(int(time.time()))
-    message = f"{timestamp}.{method.upper()}.{path}.{body_hash}"
+    nonce = str(uuid.uuid4())
+    message = build_signature_message(
+        timestamp=timestamp,
+        method=method.upper(),
+        path=path,
+        body_sha256=body_hash,
+        nonce=nonce,
+        account_id=ACCOUNT_ID or "0x0",
+    )
     signed = signing_key.sign(message.encode())
     signature_hex = signed.signature.hex()
     pub_key_hex = pub_key_override or signing_key.verify_key.encode().hex()
@@ -93,6 +102,8 @@ def _raw_signed_request(
                 "x-public-key": pub_key_hex,
                 "x-signature": signature_hex,
                 "x-timestamp": timestamp,
+                "x-nonce": nonce,
+                "x-account-id": ACCOUNT_ID or "0x0",
             },
         )
 

--- a/packages/python-sdk-memwal/tests/test_signing.py
+++ b/packages/python-sdk-memwal/tests/test_signing.py
@@ -131,14 +131,16 @@ class TestBuildSignatureMessage:
     """Tests for build_signature_message -- the exact format the server expects."""
 
     def test_format_matches_spec(self) -> None:
-        """Signature message MUST be: {timestamp}.{method}.{path}.{body_sha256}"""
+        """Signature message MUST match the canonical 6-part server format."""
         result = build_signature_message(
             timestamp="1700000000",
             method="POST",
             path="/api/remember",
             body_sha256="abc123",
+            nonce="550e8400-e29b-41d4-a716-446655440000",
+            account_id="0xabc123",
         )
-        assert result == "1700000000.POST./api/remember.abc123"
+        assert result == "1700000000.POST./api/remember.abc123.550e8400-e29b-41d4-a716-446655440000.0xabc123"
 
     def test_get_method(self) -> None:
         result = build_signature_message(
@@ -146,6 +148,8 @@ class TestBuildSignatureMessage:
             method="GET",
             path="/health",
             body_sha256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            nonce="550e8400-e29b-41d4-a716-446655440000",
+            account_id="0xabc123",
         )
         parts = result.split(".")
         assert parts[0] == "1700000001"
@@ -164,8 +168,10 @@ class TestBuildSignatureMessage:
         path = "/api/remember"
         body = json.dumps({"text": "hello", "namespace": "default"}, separators=(",", ":"))
         body_hash = sha256_hex(body)
+        nonce = "550e8400-e29b-41d4-a716-446655440000"
+        account_id = "0xabc123"
 
-        message = build_signature_message(timestamp, method, path, body_hash)
+        message = build_signature_message(timestamp, method, path, body_hash, nonce=nonce, account_id=account_id)
         sig_hex, pub_hex = sign_message(message, signing_key)
 
         # Verify (as the server would)
@@ -178,10 +184,17 @@ class TestBuildSignatureMessage:
         body_str = json.dumps(body, separators=(",", ":"))
         body_hash = sha256_hex(body_str)
 
-        message = build_signature_message("1700000000", "POST", "/api/remember", body_hash)
+        message = build_signature_message(
+            "1700000000",
+            "POST",
+            "/api/remember",
+            body_hash,
+            nonce="550e8400-e29b-41d4-a716-446655440000",
+            account_id="0xabc123",
+        )
 
-        # Extract the hash from the message
-        extracted_hash = message.split(".")[-1]
+        # Extract the hash from the canonical 6-part message
+        extracted_hash = message.split(".")[3]
         assert extracted_hash == body_hash
         assert extracted_hash == hashlib.sha256(body_str.encode("utf-8")).hexdigest()
 


### PR DESCRIPTION
…rmat

The signed message is {timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id} (nonce added in MED-1, account_id in LOW-23) and matches the Rust server auth.rs. The signing tests still asserted the old 4-part format, so 6 tests failed on dev. Update assertions/expected strings to pass nonce + account_id and extract body_sha256 at index 3.

- test_signing.py: format-matches-spec + body-sha256 extraction
- test_client.py: signature-is-verifiable
- test_integration.py: auth rejection cases
