### PR TITLE
feat(seal): default testnet SEAL to Mysten committee aggregator

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -424,8 +424,8 @@ Add to `~/.openclaw/openclaw.json`:
 | `DATABASE_URL` | PostgreSQL connection string. `pgvector` must already exist |
 | `MEMWAL_PACKAGE_ID` | Sui package ID |
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID |
-| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | Optional SEAL override for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for custom committees |
 
+`SEAL_SERVER_CONFIGS` and `SEAL_KEY_SERVERS` are optional overrides for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for custom committees.
 If neither SEAL variable is set, the sidecar uses built-in defaults for `SUI_NETWORK`: Mysten's initial committee aggregator on `testnet`, and the legacy independent key server pair on `mainnet` until an official mainnet committee aggregator is available. Deployments with existing memories encrypted by the previous testnet independent key server defaults should pin `SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8` until the data is migrated or re-encrypted.
 
 ### Usually Required

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -424,9 +424,9 @@ Add to `~/.openclaw/openclaw.json`:
 | `DATABASE_URL` | PostgreSQL connection string. `pgvector` must already exist |
 | `MEMWAL_PACKAGE_ID` | Sui package ID |
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID |
-| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | SEAL server config for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers |
+| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | Optional SEAL override for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for custom committees |
 
-If neither SEAL variable is set, the sidecar uses built-in independent key server defaults for `SUI_NETWORK`: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`.
+If neither SEAL variable is set, the sidecar uses built-in defaults for `SUI_NETWORK`: Mysten's initial committee aggregator on `testnet`, and the legacy independent key server pair on `mainnet` until an official mainnet committee aggregator is available. Deployments with existing memories encrypted by the previous testnet independent key server defaults should pin `SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8` until the data is migrated or re-encrypted.
 
 ### Usually Required
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,4 +76,5 @@ Walrus and network fields:
 - `withMemWal` builds on top of `MemWal`, so it uses the same relayer-backed config shape.
 - `MemWalManual` now defaults to `mainnet` network settings unless you pass `suiNetwork: "testnet"`.
 - `sealServerConfigs` takes priority over `sealKeyServers`; `sealKeyServers` remains supported for legacy independent key server lists.
-- Built-in SEAL defaults use independent key servers: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`. Use `sealServerConfigs` for committee aggregator configs.
+- Built-in SEAL defaults use Mysten's initial committee aggregator on `testnet`. `mainnet` keeps the legacy independent key server pair until an official mainnet committee aggregator is available.
+- Use `sealServerConfigs` to override the built-in default with another committee by providing `objectId`, `weight`, and `aggregatorUrl`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,5 +76,6 @@ Walrus and network fields:
 - `withMemWal` builds on top of `MemWal`, so it uses the same relayer-backed config shape.
 - `MemWalManual` now defaults to `mainnet` network settings unless you pass `suiNetwork: "testnet"`.
 - `sealServerConfigs` takes priority over `sealKeyServers`; `sealKeyServers` remains supported for legacy independent key server lists.
-- Built-in SEAL defaults use Mysten's initial committee aggregator on `testnet`. `mainnet` keeps the legacy independent key server pair until an official mainnet committee aggregator is available.
+- Relayer/sidecar SEAL defaults use Mysten's initial committee aggregator on `testnet`. `mainnet` keeps the legacy independent key server pair until an official mainnet committee aggregator is available.
+- `MemWalManual` keeps the legacy independent testnet default for compatibility. Pass `sealServerConfigs` to use a committee aggregator manually.
 - Use `sealServerConfigs` to override the built-in default with another committee by providing `objectId`, `weight`, and `aggregatorUrl`.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -12,7 +12,7 @@ For setup steps and deployment context, see [Self-Hosting](/relayer/self-hosting
 | `DATABASE_URL` | PostgreSQL connection string. `pgvector` must already exist |
 | `MEMWAL_PACKAGE_ID` | Sui package ID. See [Contract Overview](/contract/overview) |
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID. See [Contract Overview](/contract/overview) |
-| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | SEAL server config used by the sidecar for encrypt and decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers |
+| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | Optional SEAL override used by the sidecar for encrypt and decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers |
 | `SIDECAR_AUTH_TOKEN` | Shared secret for Rust-to-sidecar calls. The sidecar refuses to start without it |
 
 ## Usually Required
@@ -66,8 +66,9 @@ These are not all enforced at boot, but most real deployments need them.
 - `SUI_NETWORK` drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.
 - `SEAL_SERVER_CONFIGS` is a JSON array of `{ objectId, weight, aggregatorUrl?, apiKeyName?, apiKey? }`. Committee key server configs require `aggregatorUrl`.
 - `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset.
-- If neither SEAL variable is set, the sidecar uses built-in independent key server defaults for `SUI_NETWORK`: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`.
-- Committee mode is supported through `SEAL_SERVER_CONFIGS` when you need an aggregator-backed key server.
+- If neither SEAL variable is set, the sidecar uses built-in defaults for `SUI_NETWORK`: Mysten's initial committee aggregator on `testnet`, and the legacy independent key server pair on `mainnet` until an official mainnet committee aggregator is available.
+- Use `SEAL_SERVER_CONFIGS` to override the built-in default with another committee by providing `objectId`, `weight`, and `aggregatorUrl`.
+- Deployments with existing memories encrypted by the previous testnet independent key server defaults should pin `SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8` until the data is migrated or re-encrypted.
 - The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -12,7 +12,6 @@ For setup steps and deployment context, see [Self-Hosting](/relayer/self-hosting
 | `DATABASE_URL` | PostgreSQL connection string. `pgvector` must already exist |
 | `MEMWAL_PACKAGE_ID` | Sui package ID. See [Contract Overview](/contract/overview) |
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID. See [Contract Overview](/contract/overview) |
-| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | Optional SEAL override used by the sidecar for encrypt and decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers |
 | `SIDECAR_AUTH_TOKEN` | Shared secret for Rust-to-sidecar calls. The sidecar refuses to start without it |
 
 ## Usually Required
@@ -46,6 +45,8 @@ These are not all enforced at boot, but most real deployments need them.
 | `MEMWAL_ACCOUNT_ID` | none | Optional account ID in server config |
 | `WALRUS_PACKAGE_ID` | network default | Override the Walrus on-chain package used by the sidecar |
 | `WALRUS_UPLOAD_RELAY_URL` | network default | Override the Walrus upload relay used by the sidecar |
+| `SEAL_SERVER_CONFIGS` | network default | Optional JSON SEAL server config override for independent or committee servers |
+| `SEAL_KEY_SERVERS` | network default | Legacy comma-separated independent SEAL key server override. Used only when `SEAL_SERVER_CONFIGS` is unset |
 | `SEAL_THRESHOLD` | `min(2, total configured weight)` | Required configured server weight for SEAL encrypt/decrypt |
 | `ENOKI_API_KEY` | none | Optional Enoki key for sponsored sidecar transactions |
 | `ENOKI_NETWORK` | `mainnet` | Network used for Enoki-sponsored flows |

--- a/docs/relayer/nautilus-tee.md
+++ b/docs/relayer/nautilus-tee.md
@@ -144,7 +144,7 @@ These map directly to the existing self-hosted relayer config.
 | `SUI_RPC_URL` | no | Sui fullnode endpoint reachable from the enclave |
 | `SERVER_SUI_PRIVATE_KEY` | yes | Primary server key for SEAL decrypt authorization |
 | `SERVER_SUI_PRIVATE_KEYS` | yes | Optional upload key pool; takes priority for Walrus uploads |
-| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | maybe | SEAL key server config. Use `SEAL_SERVER_CONFIGS` for committee servers |
+| `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` | maybe | Optional SEAL override. Defaults use the Mysten testnet committee aggregator where available; use `SEAL_SERVER_CONFIGS` for custom committees |
 | `OPENAI_API_KEY` | yes | Embedding and LLM provider key |
 | `OPENAI_API_BASE` | no | OpenAI-compatible base URL |
 | `WALRUS_PUBLISHER_URL` | no | Walrus upload endpoint |
@@ -169,7 +169,7 @@ The enclave must be allowed to reach:
 - Walrus publisher
 - Walrus aggregator
 - Walrus upload relay, if configured
-- SEAL key servers or committee aggregators
+- SEAL key servers or committee aggregators. On testnet, the built-in default is Mysten's initial committee aggregator. Mainnet uses the legacy independent key server default until an official committee aggregator is available.
 - OpenAI-compatible embedding and LLM provider
 
 If your Nautilus deployment requires an explicit outbound allowlist, mirror the
@@ -271,7 +271,7 @@ database URLs.
 | `/health` fails | Relayer process, sidecar boot, or ingress issue | Enclave process logs and sidecar readiness logs |
 | `remember` stays running | Walrus upload, wallet signing, or job queue failure | `remember_jobs`, Apalis job rows, sidecar Walrus logs |
 | `recall` returns empty after smoke write | Wrong namespace/account, pgvector issue, or upload job incomplete | Poll remember job, verify `owner + namespace`, check PostgreSQL migrations |
-| SEAL decrypt fails | Wrong server wallet, delegate auth, SEAL config, or key server outage | `SEAL_SERVER_CONFIGS`, `SERVER_SUI_PRIVATE_KEY`, key server reachability |
+| SEAL decrypt fails | Wrong server wallet, delegate auth, SEAL config, key server outage, or committee aggregator outage | `SEAL_SERVER_CONFIGS`, `SERVER_SUI_PRIVATE_KEY`, key server or aggregator reachability |
 | Embedding calls fail | AI endpoint blocked or invalid API key | `OPENAI_API_BASE`, `OPENAI_API_KEY`, outbound allowlist |
 | TLS/cert errors to DB or Redis | Host rewrite/proxy broke hostname validation | Preserve original hostnames when proxying TLS endpoints |
 | Plaintext appears in logs | Logging hygiene regression or debug middleware | Disable debug logs and scrub host/enclave log sinks |

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -81,7 +81,6 @@ curl http://localhost:8000/health
 - `MEMWAL_PACKAGE_ID`
 - `MEMWAL_REGISTRY_ID`
 - `SERVER_SUI_PRIVATE_KEY` or `SERVER_SUI_PRIVATE_KEYS`
-- `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` — optional SEAL override for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for custom committees.
 - `SIDECAR_AUTH_TOKEN` — shared secret for Rust-to-sidecar calls. The sidecar refuses to start without it.
 
 ### Recommended
@@ -105,6 +104,7 @@ By default, the relayer enforces rate limits and storage quotas via Redis to pre
 - `SIDECAR_URL` defaults to `http://localhost:9000`
 - `SUI_NETWORK` defaults to `mainnet`
 - `SUI_RPC_URL`, Walrus endpoints, and `WALRUS_PACKAGE_ID` fall back to network defaults based on `SUI_NETWORK`
+- `SEAL_SERVER_CONFIGS` and `SEAL_KEY_SERVERS` are optional overrides for encrypt/decrypt; prefer `SEAL_SERVER_CONFIGS` for custom committees
 - `WALRUS_AGGREGATOR_URLS` can add comma-separated proxy/aggregator candidates for cold-read tail racing after Redis cache misses
 - `WALRUS_SKIP_CONSISTENCY_CHECK=false` by default; enable only for trusted MemWal-written cold reads after accepting the consistency tradeoff
 - The sidecar Walrus upload route defaults storage `epochs` by network: `50` on `testnet`, `2` on `mainnet` (unless the request passes `epochs`)

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -81,7 +81,7 @@ curl http://localhost:8000/health
 - `MEMWAL_PACKAGE_ID`
 - `MEMWAL_REGISTRY_ID`
 - `SERVER_SUI_PRIVATE_KEY` or `SERVER_SUI_PRIVATE_KEYS`
-- `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` — SEAL server config for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for committee servers.
+- `SEAL_SERVER_CONFIGS` or `SEAL_KEY_SERVERS` — optional SEAL override for encrypt/decrypt. Prefer `SEAL_SERVER_CONFIGS` for custom committees.
 - `SIDECAR_AUTH_TOKEN` — shared secret for Rust-to-sidecar calls. The sidecar refuses to start without it.
 
 ### Recommended
@@ -131,15 +131,29 @@ MEMWAL_PACKAGE_ID=0xcee7a6fd8de52ce645c38332bde23d4a30fd9426bc4681409733dd50958a
 MEMWAL_REGISTRY_ID=0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75a7edd
 ```
 
-If neither `SEAL_SERVER_CONFIGS` nor `SEAL_KEY_SERVERS` is set, the sidecar uses built-in independent key server defaults for the selected `SUI_NETWORK`: two testnet servers on `testnet`, and Overclock + Studio Mirai on `mainnet`.
-
-Use `SEAL_SERVER_CONFIGS` for committee key servers because committee entries require an `aggregatorUrl`. For example, the Mysten testnet committee config is:
+If neither `SEAL_SERVER_CONFIGS` nor `SEAL_KEY_SERVERS` is set, the sidecar uses built-in defaults for the selected `SUI_NETWORK`. On `testnet`, the default is Mysten's initial committee aggregator:
 
 ```env
 SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
 ```
 
-`SEAL_KEY_SERVERS=0x...,0x...` remains supported for independent key server object IDs. Committee mode is supported through `SEAL_SERVER_CONFIGS` when you have the object ID and aggregator URL.
+On `mainnet`, the default remains the legacy independent key server pair until Mysten publishes an official committee aggregator.
+
+Use `SEAL_SERVER_CONFIGS` to override the built-in default with another committee. Committee entries require an `aggregatorUrl`, for example:
+
+```env
+SEAL_SERVER_CONFIGS=[{"objectId":"0x...","weight":1,"aggregatorUrl":"https://seal-aggregator.example.com"}]
+```
+
+`SEAL_KEY_SERVERS=0x...,0x...` remains supported for legacy independent key server object IDs. It is only used when `SEAL_SERVER_CONFIGS` is unset. For deployments that still need the previous testnet independent defaults, pin:
+
+```env
+SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8
+```
+
+<Warning>
+Changing SEAL key server defaults only affects new encryption. If a deployment already has memories encrypted with the previous testnet independent key servers, keep those servers pinned with `SEAL_KEY_SERVERS` until the data has been migrated or re-encrypted. Otherwise, recall and restore for older blobs may fail to decrypt.
+</Warning>
 
 Using official key server of SDK is recommended. 
 

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -45,9 +45,9 @@ import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerEr
 type ResolvedSealServerConfig = Omit<SealServerConfig, "weight"> & { weight: number };
 
 // Default SEAL server configs per network.
-// Testnet uses Mysten's initial committee aggregator by default. Mainnet
-// remains on the legacy independent servers until an official committee
-// aggregator is available.
+// Keep testnet on the legacy independent servers so Manual mode can decrypt
+// data written by the hosted testnet relayer. Committee aggregators remain
+// supported through explicit sealServerConfigs.
 const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = {
     mainnet: [
         {
@@ -61,12 +61,12 @@ const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = 
     ],
     testnet: [
         {
-            // Official Mysten testnet committee aggregator. This is one
-            // decentralized SEAL server config whose aggregator fronts the
-            // committee threshold internally.
-            objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
+            objectId: "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
             weight: 1,
-            aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
+        },
+        {
+            objectId: "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
+            weight: 1,
         },
     ],
 };

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -45,9 +45,9 @@ import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerEr
 type ResolvedSealServerConfig = Omit<SealServerConfig, "weight"> & { weight: number };
 
 // Default SEAL server configs per network.
-// Keep testnet on the legacy independent servers so Manual mode can decrypt
-// data written by the hosted testnet relayer. Committee aggregators remain
-// supported through explicit sealServerConfigs.
+// Testnet uses Mysten's initial committee aggregator by default. Mainnet
+// remains on the legacy independent servers until an official committee
+// aggregator is available.
 const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = {
     mainnet: [
         {
@@ -61,12 +61,9 @@ const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = 
     ],
     testnet: [
         {
-            objectId: "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
+            objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
             weight: 1,
-        },
-        {
-            objectId: "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
-            weight: 1,
+            aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
         },
     ],
 };

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -61,6 +61,9 @@ const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, ResolvedSealServerConfig[]> = 
     ],
     testnet: [
         {
+            // Official Mysten testnet committee aggregator. This is one
+            // decentralized SEAL server config whose aggregator fronts the
+            // committee threshold internally.
             objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
             weight: 1,
             aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -49,15 +49,21 @@ MEMWAL_REGISTRY_ID=0x...
 
 # SEAL server configs for sidecar encrypt/decrypt.
 # If neither SEAL_SERVER_CONFIGS nor SEAL_KEY_SERVERS is set, the sidecar uses
-# built-in independent key server defaults for SUI_NETWORK: two testnet servers
-# on testnet, and Overclock + Studio Mirai on mainnet.
+# built-in defaults for SUI_NETWORK. Testnet defaults to Mysten's initial
+# committee aggregator. Mainnet keeps the legacy independent key server default
+# until an official committee aggregator is available.
 #
-# Prefer SEAL_SERVER_CONFIGS for committee key servers because committee entries
-# require an aggregatorUrl. Example Mysten testnet committee override:
+# Use SEAL_SERVER_CONFIGS to override the default with another committee.
+# Committee entries require an aggregatorUrl. Example Mysten testnet committee:
 # SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
 #
-# Legacy independent key server object IDs remain supported as fallback:
-# SEAL_KEY_SERVERS=0x...,0x...
+# Legacy independent key server object IDs remain supported as an override.
+# Use this when you need the previous testnet independent defaults for older data:
+# SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8
+#
+# If this deployment already has memories encrypted by the previous testnet
+# independent defaults, keep those object IDs pinned in SEAL_KEY_SERVERS until
+# the data is migrated or re-encrypted.
 
 # SEAL threshold - minimum configured server weight that must respond for
 # encrypt/decrypt to succeed. Must be <= total configured server weight.

--- a/services/server/deploy/nautilus/runtime.env.example
+++ b/services/server/deploy/nautilus/runtime.env.example
@@ -22,10 +22,11 @@ MEMWAL_REGISTRY_ID=0x...
 SERVER_SUI_PRIVATE_KEY=suiprivkey1...
 SERVER_SUI_PRIVATE_KEYS=suiprivkey1...,suiprivkey1...
 
-# SEAL. Prefer SEAL_SERVER_CONFIGS for committee servers.
-SEAL_SERVER_CONFIGS=[{"objectId":"0x...","weight":1,"aggregatorUrl":"https://seal-aggregator.example.com"}]
+# SEAL. Optional override; testnet has a built-in Mysten committee default.
+# Set SEAL_SERVER_CONFIGS when you need a custom committee aggregator.
+# SEAL_SERVER_CONFIGS=[{"objectId":"0x...","weight":1,"aggregatorUrl":"https://seal-aggregator.example.com"}]
 # SEAL_KEY_SERVERS=0x...,0x...
-SEAL_THRESHOLD=1
+# SEAL_THRESHOLD=1
 
 # Walrus
 WALRUS_PUBLISHER_URL=https://publisher.walrus-mainnet.walrus.space

--- a/services/server/scripts/__tests__/seal-config.test.ts
+++ b/services/server/scripts/__tests__/seal-config.test.ts
@@ -9,6 +9,10 @@ const MYSTEN_TESTNET_COMMITTEE = {
     aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
 };
 
+const PREVIOUS_TESTNET_INDEPENDENT_KEY_SERVERS =
+    "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75," +
+    "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8";
+
 test("SEAL_SERVER_CONFIGS overrides built-in defaults", () => {
     const configs = getSealServerConfigsFromEnv({
         SUI_NETWORK: "testnet",
@@ -60,6 +64,17 @@ test("single committee default has threshold 1", () => {
     const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "testnet" });
 
     assert.equal(getSealThresholdFromEnv(configs, {}), 1);
+});
+
+test("legacy testnet independent override keeps threshold 2", () => {
+    const configs = getSealServerConfigsFromEnv({
+        SUI_NETWORK: "testnet",
+        SEAL_KEY_SERVERS: PREVIOUS_TESTNET_INDEPENDENT_KEY_SERVERS,
+    });
+
+    assert.equal(configs.length, 2);
+    assert.ok(configs.every((config) => config.aggregatorUrl === undefined));
+    assert.equal(getSealThresholdFromEnv(configs, {}), 2);
 });
 
 test("explicit SEAL_THRESHOLD validation is unchanged", () => {

--- a/services/server/scripts/__tests__/seal-config.test.ts
+++ b/services/server/scripts/__tests__/seal-config.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "../seal-config.js";
+
+const MYSTEN_TESTNET_COMMITTEE = {
+    objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
+    weight: 1,
+    aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
+};
+
+test("SEAL_SERVER_CONFIGS overrides built-in defaults", () => {
+    const configs = getSealServerConfigsFromEnv({
+        SUI_NETWORK: "testnet",
+        SEAL_SERVER_CONFIGS: JSON.stringify([
+            {
+                objectId: "0xcustom",
+                weight: 3,
+                aggregatorUrl: "https://seal-aggregator.example.com",
+            },
+        ]),
+        SEAL_KEY_SERVERS: "0xlegacy",
+    });
+
+    assert.deepEqual(configs, [
+        {
+            objectId: "0xcustom",
+            weight: 3,
+            aggregatorUrl: "https://seal-aggregator.example.com",
+        },
+    ]);
+});
+
+test("SEAL_KEY_SERVERS remains the legacy independent-server override", () => {
+    const configs = getSealServerConfigsFromEnv({
+        SUI_NETWORK: "testnet",
+        SEAL_KEY_SERVERS: "0xone, 0xtwo",
+    });
+
+    assert.deepEqual(configs, [
+        { objectId: "0xone", weight: 1 },
+        { objectId: "0xtwo", weight: 1 },
+    ]);
+});
+
+test("testnet defaults to Mysten committee aggregator", () => {
+    const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "testnet" });
+
+    assert.deepEqual(configs, [MYSTEN_TESTNET_COMMITTEE]);
+});
+
+test("mainnet keeps independent defaults until official committee is available", () => {
+    const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "mainnet" });
+
+    assert.equal(configs.length, 2);
+    assert.ok(configs.every((config) => config.aggregatorUrl === undefined));
+});
+
+test("single committee default has threshold 1", () => {
+    const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "testnet" });
+
+    assert.equal(getSealThresholdFromEnv(configs, {}), 1);
+});
+
+test("explicit SEAL_THRESHOLD validation is unchanged", () => {
+    const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "testnet" });
+
+    assert.equal(getSealThresholdFromEnv(configs, { SEAL_THRESHOLD: "1" }), 1);
+    assert.throws(
+        () => getSealThresholdFromEnv(configs, { SEAL_THRESHOLD: "2" }),
+        /SEAL_THRESHOLD must be less than or equal to total configured SEAL server weight/,
+    );
+});

--- a/services/server/scripts/package.json
+++ b/services/server/scripts/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "sidecar": "tsx sidecar-server.ts",
-        "test": "node --test --import tsx './mcp/__tests__/*.test.ts'"
+        "test": "node --test --import tsx './mcp/__tests__/*.test.ts' './__tests__/*.test.ts'"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/services/server/scripts/seal-config.ts
+++ b/services/server/scripts/seal-config.ts
@@ -21,6 +21,10 @@ const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, SealServerConfig[]> = {
     ],
     testnet: [
         {
+            // Official Mysten testnet committee aggregator. This is a single
+            // decentralized SEAL server config whose aggregator fronts the
+            // committee threshold internally; legacy independent 2-of-2
+            // deployments should pin SEAL_KEY_SERVERS instead.
             objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
             weight: 1,
             aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",

--- a/services/server/scripts/seal-config.ts
+++ b/services/server/scripts/seal-config.ts
@@ -21,12 +21,9 @@ const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, SealServerConfig[]> = {
     ],
     testnet: [
         {
-            objectId: "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
+            objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
             weight: 1,
-        },
-        {
-            objectId: "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
-            weight: 1,
+            aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
         },
     ],
 };


### PR DESCRIPTION
Switch the built-in SEAL server config on testnet to Mysten's initial committee aggregator so fresh relayer/sidecar deployments use the decentralized committee path by default where the official committee is available.

What changed:
- Testnet built-in sidecar/server default is now one committee entry: objectId `0xb012...e1e98`, weight `1`, aggregatorUrl `https://seal-aggregator-testnet.mystenlabs.com`.
- Mainnet built-in default stays on the existing independent key server pair until Mysten publishes an official mainnet committee aggregator.
- `SEAL_SERVER_CONFIGS` still wins first and remains the override path for any custom committee by providing `objectId`, `weight`, and `aggregatorUrl`.
- `SEAL_KEY_SERVERS` still wins second and preserves the legacy independent-key-server path.
- Docs and env examples now explain committee defaults, custom committee overrides, legacy independent key servers, and the migration warning for existing testnet data encrypted with the previous independent defaults.

SDK note:
- This PR does not change the published TypeScript SDK defaults, so it does not require an SDK release for the relayer/sidecar default behavior. The SDK already supports committee aggregators through explicit `sealServerConfigs`.

Threshold note:
- The new built-in testnet sidecar default has one decentralized committee config, so MemWal's outer default threshold resolves to `1`. The Mysten aggregator fronts the Seal committee threshold internally.
- Legacy 2-of-2 independent deployments are still supported by pinning `SEAL_KEY_SERVERS=0x73d0...,0xf5d1...`; the new test covers that this path still resolves to threshold `2`.

Validation:
- `npm --prefix services/server/scripts test` passes: 29/29.
- `pnpm -C docs exec mintlify validate` passes.
- GitHub checks pass; Mintlify Deployment is skipped by workflow.