### PR TITLE
fix(server): mark single remember jobs failed on recovery enqueue errors

### DIFF
--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -181,6 +181,20 @@ async fn update_remember_job_after_wallet_error(
     .await;
 }
 
+async fn mark_remember_job_failed(state: &AppState, remember_job_id: Option<&str>, msg: &str) {
+    let Some(jid) = remember_job_id else {
+        return;
+    };
+
+    let _ = sqlx::query(
+        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+    )
+    .bind(msg)
+    .bind(jid)
+    .execute(state.db.pool())
+    .await;
+}
+
 /// A wallet job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletJob {
@@ -379,6 +393,7 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                         )
                         .await
                         {
+                            let finalize_remember_job_id = remember_job_id.clone();
                             if let Err(enqueue_err) = enqueue_finalize_uploaded_blob(
                                 state,
                                 enqueued_wallet_index,
@@ -392,7 +407,19 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                             )
                             .await
                             {
-                                return Err(enqueue_err.into_apalis_error());
+                                let msg = enqueue_err.to_string();
+                                mark_remember_job_failed(
+                                    state,
+                                    finalize_remember_job_id.as_deref(),
+                                    &msg,
+                                )
+                                .await;
+                                tracing::error!(
+                                    "[wallet-job:set-metadata] job_id={} {}",
+                                    finalize_remember_job_id.as_deref().unwrap_or("-"),
+                                    msg,
+                                );
+                                return Err(WalletJobError::Permanent(msg).into_apalis_error());
                             }
                             tracing::warn!(
                                     "[wallet-job:set-metadata] finalization failed after transfer; enqueued index-only retry: {}",
@@ -722,22 +749,9 @@ async fn execute_upload_and_transfer(
                 .await
             {
                 let msg = format!("failed to enqueue metadata/transfer recovery job: {}", e);
-                let classified = WalletJobError::classify_sidecar_error(&msg);
-                update_remember_job_after_wallet_error(
-                    state,
-                    recovery_remember_job_id.as_deref(),
-                    &classified,
-                    &msg,
-                )
-                .await;
-                tracing::error!(
-                    "[wallet-job:upload] job_id={} {} classification={} retryable={}",
-                    job_id_for_log,
-                    msg,
-                    classified.kind(),
-                    !classified.is_permanent()
-                );
-                return Err(classified);
+                mark_remember_job_failed(state, recovery_remember_job_id.as_deref(), &msg).await;
+                tracing::error!("[wallet-job:upload] job_id={} {}", job_id_for_log, msg,);
+                return Err(WalletJobError::Permanent(msg));
             }
 
             tracing::info!(
@@ -1022,7 +1036,7 @@ pub async fn execute_remember(
             .await;
 
             let mut storage = state.wallet_storage.clone();
-            storage
+            if let Err(e) = storage
                 .push(WalletJob {
                     wallet_index: key_index,
                     operation: WalletOperation::SetMetadataAndTransfer {
@@ -1044,12 +1058,12 @@ pub async fn execute_remember(
                     },
                 })
                 .await
-                .map_err(|e| {
-                    RememberJobError::Internal(format!(
-                        "failed to enqueue metadata/transfer recovery job: {}",
-                        e
-                    ))
-                })?;
+            {
+                let msg = format!("failed to enqueue metadata/transfer recovery job: {}", e);
+                tracing::error!("[remember-job] {} job_id={}", msg, job.job_id);
+                mark_remember_job_failed(state, Some(&job.job_id), &msg).await;
+                return Err(RememberJobError::Internal(msg));
+            }
 
             tracing::info!(
                 "[remember-job] job_id={} enqueued metadata/transfer recovery for blob_id={} key={}",

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -181,18 +181,67 @@ async fn update_remember_job_after_wallet_error(
     .await;
 }
 
-async fn mark_remember_job_failed(state: &AppState, remember_job_id: Option<&str>, msg: &str) {
+async fn mark_remember_job_failed(
+    pool: &sqlx::PgPool,
+    remember_job_id: Option<&str>,
+    msg: &str,
+) -> Result<(), sqlx::Error> {
     let Some(jid) = remember_job_id else {
-        return;
+        return Ok(());
     };
 
-    let _ = sqlx::query(
+    let result = sqlx::query(
         "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
     )
     .bind(msg)
     .bind(jid)
-    .execute(state.db.pool())
-    .await;
+    .execute(pool)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(sqlx::Error::RowNotFound);
+    }
+
+    Ok(())
+}
+
+fn remember_job_persist_failure_message(msg: &str, persist_err: &sqlx::Error) -> String {
+    format!(
+        "{}; failed to persist remember_jobs failed status: {}",
+        msg, persist_err
+    )
+}
+
+async fn classify_wallet_remember_handoff_failure(
+    pool: &sqlx::PgPool,
+    remember_job_id: Option<&str>,
+    msg: String,
+) -> WalletJobError {
+    // Recovery handoff failures happen after an external side effect already
+    // succeeded: a Walrus upload and sometimes an on-chain transfer. Once the
+    // polling row is durably terminal, abort retries so clients see `failed`
+    // instead of polling `uploaded` / `running` forever. If that terminal
+    // state cannot be persisted, keep the wallet handler retryable so the row
+    // is not orphaned.
+    match mark_remember_job_failed(pool, remember_job_id, &msg).await {
+        Ok(()) => WalletJobError::Permanent(msg),
+        Err(persist_err) => {
+            WalletJobError::Transient(remember_job_persist_failure_message(&msg, &persist_err))
+        }
+    }
+}
+
+async fn handle_legacy_remember_handoff_failure(
+    pool: &sqlx::PgPool,
+    remember_job_id: &str,
+    msg: String,
+) -> Result<(), RememberJobError> {
+    match mark_remember_job_failed(pool, Some(remember_job_id), &msg).await {
+        Ok(()) => Ok(()),
+        Err(persist_err) => Err(RememberJobError::Internal(
+            remember_job_persist_failure_message(&msg, &persist_err),
+        )),
+    }
 }
 
 /// A wallet job.
@@ -407,19 +456,18 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                             )
                             .await
                             {
-                                let msg = enqueue_err.to_string();
-                                mark_remember_job_failed(
-                                    state,
+                                let classified = classify_wallet_remember_handoff_failure(
+                                    state.db.pool(),
                                     finalize_remember_job_id.as_deref(),
-                                    &msg,
+                                    enqueue_err.to_string(),
                                 )
                                 .await;
                                 tracing::error!(
                                     "[wallet-job:set-metadata] job_id={} {}",
                                     finalize_remember_job_id.as_deref().unwrap_or("-"),
-                                    msg,
+                                    classified,
                                 );
-                                return Err(WalletJobError::Permanent(msg).into_apalis_error());
+                                return Err(classified.into_apalis_error());
                             }
                             tracing::warn!(
                                     "[wallet-job:set-metadata] finalization failed after transfer; enqueued index-only retry: {}",
@@ -748,10 +796,18 @@ async fn execute_upload_and_transfer(
                 })
                 .await
             {
-                let msg = format!("failed to enqueue metadata/transfer recovery job: {}", e);
-                mark_remember_job_failed(state, recovery_remember_job_id.as_deref(), &msg).await;
-                tracing::error!("[wallet-job:upload] job_id={} {}", job_id_for_log, msg,);
-                return Err(WalletJobError::Permanent(msg));
+                let classified = classify_wallet_remember_handoff_failure(
+                    state.db.pool(),
+                    recovery_remember_job_id.as_deref(),
+                    format!("failed to enqueue metadata/transfer recovery job: {}", e),
+                )
+                .await;
+                tracing::error!(
+                    "[wallet-job:upload] job_id={} {}",
+                    job_id_for_log,
+                    classified,
+                );
+                return Err(classified);
             }
 
             tracing::info!(
@@ -1061,8 +1117,8 @@ pub async fn execute_remember(
             {
                 let msg = format!("failed to enqueue metadata/transfer recovery job: {}", e);
                 tracing::error!("[remember-job] {} job_id={}", msg, job.job_id);
-                mark_remember_job_failed(state, Some(&job.job_id), &msg).await;
-                return Err(RememberJobError::Internal(msg));
+                return handle_legacy_remember_handoff_failure(state.db.pool(), &job.job_id, msg)
+                    .await;
             }
 
             tracing::info!(
@@ -1252,7 +1308,23 @@ pub async fn execute_bulk_remember(
 
 #[cfg(test)]
 mod tests {
-    use super::WalletJobError;
+    use std::sync::Arc;
+
+    use sqlx::postgres::PgPoolOptions;
+
+    use super::{
+        classify_wallet_remember_handoff_failure, mark_remember_job_failed, WalletJobError,
+    };
+    use crate::storage::db::VectorDb;
+
+    fn test_database_url() -> String {
+        std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgresql://memwal:memwal_secret@localhost:5432/memwal".into())
+    }
+
+    async fn test_db() -> Arc<VectorDb> {
+        Arc::new(VectorDb::new(&test_database_url()).await.unwrap())
+    }
 
     #[test]
     fn classify_object_lock_as_transient() {
@@ -1333,5 +1405,146 @@ mod tests {
     fn transient_errors_remain_retryable() {
         let error = WalletJobError::Transient("timeout".to_string()).into_apalis_error();
         assert!(matches!(error, apalis::prelude::Error::Failed(_)));
+    }
+
+    #[tokio::test]
+    async fn recovery_enqueue_failure_marks_remember_job_failed() {
+        let db = test_db().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        let msg = "failed to enqueue metadata/transfer recovery job: synthetic queue down";
+
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'uploaded')",
+        )
+        .bind(&job_id)
+        .bind("0xtest-owner")
+        .bind("test-ns")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let classified =
+            classify_wallet_remember_handoff_failure(db.pool(), Some(&job_id), msg.to_string())
+                .await;
+
+        match classified {
+            WalletJobError::Permanent(ref got) => assert_eq!(got, msg),
+            other => panic!("expected permanent handoff error, got {other}"),
+        }
+
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT status, error_msg FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(row.0, "failed");
+        assert_eq!(row.1.as_deref(), Some(msg));
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(db.pool())
+            .await;
+    }
+
+    #[tokio::test]
+    async fn terminal_recovery_handoff_failure_overrides_transient_looking_queue_error() {
+        let db = test_db().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        let msg = "failed to enqueue metadata/transfer recovery job: 503 service unavailable";
+
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'uploaded')",
+        )
+        .bind(&job_id)
+        .bind("0xtest-owner")
+        .bind("test-ns")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let classified =
+            classify_wallet_remember_handoff_failure(db.pool(), Some(&job_id), msg.to_string())
+                .await;
+
+        match classified {
+            WalletJobError::Permanent(ref got) => assert_eq!(got, msg),
+            other => panic!("expected permanent handoff error, got {other}"),
+        }
+
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT status, error_msg FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(row.0, "failed");
+        assert_eq!(row.1.as_deref(), Some(msg));
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(db.pool())
+            .await;
+    }
+
+    #[tokio::test]
+    async fn failed_status_persistence_keeps_wallet_handoff_retryable() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&test_database_url())
+            .await
+            .unwrap();
+        pool.close().await;
+
+        let msg = "failed to enqueue uploaded-blob finalization job: synthetic queue down";
+        let classified =
+            classify_wallet_remember_handoff_failure(&pool, Some("job-closed-pool"), msg.into())
+                .await;
+
+        match classified {
+            WalletJobError::Transient(got) => {
+                assert!(got.contains(msg));
+                assert!(got.contains("failed to persist remember_jobs failed status"));
+            }
+            other => panic!("expected transient handoff error, got {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mark_remember_job_failed_returns_real_update_error() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&test_database_url())
+            .await
+            .unwrap();
+        pool.close().await;
+
+        let err = mark_remember_job_failed(&pool, Some("job-closed-pool"), "synthetic")
+            .await
+            .expect_err("closed pool should fail");
+
+        assert!(err.to_string().contains("closed"));
+    }
+
+    #[tokio::test]
+    async fn missing_remember_job_keeps_handoff_retryable() {
+        let db = test_db().await;
+        let job_id = format!("missing-remember-job-{}", uuid::Uuid::new_v4());
+        let msg = "failed to enqueue metadata/transfer recovery job: synthetic queue down";
+
+        let classified =
+            classify_wallet_remember_handoff_failure(db.pool(), Some(&job_id), msg.to_string())
+                .await;
+
+        match classified {
+            WalletJobError::Transient(got) => {
+                assert!(got.contains(msg));
+                assert!(got.contains("failed to persist remember_jobs failed status"));
+                assert!(got.contains("no rows returned"));
+            }
+            other => panic!("expected transient handoff error, got {other}"),
+        }
     }
 }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1308,22 +1308,38 @@ pub async fn execute_bulk_remember(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::OnceLock;
 
     use sqlx::postgres::PgPoolOptions;
 
     use super::{
         classify_wallet_remember_handoff_failure, mark_remember_job_failed, WalletJobError,
     };
-    use crate::storage::db::VectorDb;
+
+    static DB_SETUP_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 
     fn test_database_url() -> String {
         std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgresql://memwal:memwal_secret@localhost:5432/memwal".into())
     }
 
-    async fn test_db() -> Arc<VectorDb> {
-        Arc::new(VectorDb::new(&test_database_url()).await.unwrap())
+    async fn test_pool() -> sqlx::PgPool {
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&test_database_url())
+            .await
+            .unwrap();
+
+        let _guard = DB_SETUP_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        sqlx::raw_sql(include_str!("../migrations/005_remember_jobs.sql"))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        pool
     }
 
     #[test]
@@ -1409,7 +1425,7 @@ mod tests {
 
     #[tokio::test]
     async fn recovery_enqueue_failure_marks_remember_job_failed() {
-        let db = test_db().await;
+        let pool = test_pool().await;
         let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
         let msg = "failed to enqueue metadata/transfer recovery job: synthetic queue down";
 
@@ -1419,13 +1435,12 @@ mod tests {
         .bind(&job_id)
         .bind("0xtest-owner")
         .bind("test-ns")
-        .execute(db.pool())
+        .execute(&pool)
         .await
         .unwrap();
 
         let classified =
-            classify_wallet_remember_handoff_failure(db.pool(), Some(&job_id), msg.to_string())
-                .await;
+            classify_wallet_remember_handoff_failure(&pool, Some(&job_id), msg.to_string()).await;
 
         match classified {
             WalletJobError::Permanent(ref got) => assert_eq!(got, msg),
@@ -1435,7 +1450,7 @@ mod tests {
         let row: (String, Option<String>) =
             sqlx::query_as("SELECT status, error_msg FROM remember_jobs WHERE id = $1")
                 .bind(&job_id)
-                .fetch_one(db.pool())
+                .fetch_one(&pool)
                 .await
                 .unwrap();
 
@@ -1444,13 +1459,13 @@ mod tests {
 
         let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
             .bind(&job_id)
-            .execute(db.pool())
+            .execute(&pool)
             .await;
     }
 
     #[tokio::test]
     async fn terminal_recovery_handoff_failure_overrides_transient_looking_queue_error() {
-        let db = test_db().await;
+        let pool = test_pool().await;
         let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
         let msg = "failed to enqueue metadata/transfer recovery job: 503 service unavailable";
 
@@ -1460,13 +1475,12 @@ mod tests {
         .bind(&job_id)
         .bind("0xtest-owner")
         .bind("test-ns")
-        .execute(db.pool())
+        .execute(&pool)
         .await
         .unwrap();
 
         let classified =
-            classify_wallet_remember_handoff_failure(db.pool(), Some(&job_id), msg.to_string())
-                .await;
+            classify_wallet_remember_handoff_failure(&pool, Some(&job_id), msg.to_string()).await;
 
         match classified {
             WalletJobError::Permanent(ref got) => assert_eq!(got, msg),
@@ -1476,7 +1490,7 @@ mod tests {
         let row: (String, Option<String>) =
             sqlx::query_as("SELECT status, error_msg FROM remember_jobs WHERE id = $1")
                 .bind(&job_id)
-                .fetch_one(db.pool())
+                .fetch_one(&pool)
                 .await
                 .unwrap();
 
@@ -1485,7 +1499,7 @@ mod tests {
 
         let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
             .bind(&job_id)
-            .execute(db.pool())
+            .execute(&pool)
             .await;
     }
 
@@ -1530,13 +1544,12 @@ mod tests {
 
     #[tokio::test]
     async fn missing_remember_job_keeps_handoff_retryable() {
-        let db = test_db().await;
+        let pool = test_pool().await;
         let job_id = format!("missing-remember-job-{}", uuid::Uuid::new_v4());
         let msg = "failed to enqueue metadata/transfer recovery job: synthetic queue down";
 
         let classified =
-            classify_wallet_remember_handoff_failure(db.pool(), Some(&job_id), msg.to_string())
-                .await;
+            classify_wallet_remember_handoff_failure(&pool, Some(&job_id), msg.to_string()).await;
 
         match classified {
             WalletJobError::Transient(got) => {

--- a/services/server/tests/live_remember_terminal_state_check.py
+++ b/services/server/tests/live_remember_terminal_state_check.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Manual live check for the async single-remember job lifecycle.
+
+This script validates the polling contract around `remember_jobs` using a
+real delegate key + account id against a live relayer.
+
+What it does:
+1. submit `POST /api/remember`
+2. poll `GET /api/remember/:job_id`
+3. print every observed status transition
+4. exit once the job becomes terminal
+
+Why it is useful for PR #180:
+- On a healthy relayer, the expected result is still `done`
+- If the recovery enqueue failure path from PR #180 ever occurs, the
+  important behavior is that polling returns terminal `failed` with an
+  error instead of hanging forever in `running` / `uploaded`
+
+Usage:
+  TEST_ACCOUNT_ID=0x... \
+  TEST_DELEGATE_KEY=abcd... \
+  TEST_BASE_URL=https://relayer.dev.memwal.ai \
+  python3 services/server/tests/live_remember_terminal_state_check.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+sys.path.insert(0, os.path.join(REPO_ROOT, "packages", "python-sdk-memwal"))
+
+from memwal import MemWal  # noqa: E402
+
+
+BASE_URL = os.environ.get("TEST_BASE_URL", "https://relayer.dev.memwal.ai").rstrip("/")
+ACCOUNT_ID = os.environ.get("TEST_ACCOUNT_ID", "").strip()
+DELEGATE_KEY = os.environ.get("TEST_DELEGATE_KEY", "").strip()
+TIMEOUT_MS = int(os.environ.get("TEST_TIMEOUT_MS", "120000"))
+POLL_INTERVAL_MS = int(os.environ.get("TEST_POLL_INTERVAL_MS", "1000"))
+
+
+def require_env(name: str, value: str) -> None:
+    if not value:
+        raise SystemExit(f"{name} is required")
+
+
+async def poll_with_status_log(client: MemWal, job_id: str) -> dict:
+    deadline = time.monotonic() + (TIMEOUT_MS / 1000)
+    seen: list[str] = []
+
+    while time.monotonic() < deadline:
+        status = await client._signed_request(  # type: ignore[attr-defined]
+            "GET",
+            f"/api/remember/{job_id}",
+            {},
+            accepted_statuses=(200, 404),
+        )
+        status_name = status.get("status", "<missing>")
+
+        if not seen or seen[-1] != status_name:
+            seen.append(status_name)
+            print("STATUS", json.dumps(status))
+
+        if status_name in {"done", "failed"}:
+            print("TERMINAL", json.dumps({"result": status_name, "statuses": seen}))
+            return status
+
+        await asyncio.sleep(POLL_INTERVAL_MS / 1000)
+
+    raise TimeoutError(
+        f"remember job {job_id} did not reach terminal state within {TIMEOUT_MS}ms"
+    )
+
+
+async def main() -> int:
+    require_env("TEST_ACCOUNT_ID", ACCOUNT_ID)
+    require_env("TEST_DELEGATE_KEY", DELEGATE_KEY)
+
+    unique = uuid.uuid4().hex[:8]
+    namespace = f"remember-terminal-check-{unique}"
+    text = (
+        f"Live remember terminal-state check {unique}: "
+        "jasmine tea is preferred over coffee."
+    )
+
+    print(
+        "CONFIG",
+        json.dumps(
+            {
+                "base_url": BASE_URL,
+                "account_id": ACCOUNT_ID,
+                "namespace": namespace,
+            }
+        ),
+    )
+
+    async with MemWal.create(
+        key=DELEGATE_KEY,
+        account_id=ACCOUNT_ID,
+        server_url=BASE_URL,
+    ) as client:
+        accepted = await client.remember(text, namespace=namespace)
+        print(
+            "ACCEPTED",
+            json.dumps({"job_id": accepted.job_id, "status": accepted.status}),
+        )
+
+        terminal = await poll_with_status_log(client, accepted.job_id)
+        status = terminal.get("status")
+
+        if status == "done":
+            print(
+                "RESULT",
+                json.dumps(
+                    {
+                        "ok": True,
+                        "job_id": accepted.job_id,
+                        "blob_id": terminal.get("blob_id"),
+                        "note": "Happy path completed. If PR #180's recovery enqueue failure occurs, this same poll path should return status=failed with error instead of hanging.",
+                    }
+                ),
+            )
+            return 0
+
+        print(
+            "RESULT",
+            json.dumps(
+                {
+                    "ok": False,
+                    "job_id": accepted.job_id,
+                    "error": terminal.get("error"),
+                    "note": "Terminal failure surfaced to polling. This is the behavior PR #180 protects when recovery enqueue handoff fails.",
+                }
+            ),
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## Summary

This PR fixes a stuck-state bug in the async single-remember pipeline.

When a remember upload succeeds but the follow-up recovery/finalization wallet job cannot be enqueued, the corresponding `remember_jobs` row could remain in a non-terminal state such as `running` or `uploaded`, even though no downstream worker would ever resume it.

This change makes those enqueue-handoff failures terminal.

## Problem

The async remember pipeline has a recovery path for partial success:

- upload succeeds
- metadata/transfer fails
- server tries to enqueue a follow-up wallet job to finish recovery

Before this PR, if that follow-up enqueue failed, the `remember_jobs` row might already have been updated to `uploaded`, but nothing else would process it after that. Clients polling `GET /api/remember/:job_id` could hang until timeout because the row still looked active.

## What changed

In `services/server/src/jobs.rs`:

- added a focused helper to mark `remember_jobs` rows as `failed` with an `error_msg`
- used that helper for enqueue-handoff failures that would otherwise orphan a single remember job
- return a terminal/permanent error for those handoff failures instead of leaving the row in a live-looking state

Covered paths:

1. `WalletOperation::UploadAndTransfer`
   - upload succeeded
   - metadata/transfer recovery enqueue fails
   - now marks the remember job as `failed`

2. `WalletOperation::SetMetadataAndTransfer`
   - metadata/transfer succeeded
   - uploaded-blob finalization enqueue fails
   - now marks the remember job as `failed`

3. legacy `execute_remember`
   - upload succeeded
   - metadata/transfer recovery enqueue fails
   - now marks the remember job as `failed`

## Why this is correct

Polling reads directly from `remember_jobs`.

If no downstream worker exists anymore, the row must be terminal. Otherwise the system reports `running` / `uploaded` even though the job is effectively dead.

This PR enforces the state-machine rule:

- if work is still actively recoverable by an enqueued worker, the row may remain non-terminal
- if the handoff to that worker fails, the row must transition to `failed`

## User impact

- no more permanently stuck single remember jobs for these enqueue failure paths
- `wait_for_remember_job()` will observe a terminal failure instead of timing out indefinitely
- operators get a concrete `error_msg` indicating which enqueue handoff failed

## Validation

Ran:

- `cargo test --manifest-path services/server/Cargo.toml jobs::tests -- --nocapture`

Result:

- `7 passed`

## Scope note

This PR is scoped to single remember job lifecycle handling only.

It does not address the separate bulk remember partial-fanout issue.
