### PR TITLE
MEM-60 define relayer compatibility policy

### DIFF
--- a/.changeset/bright-compatibility-contract.md
+++ b/.changeset/bright-compatibility-contract.md
@@ -1,0 +1,6 @@
+---
+"@mysten-incubation/memwal": patch
+"@mysten-incubation/memwal-mcp": patch
+---
+
+Add relayer API compatibility checks before protected requests and surface clear upgrade/downgrade errors when the relayer contract is unsupported.

--- a/.changeset/bright-compatibility-contract.md
+++ b/.changeset/bright-compatibility-contract.md
@@ -1,6 +1,0 @@
----
-"@mysten-incubation/memwal": patch
-"@mysten-incubation/memwal-mcp": patch
----
-
-Add relayer API compatibility checks before protected requests and surface clear upgrade/downgrade errors when the relayer contract is unsupported.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,23 @@ permissions:
   contents: read
 
 jobs:
+  compatibility-contract:
+    name: Compatibility / Contract metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Check compatibility contract
+        run: node scripts/check-compatibility-contract.mjs
+
   chatbot-e2e:
     name: Chatbot / Playwright E2E
     runs-on: ubuntu-latest

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -123,6 +123,7 @@
               "relayer/self-hosting",
               "relayer/nautilus-tee",
               "relayer/observability",
+              "relayer/versioning-and-compatibility",
               "relayer/api-reference"
             ]
           }

--- a/docs/fundamentals/architecture/data-flow-security-model.md
+++ b/docs/fundamentals/architecture/data-flow-security-model.md
@@ -71,10 +71,10 @@ flowchart LR
 
 Every protected API call goes through Ed25519 signature verification:
 
-1. The SDK signs a message: `{timestamp}.{method}.{path}.{body_sha256}` using the delegate private key
+1. The SDK signs a message: `{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}` using the delegate private key
 2. The relayer verifies the Ed25519 signature against the provided public key
-3. Timestamps must be within a **5-minute window** to prevent replay attacks
-4. The relayer resolves the public key to a `MemWalAccount` using the priority chain: cache → indexed accounts → onchain registry → header hint → config fallback
+3. Timestamps must be within a **5-minute window**, and each `x-nonce` UUID is recorded in Redis for replay protection
+4. The relayer resolves the public key to a `MemWalAccount` using the priority chain: cache → signed account header/config fallback → onchain registry scan
 5. The onchain account is fetched to verify the delegate key is registered in `delegate_keys`
 6. The resolved owner address is used to scope all subsequent operations
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -341,7 +341,7 @@ The relayer is the backend that turns SDK calls into memory operations:
 | `x-timestamp` | Unix timestamp in seconds (5-minute validity window) |
 | `x-nonce` | UUID v4 nonce for replay protection |
 | `x-account-id` | MemWalAccount object ID hint included in the canonical signature by official SDKs |
-| `x-seal-session` | Exported SEAL SessionKey for TypeScript relayer-mode decrypt flows |
+| `x-seal-session` | Exported SEAL SessionKey for TypeScript and Python relayer-mode decrypt flows |
 | `x-delegate-key` | Legacy decrypt credential; deprecated where `x-seal-session` is supported |
 
 Signature format: `{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -339,15 +339,19 @@ The relayer is the backend that turns SDK calls into memory operations:
 | `x-public-key` | Hex-encoded Ed25519 public key (32 bytes) |
 | `x-signature` | Hex-encoded Ed25519 signature (64 bytes) |
 | `x-timestamp` | Unix timestamp in seconds (5-minute validity window) |
-| `x-account-id` | Optional — MemWalAccount object ID hint |
+| `x-nonce` | UUID v4 nonce for replay protection |
+| `x-account-id` | MemWalAccount object ID hint included in the canonical signature by official SDKs |
+| `x-seal-session` | Exported SEAL SessionKey for TypeScript relayer-mode decrypt flows |
+| `x-delegate-key` | Legacy decrypt credential; deprecated where `x-seal-session` is supported |
 
-Signature format: `{timestamp}.{method}.{path}.{body_sha256}`
+Signature format: `{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}`
 
 ### Relayer API Routes
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/health` | Service health check (no auth) |
+| `GET` | `/health` | Service health check and compatibility metadata (no auth) |
+| `GET` | `/version` | Relayer/API compatibility metadata (no auth) |
 | `POST` | `/api/remember` | Store text as encrypted memory |
 | `POST` | `/api/recall` | Semantic search for memories |
 | `POST` | `/api/remember/manual` | Register client-encrypted payload |

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -3,6 +3,12 @@ title: "Changelog"
 description: "Release history for the MemWal MCP package."
 ---
 
+## 0.0.2
+
+### Added
+
+- Added relayer compatibility metadata checks before opening the MCP bridge.
+
 ## 0.0.1
 
 ### Initial Release

--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -137,8 +137,18 @@ RestoreResult(restored: int, skipped: int, total: int, namespace: str, owner: st
 Check relayer health. No authentication. Raises `MemWalError` on non-200.
 
 ```python
-HealthResult(status: str, version: str)
+HealthResult(
+    status: str,
+    version: str,
+    relayer_version: str | None = None,
+    api_version: str | None = None,
+    min_supported_sdk: dict[str, str] | None = None,
+)
 ```
+
+### `compatibility() -> dict`
+
+Fetch and validate the relayer compatibility contract from `/version`. Protected SDK calls run this check before signing the first request and raise `MemWalCompatibilityError` when the SDK/relayer pair is unsupported.
 
 ### `get_public_key_hex() -> str`
 
@@ -200,7 +210,7 @@ from memwal import delegate_key_to_sui_address, delegate_key_to_public_key
 Every request is signed with Ed25519 (PyNaCl). Canonical message:
 
 ```
-{timestamp}.{method}.{path}.{sha256(body)}.{nonce}.{account_id}
+{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
 ```
 
 Headers sent: `x-public-key`, `x-signature`, `x-timestamp`, `x-nonce` (UUID v4), `x-delegate-key`, `x-account-id`. SDKs that omit `x-nonce` are rejected by the server with `426 Upgrade Required`.

--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -213,4 +213,4 @@ Every request is signed with Ed25519 (PyNaCl). Canonical message:
 {timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
 ```
 
-Headers sent: `x-public-key`, `x-signature`, `x-timestamp`, `x-nonce` (UUID v4), `x-delegate-key`, `x-account-id`. SDKs that omit `x-nonce` are rejected by the server with `426 Upgrade Required`.
+Signed requests send `x-public-key`, `x-signature`, `x-timestamp`, `x-nonce` (UUID v4), and `x-account-id`. Relayer-mode requests also send `x-seal-session`; manual-mode requests omit decrypt credentials. SDKs that omit `x-nonce` are rejected by the server with `426 Upgrade Required`.

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -7,11 +7,12 @@ Track what's new, changed, and fixed in `memwal` (Python).
 
 For the latest version, see the [PyPI project page](https://pypi.org/project/memwal/).
 
-## Unreleased
+## 0.1.1
 
 ### Added
 
 - Relayer environment presets via `env="prod" | "dev" | "staging" | "local"` on `MemWal.create`, `MemWalSync.create`, `with_memwal_langchain`, and `with_memwal_openai`. Mirrors the TypeScript SDK / MCP package shorthand. Precedence: explicit non-default `server_url` > `env` > default; an unknown preset raises `ValueError`. `ENV_PRESETS` is exported from the package.
+- Added relayer compatibility metadata checks before protected requests, plus `compatibility()` on async and sync clients.
 
 ## 0.1.0.dev1
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -5,6 +5,8 @@ title: "Environment Variables"
 Use this page when you run your own relayer.
 For setup steps and deployment context, see [Self-Hosting](/relayer/self-hosting).
 
+Environment variables documented here are public relayer contract items. Renaming, removing, or changing their meaning follows the deprecation process in [Versioning and Compatibility](/relayer/versioning-and-compatibility).
+
 ## Required
 
 | Variable | Notes |
@@ -46,7 +48,7 @@ These are not all enforced at boot, but most real deployments need them.
 | `WALRUS_PACKAGE_ID` | network default | Override the Walrus on-chain package used by the sidecar |
 | `WALRUS_UPLOAD_RELAY_URL` | network default | Override the Walrus upload relay used by the sidecar |
 | `SEAL_SERVER_CONFIGS` | network default | Optional JSON SEAL server config override for independent or committee servers |
-| `SEAL_KEY_SERVERS` | network default | Legacy comma-separated independent SEAL key server override. Used only when `SEAL_SERVER_CONFIGS` is unset |
+| `SEAL_KEY_SERVERS` | network default | Legacy comma-separated independent SEAL key server override. Used only when `SEAL_SERVER_CONFIGS` is unset. Deprecated but supported through relayer API `1.x` |
 | `SEAL_THRESHOLD` | `min(2, total configured weight)` | Required configured server weight for SEAL encrypt/decrypt |
 | `ENOKI_API_KEY` | none | Optional Enoki key for sponsored sidecar transactions |
 | `ENOKI_NETWORK` | `mainnet` | Network used for Enoki-sponsored flows |
@@ -66,7 +68,7 @@ These are not all enforced at boot, but most real deployments need them.
 - Without `OPENAI_API_KEY`, the server can fall back to mock embeddings. That is useful for local testing, not for normal production behavior.
 - `SUI_NETWORK` drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.
 - `SEAL_SERVER_CONFIGS` is a JSON array of `{ objectId, weight, aggregatorUrl?, apiKeyName?, apiKey? }`. Committee key server configs require `aggregatorUrl`.
-- `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset.
+- `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset, is advertised as deprecated in `/version`, and will not be removed before relayer API `2.0.0`.
 - If neither SEAL variable is set, the sidecar uses built-in defaults for `SUI_NETWORK`: Mysten's initial committee aggregator on `testnet`, and the legacy independent key server pair on `mainnet` until an official mainnet committee aggregator is available.
 - Use `SEAL_SERVER_CONFIGS` to override the built-in default with another committee by providing `objectId`, `weight`, and `aggregatorUrl`.
 - Deployments with existing memories encrypted by the previous testnet independent key server defaults should pin `SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8` until the data is migrated or re-encrypted.

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -28,7 +28,7 @@ All `/api/*` routes require signed headers. The SDK handles this automatically.
 | Header | Description |
 |--------|-------------|
 | `x-account-id` | MemWalAccount object ID hint. Official SDKs always send it and include it in the canonical signature |
-| `x-seal-session` | Base64 exported SEAL SessionKey for relayer-managed decrypt flows. Used by the TypeScript SDK |
+| `x-seal-session` | Base64 exported SEAL SessionKey for relayer-managed decrypt flows. Used by the TypeScript and Python SDKs |
 | `x-delegate-key` | Legacy delegate private key credential for relayer-managed decrypt flows. Deprecated; use `x-seal-session` where supported |
 
 ### Signature Format

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -8,6 +8,7 @@ See also:
 
 - [Environment Variables](/reference/environment-variables)
 - [Configuration](/reference/configuration)
+- [Versioning and Compatibility](/relayer/versioning-and-compatibility)
 
 ## Authentication
 
@@ -20,17 +21,25 @@ All `/api/*` routes require signed headers. The SDK handles this automatically.
 | `x-public-key` | Hex-encoded Ed25519 public key (32 bytes) |
 | `x-signature` | Hex-encoded Ed25519 signature (64 bytes) |
 | `x-timestamp` | Unix timestamp in seconds (5-minute validity window) |
+| `x-nonce` | UUID v4 nonce. The relayer records it in Redis for replay protection |
 
 ### Optional Headers
 
 | Header | Description |
 |--------|-------------|
-| `x-account-id` | MemWalAccount object ID hint — speeds up account resolution when not cached |
-| `x-delegate-key` | Delegate private key (hex) — used by the default SDK for SEAL decrypt flows |
+| `x-account-id` | MemWalAccount object ID hint. Official SDKs always send it and include it in the canonical signature |
+| `x-seal-session` | Base64 exported SEAL SessionKey for relayer-managed decrypt flows. Used by the TypeScript SDK |
+| `x-delegate-key` | Legacy delegate private key credential for relayer-managed decrypt flows. Deprecated; use `x-seal-session` where supported |
 
 ### Signature Format
 
-The signed message is: `{timestamp}.{method}.{path}.{body_sha256}`
+The signed message is:
+
+```text
+{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
+```
+
+For `GET` requests, `body_sha256` is the SHA-256 of an empty byte string. If a raw client omits `x-account-id`, it must sign the empty string in the final `account_id` position. Official SDKs send `x-account-id`.
 
 The relayer verifies the Ed25519 signature, then resolves the owner by looking up the public key in onchain `MemWalAccount.delegate_keys`.
 
@@ -45,9 +54,34 @@ Service health check. No authentication required.
 ```json
 {
   "status": "ok",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "relayerVersion": "0.1.0",
+  "apiVersion": "1.0.0",
+  "minSupportedSdk": {
+    "typescript": "0.0.4",
+    "python": "0.1.0",
+    "mcp": "0.0.1"
+  },
+  "featureFlags": {
+    "auth.accountBoundNonce": true,
+    "auth.sealSessionHeader": true,
+    "runtime.versionEndpoint": true
+  },
+  "deprecations": [],
+  "build": {},
+  "mode": "production",
+  "prompt_versions": {
+    "extract": "extract.v1",
+    "ask": "ask.v1"
+  }
 }
 ```
+
+### `GET /version`
+
+Stable relayer/API compatibility metadata. No authentication required.
+
+**Response:** the compatibility object documented in [Versioning and Compatibility](/relayer/versioning-and-compatibility#runtime-metadata).
 
 ### `POST /sponsor`
 

--- a/docs/relayer/versioning-and-compatibility.md
+++ b/docs/relayer/versioning-and-compatibility.md
@@ -1,0 +1,95 @@
+---
+title: "Versioning and Compatibility"
+---
+
+The MemWal relayer is the public protocol/API layer for SDKs, MCP clients, and self-hosted deployments. Treat every route, signed header, response field, runtime config field, and documented environment variable on this page as a versioned contract.
+
+## Relayer SemVer
+
+The relayer package version follows SemVer, and the public API contract is exposed separately as `apiVersion`.
+
+| Change | Required bump | Examples |
+| --- | --- | --- |
+| Compatible public behavior | patch | bug fix, clearer error body, additive docs |
+| Additive public surface | minor | new response field, new route, new optional env var, new feature flag |
+| Breaking public surface | major | removing or renaming a header, route, env var, response field, auth canonical format, or changing field meaning |
+
+Public surfaces include:
+
+- HTTP routes under `/api/*`, `/health`, `/version`, `/config`, `/sponsor`, and `/api/mcp*`
+- signed auth headers and the canonical signature format
+- JSON request/response field names and status-code semantics
+- runtime config and environment variables used by self-hosted relayers
+- MCP transport behavior and bearer credential expectations
+
+## Compatibility Matrix
+
+| Relayer API | Relayer package | TypeScript SDK | Python SDK | MCP package | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `1.x` | `0.1.x` | `>=0.0.4` | `>=0.1.0` | `>=0.0.1` | Requires `x-nonce`; TypeScript SDK uses `x-seal-session`; Python and MCP still use documented legacy credential paths |
+
+SDKs and MCP clients read `/version` before protected requests and fail with an explicit compatibility error when the relayer API major or minimum SDK version is unsupported.
+
+## Runtime Metadata
+
+Modern relayers expose compatibility metadata at `GET /version` and include the same block in `GET /health`.
+
+```json
+{
+  "relayerVersion": "0.1.0",
+  "apiVersion": "1.0.0",
+  "minSupportedSdk": {
+    "typescript": "0.0.4",
+    "python": "0.1.0",
+    "mcp": "0.0.1"
+  },
+  "featureFlags": {
+    "auth.accountBoundNonce": true,
+    "auth.sealSessionHeader": true,
+    "runtime.versionEndpoint": true
+  },
+  "deprecations": [
+    {
+      "surface": "header:x-delegate-key",
+      "deprecatedSince": "1.0.0",
+      "removalApiVersion": "2.0.0",
+      "guidance": "Use x-seal-session for relayer-managed SEAL decrypt flows; manual-mode requests should send no decrypt credential."
+    }
+  ],
+  "build": {
+    "commit": "optional-git-sha",
+    "buildTimestamp": "optional-build-time"
+  }
+}
+```
+
+`/health` keeps the legacy `version` field for older monitoring checks. New automation should prefer `relayerVersion`.
+
+## Deprecation Process
+
+Breaking changes must follow this process unless there is an active security incident:
+
+1. Add a deprecation notice to `/version.deprecations`.
+2. Document the replacement path and removal `apiVersion`.
+3. Keep the old surface working for the rest of the current API major.
+4. Add or update contract tests and docs in the same PR.
+5. Remove the surface only in the next API major.
+
+This process applies to headers, routes, environment variables, response fields, feature flags, and MCP transport behavior.
+
+## Environment Variables
+
+Environment variables documented in [Environment Variables](/reference/environment-variables) are public contract items for self-hosted deployments. Renaming, removing, or changing their meaning is a breaking relayer API change.
+
+Additive env vars may ship in a minor release. Deprecating an env var requires a `/version.deprecations` entry, docs update, and a replacement path. `SEAL_KEY_SERVERS` is currently deprecated in favor of `SEAL_SERVER_CONFIGS` and remains supported through relayer API `1.x`.
+
+## Contract Checks
+
+CI runs `pnpm check:compatibility`, which verifies that:
+
+- relayer API and minimum supported SDK/MCP constants are valid SemVer contract values
+- SDK/MCP compatibility baselines match the relayer's minimum supported versions
+- SDK/MCP package versions are not older than the compatibility baseline they advertise
+- this policy document contains the current API version and compatibility matrix values
+
+If a public compatibility value changes, update the implementation, this document, and the relevant changelog/deprecation notes together.

--- a/docs/relayer/versioning-and-compatibility.md
+++ b/docs/relayer/versioning-and-compatibility.md
@@ -26,7 +26,7 @@ Public surfaces include:
 
 | Relayer API | Relayer package | TypeScript SDK | Python SDK | MCP package | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `1.x` | `0.1.x` | `>=0.0.4` | `>=0.1.0` | `>=0.0.1` | Requires `x-nonce`; TypeScript SDK uses `x-seal-session`; Python and MCP still use documented legacy credential paths |
+| `1.x` | `0.1.x` | `>=0.0.4` | `>=0.1.0` | `>=0.0.1` | Requires `x-nonce`; TypeScript and Python SDKs use `x-seal-session` for relayer-mode decrypt flows; MCP uses bearer delegate credentials for SSE |
 
 SDKs and MCP clients read `/version` before protected requests and fail with an explicit compatibility error when the relayer API major or minimum SDK version is unsupported.
 

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -140,7 +140,11 @@ Rebuild missing indexed entries for one namespace from Walrus. Incremental — o
 
 Check relayer health. Does not require authentication.
 
-**Returns:** `{ status: string, version: string }`
+**Returns:** `{ status: string, version: string, relayerVersion?: string, apiVersion?: string, minSupportedSdk?: ... }`
+
+### `compatibility(): Promise<RelayerVersionMetadata>`
+
+Fetch and validate the relayer compatibility contract from `/version`. Protected SDK calls run this check before signing the first request and raise `MemWalCompatibilityError` when the SDK/relayer pair is unsupported.
 
 ### `getPublicKeyHex(): Promise<string>`
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -3,6 +3,13 @@ title: "Changelog"
 description: "Release history for the MemWal TypeScript SDK."
 ---
 
+## 0.0.5
+
+### Added
+
+- Added relayer compatibility metadata checks before protected requests.
+- Added `compatibility()` and exported compatibility types/errors so callers can inspect SDK/relayer support explicitly.
+
 ## 0.0.4
 
 ### Added

--- a/docs/security/health-check-unsigned.md
+++ b/docs/security/health-check-unsigned.md
@@ -1,15 +1,15 @@
 # Unsigned Health Check Rationale
 
 ## Endpoint
-`GET /health`
+`GET /health` and `GET /version`
 
 ## Design Decision
-The health check endpoint is intentionally left unauthenticated and unsigned. It does not require a valid Ed25519 signature in headers like the rest of the API.
+The health and version endpoints are intentionally left unauthenticated and unsigned. They do not require a valid Ed25519 signature in headers like the rest of the API.
 
 ## Security Considerations
 
 1. **No Sensitive Information:** 
-   The endpoint only returns a standard `{"status": "ok"}` payload. Following security audits (INFO-6), sensitive environment state such as `process.uptime()` has been removed to prevent system reconnaissance.
+   The endpoints return service status, package/API versions, SDK compatibility metadata, feature flags, and documented deprecation notices. They do not expose secrets, environment values, uptime, database state, wallet addresses, or credentials.
 
 2. **Load Balancer Integration:**
    Standard load balancers, orchestrators (e.g. Kubernetes, Railway), and uptime monitoring tools cannot easily sign requests dynamically. Leaving the endpoint public ensures compatibility with external infrastructure components that rely on straightforward HTTP GET probes.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:docs": "pnpm --filter memwal-docs dev",
     "build:docs": "pnpm --filter memwal-docs build",
     "preview:docs": "pnpm --filter memwal-docs serve",
+    "check:compatibility": "node scripts/check-compatibility-contract.mjs",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules",
     "changeset": "changeset",
     "changeset:add": "changeset add",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mysten-incubation/memwal-mcp
 
+## 0.0.2
+
+### Added
+
+- Added relayer compatibility metadata checks before opening the MCP bridge.
+
 ## 0.0.1
 
 ### Initial Release

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "MemWal MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the MemWal relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -16,6 +16,7 @@
  */
 import type { MemWalCredentials } from "./auth.js";
 import { clearCreds, credsPath } from "./auth.js";
+import { ensureCompatibleRelayer } from "./compatibility.js";
 import { loginFlow } from "./login.js";
 import { log, note } from "./logger.js";
 
@@ -125,6 +126,8 @@ async function openSseStream(
     relayerUrl: string,
     creds: MemWalCredentials,
 ): Promise<SseHandshakeResult> {
+    await ensureCompatibleRelayer(relayerUrl);
+
     const url = `${relayerUrl.replace(/\/+$/, "")}/api/mcp/sse`;
     const controller = new AbortController();
 

--- a/packages/mcp/src/compatibility.ts
+++ b/packages/mcp/src/compatibility.ts
@@ -1,0 +1,126 @@
+export const MEMWAL_MCP_COMPATIBILITY_VERSION = "0.0.1";
+export const SUPPORTED_RELAYER_API_MAJOR = 1;
+
+interface RelayerVersionMetadata {
+    relayerVersion?: string;
+    apiVersion?: string;
+    minSupportedSdk?: {
+        mcp?: string;
+    };
+}
+
+let compatibilityCache: RelayerVersionMetadata | null = null;
+let compatibilityCacheUrl: string | null = null;
+let compatibilityPromise: Promise<void> | null = null;
+
+export async function ensureCompatibleRelayer(relayerUrl: string): Promise<void> {
+    const base = relayerUrl.replace(/\/+$/, "");
+    if (compatibilityCache && compatibilityCacheUrl === base) return;
+    if (compatibilityPromise) return compatibilityPromise;
+
+    compatibilityPromise = fetchAndValidate(base).finally(() => {
+        compatibilityPromise = null;
+    });
+    return compatibilityPromise;
+}
+
+async function fetchAndValidate(relayerUrl: string): Promise<void> {
+    const base = relayerUrl;
+    const versionResp = await fetch(`${base}/version`, { method: "GET" });
+    let metadata: RelayerVersionMetadata;
+
+    if (versionResp.ok) {
+        metadata = (await versionResp.json()) as RelayerVersionMetadata;
+    } else if (versionResp.status === 404 || versionResp.status === 405) {
+        const healthResp = await fetch(`${base}/health`, { method: "GET" });
+        if (!healthResp.ok) {
+            throw new Error(
+                `MemWal MCP compatibility check failed: GET /version returned ` +
+                    `${versionResp.status}, and GET /health returned ${healthResp.status}`
+            );
+        }
+        metadata = (await healthResp.json()) as RelayerVersionMetadata;
+    } else {
+        throw new Error(
+            `MemWal MCP compatibility check failed: GET /version returned ${versionResp.status}`
+        );
+    }
+
+    assertCompatible(metadata, base);
+    compatibilityCache = metadata;
+    compatibilityCacheUrl = base;
+}
+
+function assertCompatible(metadata: RelayerVersionMetadata, relayerUrl: string): void {
+    if (
+        !metadata.apiVersion ||
+        !metadata.relayerVersion ||
+        !metadata.minSupportedSdk ||
+        typeof metadata.minSupportedSdk !== "object"
+    ) {
+        throw new Error(
+            `MemWal relayer at ${relayerUrl} does not expose compatibility metadata. ` +
+                "Upgrade the relayer to a version that serves GET /version, or use an older MCP package."
+        );
+    }
+
+    const apiMajor = semverMajor(metadata.apiVersion);
+    if (apiMajor === null) {
+        throw new Error(
+            `MemWal relayer at ${relayerUrl} returned invalid apiVersion ` +
+                `"${metadata.apiVersion}".`
+        );
+    }
+
+    if (apiMajor !== SUPPORTED_RELAYER_API_MAJOR) {
+        throw new Error(
+            `This MemWal MCP package supports relayer API ` +
+                `${SUPPORTED_RELAYER_API_MAJOR}.x, but ${relayerUrl} reports ` +
+                `apiVersion ${metadata.apiVersion}. Upgrade or downgrade the MCP package/relayer pair.`
+        );
+    }
+
+    const minMcp = metadata.minSupportedSdk.mcp;
+    if (!minMcp) {
+        throw new Error(
+            `MemWal relayer at ${relayerUrl} did not report minSupportedSdk.mcp.`
+        );
+    }
+    if (semverMajor(minMcp) === null) {
+        throw new Error(
+            `MemWal relayer at ${relayerUrl} returned invalid minSupportedSdk.mcp "${minMcp}".`
+        );
+    }
+    if (compareSemver(MEMWAL_MCP_COMPATIBILITY_VERSION, minMcp) < 0) {
+        throw new Error(
+            `MemWal relayer at ${relayerUrl} requires MCP package >= ${minMcp}, ` +
+                `but this package supports the ${MEMWAL_MCP_COMPATIBILITY_VERSION} ` +
+                "compatibility baseline. Upgrade " +
+                "@mysten-incubation/memwal-mcp or use an older compatible relayer."
+        );
+    }
+}
+
+function semverMajor(version: string): number | null {
+    const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+    return match ? Number(match[1]) : null;
+}
+
+function compareSemver(a: string, b: string): number {
+    const left = parseSemver(a);
+    const right = parseSemver(b);
+    if (!left || !right) {
+        throw new Error(`invalid semver comparison: ${a} vs ${b}`);
+    }
+
+    for (let idx = 0; idx < 3; idx += 1) {
+        if (left[idx] !== right[idx]) return left[idx] - right[idx];
+    }
+    return 0;
+}
+
+function parseSemver(version: string): [number, number, number] | null {
+    const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+    if (!match) return null;
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+}

--- a/packages/python-sdk-memwal/README.md
+++ b/packages/python-sdk-memwal/README.md
@@ -191,7 +191,7 @@ Every request is signed with Ed25519:
 message = f"{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}"
 ```
 
-Headers sent: `x-public-key`, `x-signature`, `x-timestamp`, `x-nonce`, `x-delegate-key`, `x-account-id`.
+Signed requests send `x-public-key`, `x-signature`, `x-timestamp`, `x-nonce`, and `x-account-id`. Relayer-mode requests also send `x-seal-session`; manual-mode requests omit decrypt credentials.
 
 ## License
 

--- a/packages/python-sdk-memwal/README.md
+++ b/packages/python-sdk-memwal/README.md
@@ -188,10 +188,10 @@ Create a new async client.
 Every request is signed with Ed25519:
 
 ```
-message = f"{timestamp}.{method}.{path}.{sha256(body)}"
+message = f"{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}"
 ```
 
-Headers sent: `x-public-key`, `x-signature`, `x-timestamp`, `x-delegate-key`, `x-account-id`.
+Headers sent: `x-public-key`, `x-signature`, `x-timestamp`, `x-nonce`, `x-delegate-key`, `x-account-id`.
 
 ## License
 

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -24,6 +24,7 @@ Quick start::
 
 from .client import (
     MemWal,
+    MemWalCompatibilityError,
     MemWalError,
     MemWalRememberJobFailed,
     MemWalRememberJobNotFound,
@@ -70,6 +71,7 @@ __all__ = [
     "MemWal",
     "MemWalSync",
     "MemWalError",
+    "MemWalCompatibilityError",
     "MemWalRememberJobFailed",
     "MemWalRememberJobNotFound",
     "MemWalRememberJobTimeout",

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -112,4 +112,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -35,6 +35,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar
 import httpx
 import nacl.signing
 
+from .compatibility import compatibility_error
 from .types import (
     AnalyzedFact,
     AnalyzeResult,
@@ -134,6 +135,8 @@ class MemWal:
         self._server_config: Optional[Dict[str, str]] = None
         self._session_cache: Optional[Tuple[str, int]] = None
         self._session_build_task: Optional[asyncio.Task[str]] = None
+        self._relayer_version_metadata: Optional[Dict[str, Any]] = None
+        self._compatibility_lock: Optional[asyncio.Lock] = None
 
     @classmethod
     def create(
@@ -652,7 +655,22 @@ class MemWal:
         if response.status_code != 200:
             raise MemWalError(f"Health check failed: {response.status_code}")
         data = response.json()
-        return HealthResult(status=data["status"], version=data["version"])
+        return HealthResult(
+            status=data["status"],
+            version=data["version"],
+            relayer_version=data.get("relayerVersion"),
+            api_version=data.get("apiVersion"),
+            min_supported_sdk=data.get("minSupportedSdk"),
+            feature_flags=data.get("featureFlags"),
+            deprecations=data.get("deprecations"),
+            build=data.get("build"),
+            mode=data.get("mode"),
+        )
+
+    async def compatibility(self) -> Dict[str, Any]:
+        """Fetch and validate the relayer compatibility contract."""
+
+        return await self._ensure_compatible_relayer()
 
     # ============================================================
     # Manual API (user handles SEAL + embedding + Walrus)
@@ -726,6 +744,42 @@ class MemWal:
     # ============================================================
     # Internal: Signed HTTP Requests
     # ============================================================
+
+    async def _ensure_compatible_relayer(self) -> Dict[str, Any]:
+        if self._relayer_version_metadata is not None:
+            return self._relayer_version_metadata
+
+        if self._compatibility_lock is None:
+            self._compatibility_lock = asyncio.Lock()
+
+        async with self._compatibility_lock:
+            if self._relayer_version_metadata is not None:
+                return self._relayer_version_metadata
+
+            version_response = await self._http.get(f"{self._server_url}/version")
+            if version_response.status_code == 200:
+                metadata = version_response.json()
+            elif version_response.status_code in (404, 405):
+                health_response = await self._http.get(f"{self._server_url}/health")
+                if health_response.status_code != 200:
+                    raise MemWalError(
+                        "MemWal compatibility check failed: "
+                        f"GET /version returned {version_response.status_code}, "
+                        f"and GET /health returned {health_response.status_code}"
+                    )
+                metadata = health_response.json()
+            else:
+                raise MemWalError(
+                    "MemWal compatibility check failed: "
+                    f"GET /version returned {version_response.status_code}"
+                )
+
+            error = compatibility_error(metadata, self._server_url)
+            if error is not None:
+                raise MemWalCompatibilityError(error)
+
+            self._relayer_version_metadata = metadata
+            return metadata
 
     async def _fetch_server_config(self) -> Dict[str, str]:
         if self._server_config is not None:
@@ -842,7 +896,7 @@ class MemWal:
         """Make a signed request to the server.
 
         Signature format:
-            ``{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}``
+            ``{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}``
 
         For ``GET`` requests the canonical body string is the empty string,
         and no HTTP request body is sent. This keeps the signed payload hash
@@ -853,11 +907,14 @@ class MemWal:
             - ``x-public-key``: Ed25519 public key hex
             - ``x-signature``: Ed25519 signature hex
             - ``x-timestamp``: Unix seconds string
+            - ``x-nonce``: UUID v4 replay-protection nonce
             - ``x-seal-session``: Base64-encoded exported session envelope
             - ``x-account-id``: MemWalAccount object ID
             - ``Content-Type``: application/json
         """
         import uuid
+
+        await self._ensure_compatible_relayer()
 
         method_upper = method.upper()
         timestamp = str(int(time.time()))
@@ -899,6 +956,12 @@ class MemWal:
 
         if response.status_code not in accepted_statuses:
             err_text = response.text
+            if response.status_code == 426:
+                raise MemWalCompatibilityError(
+                    "MemWal relayer rejected this SDK as unsupported "
+                    f"(HTTP 426 Upgrade Required). Relayer response: "
+                    f"{err_text[:300] or 'upgrade required'}"
+                )
             raise _HttpStatusError(
                 status=response.status_code,
                 body=err_text,
@@ -909,6 +972,12 @@ class MemWal:
 
 class MemWalError(Exception):
     """Exception raised for MemWal API errors."""
+
+    pass
+
+
+class MemWalCompatibilityError(MemWalError):
+    """Raised when the SDK and relayer API contract are incompatible."""
 
     pass
 
@@ -1134,6 +1203,10 @@ class MemWalSync:
     def health(self) -> HealthResult:
         """Synchronous version of :meth:`MemWal.health`."""
         return self._run(self._inner.health())
+
+    def compatibility(self) -> Dict[str, Any]:
+        """Synchronous version of :meth:`MemWal.compatibility`."""
+        return self._run(self._inner.compatibility())
 
     def remember_manual(self, opts: RememberManualOptions) -> RememberManualResult:
         """Synchronous version of :meth:`MemWal.remember_manual`."""

--- a/packages/python-sdk-memwal/memwal/compatibility.py
+++ b/packages/python-sdk-memwal/memwal/compatibility.py
@@ -1,0 +1,72 @@
+"""Relayer/API compatibility checks for the Python SDK."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional, Tuple
+
+MEMWAL_PYTHON_COMPATIBILITY_VERSION = "0.1.0"
+SUPPORTED_RELAYER_API_MAJOR = 1
+
+
+def compatibility_error(metadata: Dict[str, Any], server_url: str) -> Optional[str]:
+    """Return an actionable error string when relayer metadata is unsupported."""
+
+    api_version = metadata.get("apiVersion")
+    relayer_version = metadata.get("relayerVersion")
+    min_supported = metadata.get("minSupportedSdk")
+
+    if not api_version or not relayer_version or not isinstance(min_supported, dict):
+        return (
+            f"MemWal relayer at {server_url} does not expose compatibility metadata. "
+            "Upgrade the relayer to a version that serves GET /version, or use an older SDK."
+        )
+
+    api_major = _semver_major(str(api_version))
+    if api_major is None:
+        return f'MemWal relayer at {server_url} returned invalid apiVersion "{api_version}".'
+
+    if api_major != SUPPORTED_RELAYER_API_MAJOR:
+        return (
+            "This MemWal Python SDK supports relayer API "
+            f"{SUPPORTED_RELAYER_API_MAJOR}.x, but {server_url} reports apiVersion "
+            f"{api_version}. Upgrade or downgrade the SDK/relayer pair."
+        )
+
+    min_python = min_supported.get("python")
+    if not isinstance(min_python, str):
+        return f"MemWal relayer at {server_url} did not report minSupportedSdk.python."
+    if _parse_semver(min_python) is None:
+        return (
+            f'MemWal relayer at {server_url} returned invalid '
+            f'minSupportedSdk.python "{min_python}".'
+        )
+
+    if _compare_semver(MEMWAL_PYTHON_COMPATIBILITY_VERSION, min_python) < 0:
+        return (
+            f"MemWal relayer at {server_url} requires Python SDK >= {min_python}, "
+            f"but this package supports the {MEMWAL_PYTHON_COMPATIBILITY_VERSION} "
+            "compatibility baseline. Upgrade memwal or use an older compatible relayer."
+        )
+
+    return None
+
+
+def _semver_major(version: str) -> Optional[int]:
+    parsed = _parse_semver(version)
+    return parsed[0] if parsed else None
+
+
+def _compare_semver(left: str, right: str) -> int:
+    left_parts = _parse_semver(left)
+    right_parts = _parse_semver(right)
+    if left_parts is None or right_parts is None:
+        raise ValueError(f"invalid semver comparison: {left} vs {right}")
+    return (left_parts > right_parts) - (left_parts < right_parts)
+
+
+def _parse_semver(version: str) -> Optional[Tuple[int, int, int]]:
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$", version.strip())
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -9,7 +9,7 @@ the MemWal Rust server (TEE).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 # ============================================================
 # Config
@@ -136,6 +136,13 @@ class HealthResult:
 
     status: str
     version: str
+    relayer_version: Optional[str] = None
+    api_version: Optional[str] = None
+    min_supported_sdk: Optional[Dict[str, str]] = None
+    feature_flags: Optional[Dict[str, bool]] = None
+    deprecations: Optional[List[Dict[str, Any]]] = None
+    build: Optional[Dict[str, Any]] = None
+    mode: Optional[str] = None
 
 
 @dataclass

--- a/packages/python-sdk-memwal/memwal/utils.py
+++ b/packages/python-sdk-memwal/memwal/utils.py
@@ -105,7 +105,7 @@ def build_signature_message(
 
     Current format (matches Rust server ``services/server/src/auth.rs``)::
 
-        "{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}"
+        "{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}"
 
     The trailing ``nonce`` was added in MED-1 (replay protection); the
     ``account_id`` was added in LOW-23 so an intermediary can't swap the

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for MemWal — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -16,7 +16,7 @@ import nacl.signing
 import pytest
 import respx
 
-from memwal.client import MemWal, MemWalError
+from memwal.client import MemWal, MemWalCompatibilityError, MemWalError
 from memwal.types import RecallManualOptions, RememberManualOptions
 from memwal.utils import build_signature_message, bytes_to_hex, sha256_hex
 
@@ -35,7 +35,35 @@ _TEST_PACKAGE_ID = "0x" + "11" * 32
 _TEST_SUI_RPC = "http://localhost:9001"
 
 
+def _version_payload(
+    api_version: str = "1.0.0",
+    min_python: str = "0.1.0",
+) -> dict[str, Any]:
+    return {
+        "relayerVersion": "0.1.0",
+        "apiVersion": api_version,
+        "minSupportedSdk": {
+            "typescript": "0.0.4",
+            "python": min_python,
+            "mcp": "0.0.1",
+        },
+        "featureFlags": {"runtime.versionEndpoint": True},
+        "deprecations": [],
+        "build": {},
+    }
+
+
+def _mock_version(
+    api_version: str = "1.0.0",
+    min_python: str = "0.1.0",
+) -> None:
+    respx.get(f"{_TEST_SERVER}/version").mock(
+        return_value=httpx.Response(200, json=_version_payload(api_version, min_python))
+    )
+
+
 def mock_seal_session_prereqs() -> None:
+    _mock_version()
     respx.get(f"{_TEST_SERVER}/config").mock(
         return_value=httpx.Response(
             200,
@@ -409,10 +437,58 @@ class TestHealth:
         assert result.status == "ok"
         assert result.version == "0.1.0"
 
+    @respx.mock
+    async def test_compatibility(self, memwal_client: MemWal) -> None:
+        _mock_version()
+
+        metadata = await memwal_client.compatibility()
+
+        assert metadata["apiVersion"] == "1.0.0"
+        assert metadata["minSupportedSdk"]["python"] == "0.1.0"
+
+    @respx.mock
+    async def test_compatibility_rejects_unsupported_relayer(
+        self, memwal_client: MemWal
+    ) -> None:
+        _mock_version(api_version="2.0.0")
+
+        with pytest.raises(MemWalCompatibilityError, match="supports relayer API 1.x"):
+            await memwal_client.compatibility()
+
+    @respx.mock
+    async def test_compatibility_rejects_old_sdk(self, memwal_client: MemWal) -> None:
+        _mock_version(min_python="9.0.0")
+
+        with pytest.raises(MemWalCompatibilityError, match="requires Python SDK >= 9.0.0"):
+            await memwal_client.recall("test")
+
+    @respx.mock
+    async def test_compatibility_rejects_missing_python_min(
+        self, memwal_client: MemWal
+    ) -> None:
+        payload = _version_payload()
+        del payload["minSupportedSdk"]["python"]
+        respx.get(f"{_TEST_SERVER}/version").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+
+        with pytest.raises(MemWalCompatibilityError, match="minSupportedSdk.python"):
+            await memwal_client.compatibility()
+
+    @respx.mock
+    async def test_compatibility_rejects_invalid_python_min(
+        self, memwal_client: MemWal
+    ) -> None:
+        _mock_version(min_python="latest")
+
+        with pytest.raises(MemWalCompatibilityError, match="invalid minSupportedSdk.python"):
+            await memwal_client.compatibility()
+
 
 class TestManualAPI:
     @respx.mock
     async def test_remember_manual(self, memwal_client: MemWal) -> None:
+        _mock_version()
         route = respx.post(f"{_TEST_SERVER}/api/remember/manual").mock(
             return_value=httpx.Response(
                 200,
@@ -441,6 +517,7 @@ class TestManualAPI:
 
     @respx.mock
     async def test_recall_manual(self, memwal_client: MemWal) -> None:
+        _mock_version()
         route = respx.post(f"{_TEST_SERVER}/api/recall/manual").mock(
             return_value=httpx.Response(
                 200,

--- a/packages/python-sdk-memwal/tests/test_integration.py
+++ b/packages/python-sdk-memwal/tests/test_integration.py
@@ -47,7 +47,7 @@ import httpx
 import nacl.signing
 import pytest
 
-from memwal.client import MemWal, MemWalError, MemWalSync
+from memwal.client import MemWal, MemWalCompatibilityError, MemWalError, MemWalSync
 from memwal.utils import build_signature_message, bytes_to_hex
 
 # ── Config ───────────────────────────────────────────────────────────────────
@@ -173,6 +173,8 @@ class TestAuthRejection:
         mw = MemWalSync.create(key=unregistered_key, account_id="0x0", server_url=SERVER_URL)
         with pytest.raises(MemWalError) as exc_info:
             mw.remember("hello")
+        if isinstance(exc_info.value, MemWalCompatibilityError):
+            pytest.skip("live relayer does not expose compatibility metadata yet")
         err = str(exc_info.value)
         assert "401" in err or "403" in err, f"Expected 401/403 in: {err}"
 

--- a/packages/python-sdk-memwal/tests/test_middleware.py
+++ b/packages/python-sdk-memwal/tests/test_middleware.py
@@ -51,8 +51,29 @@ _SERVER = "http://localhost:8000"
 
 _RECALL_URL = f"{_SERVER}/api/recall"
 _ANALYZE_URL = f"{_SERVER}/api/analyze"
+_VERSION_URL = f"{_SERVER}/version"
 _SUI_RPC_URL = "http://localhost:9001"
 _PACKAGE_ID = "0x" + "11" * 32
+
+
+def _mock_version() -> None:
+    respx.get(_VERSION_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "relayerVersion": "0.1.0",
+                "apiVersion": "1.0.0",
+                "minSupportedSdk": {
+                    "typescript": "0.0.4",
+                    "python": "0.1.0",
+                    "mcp": "0.0.1",
+                },
+                "featureFlags": {"runtime.versionEndpoint": True},
+                "deprecations": [],
+                "build": {},
+            },
+        )
+    )
 
 
 def _mock_seal_session_prereqs() -> None:
@@ -66,6 +87,7 @@ def _mock_seal_session_prereqs() -> None:
 
     Mirrors the helper of the same name in ``test_client.py``.
     """
+    _mock_version()
     respx.get(f"{_SERVER}/config").mock(
         return_value=httpx.Response(
             200,

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mysten-incubation/memwal
 
+## 0.0.5
+
+### Added
+
+- Added relayer compatibility metadata checks before protected requests.
+- Added `compatibility()` and exported compatibility types/errors so callers can inspect SDK/relayer support explicitly.
+
 ## 0.0.4
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "MemWal — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/sdk/src/compatibility.ts
+++ b/packages/sdk/src/compatibility.ts
@@ -1,0 +1,99 @@
+import type { RelayerVersionMetadata } from "./types.js";
+
+export const MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION = "0.0.4";
+export const SUPPORTED_RELAYER_API_MAJOR = 1;
+
+export class MemWalCompatibilityError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "MemWalCompatibilityError";
+    }
+}
+
+export function assertCompatibleRelayer(
+    metadata: Partial<RelayerVersionMetadata>,
+    serverUrl: string,
+): asserts metadata is RelayerVersionMetadata {
+    if (
+        !metadata.apiVersion ||
+        !metadata.relayerVersion ||
+        !metadata.minSupportedSdk ||
+        typeof metadata.minSupportedSdk !== "object"
+    ) {
+        throw new MemWalCompatibilityError(
+            `MemWal relayer at ${serverUrl} does not expose compatibility metadata. ` +
+                "Upgrade the relayer to a version that serves GET /version, or use an older SDK.",
+        );
+    }
+
+    const apiMajor = semverMajor(metadata.apiVersion);
+    if (apiMajor === null) {
+        throw new MemWalCompatibilityError(
+            `MemWal relayer at ${serverUrl} returned invalid apiVersion ` +
+                `"${metadata.apiVersion}".`,
+        );
+    }
+
+    if (apiMajor !== SUPPORTED_RELAYER_API_MAJOR) {
+        throw new MemWalCompatibilityError(
+            `This MemWal TypeScript SDK supports relayer API ` +
+                `${SUPPORTED_RELAYER_API_MAJOR}.x, but ${serverUrl} reports ` +
+                `apiVersion ${metadata.apiVersion}. Upgrade or downgrade the SDK/relayer pair.`,
+        );
+    }
+
+    const minSdk = metadata.minSupportedSdk.typescript;
+    if (!minSdk) {
+        throw new MemWalCompatibilityError(
+            `MemWal relayer at ${serverUrl} did not report minSupportedSdk.typescript.`,
+        );
+    }
+    if (semverMajor(minSdk) === null) {
+        throw new MemWalCompatibilityError(
+            `MemWal relayer at ${serverUrl} returned invalid ` +
+                `minSupportedSdk.typescript "${minSdk}".`,
+        );
+    }
+    if (compareSemver(MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION, minSdk) < 0) {
+        throw new MemWalCompatibilityError(
+            `MemWal relayer at ${serverUrl} requires TypeScript SDK >= ${minSdk}, ` +
+                `but this SDK supports the ${MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION} ` +
+                "compatibility baseline. Upgrade " +
+                "@mysten-incubation/memwal or use an older compatible relayer.",
+        );
+    }
+}
+
+export function compatibilityErrorFromStatus(status: number, body: string): MemWalCompatibilityError | null {
+    if (status !== 426) return null;
+
+    return new MemWalCompatibilityError(
+        "MemWal relayer rejected this SDK as unsupported (HTTP 426 Upgrade Required). " +
+            `SDK compatibility baseline: ${MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION}. ` +
+            `Relayer response: ${body.slice(0, 300) || "upgrade required"}`,
+    );
+}
+
+function semverMajor(version: string): number | null {
+    const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+    return match ? Number(match[1]) : null;
+}
+
+function compareSemver(a: string, b: string): number {
+    const left = parseSemver(a);
+    const right = parseSemver(b);
+    if (!left || !right) {
+        throw new Error(`invalid semver comparison: ${a} vs ${b}`);
+    }
+
+    for (let idx = 0; idx < 3; idx += 1) {
+        if (left[idx] !== right[idx]) return left[idx] - right[idx];
+    }
+    return 0;
+}
+
+function parseSemver(version: string): [number, number, number] | null {
+    const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+    if (!match) return null;
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,11 @@
 
 // Core client (server-mode: server handles SEAL + Walrus + embedding)
 export { MemWal } from "./memwal.js";
+export {
+    MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION,
+    MemWalCompatibilityError,
+    SUPPORTED_RELAYER_API_MAJOR,
+} from "./compatibility.js";
 
 // Delegate key utilities (no @mysten/sui dependency)
 export { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "./utils.js";
@@ -38,4 +43,8 @@ export type {
     RememberBulkStatusResult,
     RememberBulkResult,
     RememberBulkItemResult,
+    MinSupportedSdk,
+    RelayerBuildMetadata,
+    RelayerDeprecationNotice,
+    RelayerVersionMetadata,
 } from "./types.js";

--- a/packages/sdk/src/manual-entry.ts
+++ b/packages/sdk/src/manual-entry.ts
@@ -9,9 +9,15 @@
  */
 
 export { MemWalManual } from "./manual.js";
+export {
+    MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION,
+    MemWalCompatibilityError,
+    SUPPORTED_RELAYER_API_MAJOR,
+} from "./compatibility.js";
 
 export type {
     MemWalManualConfig,
+    RelayerVersionMetadata,
     SealServerConfig,
     WalletSigner,
     RememberManualOptions,

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -35,8 +35,13 @@ import type {
     RecallManualMemory,
     RestoreResult,
     SealServerConfig,
+    RelayerVersionMetadata,
 } from "./types.js";
 import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerError } from "./utils.js";
+import {
+    assertCompatibleRelayer,
+    compatibilityErrorFromStatus,
+} from "./compatibility.js";
 
 // ============================================================
 // Constants
@@ -128,6 +133,8 @@ export class MemWalManual {
     private config: MemWalManualConfig;
     private walletSigner: WalletSigner | null;
     private namespace: string;
+    private relayerVersionMetadata: RelayerVersionMetadata | null = null;
+    private compatibilityPromise: Promise<RelayerVersionMetadata> | null = null;
 
     // Lazily initialized heavy clients (typed as any to avoid peer dep compile errors)
     private _suiClient: any = null;
@@ -178,6 +185,15 @@ export class MemWalManual {
         if (this.delegatePublicKey) {
             this.delegatePublicKey.fill(0);
         }
+        this.relayerVersionMetadata = null;
+        this.compatibilityPromise = null;
+    }
+
+    /**
+     * Fetch and validate the relayer compatibility contract.
+     */
+    async compatibility(): Promise<RelayerVersionMetadata> {
+        return this.ensureCompatibleRelayer();
     }
 
     /** Whether this client uses a connected wallet signer (vs raw keypair) */
@@ -660,6 +676,42 @@ export class MemWalManual {
         return this.delegatePublicKey;
     }
 
+    private async ensureCompatibleRelayer(): Promise<RelayerVersionMetadata> {
+        if (this.relayerVersionMetadata) return this.relayerVersionMetadata;
+        if (this.compatibilityPromise) return this.compatibilityPromise;
+
+        this.compatibilityPromise = this.fetchCompatibilityMetadata().finally(() => {
+            this.compatibilityPromise = null;
+        });
+        return this.compatibilityPromise;
+    }
+
+    private async fetchCompatibilityMetadata(): Promise<RelayerVersionMetadata> {
+        const versionRes = await fetch(`${this.serverUrl}/version`, { method: "GET" });
+        let body: Partial<RelayerVersionMetadata>;
+
+        if (versionRes.ok) {
+            body = (await versionRes.json()) as Partial<RelayerVersionMetadata>;
+        } else if (versionRes.status === 404 || versionRes.status === 405) {
+            const healthRes = await fetch(`${this.serverUrl}/health`, { method: "GET" });
+            if (!healthRes.ok) {
+                throw new Error(
+                    `MemWal compatibility check failed: GET /version returned ` +
+                        `${versionRes.status}, and GET /health returned ${healthRes.status}`,
+                );
+            }
+            body = (await healthRes.json()) as Partial<RelayerVersionMetadata>;
+        } else {
+            throw new Error(
+                `MemWal compatibility check failed: GET /version returned ${versionRes.status}`,
+            );
+        }
+
+        assertCompatibleRelayer(body, this.serverUrl);
+        this.relayerVersionMetadata = body;
+        return body;
+    }
+
     /**
      * Make a signed request to the server.
      *
@@ -673,6 +725,7 @@ export class MemWalManual {
         path: string,
         body: object,
     ): Promise<T> {
+        await this.ensureCompatibleRelayer();
         const ed = await import("@noble/ed25519");
 
         const timestamp = Math.floor(Date.now() / 1000).toString();
@@ -707,6 +760,9 @@ export class MemWalManual {
         if (!res.ok) {
             // LOW-26: sanitize server error bodies before re-throwing.
             const raw = await res.text();
+            const compatibilityError = compatibilityErrorFromStatus(res.status, raw);
+            if (compatibilityError) throw compatibilityError;
+
             const { message: sanitized, serverCode } = sanitizeServerError(res.status, raw);
             const err = new Error(sanitized) as Error & {
                 status?: number;

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -51,8 +51,13 @@ import type {
     RememberBulkStatusResult,
     RememberBulkStatusItem,
     RememberBulkItemResult,
+    RelayerVersionMetadata,
 } from "./types.js";
 import { sha256hex, hexToBytes, bytesToHex, normalizeServerUrl, sanitizeServerError } from "./utils.js";
+import {
+    assertCompatibleRelayer,
+    compatibilityErrorFromStatus,
+} from "./compatibility.js";
 
 // ============================================================
 // Ed25519 Signing (lazy-loaded)
@@ -120,8 +125,11 @@ export class MemWal {
     // The public API (`MemWal.create({ key, accountId })`) is unchanged.
     private sessionCache: SessionCacheEntry | null = null;
     private serverConfig: ServerConfig | null = null;
+    private relayerVersionMetadata: RelayerVersionMetadata | null = null;
     /** Single-flight guard so concurrent requests share one SessionKey build. */
     private sessionBuildPromise: Promise<string> | null = null;
+    /** Single-flight guard so concurrent requests share one compatibility probe. */
+    private compatibilityPromise: Promise<RelayerVersionMetadata> | null = null;
 
     private constructor(config: MemWalConfig) {
         this.privateKey = typeof config.key === "string" ? hexToBytes(config.key) : config.key;
@@ -158,6 +166,8 @@ export class MemWal {
         // instance must not leak authorization tokens either.
         this.sessionCache = null;
         this.serverConfig = null;
+        this.relayerVersionMetadata = null;
+        this.compatibilityPromise = null;
     }
 
     // ============================================================
@@ -634,28 +644,21 @@ export class MemWal {
     }
 
     /**
-     * Check server health.
-     *
-     * INFO-7: The health endpoint is currently public/unsigned server-side,
-     * but we send the same signed-request envelope as every other call so
-     * that (a) the channel is authenticated whenever the server opts in, and
-     * (b) a MitM cannot trivially forge a "healthy" response for a client
-     * that has no way to tell. If the server ignores the signature headers
-     * on `/health`, this is still a harmless no-op.
+     * Check server health. The endpoint is public and does not require request signing.
      */
     async health(): Promise<HealthResult> {
-        try {
-            return await this.signedRequest<HealthResult>("GET", "/health", {});
-        } catch (err) {
-            // Fall back to a plain GET for servers that reject bodies on GET /health.
-            const res = await fetch(`${this.serverUrl}/health`);
-            if (!res.ok) {
-                throw err instanceof Error
-                    ? err
-                    : new Error(`Health check failed: ${res.status}`);
-            }
-            return res.json() as Promise<HealthResult>;
+        const res = await fetch(`${this.serverUrl}/health`);
+        if (!res.ok) {
+            throw new Error(`Health check failed: ${res.status}`);
         }
+        return res.json() as Promise<HealthResult>;
+    }
+
+    /**
+     * Fetch and validate the relayer compatibility contract.
+     */
+    async compatibility(): Promise<RelayerVersionMetadata> {
+        return this.ensureCompatibleRelayer();
     }
 
     /**
@@ -676,6 +679,42 @@ export class MemWal {
             this.publicKey = await ed.getPublicKeyAsync(this.privateKey);
         }
         return this.publicKey;
+    }
+
+    private async ensureCompatibleRelayer(): Promise<RelayerVersionMetadata> {
+        if (this.relayerVersionMetadata) return this.relayerVersionMetadata;
+        if (this.compatibilityPromise) return this.compatibilityPromise;
+
+        this.compatibilityPromise = this.fetchCompatibilityMetadata().finally(() => {
+            this.compatibilityPromise = null;
+        });
+        return this.compatibilityPromise;
+    }
+
+    private async fetchCompatibilityMetadata(): Promise<RelayerVersionMetadata> {
+        const versionRes = await fetch(`${this.serverUrl}/version`, { method: "GET" });
+        let body: Partial<RelayerVersionMetadata>;
+
+        if (versionRes.ok) {
+            body = (await versionRes.json()) as Partial<RelayerVersionMetadata>;
+        } else if (versionRes.status === 404 || versionRes.status === 405) {
+            const healthRes = await fetch(`${this.serverUrl}/health`, { method: "GET" });
+            if (!healthRes.ok) {
+                throw new Error(
+                    `MemWal compatibility check failed: GET /version returned ` +
+                        `${versionRes.status}, and GET /health returned ${healthRes.status}`,
+                );
+            }
+            body = (await healthRes.json()) as Partial<RelayerVersionMetadata>;
+        } else {
+            throw new Error(
+                `MemWal compatibility check failed: GET /version returned ${versionRes.status}`,
+            );
+        }
+
+        assertCompatibleRelayer(body, this.serverUrl);
+        this.relayerVersionMetadata = body;
+        return body;
     }
 
     // ============================================================
@@ -822,7 +861,7 @@ export class MemWal {
      * Make a signed request to the server.
      *
      * Signature format (LOW-23 updated):
-     *   "{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}"
+     *   "{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}"
      *
      * Headers: x-public-key, x-signature, x-timestamp, x-nonce, x-account-id
      *
@@ -863,6 +902,7 @@ export class MemWal {
         const options = Array.isArray(acceptedStatusesOrOptions)
             ? requestOptions
             : acceptedStatusesOrOptions;
+        await this.ensureCompatibleRelayer();
         const ed = await getEd();
 
         const timestamp = Math.floor(Date.now() / 1000).toString();
@@ -911,6 +951,9 @@ export class MemWal {
         if (!acceptedStatuses.includes(res.status)) {
             // LOW-26: sanitize server error bodies before surfacing to callers.
             const raw = await res.text();
+            const compatibilityError = compatibilityErrorFromStatus(res.status, raw);
+            if (compatibilityError) throw compatibilityError;
+
             const { message, serverCode } = sanitizeServerError(res.status, raw);
             const err = new Error(message) as Error & {
                 status?: number;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -158,9 +158,47 @@ export interface AnalyzeWaitResult extends RememberBulkResult {
 }
 
 /** Server health response */
-export interface HealthResult {
+export interface HealthResult extends Partial<RelayerVersionMetadata> {
     status: string;
+    /** Backward-compatible relayer package version alias. */
     version: string;
+    /** "production" or "benchmark" when returned by modern relayers. */
+    mode?: string;
+    prompt_versions?: {
+        extract: string;
+        ask: string;
+    };
+}
+
+/** Minimum SDK versions accepted by a relayer API contract. */
+export interface MinSupportedSdk {
+    typescript: string;
+    python: string;
+    mcp: string;
+}
+
+/** Public deprecation metadata returned by GET /version and GET /health. */
+export interface RelayerDeprecationNotice {
+    surface: string;
+    deprecatedSince: string;
+    removalApiVersion: string;
+    guidance: string;
+}
+
+/** Public build metadata returned by GET /version and GET /health. */
+export interface RelayerBuildMetadata {
+    commit?: string;
+    buildTimestamp?: string;
+}
+
+/** Runtime compatibility metadata returned by GET /version. */
+export interface RelayerVersionMetadata {
+    relayerVersion: string;
+    apiVersion: string;
+    minSupportedSdk: MinSupportedSdk;
+    featureFlags: Record<string, boolean>;
+    deprecations: RelayerDeprecationNotice[];
+    build: RelayerBuildMetadata;
 }
 
 // ============================================================

--- a/scripts/check-compatibility-contract.mjs
+++ b/scripts/check-compatibility-contract.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+
+function read(relPath) {
+    return fs.readFileSync(path.join(root, relPath), "utf8");
+}
+
+function json(relPath) {
+    return JSON.parse(read(relPath));
+}
+
+function capture(label, text, regex) {
+    const match = text.match(regex);
+    if (!match) {
+        throw new Error(`Missing ${label}`);
+    }
+    return match[1];
+}
+
+function assertEqual(label, actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+    }
+}
+
+function assertContains(label, text, expected) {
+    if (!text.includes(expected)) {
+        throw new Error(`${label}: missing ${expected}`);
+    }
+}
+
+function parseSemver(label, version) {
+    const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+    if (!match) {
+        throw new Error(`${label}: invalid semver ${version}`);
+    }
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemver(left, right) {
+    const a = parseSemver("left semver", left);
+    const b = parseSemver("right semver", right);
+    for (let idx = 0; idx < 3; idx += 1) {
+        if (a[idx] !== b[idx]) return a[idx] - b[idx];
+    }
+    return 0;
+}
+
+function assertLessOrEqualSemver(label, actual, ceiling) {
+    if (compareSemver(actual, ceiling) > 0) {
+        throw new Error(`${label}: ${actual} must be <= package version ${ceiling}`);
+    }
+}
+
+const serverCargo = read("services/server/Cargo.toml");
+const serverCompatibility = read("services/server/src/compatibility.rs");
+const tsPackage = json("packages/sdk/package.json");
+const pythonProject = read("packages/python-sdk-memwal/pyproject.toml");
+const pythonCompatibility = read("packages/python-sdk-memwal/memwal/compatibility.py");
+const mcpPackage = json("packages/mcp/package.json");
+const mcpCompatibility = read("packages/mcp/src/compatibility.ts");
+const sdkCompatibility = read("packages/sdk/src/compatibility.ts");
+const policyDoc = read("docs/relayer/versioning-and-compatibility.md");
+
+const relayerPackageVersion = capture(
+    "server package version",
+    serverCargo,
+    /^version\s*=\s*"([^"]+)"/m,
+);
+const apiVersion = capture(
+    "RELAYER_API_VERSION",
+    serverCompatibility,
+    /RELAYER_API_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+);
+const minTypescript = capture(
+    "MIN_TYPESCRIPT_SDK_VERSION",
+    serverCompatibility,
+    /MIN_TYPESCRIPT_SDK_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+);
+const minPython = capture(
+    "MIN_PYTHON_SDK_VERSION",
+    serverCompatibility,
+    /MIN_PYTHON_SDK_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+);
+const minMcp = capture(
+    "MIN_MCP_PACKAGE_VERSION",
+    serverCompatibility,
+    /MIN_MCP_PACKAGE_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+);
+
+const pythonVersion = capture("Python package version", pythonProject, /^version\s*=\s*"([^"]+)"/m);
+const tsSdkVersion = capture(
+    "MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION",
+    sdkCompatibility,
+    /MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION\s*=\s*"([^"]+)"/,
+);
+const pythonSdkVersion = capture(
+    "MEMWAL_PYTHON_COMPATIBILITY_VERSION",
+    pythonCompatibility,
+    /MEMWAL_PYTHON_COMPATIBILITY_VERSION\s*=\s*"([^"]+)"/,
+);
+const mcpSdkVersion = capture(
+    "MEMWAL_MCP_COMPATIBILITY_VERSION",
+    mcpCompatibility,
+    /MEMWAL_MCP_COMPATIBILITY_VERSION\s*=\s*"([^"]+)"/,
+);
+
+assertEqual("Rust min TypeScript SDK", minTypescript, tsSdkVersion);
+assertEqual("Rust min Python SDK", minPython, pythonSdkVersion);
+assertEqual("Rust min MCP package", minMcp, mcpSdkVersion);
+assertLessOrEqualSemver("TypeScript compatibility baseline", tsSdkVersion, tsPackage.version);
+assertLessOrEqualSemver("Python compatibility baseline", pythonSdkVersion, pythonVersion);
+assertLessOrEqualSemver("MCP compatibility baseline", mcpSdkVersion, mcpPackage.version);
+
+for (const value of [
+    apiVersion,
+    relayerPackageVersion,
+    minTypescript,
+    minPython,
+    minMcp,
+]) {
+    assertContains("versioning policy doc", policyDoc, value);
+}
+
+console.log("compatibility contract OK");

--- a/services/server/benchmarks/README.md
+++ b/services/server/benchmarks/README.md
@@ -326,7 +326,7 @@ Variance across runs is ~±2-3 points due to judge non-determinism. Retrieval it
 - The client's request signing is out of date with the server's auth scheme
   (`services/server/src/auth.rs`). `client.py::_sign_request` must send an
   `x-nonce` header (UUIDv4) and sign the 6-field canonical message
-  `{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}`. If you see
+  `{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}`. If you see
   426 on every request, the harness predates the MED-1 nonce / LOW-23
   account-id-in-message changes — update `_sign_request` to match `auth.rs` and
   `packages/sdk/src/memwal.ts`.

--- a/services/server/benchmarks/core/client.py
+++ b/services/server/benchmarks/core/client.py
@@ -69,7 +69,7 @@ class MemWalClient:
 
         Canonical message (must match services/server/src/auth.rs and
         packages/sdk/src/memwal.ts):
-            "{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}"
+            "{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}"
         Headers sent: x-public-key, x-signature, x-timestamp, x-nonce, x-account-id.
 
         `nonce` is a fresh UUIDv4 per call (MED-1 replay protection — the server

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -24,10 +24,12 @@ pub(crate) const PROTECTED_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024;
 /// - `x-public-key`: hex-encoded Ed25519 public key (32 bytes)
 /// - `x-signature`: hex-encoded Ed25519 signature (64 bytes)
 /// - `x-timestamp`: Unix timestamp (seconds)
-/// - `x-account-id` (optional): account object ID hint (skips cache/registry lookup)
+/// - `x-nonce`: UUID v4 replay-protection nonce
+/// - `x-account-id`: account object ID hint included in the canonical signature
 ///
 /// Flow:
-/// 1. Verify Ed25519 signature: `{timestamp}.{method}.{path}.{body_sha256}`
+/// 1. Verify Ed25519 signature:
+///    `{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}`
 /// 2. Resolve account: cache → signed header hint/config fallback → registry scan
 /// 3. Verify onchain: public_key ∈ MemWalAccount.delegate_keys
 /// 4. Cache the mapping for future requests

--- a/services/server/src/compatibility.rs
+++ b/services/server/src/compatibility.rs
@@ -1,0 +1,154 @@
+//! Public relayer/API compatibility metadata.
+//!
+//! These constants are part of the relayer contract. Keep them in sync with
+//! docs/relayer/versioning-and-compatibility.md and the SDK compatibility
+//! guards; scripts/check-compatibility-contract.mjs verifies that in CI.
+
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+pub const RELAYER_API_VERSION: &str = "1.0.0";
+pub const MIN_TYPESCRIPT_SDK_VERSION: &str = "0.0.4";
+pub const MIN_PYTHON_SDK_VERSION: &str = "0.1.0";
+pub const MIN_MCP_PACKAGE_VERSION: &str = "0.0.1";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VersionResponse {
+    #[serde(rename = "relayerVersion")]
+    pub relayer_version: String,
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    #[serde(rename = "minSupportedSdk")]
+    pub min_supported_sdk: MinSupportedSdk,
+    #[serde(rename = "featureFlags")]
+    pub feature_flags: BTreeMap<String, bool>,
+    pub deprecations: Vec<DeprecationNotice>,
+    pub build: BuildMetadata,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MinSupportedSdk {
+    pub typescript: String,
+    pub python: String,
+    pub mcp: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DeprecationNotice {
+    pub surface: String,
+    #[serde(rename = "deprecatedSince")]
+    pub deprecated_since: String,
+    #[serde(rename = "removalApiVersion")]
+    pub removal_api_version: String,
+    pub guidance: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BuildMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    #[serde(rename = "buildTimestamp", skip_serializing_if = "Option::is_none")]
+    pub build_timestamp: Option<String>,
+}
+
+pub fn version_response() -> VersionResponse {
+    VersionResponse {
+        relayer_version: env!("CARGO_PKG_VERSION").to_string(),
+        api_version: RELAYER_API_VERSION.to_string(),
+        min_supported_sdk: MinSupportedSdk {
+            typescript: MIN_TYPESCRIPT_SDK_VERSION.to_string(),
+            python: MIN_PYTHON_SDK_VERSION.to_string(),
+            mcp: MIN_MCP_PACKAGE_VERSION.to_string(),
+        },
+        feature_flags: feature_flags(),
+        deprecations: deprecations(),
+        build: BuildMetadata {
+            commit: first_metadata_value(&[
+                option_env!("GIT_SHA"),
+                option_env!("GITHUB_SHA"),
+                option_env!("RAILWAY_GIT_COMMIT_SHA"),
+            ])
+            .or_else(|| first_runtime_env(&["GIT_SHA", "GITHUB_SHA", "RAILWAY_GIT_COMMIT_SHA"])),
+            build_timestamp: first_metadata_value(&[
+                option_env!("BUILD_TIMESTAMP"),
+                option_env!("SOURCE_DATE_EPOCH"),
+            ])
+            .or_else(|| first_runtime_env(&["BUILD_TIMESTAMP", "SOURCE_DATE_EPOCH"])),
+        },
+    }
+}
+
+fn feature_flags() -> BTreeMap<String, bool> {
+    BTreeMap::from([
+        ("auth.accountBoundNonce".to_string(), true),
+        ("auth.sealSessionHeader".to_string(), true),
+        ("config.publicDeploymentMetadata".to_string(), true),
+        ("remember.asyncJobs".to_string(), true),
+        ("remember.bulk".to_string(), true),
+        ("runtime.versionEndpoint".to_string(), true),
+    ])
+}
+
+fn deprecations() -> Vec<DeprecationNotice> {
+    vec![
+        DeprecationNotice {
+            surface: "header:x-delegate-key".to_string(),
+            deprecated_since: "1.0.0".to_string(),
+            removal_api_version: "2.0.0".to_string(),
+            guidance: "Use x-seal-session for relayer-managed SEAL decrypt flows; manual-mode requests should send no decrypt credential.".to_string(),
+        },
+        DeprecationNotice {
+            surface: "env:SEAL_KEY_SERVERS".to_string(),
+            deprecated_since: "1.0.0".to_string(),
+            removal_api_version: "2.0.0".to_string(),
+            guidance: "Use SEAL_SERVER_CONFIGS so independent and committee key-server configs share one JSON schema.".to_string(),
+        },
+    ]
+}
+
+fn first_metadata_value(values: &[Option<&'static str>]) -> Option<String> {
+    values
+        .iter()
+        .flatten()
+        .map(|value| value.trim())
+        .find(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn first_runtime_env(names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .filter_map(|name| std::env::var(name).ok())
+        .map(|value| value.trim().to_string())
+        .find(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        version_response, MIN_MCP_PACKAGE_VERSION, MIN_PYTHON_SDK_VERSION,
+        MIN_TYPESCRIPT_SDK_VERSION, RELAYER_API_VERSION,
+    };
+
+    #[test]
+    fn version_response_exposes_contract_metadata() {
+        let response = version_response();
+
+        assert_eq!(response.relayer_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(response.api_version, RELAYER_API_VERSION);
+        assert_eq!(
+            response.min_supported_sdk.typescript,
+            MIN_TYPESCRIPT_SDK_VERSION
+        );
+        assert_eq!(response.min_supported_sdk.python, MIN_PYTHON_SDK_VERSION);
+        assert_eq!(response.min_supported_sdk.mcp, MIN_MCP_PACKAGE_VERSION);
+        assert_eq!(
+            response.feature_flags.get("runtime.versionEndpoint"),
+            Some(&true)
+        );
+        assert!(response
+            .deprecations
+            .iter()
+            .any(|notice| notice.surface == "header:x-delegate-key"));
+    }
+}

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod compatibility;
 mod engine;
 mod jobs;
 mod mcp_proxy;
@@ -570,6 +571,10 @@ async fn main() {
         .route(
             "/health",
             get(routes::health).layer(DefaultBodyLimit::max(16 * 1024)),
+        )
+        .route(
+            "/version",
+            get(routes::version).layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/config",

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -109,7 +109,7 @@ pub async fn stats(
 }
 
 // ============================================================
-// /health + /config
+// /health + /version + /config
 // ============================================================
 
 /// GET /health
@@ -117,6 +117,7 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> 
     Json(HealthResponse {
         status: "ok".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
+        compatibility: crate::compatibility::version_response(),
         mode: if state.config.benchmark_mode {
             "benchmark".to_string()
         } else {
@@ -131,6 +132,11 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> 
             ask: ASK_SYSTEM_PROMPT_VERSION.to_string(),
         },
     })
+}
+
+/// GET /version
+pub async fn version() -> Json<crate::compatibility::VersionResponse> {
+    Json(crate::compatibility::version_response())
 }
 
 /// GET /config

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -5,7 +5,8 @@
 //!   (+ the async prep tasks and the summarize-for-embedding helpers)
 //! - `recall` — `/api/recall`, `/api/recall/manual` (+ the recall-embedding cache)
 //! - `analyze` — `/api/analyze` (fact extraction → store; sync bypass in benchmark mode)
-//! - `admin` — `/api/ask`, `/api/forget`, `/api/stats`, `/api/restore`, `/health`, `/config`
+//! - `admin` — `/api/ask`, `/api/forget`, `/api/stats`, `/api/restore`,
+//!   `/health`, `/version`, `/config`
 //! - `sponsor` — `/sponsor`, `/sponsor/execute` (Enoki proxy)
 //!
 //! Shared route-level helpers (`enqueue_wallet_job`, `truncate_str`,
@@ -21,7 +22,7 @@ mod sponsor;
 
 // Re-export every handler so `main.rs` keeps using `routes::<name>`
 // without having to know which submodule each handler lives in.
-pub use admin::{ask, forget, get_config, health, restore, stats};
+pub use admin::{ask, forget, get_config, health, restore, stats, version};
 pub use analyze::analyze;
 pub use recall::{recall, recall_manual};
 pub use remember::{

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -835,6 +835,8 @@ pub struct StatsResponse {
 pub struct HealthResponse {
     pub status: String,
     pub version: String,
+    #[serde(flatten)]
+    pub compatibility: crate::compatibility::VersionResponse,
     /// "production" or "benchmark" — lets benchmark harness runs verify
     /// at startup that they're hitting a benchmark-mode server before
     /// ingesting plaintext memories. Mirrors `Config::benchmark_mode`.
@@ -1433,6 +1435,7 @@ mod tests {
         let resp = HealthResponse {
             status: "ok".to_string(),
             version: "0.1.0".to_string(),
+            compatibility: crate::compatibility::version_response(),
             mode: "benchmark".to_string(),
             prompt_versions: PromptVersions {
                 extract: "extract.v1".to_string(),
@@ -1442,5 +1445,14 @@ mod tests {
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["prompt_versions"]["extract"], "extract.v1");
         assert_eq!(json["prompt_versions"]["ask"], "ask.v1");
+        assert_eq!(
+            json["apiVersion"],
+            crate::compatibility::RELAYER_API_VERSION
+        );
+        assert_eq!(json["relayerVersion"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            json["minSupportedSdk"]["typescript"],
+            crate::compatibility::MIN_TYPESCRIPT_SDK_VERSION
+        );
     }
 }

--- a/services/server/tests/e2e_test.py
+++ b/services/server/tests/e2e_test.py
@@ -141,7 +141,22 @@ def test_health() -> None:
     with urllib.request.urlopen(req) as resp:
         data = json.loads(resp.read())
         assert data["status"] == "ok", f"Expected status=ok, got {data}"
+        assert data["apiVersion"], f"Expected apiVersion in health metadata, got {data}"
+        assert data["minSupportedSdk"]["typescript"], f"Expected SDK matrix in health, got {data}"
         print(f"[pass] GET /health → {data}")
+
+
+def test_version() -> None:
+    req = urllib.request.Request(f"{BASE_URL}/version")
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+        assert data["relayerVersion"], f"Expected relayerVersion, got {data}"
+        assert data["apiVersion"], f"Expected apiVersion, got {data}"
+        assert data["minSupportedSdk"]["python"], f"Expected SDK matrix, got {data}"
+        assert data["featureFlags"]["runtime.versionEndpoint"] is True, (
+            f"Expected runtime.versionEndpoint feature flag, got {data}"
+        )
+        print(f"[pass] GET /version → {data}")
 
 
 def test_unsigned_rejected() -> None:
@@ -379,6 +394,7 @@ def main() -> int:
 
     contract_checks = (
         ("health", test_health),
+        ("version", test_version),
         ("unsigned_rejected", test_unsigned_rejected),
         ("wrong_signature_rejected", test_wrong_signature_rejected),
         ("expired_timestamp_rejected", test_expired_timestamp_rejected),


### PR DESCRIPTION
## Summary
- Document relayer SemVer and SDK/MCP compatibility policy
- Expose relayer/API compatibility metadata through `/version` and `/health`
- Add SDK/MCP compatibility checks and contract metadata validation
- Align Python SDK credential docs with `x-seal-session` behavior
- Bump publish versions: `@mysten-incubation/memwal` 0.0.5, `@mysten-incubation/memwal-mcp` 0.0.2, Python `memwal` 0.1.1

## Verification
- `pnpm check:compatibility`
- `pnpm --filter @mysten-incubation/memwal typecheck`
- `pnpm --filter @mysten-incubation/memwal-mcp typecheck`
- `cargo test compatibility --manifest-path services/server/Cargo.toml`
- `cargo test health_response --manifest-path services/server/Cargo.toml`

Linear: https://linear.app/commandoss/issue/MEM-60/all-define-relayer-versioning-and-sdk-compatibility-policy