### PR TITLE
Keep testnet Seal defaults on legacy key servers

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -67,9 +67,10 @@ These are not all enforced at boot, but most real deployments need them.
 - `SUI_NETWORK` drives the default RPC URL, Walrus endpoints, Walrus package ID, and upload relay selection.
 - `SEAL_SERVER_CONFIGS` is a JSON array of `{ objectId, weight, aggregatorUrl?, apiKeyName?, apiKey? }`. Committee key server configs require `aggregatorUrl`.
 - `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset.
-- If neither SEAL variable is set, the sidecar uses built-in defaults for `SUI_NETWORK`: Mysten's initial committee aggregator on `testnet`, and the legacy independent key server pair on `mainnet` until an official mainnet committee aggregator is available.
-- Use `SEAL_SERVER_CONFIGS` to override the built-in default with another committee by providing `objectId`, `weight`, and `aggregatorUrl`.
-- Deployments with existing memories encrypted by the previous testnet independent key server defaults should pin `SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8` until the data is migrated or re-encrypted.
+- If neither SEAL variable is set, the sidecar uses built-in defaults for `SUI_NETWORK`: the original Mysten independent key server pair on `testnet`, and the legacy independent key server pair on `mainnet` until an official mainnet committee aggregator is available.
+- Use `SEAL_SERVER_CONFIGS` to opt into a committee key server by providing `objectId`, `weight`, and `aggregatorUrl`. Mysten's testnet committee aggregator is `0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98` with `https://seal-aggregator-testnet.mystenlabs.com`.
+- The Mysten testnet committee aggregator is a single logical server config from the SDK's point of view. Its 3-of-5 committee threshold is handled by the aggregator, so leave `SEAL_THRESHOLD` unset or set it to `1` when opting into that committee config.
+- Keep the independent testnet defaults, or pin `SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8`, for deployments with existing memories encrypted by those key servers until the data is migrated or re-encrypted.
 - The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -131,28 +131,30 @@ MEMWAL_PACKAGE_ID=0xcee7a6fd8de52ce645c38332bde23d4a30fd9426bc4681409733dd50958a
 MEMWAL_REGISTRY_ID=0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75a7edd
 ```
 
-If neither `SEAL_SERVER_CONFIGS` nor `SEAL_KEY_SERVERS` is set, the sidecar uses built-in defaults for the selected `SUI_NETWORK`. On `testnet`, the default is Mysten's initial committee aggregator:
-
-```env
-SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
-```
-
-On `mainnet`, the default remains the legacy independent key server pair until Mysten publishes an official committee aggregator.
-
-Use `SEAL_SERVER_CONFIGS` to override the built-in default with another committee. Committee entries require an `aggregatorUrl`, for example:
-
-```env
-SEAL_SERVER_CONFIGS=[{"objectId":"0x...","weight":1,"aggregatorUrl":"https://seal-aggregator.example.com"}]
-```
-
-`SEAL_KEY_SERVERS=0x...,0x...` remains supported for legacy independent key server object IDs. It is only used when `SEAL_SERVER_CONFIGS` is unset. For deployments that still need the previous testnet independent defaults, pin:
+If neither `SEAL_SERVER_CONFIGS` nor `SEAL_KEY_SERVERS` is set, the sidecar uses built-in defaults for the selected `SUI_NETWORK`. On `testnet`, the default remains Mysten's original independent key server pair so existing encrypted memories remain decryptable:
 
 ```env
 SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8
 ```
 
+On `mainnet`, the default remains the legacy independent key server pair until Mysten publishes an official committee aggregator.
+
+Use `SEAL_SERVER_CONFIGS` to opt into a committee key server. Committee entries require an `aggregatorUrl`, for example:
+
+```env
+SEAL_SERVER_CONFIGS=[{"objectId":"0x...","weight":1,"aggregatorUrl":"https://seal-aggregator.example.com"}]
+```
+
+Mysten's official testnet committee aggregator is:
+
+```env
+SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
+```
+
+Although that committee is 3-of-5 internally, Seal exposes it to the SDK as one logical server config. The aggregator handles the internal committee threshold, so leave `SEAL_THRESHOLD` unset or set it to `1` when using this committee config. Because it uses a different key server object, do not switch an existing deployment to it until older data has been migrated or re-encrypted.
+
 <Warning>
-Changing SEAL key server defaults only affects new encryption. If a deployment already has memories encrypted with the previous testnet independent key servers, keep those servers pinned with `SEAL_KEY_SERVERS` until the data has been migrated or re-encrypted. Otherwise, recall and restore for older blobs may fail to decrypt.
+Changing SEAL key server defaults only affects new encryption. If a deployment already has memories encrypted with the testnet independent key servers, keep those servers as the default or pin them with `SEAL_KEY_SERVERS` until the data has been migrated or re-encrypted. Otherwise, recall and restore for older blobs may fail to decrypt.
 </Warning>
 
 Using official key server of SDK is recommended. 

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -49,25 +49,29 @@ MEMWAL_REGISTRY_ID=0x...
 
 # SEAL server configs for sidecar encrypt/decrypt.
 # If neither SEAL_SERVER_CONFIGS nor SEAL_KEY_SERVERS is set, the sidecar uses
-# built-in defaults for SUI_NETWORK. Testnet defaults to Mysten's initial
-# committee aggregator. Mainnet keeps the legacy independent key server default
-# until an official committee aggregator is available.
+# built-in defaults for SUI_NETWORK. Testnet keeps the original Mysten
+# independent key server pair so older encrypted memories remain decryptable.
+# Mainnet also uses its legacy independent key server default until an official
+# mainnet committee aggregator is available.
 #
-# Use SEAL_SERVER_CONFIGS to override the default with another committee.
-# Committee entries require an aggregatorUrl. Example Mysten testnet committee:
+# Use SEAL_SERVER_CONFIGS to opt into a committee key server. Committee entries
+# require an aggregatorUrl. Example Mysten testnet committee:
 # SEAL_SERVER_CONFIGS=[{"objectId":"0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98","weight":1,"aggregatorUrl":"https://seal-aggregator-testnet.mystenlabs.com"}]
+# The Mysten committee is 3-of-5 internally, but Seal exposes it as one logical
+# server config. Leave SEAL_THRESHOLD unset or set it to 1 when using this
+# committee config. Do not switch existing deployments until older data is
+# migrated or re-encrypted.
 #
-# Legacy independent key server object IDs remain supported as an override.
-# Use this when you need the previous testnet independent defaults for older data:
+# Explicit legacy independent key server override:
 # SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8
 #
-# If this deployment already has memories encrypted by the previous testnet
-# independent defaults, keep those object IDs pinned in SEAL_KEY_SERVERS until
-# the data is migrated or re-encrypted.
+# Existing testnet deployments can omit SEAL_KEY_SERVERS and still use the
+# built-in default above; pin it explicitly if you want to guard against future
+# default changes.
 
 # SEAL threshold - minimum configured server weight that must respond for
 # encrypt/decrypt to succeed. Must be <= total configured server weight.
-# Default: min(2, total configured weight); a single committee config defaults to 1.
+# Default: min(2, total configured weight).
 # SEAL_THRESHOLD=2
 
 # Walrus on-chain package ID (auto-detected from SUI_NETWORK if not set)

--- a/services/server/scripts/__tests__/seal-config.test.ts
+++ b/services/server/scripts/__tests__/seal-config.test.ts
@@ -9,9 +9,20 @@ const MYSTEN_TESTNET_COMMITTEE = {
     aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
 };
 
-const PREVIOUS_TESTNET_INDEPENDENT_KEY_SERVERS =
-    "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75," +
-    "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8";
+const MYSTEN_TESTNET_INDEPENDENT_KEY_SERVERS = [
+    {
+        objectId: "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
+        weight: 1,
+    },
+    {
+        objectId: "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
+        weight: 1,
+    },
+];
+
+const MYSTEN_TESTNET_INDEPENDENT_KEY_SERVER_IDS = MYSTEN_TESTNET_INDEPENDENT_KEY_SERVERS.map(
+    ({ objectId }) => objectId,
+).join(",");
 
 test("SEAL_SERVER_CONFIGS overrides built-in defaults", () => {
     const configs = getSealServerConfigsFromEnv({
@@ -47,10 +58,10 @@ test("SEAL_KEY_SERVERS remains the legacy independent-server override", () => {
     ]);
 });
 
-test("testnet defaults to Mysten committee aggregator", () => {
+test("testnet defaults to the legacy Mysten independent key servers", () => {
     const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "testnet" });
 
-    assert.deepEqual(configs, [MYSTEN_TESTNET_COMMITTEE]);
+    assert.deepEqual(configs, MYSTEN_TESTNET_INDEPENDENT_KEY_SERVERS);
 });
 
 test("mainnet keeps independent defaults until official committee is available", () => {
@@ -60,16 +71,16 @@ test("mainnet keeps independent defaults until official committee is available",
     assert.ok(configs.every((config) => config.aggregatorUrl === undefined));
 });
 
-test("single committee default has threshold 1", () => {
+test("testnet independent default keeps threshold 2", () => {
     const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "testnet" });
 
-    assert.equal(getSealThresholdFromEnv(configs, {}), 1);
+    assert.equal(getSealThresholdFromEnv(configs, {}), 2);
 });
 
 test("legacy testnet independent override keeps threshold 2", () => {
     const configs = getSealServerConfigsFromEnv({
         SUI_NETWORK: "testnet",
-        SEAL_KEY_SERVERS: PREVIOUS_TESTNET_INDEPENDENT_KEY_SERVERS,
+        SEAL_KEY_SERVERS: MYSTEN_TESTNET_INDEPENDENT_KEY_SERVER_IDS,
     });
 
     assert.equal(configs.length, 2);
@@ -77,12 +88,23 @@ test("legacy testnet independent override keeps threshold 2", () => {
     assert.equal(getSealThresholdFromEnv(configs, {}), 2);
 });
 
+test("Mysten committee aggregator remains available through SEAL_SERVER_CONFIGS", () => {
+    const configs = getSealServerConfigsFromEnv({
+        SUI_NETWORK: "testnet",
+        SEAL_SERVER_CONFIGS: JSON.stringify([MYSTEN_TESTNET_COMMITTEE]),
+    });
+
+    assert.deepEqual(configs, [MYSTEN_TESTNET_COMMITTEE]);
+    assert.equal(getSealThresholdFromEnv(configs, {}), 1);
+});
+
 test("explicit SEAL_THRESHOLD validation is unchanged", () => {
     const configs = getSealServerConfigsFromEnv({ SUI_NETWORK: "testnet" });
 
     assert.equal(getSealThresholdFromEnv(configs, { SEAL_THRESHOLD: "1" }), 1);
+    assert.equal(getSealThresholdFromEnv(configs, { SEAL_THRESHOLD: "2" }), 2);
     assert.throws(
-        () => getSealThresholdFromEnv(configs, { SEAL_THRESHOLD: "2" }),
+        () => getSealThresholdFromEnv(configs, { SEAL_THRESHOLD: "3" }),
         /SEAL_THRESHOLD must be less than or equal to total configured SEAL server weight/,
     );
 });

--- a/services/server/scripts/seal-config.ts
+++ b/services/server/scripts/seal-config.ts
@@ -21,13 +21,16 @@ const DEFAULT_SEAL_SERVER_CONFIGS: Record<string, SealServerConfig[]> = {
     ],
     testnet: [
         {
-            // Official Mysten testnet committee aggregator. This is a single
-            // decentralized SEAL server config whose aggregator fronts the
-            // committee threshold internally; legacy independent 2-of-2
-            // deployments should pin SEAL_KEY_SERVERS instead.
-            objectId: "0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98",
+            // Keep the original Mysten testnet independent key servers as the
+            // built-in default so existing encrypted memories remain decryptable.
+            // Operators can opt into Mysten's committee Seal aggregator with
+            // SEAL_SERVER_CONFIGS after migrating or re-encrypting old data.
+            objectId: "0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75",
             weight: 1,
-            aggregatorUrl: "https://seal-aggregator-testnet.mystenlabs.com",
+        },
+        {
+            objectId: "0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8",
+            weight: 1,
         },
     ],
 };


### PR DESCRIPTION
## Title

Keep default Seal testnet config on legacy Mysten independent key servers

## Summary

This keeps the relayer/sidecar default Seal testnet configuration on the original Mysten independent key server pair instead of switching the default to Mysten’s committee aggregator.

The committee aggregator is still documented and supported through `SEAL_SERVER_CONFIGS`, but it is no longer the built-in default. This avoids breaking decryptability for existing memories encrypted with the previous testnet key server objects.

## Changes

- Restored testnet default Seal config to the two original Mysten independent key servers:
  - `0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75`
  - `0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8`
- Added an inline comment explaining why the default stays on the old key servers.
- Kept Mysten’s committee aggregator available as an opt-in `SEAL_SERVER_CONFIGS` override:
  - `0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98`
  - `https://seal-aggregator-testnet.mystenlabs.com`
- Updated docs/env examples to explain:
  - default independent key server behavior
  - committee aggregator opt-in path
  - why existing deployments should not switch until old data is migrated or re-encrypted
- Updated Seal config tests for the reverted default behavior.

## Test Plan

- `npm test --prefix services/server/scripts`
- `git diff --check`

## Notes

This intentionally does not make the committee aggregator the default yet because changing the key server object used for new encryption can make older encrypted memories fail to decrypt unless deployments explicitly keep the old key servers or migrate/re-encrypt data first.

Addresses MEM-49.