### PR TITLE
fix(python-sdk): align GET signing and use seal sessions

### DIFF
--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -26,12 +26,14 @@ Example::
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import random
 import time
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar
 
 import httpx
+import nacl.signing
 
 from .types import (
     AnalyzedFact,
@@ -62,14 +64,20 @@ from .types import (
     RestoreResult,
 )
 from .utils import (
+    build_seal_session_personal_message,
     build_signature_message,
     build_signing_key,
     bytes_to_hex,
+    delegate_key_to_sui_address,
+    encode_sui_private_key,
     sha256_hex,
     sign_message,
+    sign_sui_personal_message,
 )
 
 T = TypeVar("T")
+SEAL_SESSION_TTL_MIN = 5
+SEAL_SESSION_SAFETY_MARGIN_MS = 30_000
 
 
 # ============================================================
@@ -123,6 +131,9 @@ class MemWal:
         self._server_url = config.server_url.rstrip("/")
         self._namespace = config.namespace
         self._client: Optional[httpx.AsyncClient] = None
+        self._server_config: Optional[Dict[str, str]] = None
+        self._session_cache: Optional[Tuple[str, int]] = None
+        self._session_build_task: Optional[asyncio.Task[str]] = None
 
     @classmethod
     def create(
@@ -659,11 +670,16 @@ class MemWal:
         Returns:
             :class:`RememberManualResult` with id, blob_id, owner, namespace.
         """
-        data = await self._signed_request("POST", "/api/remember/manual", {
-            "blob_id": opts.blob_id,
-            "vector": opts.vector,
-            "namespace": opts.namespace or self._namespace,
-        })
+        data = await self._signed_request(
+            "POST",
+            "/api/remember/manual",
+            {
+                "blob_id": opts.blob_id,
+                "vector": opts.vector,
+                "namespace": opts.namespace or self._namespace,
+            },
+            include_seal_session=False,
+        )
         return RememberManualResult(
             id=data["id"],
             blob_id=data["blob_id"],
@@ -683,11 +699,16 @@ class MemWal:
         Returns:
             :class:`RecallManualResult` with blob_id + distance pairs.
         """
-        data = await self._signed_request("POST", "/api/recall/manual", {
-            "vector": opts.vector,
-            "limit": opts.limit,
-            "namespace": opts.namespace or self._namespace,
-        })
+        data = await self._signed_request(
+            "POST",
+            "/api/recall/manual",
+            {
+                "vector": opts.vector,
+                "limit": opts.limit,
+                "namespace": opts.namespace or self._namespace,
+            },
+            include_seal_session=False,
+        )
         hits = [
             RecallManualHit(blob_id=h["blob_id"], distance=h["distance"])
             for h in data.get("results", [])
@@ -706,29 +727,141 @@ class MemWal:
     # Internal: Signed HTTP Requests
     # ============================================================
 
+    async def _fetch_server_config(self) -> Dict[str, str]:
+        if self._server_config is not None:
+            return self._server_config
+
+        response = await self._http.get(f"{self._server_url}/config")
+        if response.status_code != 200:
+            raise MemWalError(f"GET /config returned {response.status_code}")
+
+        data = response.json()
+        package_id = data.get("packageId")
+        network = data.get("network")
+        sui_rpc_url = data.get("suiRpcUrl")
+        if not package_id or not network or not sui_rpc_url:
+            raise MemWalError("GET /config response missing packageId / network / suiRpcUrl")
+
+        self._server_config = {
+            "packageId": package_id,
+            "network": network,
+            "suiRpcUrl": sui_rpc_url,
+        }
+        return self._server_config
+
+    async def _assert_first_package_version(self, sui_rpc_url: str, package_id: str) -> None:
+        response = await self._http.post(
+            sui_rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "sui_getObject",
+                "params": [package_id, {"showBcs": False, "showContent": False, "showType": False}],
+            },
+        )
+        if response.status_code != 200:
+            raise MemWalError(f"sui_getObject returned {response.status_code}")
+
+        body = response.json()
+        result = body.get("result", {})
+        version = None
+        if isinstance(result, dict):
+            data = result.get("data")
+            if isinstance(data, dict):
+                version = data.get("version")
+            if version is None:
+                obj = result.get("object")
+                if isinstance(obj, dict):
+                    version = obj.get("version")
+        if str(version) != "1":
+            raise MemWalError(
+                f"SEAL package {package_id} must be at version 1 to build x-seal-session, got {version!r}"
+            )
+
+    async def _build_seal_session_inner(self) -> str:
+        cfg = await self._fetch_server_config()
+        await self._assert_first_package_version(cfg["suiRpcUrl"], cfg["packageId"])
+
+        session_signing_key = nacl.signing.SigningKey.generate()
+        session_public_key = bytes(session_signing_key.verify_key)
+        creation_time_ms = int(time.time() * 1000)
+        personal_message = build_seal_session_personal_message(
+            package_id=cfg["packageId"],
+            ttl_min=SEAL_SESSION_TTL_MIN,
+            creation_time_ms=creation_time_ms,
+            session_public_key_bytes=session_public_key,
+        )
+        personal_message_signature = sign_sui_personal_message(
+            personal_message,
+            self._signing_key,
+        )
+
+        json_str = json.dumps(
+            {
+                "address": delegate_key_to_sui_address(self._private_key_hex),
+                "packageId": cfg["packageId"],
+                "mvrName": None,
+                "creationTimeMs": creation_time_ms,
+                "ttlMin": SEAL_SESSION_TTL_MIN,
+                "personalMessageSignature": personal_message_signature,
+                "sessionKey": encode_sui_private_key(bytes(session_signing_key)),
+            },
+            separators=(",", ":"),
+        )
+        session_bytes = base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
+        self._session_cache = (
+            session_bytes,
+            int(time.time() * 1000) + SEAL_SESSION_TTL_MIN * 60_000 - SEAL_SESSION_SAFETY_MARGIN_MS,
+        )
+        return session_bytes
+
+    async def _build_seal_session(self) -> str:
+        now_ms = int(time.time() * 1000)
+        if self._session_cache is not None:
+            cached_bytes, expires_at_ms = self._session_cache
+            if now_ms < expires_at_ms:
+                return cached_bytes
+
+        if self._session_build_task is not None:
+            return await self._session_build_task
+
+        self._session_build_task = asyncio.create_task(self._build_seal_session_inner())
+        try:
+            return await self._session_build_task
+        finally:
+            self._session_build_task = None
+
     async def _signed_request(
         self,
         method: str,
         path: str,
         body: Dict[str, Any],
         accepted_statuses: tuple = (200,),
+        include_seal_session: bool = True,
     ) -> Dict[str, Any]:
         """Make a signed request to the server.
 
-        Signature format: ``{timestamp}.{method}.{path}.{body_sha256}``
+        Signature format:
+            ``{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}``
+
+        For ``GET`` requests the canonical body string is the empty string,
+        and no HTTP request body is sent. This keeps the signed payload hash
+        byte-compatible with the TypeScript SDK and with intermediaries that
+        strip ``GET`` bodies on the wire.
 
         Headers sent:
             - ``x-public-key``: Ed25519 public key hex
             - ``x-signature``: Ed25519 signature hex
             - ``x-timestamp``: Unix seconds string
-            - ``x-delegate-key``: Private key hex
+            - ``x-seal-session``: Base64-encoded exported session envelope
             - ``x-account-id``: MemWalAccount object ID
             - ``Content-Type``: application/json
         """
         import uuid
 
+        method_upper = method.upper()
         timestamp = str(int(time.time()))
-        body_str = json.dumps(body, separators=(",", ":"))
+        body_str = "" if method_upper == "GET" else json.dumps(body, separators=(",", ":"))
         body_hash = sha256_hex(body_str)
         # MED-1 / LOW-23: nonce + account_id are part of the canonical signed
         # message. Server rejects the request as "unsupported legacy SDK"
@@ -737,7 +870,7 @@ class MemWal:
 
         message = build_signature_message(
             timestamp,
-            method.upper(),
+            method_upper,
             path,
             body_hash,
             nonce=nonce,
@@ -752,15 +885,16 @@ class MemWal:
             "x-signature": signature_hex,
             "x-timestamp": timestamp,
             "x-nonce": nonce,
-            "x-delegate-key": self._private_key_hex,
             "x-account-id": self._account_id,
         }
+        if include_seal_session:
+            headers["x-seal-session"] = await self._build_seal_session()
 
         response = await self._http.request(
-            method=method.upper(),
+            method=method_upper,
             url=url,
             headers=headers,
-            content=body_str,
+            content=None if method_upper == "GET" else body_str,
         )
 
         if response.status_code not in accepted_statuses:

--- a/packages/python-sdk-memwal/memwal/utils.py
+++ b/packages/python-sdk-memwal/memwal/utils.py
@@ -7,10 +7,15 @@ Uses PyNaCl (nacl.signing) as the primary Ed25519 implementation.
 
 from __future__ import annotations
 
+import base64
 import hashlib
+from datetime import datetime, timezone
 from typing import Tuple
 
 import nacl.signing
+
+_BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+_SUI_ED25519_SCHEME_FLAG = 0
 
 
 def hex_to_bytes(hex_str: str) -> bytes:
@@ -170,3 +175,116 @@ def delegate_key_to_public_key(private_key_hex: str) -> bytes:
     """
     signing_key = build_signing_key(private_key_hex)
     return bytes(signing_key.verify_key)
+
+
+def _bech32_polymod(values: bytes) -> int:
+    generators = [
+        0x3B6A57B2,
+        0x26508E6D,
+        0x1EA119FA,
+        0x3D4233DD,
+        0x2A1462B3,
+    ]
+    chk = 1
+    for value in values:
+        top = chk >> 25
+        chk = ((chk & 0x1FFFFFF) << 5) ^ value
+        for i in range(5):
+            if (top >> i) & 1:
+                chk ^= generators[i]
+    return chk
+
+
+def _bech32_hrp_expand(hrp: str) -> bytes:
+    return bytes([ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp])
+
+
+def _bech32_create_checksum(hrp: str, data: bytes) -> bytes:
+    values = _bech32_hrp_expand(hrp) + data
+    polymod = _bech32_polymod(values + bytes(6)) ^ 1
+    return bytes((polymod >> 5 * (5 - i)) & 31 for i in range(6))
+
+
+def _convertbits(data: bytes, frombits: int, tobits: int, pad: bool = True) -> bytes:
+    acc = 0
+    bits = 0
+    ret = []
+    maxv = (1 << tobits) - 1
+    max_acc = (1 << (frombits + tobits - 1)) - 1
+    for value in data:
+        if value < 0 or value >> frombits:
+            raise ValueError("invalid value for convertbits")
+        acc = ((acc << frombits) | value) & max_acc
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad:
+        if bits:
+            ret.append((acc << (tobits - bits)) & maxv)
+    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
+        raise ValueError("invalid incomplete group for convertbits")
+    return bytes(ret)
+
+
+def bech32_encode(hrp: str, data: bytes) -> str:
+    combined = data + _bech32_create_checksum(hrp, data)
+    return hrp + "1" + "".join(_BECH32_CHARSET[d] for d in combined)
+
+
+def encode_sui_private_key(seed_bytes: bytes) -> str:
+    """Encode a 32-byte Ed25519 seed to Sui bech32 `suiprivkey...` format."""
+    if len(seed_bytes) != 32:
+        raise ValueError(f"Ed25519 seed must be exactly 32 bytes, got {len(seed_bytes)}")
+    payload = bytes([_SUI_ED25519_SCHEME_FLAG]) + seed_bytes
+    return bech32_encode("suiprivkey", _convertbits(payload, 8, 5))
+
+
+def uleb128_encode(value: int) -> bytes:
+    """Encode an integer using ULEB128."""
+    if value < 0:
+        raise ValueError("ULEB128 only supports non-negative integers")
+    encoded = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            encoded.append(byte | 0x80)
+        else:
+            encoded.append(byte)
+            return bytes(encoded)
+
+
+def serialize_bcs_byte_vector(value: bytes) -> bytes:
+    """BCS `vector<u8>` encoding: ULEB128 length prefix followed by bytes."""
+    return uleb128_encode(len(value)) + value
+
+
+def build_seal_session_personal_message(
+    package_id: str,
+    ttl_min: int,
+    creation_time_ms: int,
+    session_public_key_bytes: bytes,
+) -> bytes:
+    """Build the SEAL SessionKey personal message string expected by Mysten SEAL."""
+    creation_time_utc = datetime.fromtimestamp(
+        creation_time_ms / 1000, tz=timezone.utc
+    ).strftime("%Y-%m-%d %H:%M:%S UTC")
+    session_public_key_b64 = base64.b64encode(session_public_key_bytes).decode("ascii")
+    message = (
+        f"Accessing keys of package {package_id} for {ttl_min} mins from "
+        f"{creation_time_utc}, session key {session_public_key_b64}"
+    )
+    return message.encode("utf-8")
+
+
+def sign_sui_personal_message(
+    message: bytes, signing_key: nacl.signing.SigningKey
+) -> str:
+    """Sign a Sui PersonalMessage and return serialized base64 signature."""
+    intent_message = b"\x03\x00\x00" + serialize_bcs_byte_vector(message)
+    digest = hashlib.blake2b(intent_message, digest_size=32).digest()
+    signature_bytes = signing_key.sign(digest).signature
+    public_key_bytes = bytes(signing_key.verify_key)
+    serialized = bytes([_SUI_ED25519_SCHEME_FLAG]) + signature_bytes + public_key_bytes
+    return base64.b64encode(serialized).decode("ascii")

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -7,7 +7,9 @@ that the client sends correct headers, body, and handles errors.
 
 from __future__ import annotations
 
+import base64
 import json
+from typing import Any
 
 import httpx
 import nacl.signing
@@ -29,6 +31,38 @@ _TEST_KEY_HEX = bytes_to_hex(bytes(_TEST_KEY))
 _TEST_PUB_HEX = bytes_to_hex(bytes(_TEST_KEY.verify_key))
 _TEST_ACCOUNT_ID = "0xabc123"
 _TEST_SERVER = "http://localhost:8000"
+_TEST_PACKAGE_ID = "0x" + "11" * 32
+_TEST_SUI_RPC = "http://localhost:9001"
+
+
+def mock_seal_session_prereqs() -> None:
+    respx.get(f"{_TEST_SERVER}/config").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "packageId": _TEST_PACKAGE_ID,
+                "network": "testnet",
+                "suiRpcUrl": _TEST_SUI_RPC,
+            },
+        )
+    )
+    respx.post(_TEST_SUI_RPC).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "result": {
+                    "data": {
+                        "version": "1",
+                    }
+                }
+            },
+        )
+    )
+
+
+def decode_seal_session_header(request: httpx.Request) -> dict[str, Any]:
+    header = request.headers["x-seal-session"]
+    return json.loads(base64.b64decode(header).decode("utf-8"))
 
 
 @pytest.fixture
@@ -50,6 +84,7 @@ class TestRemember:
     @respx.mock
     async def test_sends_correct_body(self, memwal_client: MemWal) -> None:
         """remember() should POST to /api/remember with text and namespace."""
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/remember").mock(
             return_value=httpx.Response(
                 202,
@@ -73,6 +108,7 @@ class TestRemember:
     @respx.mock
     async def test_sends_correct_headers(self, memwal_client: MemWal) -> None:
         """remember() should include all required auth headers."""
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/remember").mock(
             return_value=httpx.Response(
                 202,
@@ -95,13 +131,22 @@ class TestRemember:
         assert "x-timestamp" in headers
         assert headers["x-timestamp"].isdigit()
         assert "x-nonce" in headers
-        assert headers["x-delegate-key"] == _TEST_KEY_HEX
         assert headers["x-account-id"] == _TEST_ACCOUNT_ID
+        assert "x-seal-session" in headers
+        assert "x-delegate-key" not in headers
         assert headers["content-type"] == "application/json"
+
+        session = decode_seal_session_header(request)
+        assert session["address"].startswith("0x")
+        assert session["packageId"] == _TEST_PACKAGE_ID
+        assert session["ttlMin"] == 5
+        assert session["sessionKey"].startswith("suiprivkey")
+        assert session["personalMessageSignature"]
 
     @respx.mock
     async def test_signature_is_verifiable(self, memwal_client: MemWal) -> None:
         """The signature in headers should be verifiable with the public key."""
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/remember").mock(
             return_value=httpx.Response(
                 202,
@@ -141,6 +186,7 @@ class TestRemember:
     @respx.mock
     async def test_custom_namespace(self, memwal_client: MemWal) -> None:
         """remember() should use custom namespace when provided."""
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/remember").mock(
             return_value=httpx.Response(
                 202,
@@ -168,6 +214,7 @@ class TestRecall:
     @respx.mock
     async def test_sends_correct_body(self, memwal_client: MemWal) -> None:
         """recall() should POST to /api/recall with query, limit, namespace."""
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/recall").mock(
             return_value=httpx.Response(
                 200,
@@ -198,6 +245,7 @@ class TestRecall:
     @respx.mock
     async def test_sends_correct_headers(self, memwal_client: MemWal) -> None:
         """recall() should include all required auth headers."""
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/recall").mock(
             return_value=httpx.Response(
                 200,
@@ -211,6 +259,38 @@ class TestRecall:
         assert headers["x-public-key"] == _TEST_PUB_HEX
         assert len(headers["x-signature"]) == 128
         assert headers["x-account-id"] == _TEST_ACCOUNT_ID
+        assert "x-seal-session" in headers
+        assert "x-delegate-key" not in headers
+
+    @respx.mock
+    async def test_get_signed_request_uses_empty_body_hash_and_no_wire_body(
+        self, memwal_client: MemWal
+    ) -> None:
+        mock_seal_session_prereqs()
+        route = respx.get(f"{_TEST_SERVER}/api/remember/job-1").mock(
+            return_value=httpx.Response(
+                200,
+                json={"job_id": "job-1", "status": "done", "blob_id": "b1", "owner": "0xowner"},
+            )
+        )
+
+        result = await memwal_client.wait_for_remember_job("job-1", poll_interval_ms=0, timeout_ms=100)
+
+        request = route.calls[0].request
+        assert request.content == b""
+
+        headers = request.headers
+        message = build_signature_message(
+            timestamp=headers["x-timestamp"],
+            method="GET",
+            path="/api/remember/job-1",
+            body_sha256=sha256_hex(""),
+            nonce=headers["x-nonce"],
+            account_id=headers["x-account-id"],
+        )
+        verify_key = nacl.signing.VerifyKey(bytes.fromhex(headers["x-public-key"]))
+        verify_key.verify(message.encode("utf-8"), bytes.fromhex(headers["x-signature"]))
+        assert result.blob_id == "b1"
 
 
 # ============================================================
@@ -222,6 +302,7 @@ class TestErrorHandling:
     @respx.mock
     async def test_non_200_raises_memwal_error(self, memwal_client: MemWal) -> None:
         """Non-200 responses should raise MemWalError with status and body."""
+        mock_seal_session_prereqs()
         respx.post(f"{_TEST_SERVER}/api/remember").mock(
             return_value=httpx.Response(
                 401,
@@ -235,6 +316,7 @@ class TestErrorHandling:
     @respx.mock
     async def test_500_raises_memwal_error(self, memwal_client: MemWal) -> None:
         """Server errors should raise MemWalError."""
+        mock_seal_session_prereqs()
         respx.post(f"{_TEST_SERVER}/api/recall").mock(
             return_value=httpx.Response(
                 500,
@@ -264,6 +346,7 @@ class TestErrorHandling:
 class TestAnalyze:
     @respx.mock
     async def test_analyze(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/analyze").mock(
             return_value=httpx.Response(
                 200,
@@ -289,6 +372,7 @@ class TestAnalyze:
 class TestRestore:
     @respx.mock
     async def test_restore(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/restore").mock(
             return_value=httpx.Response(
                 200,
@@ -348,8 +432,11 @@ class TestManualAPI:
         result = await memwal_client.remember_manual(opts)
 
         body = json.loads(route.calls[0].request.content)
+        headers = route.calls[0].request.headers
         assert body["blob_id"] == "blob-xyz"
         assert body["vector"] == [0.1, 0.2, 0.3]
+        assert "x-seal-session" not in headers
+        assert "x-delegate-key" not in headers
         assert result.blob_id == "blob-xyz"
 
     @respx.mock
@@ -370,8 +457,11 @@ class TestManualAPI:
         result = await memwal_client.recall_manual(opts)
 
         body = json.loads(route.calls[0].request.content)
+        headers = route.calls[0].request.headers
         assert body["vector"] == [0.1, 0.2, 0.3]
         assert body["limit"] == 5
+        assert "x-seal-session" not in headers
+        assert "x-delegate-key" not in headers
         assert len(result.results) == 1
         assert result.results[0].blob_id == "b1"
 
@@ -386,6 +476,7 @@ class TestPublicKey:
 class TestAsk:
     @respx.mock
     async def test_ask(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/ask").mock(
             return_value=httpx.Response(
                 200,
@@ -413,6 +504,7 @@ class TestAsk:
 
     @respx.mock
     async def test_ask_empty_memories(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
         respx.post(f"{_TEST_SERVER}/api/ask").mock(
             return_value=httpx.Response(
                 200,
@@ -430,6 +522,7 @@ class TestAsk:
 
     @respx.mock
     async def test_ask_custom_namespace(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
         route = respx.post(f"{_TEST_SERVER}/api/ask").mock(
             return_value=httpx.Response(
                 200,
@@ -461,3 +554,19 @@ class TestContextManager:
         ) as client:
             result = await client.health()
             assert result.status == "ok"
+
+
+class TestSealSession:
+    @respx.mock
+    async def test_builds_cached_session_envelope(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
+
+        first = await memwal_client._build_seal_session()
+        second = await memwal_client._build_seal_session()
+
+        exported = json.loads(base64.b64decode(first).decode("utf-8"))
+        assert first == second
+        assert exported["packageId"] == _TEST_PACKAGE_ID
+        assert exported["ttlMin"] == 5
+        assert exported["sessionKey"].startswith("suiprivkey")
+        assert exported["personalMessageSignature"]

--- a/packages/python-sdk-memwal/tests/test_integration.py
+++ b/packages/python-sdk-memwal/tests/test_integration.py
@@ -13,7 +13,8 @@ No-auth tests (always run, no env vars needed):
   - Unregistered key → SDK raises MemWalError
 
 Authenticated tests (require MEMWAL_KEY + MEMWAL_ACCOUNT_ID):
-  - remember()
+  - remember() acceptance
+  - remember_and_wait()
   - recall()
   - analyze()
   - ask()
@@ -181,30 +182,39 @@ class TestAuthRejection:
 
 @requires_key
 class TestRemember:
-    """remember() against live server."""
+    """remember() / remember_and_wait() against live server."""
 
-    def test_remember_returns_id_and_blob(self) -> None:
+    def test_remember_returns_job_id_and_status(self) -> None:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
         result = mw.remember("Integration test: the sky is blue", namespace="sdk-test")
+        assert result.job_id is not None and isinstance(result.job_id, str)
+        assert result.status in ("pending", "running")
+        print(f"\n  accepted job={result.job_id[:8]}... status={result.status}")
+
+    def test_remember_and_wait_returns_blob_and_owner(self) -> None:
+        mw = MemWalSync.create(
+            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
+        )
+        result = mw.remember_and_wait("Integration test: the sky is blue", namespace="sdk-test")
         assert result.id is not None and isinstance(result.id, str)
         assert result.blob_id is not None and isinstance(result.blob_id, str)
         assert result.owner.startswith("0x")
-        print(f"\n  id={result.id[:8]}... blob={result.blob_id[:8]}...")
+        print(f"\n  done job={result.id[:8]}... blob={result.blob_id[:8]}...")
 
     def test_remember_default_namespace(self) -> None:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
-        result = mw.remember("Integration test: namespace default")
+        result = mw.remember_and_wait("Integration test: namespace default")
         assert result.namespace == "default"
 
     def test_remember_custom_namespace(self) -> None:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
-        result = mw.remember("Integration test: custom namespace", namespace="sdk-test")
+        result = mw.remember_and_wait("Integration test: custom namespace", namespace="sdk-test")
         assert result.namespace == "sdk-test"
 
 
@@ -292,7 +302,7 @@ class TestFullFlow:
         )
 
         # Store a distinctive memory in an isolated namespace
-        mem = mw.remember(text, namespace=ns)
+        mem = mw.remember_and_wait(text, namespace=ns)
         assert mem.id is not None
 
         # Recall — should find the stored memory
@@ -309,7 +319,7 @@ class TestFullFlow:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
-        mw.remember("I am allergic to shellfish", namespace="sdk-test")
+        mw.remember_and_wait("I am allergic to shellfish", namespace="sdk-test")
         result = mw.ask("What are my food allergies?", limit=3, namespace="sdk-test")
         assert isinstance(result.answer, str)
         assert len(result.answer) > 0
@@ -335,13 +345,14 @@ class TestAsync:
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         ) as mw:
             result = await mw.remember("Async SDK test: Paris is the capital of France")
-            assert result.id is not None
+            assert result.job_id is not None
+            assert result.status in ("pending", "running")
 
     async def test_async_recall(self) -> None:
         async with MemWal.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         ) as mw:
-            await mw.remember("Async SDK test: I enjoy reading")
+            await mw.remember_and_wait("Async SDK test: I enjoy reading")
             result = await mw.recall("reading books", limit=3)
             assert isinstance(result.results, list)
 

--- a/packages/python-sdk-memwal/tests/test_middleware.py
+++ b/packages/python-sdk-memwal/tests/test_middleware.py
@@ -51,6 +51,37 @@ _SERVER = "http://localhost:8000"
 
 _RECALL_URL = f"{_SERVER}/api/recall"
 _ANALYZE_URL = f"{_SERVER}/api/analyze"
+_SUI_RPC_URL = "http://localhost:9001"
+_PACKAGE_ID = "0x" + "11" * 32
+
+
+def _mock_seal_session_prereqs() -> None:
+    """Register mocks for the SEAL session prerequisites.
+
+    Every relayer-mode signed request (recall, analyze, remember) now starts
+    by fetching ``GET /config`` and verifying the SEAL package version via
+    ``sui_getObject``. Tests that drive MemWal through ``with_memwal_*`` must
+    register these or the first signed request raises
+    ``AllMockedAssertionError`` from respx.
+
+    Mirrors the helper of the same name in ``test_client.py``.
+    """
+    respx.get(f"{_SERVER}/config").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "packageId": _PACKAGE_ID,
+                "network": "testnet",
+                "suiRpcUrl": _SUI_RPC_URL,
+            },
+        )
+    )
+    respx.post(_SUI_RPC_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"result": {"data": {"version": "1"}}},
+        )
+    )
 
 
 def _mock_recall(memories: list, *, total: int | None = None) -> httpx.Response:
@@ -213,6 +244,7 @@ class TestWithMemWalLangChain:
     @respx.mock
     async def test_memories_injected_as_system_message(self) -> None:
         """When memories are found, a SystemMessage is injected before the HumanMessage."""
+        _mock_seal_session_prereqs()
         from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
         from langchain_core.outputs import ChatGeneration, ChatResult
 
@@ -249,6 +281,7 @@ class TestWithMemWalLangChain:
     @respx.mock
     async def test_no_memories_found_no_injection(self) -> None:
         """When no memories match, the message list is passed unchanged."""
+        _mock_seal_session_prereqs()
         from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
         from langchain_core.outputs import ChatGeneration, ChatResult
 
@@ -278,6 +311,7 @@ class TestWithMemWalLangChain:
     @respx.mock
     async def test_min_relevance_filters_low_score_memories(self) -> None:
         """Memories below min_relevance are filtered out."""
+        _mock_seal_session_prereqs()
         from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
         from langchain_core.outputs import ChatGeneration, ChatResult
 
@@ -313,6 +347,7 @@ class TestWithMemWalLangChain:
     @respx.mock
     async def test_recall_failure_does_not_block_llm(self) -> None:
         """If MemWal recall fails, the LLM is still called with original messages."""
+        _mock_seal_session_prereqs()
         from langchain_core.messages import HumanMessage
 
         llm = self._make_llm()
@@ -329,6 +364,7 @@ class TestWithMemWalLangChain:
     @respx.mock
     async def test_auto_save_triggers_analyze(self) -> None:
         """With auto_save=True, analyze() is called fire-and-forget after LLM call."""
+        _mock_seal_session_prereqs()
         from langchain_core.messages import HumanMessage
 
         llm = self._make_llm()
@@ -348,6 +384,7 @@ class TestWithMemWalLangChain:
     @respx.mock
     async def test_no_user_message_no_recall(self) -> None:
         """If there's no user message, recall is not called."""
+        _mock_seal_session_prereqs()
         from langchain_core.messages import SystemMessage
 
         llm = self._make_llm()
@@ -402,6 +439,7 @@ class TestWithMemWalOpenAI:
     @respx.mock
     async def test_async_client_injects_memory(self) -> None:
         """Async OpenAI client: memory injected as system message before user message."""
+        _mock_seal_session_prereqs()
         client = self._make_async_client()
         captured_messages: list = []
 
@@ -434,6 +472,7 @@ class TestWithMemWalOpenAI:
     @respx.mock
     async def test_async_client_no_memories_no_injection(self) -> None:
         """No memories → original messages passed unchanged."""
+        _mock_seal_session_prereqs()
         client = self._make_async_client()
         captured: list = []
 
@@ -460,6 +499,7 @@ class TestWithMemWalOpenAI:
     @respx.mock
     async def test_async_client_recall_failure_resilient(self) -> None:
         """If recall fails, the LLM call still proceeds."""
+        _mock_seal_session_prereqs()
         client = self._make_async_client()
 
         respx.post(_RECALL_URL).mock(return_value=httpx.Response(500, text="error"))
@@ -477,6 +517,7 @@ class TestWithMemWalOpenAI:
     @respx.mock
     async def test_async_client_auto_save(self) -> None:
         """With auto_save=True, analyze is triggered after completion."""
+        _mock_seal_session_prereqs()
         client = self._make_async_client()
 
         respx.post(_RECALL_URL).mock(return_value=_mock_recall([]))
@@ -496,6 +537,7 @@ class TestWithMemWalOpenAI:
     @respx.mock
     async def test_min_relevance_filter(self) -> None:
         """Memories with relevance below min_relevance are not injected."""
+        _mock_seal_session_prereqs()
         client = self._make_async_client()
         captured: list = []
 
@@ -528,6 +570,7 @@ class TestWithMemWalOpenAI:
     @respx.mock
     def test_sync_client_wraps_create(self) -> None:
         """Sync OpenAI client wrapper is applied correctly."""
+        _mock_seal_session_prereqs()
         client = self._make_sync_client()
         original_create = client.chat.completions.create
 

--- a/packages/python-sdk-memwal/tests/test_signing.py
+++ b/packages/python-sdk-memwal/tests/test_signing.py
@@ -7,18 +7,22 @@ Validates that:
 3. The signature message format matches the server expectation exactly
 """
 
+import base64
 import hashlib
 import json
 
 import nacl.signing
 
 from memwal.utils import (
+    build_seal_session_personal_message,
     build_signature_message,
     build_signing_key,
     bytes_to_hex,
+    encode_sui_private_key,
     hex_to_bytes,
     sha256_hex,
     sign_message,
+    sign_sui_personal_message,
 )
 
 
@@ -242,3 +246,29 @@ class TestDelegateKeyUtils:
         scheme_input = bytes([0x00]) + pub
         expected = "0x" + hashlib.blake2b(scheme_input, digest_size=32).hexdigest()
         assert delegate_key_to_sui_address(self._KEY) == expected
+
+
+class TestSealSessionUtils:
+    def test_encode_sui_private_key(self) -> None:
+        seed = b"\x02" * 32
+        encoded = encode_sui_private_key(seed)
+        assert encoded.startswith("suiprivkey1")
+
+    def test_build_personal_message(self) -> None:
+        message = build_seal_session_personal_message(
+            package_id="0x" + "11" * 32,
+            ttl_min=5,
+            creation_time_ms=1_700_000_000_000,
+            session_public_key_bytes=b"\x03" * 32,
+        )
+        decoded = message.decode("utf-8")
+        assert "Accessing keys of package" in decoded
+        assert "for 5 mins" in decoded
+        assert "session key" in decoded
+
+    def test_sign_sui_personal_message(self) -> None:
+        key = nacl.signing.SigningKey.generate()
+        signature = sign_sui_personal_message(b"hello", key)
+        raw = json.loads(json.dumps(signature))  # assert it's JSON-safe text
+        assert isinstance(raw, str)
+        assert len(base64.b64decode(signature)) == 97


### PR DESCRIPTION
## Summary

This PR fixes two Python SDK protocol mismatches with the TypeScript SDK:

- [ENG-1778](https://linear.app/commandoss/issue/ENG-1778/make-python-sdk-get-signingbody-behavior-match-typescript-sdk): make Python SDK GET signing/body behavior match TypeScript SDK
- [ENG-1777](https://linear.app/commandoss/issue/ENG-1777/migrate-python-sdk-from-legacy-x-delegate-key-to-x-seal-session): migrate Python SDK from legacy `x-delegate-key` to `x-seal-session`

## What changed

- Updated Python SDK signed requests so `GET` uses the empty string as the canonical body and sends no HTTP body on the wire
- Replaced raw `x-delegate-key` transmission with client-built `x-seal-session` for relayer-mode requests
- Added SEAL session construction helpers in the Python SDK, including exported session envelope generation and short-lived session caching
- Kept manual-mode routes opted out of decrypt credentials so they do not send an unnecessary SEAL session
- Added test coverage for:
  - `GET` no-body signing parity
  - `x-seal-session` header behavior
  - absence of `x-delegate-key`
  - manual-mode header omission
  - SEAL session helper utilities
- Updated the Python SDK integration tests to match the current async `remember()` contract and to wait for completion before downstream `ask()` / `recall()` assertions

## Why

### ENG-1778

The Python SDK was hashing and sending `json.dumps({})` for `GET` requests, while the TypeScript SDK signs an empty body and sends no body. That mismatch can break auth when proxies or clients drop `GET` bodies.

### ENG-1777

The Python SDK was still sending the raw delegate private key in `x-delegate-key`. The TypeScript SDK has already moved to short-lived `x-seal-session`, which is a better fit for the current security model and avoids putting the raw delegate key on the wire.

## Validation

Unit tests:
- `python3 -m pytest packages/python-sdk-memwal/tests/test_client.py packages/python-sdk-memwal/tests/test_signing.py -q`
- Result: `48 passed`

Live dev relayer checks:
- Target: `https://relayer.dev.memwal.ai`
- Verified end to end with real credentials:
  - `remember` accepted successfully
  - `wait_for_remember_job` completed successfully
  - `recall` returned the stored text
- Verified targeted integration coverage:
  - `python3 -m pytest packages/python-sdk-memwal/tests/test_integration.py -q -k 'TestRemember or test_remember_then_recall_finds_it or test_remember_then_ask_uses_memory or test_async_remember or test_async_recall'`
  - Result: `8 passed, 15 deselected`
