### PR TITLE
MEM-62: workshop MemWal friction fixes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -84,9 +84,9 @@ Generate them at:
 import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
-  key: "<your-ed25519-private-key-hex>",
-  accountId: "<your-memwal-account-id>",
-  serverUrl: "https://relayer.memwal.ai",
+  key: process.env.MEMWAL_PRIVATE_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+  serverUrl: process.env.MEMWAL_SERVER_URL ?? "https://relayer.memwal.ai",
   namespace: "my-app",
 });
 ```
@@ -94,20 +94,40 @@ const memwal = MemWal.create({
 ### 3. Store and Recall Memories
 
 ```ts
-// Store a memory
-const job = await memwal.remember("User prefers dark mode and works in TypeScript.");
-await memwal.waitForRememberJob(job.job_id);
+// Store one already-distilled fact and wait until it is indexed.
+await memwal.rememberAndWait(
+  "User prefers dark mode and works in TypeScript.",
+  undefined,
+  { timeoutMs: 30_000 },
+);
 
 // Recall by meaning
 const result = await memwal.recall("What are the user's preferences?");
 console.log(result.results);
 
-// Extract and store facts from text
-const analyzed = await memwal.analyze("I live in Hanoi and prefer dark mode.");
-await memwal.waitForRememberJobs(analyzed.job_ids);
+// Extract facts from free-form text and wait until all accepted facts are indexed.
+const analyzed = await memwal.analyzeAndWait(
+  "I live in Hanoi and prefer dark mode.",
+  undefined,
+  { timeoutMs: 30_000 },
+);
+console.log(analyzed.facts.map((fact) => fact.text));
 
 // Check relayer health
 await memwal.health();
+```
+
+Use `*AndWait` when a workshop UI saves and then immediately recalls in the
+same flow. Indexing can lag by a few seconds, so `remember()` / `analyze()`
+may return before recall can find the new memory. Manual polling is still
+available for advanced async UIs:
+
+```ts
+const accepted = await memwal.remember("User likes Sui.");
+const stored = await memwal.waitForRememberJob(accepted.job_id, {
+  pollIntervalMs: 750,
+  timeoutMs: 30_000,
+});
 ```
 
 ---
@@ -131,7 +151,7 @@ await memwal.health();
 |---|---|---|
 | `remember(text, namespace?)` | Accept one memory job immediately | `{ job_id, status }` |
 | `rememberAndWait(text, namespace?, opts?)` | Store one memory and wait for completion | `{ id, job_id, blob_id, owner, namespace }` |
-| `recall(query, limit?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
+| `recall(query, limitOrOptions?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
 | `analyze(text, namespace?)` | Extract facts and accept one memory job per fact | `{ job_ids, facts, fact_count, status, owner }` |
 | `analyzeAndWait(text, namespace?, opts?)` | Extract facts and wait for all fact jobs to complete | `{ results, facts, total, succeeded, failed, owner }` |
 | `restore(namespace, limit?)` | Rebuild missing index entries from Walrus | `{ restored, skipped, total, namespace, owner }` |
@@ -146,6 +166,178 @@ await memwal.health();
 | `recallManual({ vector, limit?, namespace? })` | Search with pre-computed vector (returns blob IDs only) |
 | `embed(text)` | Generate embedding vector (no storage) |
 
+### All Response Shapes
+
+```ts
+interface RememberAcceptedResult {
+  job_id: string;
+  status: string;
+}
+
+interface RememberJobStatus {
+  job_id: string;
+  status: "pending" | "running" | "uploaded" | "done" | "failed" | "not_found";
+  owner?: string;
+  namespace?: string;
+  blob_id?: string;
+  error?: string;
+}
+
+interface RememberResult {
+  id: string;
+  job_id?: string;
+  blob_id: string;
+  owner: string;
+  namespace: string;
+}
+
+interface RecallMemory {
+  blob_id: string;
+  text: string;
+  distance: number;
+}
+
+interface RecallResult {
+  results: RecallMemory[];
+  total: number;
+}
+
+interface RecallOptions {
+  limit?: number;
+  topK?: number;
+  namespace?: string;
+  maxDistance?: number;
+}
+
+interface RememberBulkAcceptedResult {
+  job_ids: string[];
+  total: number;
+  status: string;
+}
+
+interface AnalyzedFact {
+  text: string;
+  id: string;
+  job_id?: string;
+  blob_id?: string;
+}
+
+interface AnalyzeResult {
+  job_ids: string[];
+  facts: AnalyzedFact[];
+  fact_count: number;
+  status: string;
+  owner: string;
+}
+
+interface RememberBulkStatusItem {
+  job_id: string;
+  status: "pending" | "running" | "uploaded" | "done" | "failed" | "not_found";
+  blob_id?: string;
+  error?: string;
+}
+
+interface RememberBulkStatusResult {
+  results: RememberBulkStatusItem[];
+}
+
+interface RememberBulkItemResult {
+  id: string;
+  blob_id: string;
+  status: "done" | "failed" | "timeout";
+  namespace: string;
+  error?: string;
+}
+
+interface RememberBulkResult {
+  results: RememberBulkItemResult[];
+  total: number;
+  succeeded: number;
+  failed: number;
+}
+
+interface AnalyzeWaitResult extends RememberBulkResult {
+  facts: AnalyzedFact[];
+  owner: string;
+}
+
+interface EmbedResult {
+  vector: number[];
+}
+
+interface RestoreResult {
+  restored: number;
+  skipped: number;
+  total: number;
+  namespace: string;
+  owner: string;
+}
+
+interface HealthResult {
+  status: string;
+  version: string;
+  mode?: string;
+  prompt_versions?: {
+    extract: string;
+    ask: string;
+  };
+  relayerVersion?: string;
+  apiVersion?: string;
+  minSupportedSdk?: {
+    typescript: string;
+    python: string;
+    mcp: string;
+  };
+  featureFlags?: Record<string, boolean>;
+  deprecations?: Array<{
+    surface: string;
+    deprecatedSince: string;
+    removalApiVersion: string;
+    guidance: string;
+  }>;
+  build?: {
+    commit?: string;
+    buildTimestamp?: string;
+  };
+}
+```
+
+`facts[].text` is the extracted fact text to render in UIs. `job_ids[]`
+aligns with the accepted fact jobs; use `analyzeAndWait()` when the UI needs
+those facts indexed before continuing.
+
+### Recall Distance and Filtering
+
+`recall()` returns the closest K memories by vector distance. There is no
+default relevance threshold, so small namespaces may return weak filler results
+because they are still the closest available matches.
+
+Lower distance means more similar:
+
+| Distance | Rough meaning |
+|---|---|
+| `< 0.25` | Duplicate or very close |
+| `0.25 - 0.55` | Related |
+| `0.55 - 0.7` | Weak/noisy |
+| `>= 0.7` | Usually unrelated |
+
+Use SDK-side filtering when you only want clearly relevant results:
+
+```ts
+const memories = await memwal.recall("what did I eat yesterday?", {
+  topK: 10,
+  namespace: "reading-tracker",
+  maxDistance: 0.7,
+});
+```
+
+Equivalent manual filtering:
+
+```ts
+const memories = await memwal.recall("what did I eat yesterday?", 10, "reading-tracker");
+const relevant = memories.results.filter((memory) => memory.distance < 0.7);
+```
+
 ---
 
 ## Configuration
@@ -156,7 +348,7 @@ await memwal.health();
 |---|---|---|---|---|
 | `key` | `string` | Yes | — | Ed25519 delegate private key in hex |
 | `accountId` | `string` | Yes | — | MemWalAccount object ID on Sui |
-| `serverUrl` | `string` | No | `http://localhost:8000` | Relayer URL |
+| `serverUrl` | `string` | No | `https://relayer.memwal.ai` | Relayer URL |
 | `namespace` | `string` | No | `"default"` | Default namespace for memory isolation |
 
 ### Managed Relayer Endpoints
@@ -165,6 +357,50 @@ await memwal.health();
 |---|---|
 | **Production** (mainnet) | `https://relayer.memwal.ai` |
 | **Staging** (testnet) | `https://relayer.staging.memwal.ai` |
+
+### Framework and Key Handling
+
+Delegate private keys belong on the server only. In Next.js App Router, call
+MemWal from server actions, route handlers, or other server-only modules that
+read `MEMWAL_PRIVATE_KEY` from server env.
+
+`"use server"` files can only export async functions; keep constants, schemas,
+and reusable client builders in a separate server-only module.
+
+```ts
+// app/actions/memory.ts
+"use server";
+
+import { getMemWal } from "@/lib/memwal";
+
+export async function savePreference(text: string) {
+  const memwal = getMemWal();
+  return memwal.rememberAndWait(text, "my-app", { timeoutMs: 30_000 });
+}
+```
+
+```ts
+// lib/memwal.ts
+import "server-only";
+import { MemWal } from "@mysten-incubation/memwal";
+
+export function getMemWal() {
+  return MemWal.create({
+    key: process.env.MEMWAL_PRIVATE_KEY!,
+    accountId: process.env.MEMWAL_ACCOUNT_ID!,
+    serverUrl: process.env.MEMWAL_SERVER_URL ?? "https://relayer.memwal.ai",
+    namespace: "my-app",
+  });
+}
+```
+
+Namespace strategy: `owner + namespace` is the isolation boundary. Use one
+namespace per app by default, then split by user, team, or feature when a
+single app needs separate memory spaces.
+
+Relayer choice: use staging/testnet for learning and prototypes; use
+production/mainnet for production data. Do not mix staging credentials with
+mainnet relayer configs.
 
 ---
 
@@ -242,9 +478,12 @@ Lifecycle hooks run automatically:
 |---|---|
 | `health()` returns error | Check relayer URL is correct and reachable |
 | `recall()` returns empty | Verify namespace matches what was used in `remember()` |
-| `401 Unauthorized` | Verify delegate key is correct and registered on the account |
+| `recall()` returns unrelated filler | Recall is top-K without a default relevance threshold; filter by `distance`, for example `distance < 0.7` |
+| `401 Unauthorized` | Usually wrong `MEMWAL_PRIVATE_KEY`, key not registered on the account, account ID mismatch, or staging/mainnet mismatch. Check `.env.local` and dashboard credentials |
 | SDK import errors | Run `pnpm add @mysten-incubation/memwal` — check Node.js ≥ 18 |
 | Manual client errors | Install peer deps: `@mysten/sui @mysten/seal @mysten/walrus` |
+| Direct Sui reads fail or examples look stale | Prefer `SuiGrpcClient` from `@mysten/sui/grpc`; JSON-RPC snippets using `SuiClient` / `getFullnodeUrl` may be stale |
+| `forget` expectations are unclear | Current relayer `POST /api/forget` removes vector index rows so memories are unrecallable; Walrus blobs persist until epoch expiry |
 
 ---
 

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -137,6 +137,26 @@ export default function Dashboard() {
     const hasResolvedAccount = Boolean(effectiveAccountObjectId)
     const isRecoveringExistingAccount = !delegateKey && hasResolvedAccount
     const isNewAccount = !delegateKey && !loadingAccount && !hasResolvedAccount
+    const activeEnvironmentLabel = config.suiNetwork === 'mainnet'
+        ? 'production / mainnet'
+        : 'staging / testnet'
+    const expectedRelayerUrl = config.suiNetwork === 'mainnet'
+        ? 'https://relayer.memwal.ai'
+        : 'https://relayer.staging.memwal.ai'
+    const normalizedRelayerUrl = config.memwalServerUrl.toLowerCase()
+    const relayerEnvironmentLabel = normalizedRelayerUrl.includes('localhost') || normalizedRelayerUrl.includes('127.0.0.1')
+        ? 'local development'
+        : normalizedRelayerUrl.includes('staging')
+            ? 'staging / testnet'
+            : normalizedRelayerUrl.includes('dev')
+                ? 'dev / testnet'
+                : 'production / mainnet'
+    const relayerLooksMismatched =
+        (config.suiNetwork === 'mainnet' && normalizedRelayerUrl.includes('staging')) ||
+        (config.suiNetwork !== 'mainnet' &&
+            normalizedRelayerUrl.includes('relayer.memwal.ai') &&
+            !normalizedRelayerUrl.includes('staging') &&
+            !normalizedRelayerUrl.includes('dev'))
     const dashboardSubtitle = delegateKey
         ? 'manage your memwal account and delegate keys'
         : loadingAccount
@@ -310,9 +330,9 @@ export default function Dashboard() {
     const sdkSnippet = `import { MemWal } from "@mysten-incubation/memwal"
 
 const memwal = MemWal.create({
-  key: "${PRIVATE_KEY_PLACEHOLDER}",
-  accountId: "${effectiveAccountObjectId ?? ACCOUNT_ID_PLACEHOLDER}",
-  serverUrl: "${config.memwalServerUrl}",
+  key: process.env.MEMWAL_PRIVATE_KEY ?? "${PRIVATE_KEY_PLACEHOLDER}",
+  accountId: process.env.MEMWAL_ACCOUNT_ID ?? "${effectiveAccountObjectId ?? ACCOUNT_ID_PLACEHOLDER}",
+  serverUrl: process.env.MEMWAL_SERVER_URL ?? "${config.memwalServerUrl}",
 })
 
 // Remember something
@@ -328,9 +348,9 @@ import { withMemWal } from "@mysten-incubation/memwal/ai"
 import { openai } from "@ai-sdk/openai"
 
 const model = withMemWal(openai("gpt-4o"), {
-  key: "${PRIVATE_KEY_PLACEHOLDER}",
-  accountId: "${effectiveAccountObjectId ?? ACCOUNT_ID_PLACEHOLDER}",
-  serverUrl: "${config.memwalServerUrl}",
+  key: process.env.MEMWAL_PRIVATE_KEY ?? "${PRIVATE_KEY_PLACEHOLDER}",
+  accountId: process.env.MEMWAL_ACCOUNT_ID ?? "${effectiveAccountObjectId ?? ACCOUNT_ID_PLACEHOLDER}",
+  serverUrl: process.env.MEMWAL_SERVER_URL ?? "${config.memwalServerUrl}",
 })
 
 const result = await generateText({
@@ -450,15 +470,29 @@ const result = await generateText({
                     <div className="card" style={{ marginBottom: 24 }}>
                     <div className="card-header">
                         <div>
-                            <div className="card-title">your delegate key</div>
-                            <div className="card-subtitle">your Ed25519 key for SDK authentication</div>
+                            <div className="card-title">SDK credentials</div>
+                            <div className="card-subtitle">copy the delegate private key into server env as MEMWAL_PRIVATE_KEY</div>
                         </div>
+                    </div>
+
+                    <div className="warning-box" style={{ marginBottom: 12 }}>
+                        <p>
+                            active environment: <strong>{activeEnvironmentLabel}</strong>. configured relayer:
+                            {' '}<code>{config.memwalServerUrl}</code> ({relayerEnvironmentLabel}).
+                            {' '}matching relayer: <code>{expectedRelayerUrl}</code>.
+                            {' '}do not mix staging/testnet credentials with production/mainnet relayer configs.
+                        </p>
+                        {relayerLooksMismatched && (
+                            <p style={{ marginTop: 8 }}>
+                                this dashboard network and relayer URL look mismatched; API calls may fail with 401.
+                            </p>
+                        )}
                     </div>
 
                     {/* Account ID */}
                     {effectiveAccountObjectId && (
                         <div className="key-display key-display--white" style={{ marginBottom: 12 }}>
-                            <div className="key-label">account ID</div>
+                            <div className="key-label">account ID — MEMWAL_ACCOUNT_ID</div>
                             <div className="key-value" style={{ fontSize: '0.78rem' }}>
                                 {effectiveAccountObjectId}
                             </div>
@@ -469,13 +503,34 @@ const result = await generateText({
                                 >
                                     <Copy size={12} /> {copied === 'acct' ? 'copied!' : 'copy'}
                                 </button>
+                                <button
+                                    className="btn btn-secondary btn-sm"
+                                    onClick={() => copyToClipboard(`MEMWAL_ACCOUNT_ID=${effectiveAccountObjectId}`, 'acct-env')}
+                                >
+                                    <Copy size={12} /> {copied === 'acct-env' ? 'copied!' : 'copy env line'}
+                                </button>
                             </div>
                         </div>
                     )}
 
+                    <div className="key-display key-display--white" style={{ marginBottom: 12 }}>
+                        <div className="key-label">relayer URL — MEMWAL_SERVER_URL</div>
+                        <div className="key-value" style={{ fontSize: '0.78rem' }}>
+                            {config.memwalServerUrl}
+                        </div>
+                        <div className="key-actions">
+                            <button
+                                className="btn btn-secondary btn-sm"
+                                onClick={() => copyToClipboard(`MEMWAL_SERVER_URL=${config.memwalServerUrl}`, 'server-env')}
+                            >
+                                <Copy size={12} /> {copied === 'server-env' ? 'copied!' : 'copy env line'}
+                            </button>
+                        </div>
+                    </div>
+
                     {/* Public Key */}
                     <div className="key-display key-display--white" style={{ marginBottom: 12 }}>
-                        <div className="key-label">public key</div>
+                        <div className="key-label">delegate public key — shareable, not the .env private key</div>
                         <div className="key-value">
                             {delegatePublicKey}
                         </div>
@@ -491,7 +546,7 @@ const result = await generateText({
 
                     {/* Private Key */}
                     <div className="key-display key-display--white">
-                        <div className="key-label">private key</div>
+                        <div className="key-label">delegate private key — server-side MEMWAL_PRIVATE_KEY</div>
                         {showKey ? (
                             <>
                                 <div className="key-value">{delegateKey}</div>
@@ -501,6 +556,12 @@ const result = await generateText({
                                         onClick={() => copyToClipboard(delegateKey!, 'priv')}
                                     >
                                         <Copy size={12} /> {copied === 'priv' ? 'copied!' : 'copy'}
+                                    </button>
+                                    <button
+                                        className="btn btn-secondary btn-sm"
+                                        onClick={() => copyToClipboard(`MEMWAL_PRIVATE_KEY=${delegateKey}`, 'priv-env')}
+                                    >
+                                        <Copy size={12} /> {copied === 'priv-env' ? 'copied!' : 'copy env line'}
                                     </button>
                                     <button className="btn btn-secondary btn-sm" onClick={() => setShowKey(false)}>
                                         <EyeOff size={12} /> hide

--- a/apps/chatbot/.env.example
+++ b/apps/chatbot/.env.example
@@ -14,7 +14,10 @@ POSTGRES_URL=****
 # https://vercel.com/docs/redis
 REDIS_URL=****
 
-# MemWal SDK — Ed25519 delegate key for memory layer
-# Get your delegate key from the MemWal setup wizard
-MEMWAL_KEY=****
-MEMWAL_SERVER_URL=http://localhost:3001
+# MemWal SDK — server-side delegate private key for memory layer.
+# Get these values from the MemWal dashboard. Run `pnpm verify:memwal` before starting.
+MEMWAL_PRIVATE_KEY=****
+MEMWAL_ACCOUNT_ID=0x...
+# Optional: paste the dashboard delegate public key so `pnpm verify:memwal` can catch mismatches.
+MEMWAL_DELEGATE_PUBLIC_KEY=
+MEMWAL_SERVER_URL=http://localhost:8000

--- a/apps/chatbot/README.md
+++ b/apps/chatbot/README.md
@@ -58,6 +58,11 @@ You will need to use the environment variables [defined in `.env.example`](.env.
 
 > Note: You should not commit your `.env` file or it will expose secrets that will allow others to control access to your various AI and authentication provider accounts.
 
+For MemWal memory, set `MEMWAL_PRIVATE_KEY`, `MEMWAL_ACCOUNT_ID`, and
+`MEMWAL_SERVER_URL` in `.env.local`. The private key is the delegate private key
+from the MemWal dashboard and must stay server-side. Run `pnpm verify:memwal`
+to derive the public key locally before the first relayer call.
+
 1. Install Vercel CLI: `npm i -g vercel`
 2. Link local instance with Vercel and GitHub accounts (creates `.vercel` directory): `vercel link`
 3. Download your environment variables: `vercel env pull`

--- a/apps/chatbot/components/multimodal-input.tsx
+++ b/apps/chatbot/components/multimodal-input.tsx
@@ -659,7 +659,7 @@ function PureMemWalButton({
             )}
             onClick={() => setShowKeyInput(!showKeyInput)}
             variant="ghost"
-            title={hasKey ? "Key configured" : "Set your MEMWAL key"}
+            title={hasKey ? "Private key configured" : "Set MEMWAL_PRIVATE_KEY"}
           >
             <KeyIcon className="size-3" />
           </Button>
@@ -681,14 +681,14 @@ function PureMemWalButton({
         >
           <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
             <KeyIcon className="size-3" />
-            memwal key (ed25519 private key hex)
+            MEMWAL_PRIVATE_KEY (ed25519 private key hex)
           </div>
           <div className="flex gap-1.5 mb-2">
             <input
               type="password"
               value={keyInput}
               onChange={(e) => setKeyInput(e.target.value)}
-              placeholder="Enter your delegate key..."
+              placeholder="Enter your delegate private key..."
               className="flex-1 rounded-md border border-border bg-muted px-2 py-1.5 text-xs font-mono outline-none focus:border-primary"
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {

--- a/apps/chatbot/lib/ai/providers.ts
+++ b/apps/chatbot/lib/ai/providers.ts
@@ -71,17 +71,17 @@ export function getArtifactModel() {
 
 /**
  * Wrap a language model with MemWal memory layer.
- * Requires MEMWAL_KEY env var. Falls back to base model if not configured.
+ * Requires MEMWAL_PRIVATE_KEY env var. Falls back to MEMWAL_KEY for older deploys.
  */
 export function getMemWalModel(modelId: string, memwalKey?: string, memwalAccountId?: string) {
   const baseModel = getLanguageModel(modelId);
 
-  const key = memwalKey || process.env.MEMWAL_KEY;
+  const key = memwalKey || process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY;
   const memwalServerUrl = process.env.MEMWAL_SERVER_URL;
   const accountId = memwalAccountId || process.env.MEMWAL_ACCOUNT_ID;
 
   if (!key) {
-    console.warn("[MemWal] MEMWAL_KEY not set — memory layer disabled");
+    console.warn("[MemWal] MEMWAL_PRIVATE_KEY not set — memory layer disabled");
     return baseModel;
   }
 
@@ -100,4 +100,3 @@ export function getMemWalModel(modelId: string, memwalKey?: string, memwalAccoun
     debug: true,
   });
 }
-

--- a/apps/chatbot/lib/ai/tools/save-memory.ts
+++ b/apps/chatbot/lib/ai/tools/save-memory.ts
@@ -20,7 +20,7 @@ export const saveMemory = ({
         ),
     }),
     execute: async ({ text }) => {
-      const key = memwalKey || process.env.MEMWAL_KEY;
+      const key = memwalKey || process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY;
       const accountId = memwalAccountId || process.env.MEMWAL_ACCOUNT_ID;
       const serverUrl = process.env.MEMWAL_SERVER_URL || "http://localhost:8000";
 
@@ -28,7 +28,7 @@ export const saveMemory = ({
         return {
           saved: false,
           text,
-          error: "MemWal not configured — MEMWAL_KEY or MEMWAL_ACCOUNT_ID missing",
+          error: "MemWal not configured — MEMWAL_PRIVATE_KEY or MEMWAL_ACCOUNT_ID missing",
         };
       }
 

--- a/apps/chatbot/package.json
+++ b/apps/chatbot/package.json
@@ -15,6 +15,7 @@
     "db:pull": "drizzle-kit pull",
     "db:check": "drizzle-kit check",
     "db:up": "drizzle-kit up",
+    "verify:memwal": "tsx ../../scripts/verify-memwal-credentials.ts",
     "playwright:install": "playwright install --with-deps chromium",
     "test:e2e": "PLAYWRIGHT=True playwright test",
     "test:e2e:ui": "PLAYWRIGHT=True playwright test --ui",

--- a/apps/noter/README.md
+++ b/apps/noter/README.md
@@ -70,7 +70,16 @@ OPENROUTER_API_KEY=...
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# MemWal memory
+MEMWAL_PRIVATE_KEY=...
+MEMWAL_ACCOUNT_ID=0x...
+MEMWAL_SERVER_URL=http://localhost:8000
 ```
+
+`MEMWAL_PRIVATE_KEY` is the delegate private key from the MemWal dashboard and
+must stay server-side. Run `pnpm verify:memwal` before starting the app to
+derive the public key locally and catch obvious credential mismatches.
 
 ### Getting OAuth Credentials
 

--- a/apps/noter/app/api/memory/remember-one/route.ts
+++ b/apps/noter/app/api/memory/remember-one/route.ts
@@ -55,7 +55,7 @@ export async function POST(req: Request) {
     }
 
     const { key, accountId } = await resolveUserKey(req);
-    if ((!key || !accountId) && (!process.env.MEMWAL_KEY || !process.env.MEMWAL_ACCOUNT_ID)) {
+    if ((!key || !accountId) && (!(process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY) || !process.env.MEMWAL_ACCOUNT_ID)) {
       return Response.json(
         { error: "[MemWal] No accountId configured — sign in with Enoki or set MEMWAL_ACCOUNT_ID in .env" },
         { status: 401 },

--- a/apps/noter/app/api/memory/remember/route.ts
+++ b/apps/noter/app/api/memory/remember/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: Request) {
     }
 
     const { key, accountId } = await resolveUserKey(req);
-    if ((!key || !accountId) && (!process.env.MEMWAL_KEY || !process.env.MEMWAL_ACCOUNT_ID)) {
+    if ((!key || !accountId) && (!(process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY) || !process.env.MEMWAL_ACCOUNT_ID)) {
       return Response.json({ facts: [], count: 0 });
     }
 

--- a/apps/noter/package.json
+++ b/apps/noter/package.json
@@ -12,6 +12,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:reset": "tsx scripts/reset-db.ts && drizzle-kit push",
+    "verify:memwal": "tsx ../../scripts/verify-memwal-credentials.ts",
     "clean": "rm -rf .next out build"
   },
   "dependencies": {

--- a/apps/noter/package/feature/note/hook/use-pdw-client.ts
+++ b/apps/noter/package/feature/note/hook/use-pdw-client.ts
@@ -3,7 +3,7 @@
 /**
  * memwal Status Hook
  *
- * Simple hook to check if MemWal is configured (MEMWAL_KEY set).
+ * Simple hook to check if MemWal is configured (MEMWAL_PRIVATE_KEY set).
  * No client-side SDK needed — all operations go through server.
  */
 

--- a/apps/noter/package/feature/note/lib/pdw-client.ts
+++ b/apps/noter/package/feature/note/lib/pdw-client.ts
@@ -28,11 +28,11 @@ export function getMemWalClient(
   key?: string | null,
   accountId?: string | null,
 ): MemWal {
-  const resolvedKey = key || process.env.MEMWAL_KEY;
+  const resolvedKey = key || process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY;
   const resolvedAccountId = accountId || process.env.MEMWAL_ACCOUNT_ID;
 
   if (!resolvedKey) {
-    throw new Error("[MemWal] No key configured — sign in with Enoki or set MEMWAL_KEY in .env");
+    throw new Error("[MemWal] No key configured — sign in with Enoki or set MEMWAL_PRIVATE_KEY in .env");
   }
   if (!resolvedAccountId) {
     throw new Error("[MemWal] No accountId configured — sign in with Enoki or set MEMWAL_ACCOUNT_ID in .env");

--- a/apps/noter/package/feature/note/ui/pdw-status-indicator.tsx
+++ b/apps/noter/package/feature/note/ui/pdw-status-indicator.tsx
@@ -41,7 +41,7 @@ export function PDWStatusIndicator() {
             </div>
           </TooltipTrigger>
           <TooltipContent>
-            <p className="text-xs">MemWal not configured (MEMWAL_KEY not set)</p>
+            <p className="text-xs">MemWal not configured (MEMWAL_PRIVATE_KEY not set)</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/apps/noter/package/shared/lib/trpc/init.ts
+++ b/apps/noter/package/shared/lib/trpc/init.ts
@@ -23,12 +23,12 @@ async function loadUserMemwalKey(userId: string) {
   try {
     const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
     return {
-      memwalKey: user?.delegatePrivateKey ?? process.env.MEMWAL_KEY ?? null,
+      memwalKey: user?.delegatePrivateKey ?? process.env.MEMWAL_PRIVATE_KEY ?? process.env.MEMWAL_KEY ?? null,
       memwalAccountId: user?.delegateAccountId ?? process.env.MEMWAL_ACCOUNT_ID ?? null,
     };
   } catch {
     return {
-      memwalKey: process.env.MEMWAL_KEY ?? null,
+      memwalKey: process.env.MEMWAL_PRIVATE_KEY ?? process.env.MEMWAL_KEY ?? null,
       memwalAccountId: process.env.MEMWAL_ACCOUNT_ID ?? null,
     };
   }

--- a/apps/researcher/.env.example
+++ b/apps/researcher/.env.example
@@ -6,9 +6,13 @@ OPENROUTER_API_KEY=
 # Local: postgresql://user:pass@localhost:5432/researcher
 POSTGRES_URL=
 
-# memwal SDK — Ed25519 delegate key for memory layer
-MEMWAL_KEY=
-MEMWAL_SERVER_URL=http://localhost:3001
+# MemWal SDK — server-side delegate private key for memory layer.
+# Get these values from the MemWal dashboard. Run `pnpm verify:memwal` before starting.
+MEMWAL_PRIVATE_KEY=
+MEMWAL_ACCOUNT_ID=
+# Optional: paste the dashboard delegate public key so `pnpm verify:memwal` can catch mismatches.
+MEMWAL_DELEGATE_PUBLIC_KEY=
+MEMWAL_SERVER_URL=http://localhost:8000
 
 # Auth secret for JWT session signing
 # Generate: openssl rand -base64 32

--- a/apps/researcher/app/(chat)/api/chat/route.ts
+++ b/apps/researcher/app/(chat)/api/chat/route.ts
@@ -134,7 +134,7 @@ export async function POST(request: Request) {
     const modelMessages = await convertToModelMessages(uiMessages);
 
     // Resolve sprint context — pre-built during preparation and stored on chat record
-    const memwalKey = session.user.privateKey || process.env.MEMWAL_KEY;
+    const memwalKey = session.user.privateKey || process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY;
     const memwalAccountId = session.user.accountId || process.env.MEMWAL_ACCOUNT_ID;
     const resolvedSprintIds: string[] = chat?.sprintIds ?? [];
     const prebuiltSprintContext: string | null = chat?.sprintContext ?? null;

--- a/apps/researcher/app/api/sprint/prepare/route.ts
+++ b/apps/researcher/app/api/sprint/prepare/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
   }
 
   const { chatId, sprintIds, visibility = "private" } = body;
-  const memwalKey = session.user.privateKey || process.env.MEMWAL_KEY;
+  const memwalKey = session.user.privateKey || process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY;
   const memwalAccountId = session.user.accountId || process.env.MEMWAL_ACCOUNT_ID;
   const userId = session.user.id;
 

--- a/apps/researcher/app/api/sprint/save/route.ts
+++ b/apps/researcher/app/api/sprint/save/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     return new ChatbotError("bad_request:api").toResponse();
   }
 
-  const memwalKey = session.user.privateKey || process.env.MEMWAL_KEY;
+  const memwalKey = session.user.privateKey || process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY;
   const memwalAccountId = session.user.accountId || process.env.MEMWAL_ACCOUNT_ID;
   if (!memwalKey) {
     return new ChatbotError(

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -15,6 +15,7 @@
         "db:pull": "drizzle-kit pull",
         "db:check": "drizzle-kit check",
         "db:up": "drizzle-kit up",
+        "verify:memwal": "tsx ../../scripts/verify-memwal-credentials.ts",
         "test": "export PLAYWRIGHT=True && pnpm exec playwright test"
     },
     "dependencies": {

--- a/apps/researcher/scripts/migrate-user-pubkey.ts
+++ b/apps/researcher/scripts/migrate-user-pubkey.ts
@@ -1,9 +1,9 @@
 /**
  * One-time migration script: derives an ed25519 public key from
- * the MEMWAL_KEY env var and assigns it to an existing user record.
+ * the MEMWAL_PRIVATE_KEY env var and assigns it to an existing user record.
  *
  * Usage:
- *   MEMWAL_KEY=<hex-private-key> npx tsx scripts/migrate-user-pubkey.ts [userId]
+ *   MEMWAL_PRIVATE_KEY=<hex-private-key> npx tsx scripts/migrate-user-pubkey.ts [userId]
  *
  * If userId is omitted, lists all users so you can pick the right one.
  */
@@ -39,9 +39,9 @@ function bytesToHex(bytes: Uint8Array): string {
 }
 
 async function main() {
-  const privKeyHex = process.env.MEMWAL_KEY;
+  const privKeyHex = process.env.MEMWAL_PRIVATE_KEY || process.env.MEMWAL_KEY;
   if (!privKeyHex) {
-    console.error("MEMWAL_KEY env var is required");
+    console.error("MEMWAL_PRIVATE_KEY env var is required");
     process.exit(1);
   }
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -83,7 +83,7 @@ Config:
 |---|---|---|---|---|
 | `key` | `string` | Yes | — | Ed25519 delegate private key in hex |
 | `accountId` | `string` | Yes | — | MemWalAccount object ID on Sui |
-| `serverUrl` | `string` | No | `http://localhost:8000` | Relayer URL |
+| `serverUrl` | `string` | No | `https://relayer.memwal.ai` | Relayer URL |
 | `namespace` | `string` | No | `"default"` | Default namespace for memory isolation |
 
 ### `remember(text, namespace?): Promise<RememberAcceptedResult>`
@@ -100,11 +100,13 @@ Returns:
 
 Use `rememberAndWait(text, namespace?, opts?)` or `waitForRememberJob(job_id, opts?)` to resolve the completed `{ id, job_id, blob_id, owner, namespace }` result.
 
-### `recall(query, limit?, namespace?): Promise<RecallResult>`
+### `recall(query, limitOrOptions?, namespace?): Promise<RecallResult>`
 
 Search for memories matching a natural language query, scoped to `owner + namespace`.
 
-- `limit` defaults to `10`
+- `limitOrOptions` defaults to `10`
+- Pass a number for the legacy limit form, or `{ limit, topK, namespace, maxDistance }`
+- `maxDistance` filters weak matches client-side by dropping results where `distance >= maxDistance`
 
 Returns:
 ```ts
@@ -290,7 +292,7 @@ Used by `MemWal.create(config)` and `withMemWal(model, options)`.
 |---|---|---|
 | `key` | yes | Delegate private key in hex |
 | `accountId` | yes | MemWalAccount object ID on Sui |
-| `serverUrl` | no | Relayer URL. Default: `http://localhost:8000` |
+| `serverUrl` | no | Relayer URL. Default: `https://relayer.memwal.ai` |
 | `namespace` | no | Default memory boundary. Default: `"default"` |
 
 ### MemWalManualConfig

--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -83,9 +83,10 @@ RememberBulkResult(
 
 `remember_bulk_async` + `wait_for_remember_jobs` in one call.
 
-### `recall(query, limit=10, namespace=None) -> RecallResult`
+### `recall(query, limit=10, namespace=None, max_distance=None) -> RecallResult`
 
 Search memories matching a natural-language query, scoped to `owner + namespace`.
+When `max_distance` is set, the client drops weak matches where `distance >= max_distance`.
 
 ```python
 RecallResult(

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,7 +15,7 @@ Used by:
 | --- | --- | --- |
 | `key` | yes | Delegate private key in hex |
 | `accountId` | yes | MemWalAccount object ID on Sui |
-| `serverUrl` | no | Relayer URL. Default: `http://localhost:8000` |
+| `serverUrl` | no | Relayer URL. Default: `https://relayer.memwal.ai` |
 | `namespace` | no | Default memory boundary. Default: `"default"` |
 
 ## `MemWalManualConfig`

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -19,7 +19,7 @@ Config:
 | --- | --- | --- | --- | --- |
 | `key` | `string` | Yes | — | Ed25519 delegate private key in hex |
 | `accountId` | `string` | Yes | — | MemWalAccount object ID on Sui |
-| `serverUrl` | `string` | No | `http://localhost:8000` | Relayer URL |
+| `serverUrl` | `string` | No | `https://relayer.memwal.ai` | Relayer URL |
 | `namespace` | `string` | No | `"default"` | Default namespace for memory isolation |
 
 For the full config surface, see [Configuration](/reference/configuration).
@@ -77,11 +77,13 @@ Submit up to 20 memories in one request and return the accepted job IDs immediat
 
 Submit a bulk remember request and wait until every job reaches a terminal state.
 
-### `recall(query, limit?, namespace?): Promise<RecallResult>`
+### `recall(query, limitOrOptions?, namespace?): Promise<RecallResult>`
 
 Search for memories matching a natural language query, scoped to `owner + namespace`.
 
-- `limit` defaults to `10`
+- `limitOrOptions` defaults to `10`
+- Pass a number for the legacy limit form, or `{ limit, topK, namespace, maxDistance }`
+- `maxDistance` filters weak matches client-side by dropping results where `distance >= maxDistance`
 
 **Returns:**
 
@@ -95,6 +97,8 @@ Search for memories matching a natural language query, scoped to `owner + namesp
   total: number;
 }
 ```
+
+`distance` is cosine distance — lower is more similar.
 
 ### `analyze(text, namespace?): Promise<AnalyzeResult>`
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:docs": "pnpm --filter memwal-docs dev",
     "build:docs": "pnpm --filter memwal-docs build",
     "preview:docs": "pnpm --filter memwal-docs serve",
+    "verify:memwal": "tsx scripts/verify-memwal-credentials.ts",
     "check:compatibility": "node scripts/check-compatibility-contract.mjs",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules",
     "changeset": "changeset",

--- a/packages/python-sdk-memwal/README.md
+++ b/packages/python-sdk-memwal/README.md
@@ -23,10 +23,14 @@ pip install memwal[all]         # Everything
 Set your environment variables first:
 
 ```bash
-export MEMWAL_KEY="your-ed25519-delegate-key-hex"
+export MEMWAL_PRIVATE_KEY="your-ed25519-delegate-private-key-hex"
 export MEMWAL_ACCOUNT_ID="0x-your-memwal-account-id"
 export MEMWAL_SERVER_URL="https://relayer.memwal.ai"
 ```
+
+`MEMWAL_KEY` is still accepted as a backwards-compatibility alias, but new apps
+should use `MEMWAL_PRIVATE_KEY` so it is clear that the delegate private key is
+the server-side secret.
 
 ### Async (recommended)
 
@@ -37,7 +41,7 @@ from memwal import MemWal
 
 async def main():
     memwal = MemWal.create(
-        key=os.environ["MEMWAL_KEY"],
+        key=os.environ["MEMWAL_PRIVATE_KEY"],
         account_id=os.environ["MEMWAL_ACCOUNT_ID"],
         server_url=os.environ.get("MEMWAL_SERVER_URL", "https://relayer.memwal.ai"),
     )
@@ -47,7 +51,7 @@ async def main():
     print(result.blob_id)
 
     # Recall memories
-    matches = await memwal.recall("food allergies")
+    matches = await memwal.recall("food allergies", limit=10, max_distance=0.7)
     for memory in matches.results:
         print(f"{memory.text} (relevance: {1 - memory.distance:.2f})")
 
@@ -68,7 +72,7 @@ import os
 from memwal import MemWalSync
 
 client = MemWalSync.create(
-    key=os.environ["MEMWAL_KEY"],
+    key=os.environ["MEMWAL_PRIVATE_KEY"],
     account_id=os.environ["MEMWAL_ACCOUNT_ID"],
     server_url=os.environ.get("MEMWAL_SERVER_URL", "https://relayer.memwal.ai"),
 )
@@ -85,7 +89,7 @@ import os
 from memwal import MemWal
 
 async with MemWal.create(
-    key=os.environ["MEMWAL_KEY"],
+    key=os.environ["MEMWAL_PRIVATE_KEY"],
     account_id=os.environ["MEMWAL_ACCOUNT_ID"],
 ) as memwal:
     await memwal.remember("I prefer dark mode")
@@ -100,7 +104,7 @@ Same shorthand as the TypeScript SDK and MCP package.
 from memwal import MemWal
 
 memwal = MemWal.create(
-    key=os.environ["MEMWAL_KEY"],
+    key=os.environ["MEMWAL_PRIVATE_KEY"],
     account_id=os.environ["MEMWAL_ACCOUNT_ID"],
     env="prod",   # prod | dev | staging | local
 )
@@ -130,7 +134,7 @@ from memwal import with_memwal_langchain
 llm = ChatOpenAI(model="gpt-4o")
 smart_llm = with_memwal_langchain(
     llm,
-    key=os.environ["MEMWAL_KEY"],
+    key=os.environ["MEMWAL_PRIVATE_KEY"],
     account_id=os.environ["MEMWAL_ACCOUNT_ID"],
     server_url=os.environ.get("MEMWAL_SERVER_URL", "https://relayer.memwal.ai"),
     max_memories=5,
@@ -151,7 +155,7 @@ from memwal import with_memwal_openai
 client = AsyncOpenAI()
 smart_client = with_memwal_openai(
     client,
-    key=os.environ["MEMWAL_KEY"],
+    key=os.environ["MEMWAL_PRIVATE_KEY"],
     account_id=os.environ["MEMWAL_ACCOUNT_ID"],
     server_url=os.environ.get("MEMWAL_SERVER_URL", "https://relayer.memwal.ai"),
 )
@@ -174,7 +178,7 @@ Create a new async client.
 | Method | Description |
 |--------|-------------|
 | `await remember(text, namespace?)` | Store a memory |
-| `await recall(query, limit?, namespace?)` | Search memories |
+| `await recall(query, limit?, namespace?, max_distance?)` | Search memories, optionally filtering by distance |
 | `await analyze(text, namespace?)` | Extract and store facts |
 | `await ask(question, limit?, namespace?)` | Ask a question answered using memories |
 | `await restore(namespace, limit?)` | Restore a namespace |

--- a/packages/python-sdk-memwal/examples/.env.example
+++ b/packages/python-sdk-memwal/examples/.env.example
@@ -1,7 +1,9 @@
 # Local server (default) or remote relayer
-MEMWAL_SERVER_URL=http://localhost:3001
+MEMWAL_SERVER_URL=http://localhost:8000
 # Ed25519 delegate private key (64-hex). Get from MemWal dashboard.
-MEMWAL_KEY=21b423e72282dcc47805de48ef9130331b642667b7b2a5cd621767928205e360
+MEMWAL_PRIVATE_KEY=21b423e72282dcc47805de48ef9130331b642667b7b2a5cd621767928205e360
+# Optional: paste the dashboard delegate public key so verification can catch mismatches.
+MEMWAL_DELEGATE_PUBLIC_KEY=
 # MemWalAccount object ID on Sui (the wallet's account)
 MEMWAL_ACCOUNT_ID=0x8a1121b8f95d79e68bd07efaf71689ce6fd832b369cdb1b2a943ec7beb822392
 # Namespace for these test memories

--- a/packages/python-sdk-memwal/examples/async_remember_demo.py
+++ b/packages/python-sdk-memwal/examples/async_remember_demo.py
@@ -65,13 +65,13 @@ def _ms(start: float) -> int:
 
 
 async def main() -> None:
-    server_url = os.environ.get("MEMWAL_SERVER_URL", "http://localhost:3001")
-    key = os.environ.get("MEMWAL_KEY")
+    server_url = os.environ.get("MEMWAL_SERVER_URL", "http://localhost:8000")
+    key = os.environ.get("MEMWAL_PRIVATE_KEY") or os.environ.get("MEMWAL_KEY")
     account_id = os.environ.get("MEMWAL_ACCOUNT_ID")
     namespace = os.environ.get("MEMWAL_NAMESPACE", "python-sdk-example")
 
     if not key or not account_id:
-        print("ERROR: set MEMWAL_KEY + MEMWAL_ACCOUNT_ID in examples/.env")
+        print("ERROR: set MEMWAL_PRIVATE_KEY + MEMWAL_ACCOUNT_ID in examples/.env")
         sys.exit(2)
 
     print(f"server      : {server_url}")

--- a/packages/python-sdk-memwal/examples/interactive_demo.py
+++ b/packages/python-sdk-memwal/examples/interactive_demo.py
@@ -94,13 +94,13 @@ def _log_offset() -> int:
 
 
 async def main() -> None:
-    server_url = os.environ.get("MEMWAL_SERVER_URL", "http://localhost:3001")
-    key = os.environ.get("MEMWAL_KEY")
+    server_url = os.environ.get("MEMWAL_SERVER_URL", "http://localhost:8000")
+    key = os.environ.get("MEMWAL_PRIVATE_KEY") or os.environ.get("MEMWAL_KEY")
     account_id = os.environ.get("MEMWAL_ACCOUNT_ID")
     namespace = os.environ.get("MEMWAL_NAMESPACE", "python-sdk-example")
 
     if not key or not account_id:
-        print("ERROR: set MEMWAL_KEY + MEMWAL_ACCOUNT_ID in examples/.env")
+        print("ERROR: set MEMWAL_PRIVATE_KEY + MEMWAL_ACCOUNT_ID in examples/.env")
         sys.exit(2)
 
     print(f"server      : {server_url}")

--- a/packages/python-sdk-memwal/examples/verify_credentials.py
+++ b/packages/python-sdk-memwal/examples/verify_credentials.py
@@ -1,0 +1,67 @@
+"""Verify MemWal example credentials before calling the relayer.
+
+Usage:
+    MEMWAL_PRIVATE_KEY=<hex> MEMWAL_ACCOUNT_ID=0x... python examples/verify_credentials.py
+
+Optional:
+    Set MEMWAL_DELEGATE_PUBLIC_KEY to the dashboard public key to fail on
+    public/private key mismatch.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import nacl.signing
+
+HEX_32_BYTES = re.compile(r"^(0x)?[0-9a-fA-F]{64}$")
+ACCOUNT_ID = re.compile(r"^0x[0-9a-fA-F]{64}$")
+
+
+def normalize_hex(value: str) -> str:
+    value = value.strip()
+    return value[2:] if value.lower().startswith("0x") else value
+
+
+def main() -> None:
+    private_key = os.environ.get("MEMWAL_PRIVATE_KEY") or os.environ.get("MEMWAL_KEY") or ""
+    account_id = os.environ.get("MEMWAL_ACCOUNT_ID") or ""
+    expected_public_key = os.environ.get("MEMWAL_DELEGATE_PUBLIC_KEY") or ""
+    server_url = os.environ.get("MEMWAL_SERVER_URL") or ""
+
+    if not private_key:
+        raise SystemExit("MEMWAL_PRIVATE_KEY is required")
+    if not HEX_32_BYTES.match(private_key):
+        raise SystemExit("MEMWAL_PRIVATE_KEY must be a 64-character Ed25519 private key hex string")
+    if account_id and not ACCOUNT_ID.match(account_id):
+        raise SystemExit("MEMWAL_ACCOUNT_ID must be a 0x-prefixed 32-byte Sui object ID")
+
+    signing_key = nacl.signing.SigningKey(bytes.fromhex(normalize_hex(private_key)))
+    derived_public_key = signing_key.verify_key.encode().hex()
+
+    if expected_public_key and derived_public_key != normalize_hex(expected_public_key).lower():
+        raise SystemExit(
+            "MEMWAL_PRIVATE_KEY does not derive MEMWAL_DELEGATE_PUBLIC_KEY. "
+            "You may have pasted a public key or a key from another account."
+        )
+
+    print("MemWal credentials look parseable.")
+    print(f"Derived delegate public key: {derived_public_key}")
+    if account_id:
+        print(f"Account ID: {account_id}")
+    if server_url:
+        print(f"Relayer URL: {server_url}")
+    if not expected_public_key:
+        print("Set MEMWAL_DELEGATE_PUBLIC_KEY to fail on public/private key mismatch.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(exc, file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -112,4 +112,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -79,6 +79,11 @@ from .utils import (
 T = TypeVar("T")
 SEAL_SESSION_TTL_MIN = 5
 SEAL_SESSION_SAFETY_MARGIN_MS = 30_000
+AUTH_REJECTED_MESSAGE = (
+    "401 from relayer: typically wrong private key, key not registered on this "
+    "account, account ID mismatch, or staging/mainnet mismatch. Check .env.local "
+    "and dashboard credentials."
+)
 
 
 # ============================================================
@@ -472,6 +477,7 @@ class MemWal:
         query: str,
         limit: int = 10,
         namespace: Optional[str] = None,
+        max_distance: Optional[float] = None,
     ) -> RecallResult:
         """Recall memories similar to a query.
 
@@ -481,6 +487,8 @@ class MemWal:
             query: Search query.
             limit: Max number of results (default: 10).
             namespace: Override the default namespace.
+            max_distance: Optional client-side relevance threshold. Memories with
+                ``distance >= max_distance`` are dropped.
 
         Returns:
             :class:`RecallResult` with decrypted text results.
@@ -498,6 +506,9 @@ class MemWal:
             )
             for m in data.get("results", [])
         ]
+        if max_distance is not None:
+            memories = [m for m in memories if m.distance < max_distance]
+            return RecallResult(results=memories, total=len(memories))
         return RecallResult(results=memories, total=data.get("total", len(memories)))
 
     async def analyze(self, text: str, namespace: Optional[str] = None) -> AnalyzeResult:
@@ -991,7 +1002,10 @@ class _HttpStatusError(MemWalError):
     """
 
     def __init__(self, status: int, body: str) -> None:
-        super().__init__(f"MemWal API error ({status}): {body}")
+        if status == 401:
+            super().__init__(AUTH_REJECTED_MESSAGE)
+        else:
+            super().__init__(f"MemWal API error ({status}): {body}")
         self.status = status
         self.body = body
 
@@ -1170,10 +1184,14 @@ class MemWalSync:
         return self._run(self._inner.remember_bulk_and_wait(items, opts))
 
     def recall(
-        self, query: str, limit: int = 10, namespace: Optional[str] = None
+        self,
+        query: str,
+        limit: int = 10,
+        namespace: Optional[str] = None,
+        max_distance: Optional[float] = None,
     ) -> RecallResult:
         """Synchronous version of :meth:`MemWal.recall`."""
-        return self._run(self._inner.recall(query, limit, namespace))
+        return self._run(self._inner.recall(query, limit, namespace, max_distance))
 
     def analyze(self, text: str, namespace: Optional[str] = None) -> AnalyzeResult:
         """Synchronous version of :meth:`MemWal.analyze`."""

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python SDK for MemWal — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/run_tests.py
+++ b/packages/python-sdk-memwal/run_tests.py
@@ -8,7 +8,7 @@ Usage:
     python3 run_tests.py
 
 With dev server (integration tests):
-    MEMWAL_KEY=<hex> MEMWAL_ACCOUNT_ID=0x... MEMWAL_SERVER_URL=https://... python3 run_tests.py
+    MEMWAL_PRIVATE_KEY=<hex> MEMWAL_ACCOUNT_ID=0x... MEMWAL_SERVER_URL=https://... python3 run_tests.py
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ DIM    = "\033[2m"
 RESET  = "\033[0m"
 
 SERVER_URL  = os.environ.get("MEMWAL_SERVER_URL", "https://relayer.dev.memwal.ai")
-PRIVATE_KEY = os.environ.get("MEMWAL_KEY", "")
+PRIVATE_KEY = os.environ.get("MEMWAL_PRIVATE_KEY") or os.environ.get("MEMWAL_KEY", "")
 ACCOUNT_ID  = os.environ.get("MEMWAL_ACCOUNT_ID", "")
 HAS_KEY     = bool(PRIVATE_KEY and ACCOUNT_ID)
 
@@ -192,7 +192,7 @@ def main() -> None:
     print(f"  {'─' * 78}")
 
     if not HAS_KEY:
-        print(f"\n  {YELLOW}Integration tests skipped — set MEMWAL_KEY + MEMWAL_ACCOUNT_ID to run them{RESET}")
+        print(f"\n  {YELLOW}Integration tests skipped — set MEMWAL_PRIVATE_KEY + MEMWAL_ACCOUNT_ID to run them{RESET}")
         print_totals(total_passed, total_failed, all_failures)
         return
 

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -291,6 +291,31 @@ class TestRecall:
         assert "x-delegate-key" not in headers
 
     @respx.mock
+    async def test_max_distance_filters_results(self, memwal_client: MemWal) -> None:
+        """recall() should filter weak matches when max_distance is provided."""
+        mock_seal_session_prereqs()
+        route = respx.post(f"{_TEST_SERVER}/api/recall").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"blob_id": "b1", "text": "I love coffee", "distance": 0.2},
+                        {"blob_id": "b2", "text": "I live in Tokyo", "distance": 0.7},
+                    ],
+                    "total": 2,
+                },
+            )
+        )
+
+        result = await memwal_client.recall("coffee", limit=10, max_distance=0.7)
+
+        body = json.loads(route.calls[0].request.content)
+        assert body["limit"] == 10
+        assert len(result.results) == 1
+        assert result.total == 1
+        assert result.results[0].blob_id == "b1"
+
+    @respx.mock
     async def test_get_signed_request_uses_empty_body_hash_and_no_wire_body(
         self, memwal_client: MemWal
     ) -> None:
@@ -340,6 +365,22 @@ class TestErrorHandling:
 
         with pytest.raises(MemWalError, match="401"):
             await memwal_client.remember("test")
+
+    @respx.mock
+    async def test_empty_401_uses_workshop_friendly_message(
+        self, memwal_client: MemWal
+    ) -> None:
+        """Empty-body auth failures should still give actionable guidance."""
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/recall").mock(
+            return_value=httpx.Response(401, text="")
+        )
+
+        with pytest.raises(
+            MemWalError,
+            match="wrong private key.*account ID mismatch.*staging/mainnet mismatch",
+        ):
+            await memwal_client.recall("test")
 
     @respx.mock
     async def test_500_raises_memwal_error(self, memwal_client: MemWal) -> None:

--- a/packages/python-sdk-memwal/tests/test_integration.py
+++ b/packages/python-sdk-memwal/tests/test_integration.py
@@ -12,7 +12,7 @@ No-auth tests (always run, no env vars needed):
   - Future timestamp → 401
   - Unregistered key → SDK raises MemWalError
 
-Authenticated tests (require MEMWAL_KEY + MEMWAL_ACCOUNT_ID):
+Authenticated tests (require MEMWAL_PRIVATE_KEY + MEMWAL_ACCOUNT_ID):
   - remember() acceptance
   - remember_and_wait()
   - recall()
@@ -26,10 +26,10 @@ Usage:
   python -m pytest tests/test_integration.py -v -m "not requires_key"
 
   # Run full suite with real credentials
-  MEMWAL_KEY=<hex> MEMWAL_ACCOUNT_ID=0x... python -m pytest tests/test_integration.py -v
+  MEMWAL_PRIVATE_KEY=<hex> MEMWAL_ACCOUNT_ID=0x... python -m pytest tests/test_integration.py -v
 
   # Run against dev server using env vars
-  export MEMWAL_KEY="944aa24c09d8b6d6cc6a8fbedc6dc0942a46e49db7d36596e1b6af6061ec9261"
+  export MEMWAL_PRIVATE_KEY="944aa24c09d8b6d6cc6a8fbedc6dc0942a46e49db7d36596e1b6af6061ec9261"
   export MEMWAL_ACCOUNT_ID="0x70f9a6ff2df0ef6a9ecbfdc3f44c27c289ec3eb0cab5e10a5c07ca6165528565"
   export MEMWAL_SERVER_URL="https://relayer.dev.memwal.ai"
   python -m pytest tests/test_integration.py -v
@@ -53,14 +53,14 @@ from memwal.utils import build_signature_message, bytes_to_hex
 # ── Config ───────────────────────────────────────────────────────────────────
 
 SERVER_URL = os.environ.get("MEMWAL_SERVER_URL", "https://relayer.dev.memwal.ai")
-PRIVATE_KEY_HEX = os.environ.get("MEMWAL_KEY", "")
+PRIVATE_KEY_HEX = os.environ.get("MEMWAL_PRIVATE_KEY") or os.environ.get("MEMWAL_KEY", "")
 ACCOUNT_ID = os.environ.get("MEMWAL_ACCOUNT_ID", "")
 
 HAS_KEY = bool(PRIVATE_KEY_HEX and ACCOUNT_ID)
 
 requires_key = pytest.mark.skipif(
     not HAS_KEY,
-    reason="MEMWAL_KEY and MEMWAL_ACCOUNT_ID not set",
+    reason="MEMWAL_PRIVATE_KEY and MEMWAL_ACCOUNT_ID not set",
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -26,15 +26,21 @@ pnpm add @mysten/sui @mysten/seal @mysten/walrus ai zod
 import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
-  key: "your-delegate-key-hex",
-  accountId: "your-memwal-account-id",
-  serverUrl: "https://your-relayer-url.com",
+  key: process.env.MEMWAL_PRIVATE_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+  serverUrl: process.env.MEMWAL_SERVER_URL ?? "https://relayer.memwal.ai",
   namespace: "demo",
 });
 
-const job = await memwal.remember("User prefers dark mode and uses TypeScript.");
-await memwal.waitForRememberJob(job.job_id);
-const memories = await memwal.recall("What are the user's preferences?");
+await memwal.rememberAndWait(
+  "User prefers dark mode and uses TypeScript.",
+  undefined,
+  { timeoutMs: 30_000 },
+);
+const memories = await memwal.recall("What are the user's preferences?", {
+  topK: 10,
+  maxDistance: 0.7,
+});
 await memwal.restore("demo");
 ```
 

--- a/packages/sdk/src/ai/middleware.ts
+++ b/packages/sdk/src/ai/middleware.ts
@@ -10,7 +10,7 @@
  * import { openai } from "@ai-sdk/openai"
  *
  * const model = withMemWal(openai("gpt-4o"), {
- *   key: process.env.MEMWAL_KEY,  // Ed25519 delegate key (hex)
+ *   key: process.env.MEMWAL_PRIVATE_KEY,  // Ed25519 delegate private key (hex)
  * })
  *
  * const result = await generateText({

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -30,6 +30,7 @@ export type {
     RememberResult,
     RecallResult,
     RecallMemory,
+    RecallOptions,
     EmbedResult,
     AnalyzeResult,
     AnalyzeWaitResult,

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -33,6 +33,7 @@ import type {
     RememberResult,
     RecallResult,
     RecallMemory,
+    RecallOptions,
     EmbedResult,
     AnalyzeResult,
     AnalyzeWaitResult,
@@ -112,6 +113,10 @@ function pollingDelayMs(baseMs: number, attempt: number): number {
 
 function isTransientPollingStatus(status: number): boolean {
     return status === 0 || status === 429 || status >= 500;
+}
+
+function normalizeSuiNetworkForGrpc(network: string): string {
+    return network === "local" ? "localnet" : network;
 }
 
 export class MemWal {
@@ -467,7 +472,7 @@ export class MemWal {
      * verify → embed query → search → Walrus download → decrypt → return plaintext
      *
      * @param query - Search query
-     * @param limit - Max number of results (default: 10)
+     * @param limitOrOptions - Max number of results (default: 10), or recall options
      * @returns RecallResult with decrypted text results
      *
      * @example
@@ -478,15 +483,43 @@ export class MemWal {
      * }
      * ```
      */
-    async recall(query: string, limit: number = 10, namespace?: string): Promise<RecallResult> {
+    async recall(
+        query: string,
+        limitOrOptions: number | RecallOptions | undefined = 10,
+        namespace?: string,
+    ): Promise<RecallResult> {
+        let options: RecallOptions;
+        if (limitOrOptions == null) {
+            options = { limit: 10, namespace };
+        } else if (typeof limitOrOptions === "number") {
+            options = { limit: limitOrOptions, namespace };
+        } else {
+            options = limitOrOptions;
+        }
+        const limit = options.topK ?? options.limit ?? 10;
+        const resolvedNamespace = options.namespace ?? this.namespace;
+
         const ac = new AbortController();
         const tid = setTimeout(() => ac.abort(), 15000);
         try {
-            return await this.signedRequest<RecallResult>("POST", "/api/recall", {
+            const result = await this.signedRequest<RecallResult>("POST", "/api/recall", {
                 query,
                 limit,
-                namespace: namespace ?? this.namespace,
+                namespace: resolvedNamespace,
             }, { signal: ac.signal });
+
+            if (typeof options.maxDistance === "number") {
+                const filtered = result.results.filter(
+                    (memory) => memory.distance < options.maxDistance!,
+                );
+                return {
+                    ...result,
+                    results: filtered,
+                    total: filtered.length,
+                };
+            }
+
+            return result;
         } finally {
             clearTimeout(tid);
         }
@@ -759,14 +792,29 @@ export class MemWal {
 
     private async buildSealSessionInner(): Promise<string> {
         const cfg = await this.fetchServerConfig();
-        // @mysten/sui renamed/moved `SuiClient` between minor versions:
-        //   - pre-2.6:  `SuiClient` in `@mysten/sui/client`
-        //   - 2.6+:     `SuiJsonRpcClient` in `@mysten/sui/jsonRpc`
-        // Probe both paths so the SDK works across the supported range.
         const sealMod = (await import("@mysten/seal")) as any;
         const ed25519Mod = (await import("@mysten/sui/keypairs/ed25519")) as any;
         const SessionKey = sealMod.SessionKey;
         const Ed25519Keypair = ed25519Mod.Ed25519Keypair;
+
+        const clientCandidates: Array<{ name: string; client: any }> = [];
+
+        // Prefer Sui's gRPC client on modern @mysten/sui versions. Keep the
+        // JSON-RPC probes as compatibility fallbacks for older peer installs.
+        try {
+            const mod = (await import("@mysten/sui/grpc")) as any;
+            if (typeof mod.SuiGrpcClient === "function") {
+                clientCandidates.push({
+                    name: "SuiGrpcClient",
+                    client: new mod.SuiGrpcClient({
+                        network: normalizeSuiNetworkForGrpc(cfg.network),
+                        baseUrl: cfg.suiRpcUrl,
+                    }),
+                });
+            }
+        } catch {
+            /* @mysten/sui/grpc is not present on this version */
+        }
 
         let SuiClient: any = undefined;
         try {
@@ -783,23 +831,45 @@ export class MemWal {
                 /* not present on this version either */
             }
         }
-        if (typeof SuiClient !== "function" || typeof Ed25519Keypair !== "function") {
+        if (typeof SuiClient === "function") {
+            clientCandidates.push({
+                name: "SuiClient",
+                client: new SuiClient({ url: cfg.suiRpcUrl }),
+            });
+        }
+
+        if (clientCandidates.length === 0 || typeof Ed25519Keypair !== "function") {
             throw new Error(
-                "SuiClient/SuiJsonRpcClient or Ed25519Keypair not found in @mysten/sui. " +
+                "SuiGrpcClient/SuiClient or Ed25519Keypair not found in @mysten/sui. " +
                 "Ensure @mysten/sui >=2.5.0 and @mysten/seal >=1.1.0 are installed."
             );
         }
 
         const keypair = Ed25519Keypair.fromSecretKey(this.privateKey);
-        const suiClient = new SuiClient({ url: cfg.suiRpcUrl });
 
-        const session = await SessionKey.create({
-            address: keypair.getPublicKey().toSuiAddress(),
-            packageId: cfg.packageId,
-            ttlMin: SEAL_SESSION_TTL_MIN,
-            signer: keypair,
-            suiClient: suiClient as any,
-        });
+        // gRPC getObject returns { object } whereas legacy JSON-RPC returns
+        // { data }. SessionKey accepts either through the shared core client
+        // interface. If the relayer still serves a JSON-RPC URL in config,
+        // the legacy client remains a runtime fallback.
+        let session: any = undefined;
+        let lastClientError: unknown;
+        for (const candidate of clientCandidates) {
+            try {
+                session = await SessionKey.create({
+                    address: keypair.getPublicKey().toSuiAddress(),
+                    packageId: cfg.packageId,
+                    ttlMin: SEAL_SESSION_TTL_MIN,
+                    signer: keypair,
+                    suiClient: candidate.client as any,
+                });
+                break;
+            } catch (err) {
+                lastClientError = err;
+            }
+        }
+        if (!session) {
+            throw lastClientError;
+        }
 
         // Eagerly sign the personal message so the exported envelope is
         // fully self-contained. `SessionKey.create()` defers this signing

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -14,7 +14,7 @@ export interface MemWalConfig {
     key: string | Uint8Array;
     /** MemWalAccount object ID on Sui (ensures correct account when delegate key exists in multiple accounts) */
     accountId: string;
-    /** Server URL (default: http://localhost:8000) */
+    /** Server URL (default: https://relayer.memwal.ai) */
     serverUrl?: string;
     /** Default namespace for memory isolation (default: "default") */
     namespace?: string;
@@ -62,6 +62,18 @@ export interface RecallMemory {
 export interface RecallResult {
     results: RecallMemory[];
     total: number;
+}
+
+/** Options for recall(). */
+export interface RecallOptions {
+    /** Max number of nearest memories to request from the relayer (default: 10). */
+    limit?: number;
+    /** Alias for limit, useful when describing top-K search behaviour. */
+    topK?: number;
+    /** Namespace override (default: config namespace or "default"). */
+    namespace?: string;
+    /** Drop memories whose distance is greater than or equal to this value. */
+    maxDistance?: number;
 }
 
 /** Result from rememberBulk() / rememberBulkAsync() */
@@ -270,7 +282,7 @@ export interface SealServerConfig {
 export interface MemWalManualConfig {
     /** Ed25519 delegate private key (hex or Uint8Array) for server auth */
     key: string | Uint8Array;
-    /** Server URL (default: http://localhost:8000) */
+    /** Server URL (default: https://relayer.memwal.ai) */
     serverUrl?: string;
     /**
      * Sui private key (bech32 suiprivkey1...) for SEAL + Walrus signing.

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -119,6 +119,16 @@ export function sanitizeServerError(
     status: number,
     rawBody: string,
 ): { message: string; raw: string; serverCode?: string } {
+    if (status === 401) {
+        return {
+            message:
+                "401 from relayer: typically wrong private key, key not registered on this account, " +
+                "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials.",
+            raw: rawBody,
+            serverCode: "AUTH_REJECTED",
+        };
+    }
+
     const MAX = 200;
     let serverCode: string | undefined;
     let text = rawBody;
@@ -192,4 +202,3 @@ export async function delegateKeyToPublicKey(privateKeyHex: string): Promise<Uin
     const ed = await import("@noble/ed25519");
     return ed.getPublicKeyAsync(hexToBytes(privateKeyHex));
 }
-

--- a/scripts/verify-memwal-credentials.ts
+++ b/scripts/verify-memwal-credentials.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env tsx
+
+import { delegateKeyToPublicKey } from "../packages/sdk/src/utils.ts";
+
+const HEX_32_BYTES = /^(0x)?[0-9a-fA-F]{64}$/;
+const ACCOUNT_ID = /^0x[0-9a-fA-F]{64}$/;
+
+function normalizeHex(value: string): string {
+    return value.trim().replace(/^0x/i, "").toLowerCase();
+}
+
+async function main() {
+    const privateKey =
+        process.env.MEMWAL_PRIVATE_KEY ?? process.env.MEMWAL_KEY ?? "";
+    const accountId = process.env.MEMWAL_ACCOUNT_ID ?? "";
+    const expectedPublicKey = process.env.MEMWAL_DELEGATE_PUBLIC_KEY ?? "";
+    const serverUrl = process.env.MEMWAL_SERVER_URL ?? "";
+
+    if (!privateKey) {
+        throw new Error("MEMWAL_PRIVATE_KEY is required");
+    }
+    if (!HEX_32_BYTES.test(privateKey)) {
+        throw new Error("MEMWAL_PRIVATE_KEY must be a 64-character Ed25519 private key hex string");
+    }
+    if (accountId && !ACCOUNT_ID.test(accountId)) {
+        throw new Error("MEMWAL_ACCOUNT_ID must be a 0x-prefixed 32-byte Sui object ID");
+    }
+
+    const derivedPublicKey = Buffer.from(
+        await delegateKeyToPublicKey(normalizeHex(privateKey)),
+    ).toString("hex");
+
+    if (expectedPublicKey) {
+        const expected = normalizeHex(expectedPublicKey);
+        if (!HEX_32_BYTES.test(expectedPublicKey) || derivedPublicKey !== expected) {
+            throw new Error(
+                "MEMWAL_PRIVATE_KEY does not derive MEMWAL_DELEGATE_PUBLIC_KEY. " +
+                "You may have pasted a public key or a key from another account.",
+            );
+        }
+    }
+
+    console.log("MemWal credentials look parseable.");
+    console.log(`Derived delegate public key: ${derivedPublicKey}`);
+    if (accountId) console.log(`Account ID: ${accountId}`);
+    if (serverUrl) console.log(`Relayer URL: ${serverUrl}`);
+    if (!expectedPublicKey) {
+        console.log("Set MEMWAL_DELEGATE_PUBLIC_KEY to make this script fail on public/private key mismatch.");
+    }
+}
+
+main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Updates SKILL.md and SDK docs for response shapes, `*AndWait` guidance, namespace/key handling, recall distance filtering, and 401 troubleshooting.
- Adds client-side recall distance filtering support in TS/Python SDKs.
- Renames runtime and example env guidance to `MEMWAL_PRIVATE_KEY` and removes the old `MEMWAL_KEY` fallback to avoid credential ambiguity.
- Adds credential verification helpers.

## Deployment note
Railway/services that use MemWal memory must set `MEMWAL_PRIVATE_KEY` now; `MEMWAL_KEY` is no longer read.

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc`
- `python3 -m pytest packages/python-sdk-memwal/tests/test_client.py -q`
- `git diff --check`

Note: npm latest for `@mysten-incubation/memwal` is still `0.0.4`; local package is already `0.0.5`, so no new TS changeset was added to avoid bumping to `0.0.6`.