### PR TITLE
Feat: Filter recall results by Walrus blob lease epoch

### DIFF
--- a/services/server/migrations/010_blob_end_epoch.sql
+++ b/services/server/migrations/010_blob_end_epoch.sql
@@ -1,0 +1,46 @@
+-- Blob-expiry tracking on `vector_entries`. Walrus storage leases are
+-- denominated in EPOCHS (integers), not wall-clock time, and epoch duration
+-- drifts (advances via on-chain events, not a fixed clock). Any
+-- created_at-based heuristic drifts in both directions — too-late serves a
+-- dead blob (404), too-early prunes a still-alive memory (data loss). Working
+-- in exact epoch numbers removes the drift entirely: each blob is sealed
+-- until a fixed `end_epoch`, and "is it expired?" is the integer test
+-- `end_epoch <= current_epoch`.
+--
+-- `end_epoch`  — the blob's on-chain `storage.end_epoch` (a u32 on chain;
+--   stored BIGINT for headroom). Recorded at write time from the upload
+--   result (no extra chain call) and filled in for legacy rows by a separate
+--   re-runnable backfill script. NULL means "no expiry tracked" — benchmark
+--   rows and any row not yet backfilled. The recall filter treats NULL as
+--   ALWAYS-SERVED, so this migration is purely additive: behaviour doesn't
+--   change for any row until a real `end_epoch` is written.
+--
+-- `object_id` — the blob's Sui object id. Already returned by the upload but
+--   previously discarded. Persisting it lets the backfill (and any future
+--   on-chain re-read) skip the expensive blob_id → object_id resolution
+--   scan, leaving that cost only for the pre-existing legacy backlog.
+--
+-- Both columns are NULLABLE with no default and no data backfill here: the
+-- migration is pure DDL and must stay cheap (it runs at every server boot).
+-- The data step is the standalone backfill script, deliberately separate so
+-- a chain-read failure can't block startup.
+
+ALTER TABLE vector_entries
+    ADD COLUMN IF NOT EXISTS end_epoch BIGINT NULL;
+
+ALTER TABLE vector_entries
+    ADD COLUMN IF NOT EXISTS object_id TEXT NULL;
+
+-- No dedicated end_epoch index. The recall filter
+--   WHERE owner=$ AND namespace=$ AND (end_epoch IS NULL OR end_epoch > $)
+-- is driven by the existing (owner, namespace) index from migration 002;
+-- end_epoch is a cheap recheck on the already-narrow per-owner row set.
+-- A standalone partial index on `(end_epoch) WHERE end_epoch IS NOT NULL`
+-- can't serve this query because the `OR end_epoch IS NULL` branch
+-- contradicts the index predicate — confirmed via EXPLAIN; the planner
+-- rechecks regardless. It would just add write-maintenance cost. If a
+-- prune (`DELETE WHERE end_epoch <= current`) is ever added, a tuned
+-- index can come with it.
+--
+-- DROP an index left over from an earlier draft of this migration.
+DROP INDEX IF EXISTS idx_vector_entries_end_epoch;

--- a/services/server/scripts/backfill-end-epoch.ts
+++ b/services/server/scripts/backfill-end-epoch.ts
@@ -1,0 +1,398 @@
+/**
+ * Backfill `vector_entries.end_epoch` for legacy rows.
+ *
+ * Rows written before the expiry feature shipped have no `end_epoch`, so the
+ * recall filter falls back to "always serve" for them — safe, but means the
+ * fix is incomplete until this script runs and fills in real lease state.
+ *
+ * Strategy: read each blob's `storage.end_epoch` straight from chain via
+ * `walrusClient.getBlobObject(objectId)`. That's exact (no timestamp→epoch
+ * estimation, no assumption about how many epochs were originally bought) and
+ * works for our `deletable: true` blobs (`getVerifiedBlobStatus` doesn't —
+ * it omits `endEpoch` for the deletable variant).
+ *
+ * `getBlobObject` needs the Sui object id, but legacy rows store only
+ * `blob_id`. We resolve in this order:
+ *   1. Row already has `object_id` (written by post-feature paths) — use it.
+ *   2. Otherwise, the sidecar's `/walrus/query-blobs` does a per-owner wallet
+ *      scan that returns `blobId` already converted to the base64url form
+ *      stored in `vector_entries.blob_id` — so map lookups match the DB
+ *      directly with no u256↔base64url encoding step on this side.
+ *
+ * Safety properties:
+ *   - DRY-RUN BY DEFAULT. `--apply` writes; `--limit N` caps rows; `--owner
+ *     0x…` scopes to one wallet.
+ *   - Re-runnable: the UPDATE is guarded `WHERE end_epoch IS NULL`, so it
+ *     can't overwrite a value the live server has written.
+ *   - Benchmark rows (`plaintext IS NOT NULL`) are skipped — they have no
+ *     Walrus blob.
+ *   - We only write `end_epoch = 0` (= "filtered/dead") when the chain itself
+ *     confirms the blob is gone (ObjectError.code = notExists/deleted). Any
+ *     other failure — transient RPC, unresolved object id, partial scan — is
+ *     left NULL for the next run. We never guess in the dead direction.
+ *
+ * Same env shape as the server so one script can target dev or mainnet:
+ *   DATABASE_URL          source DB
+ *   SUI_NETWORK           testnet | mainnet — cross-checked against sidecar
+ *   SIDECAR_URL           default http://127.0.0.1:9000
+ *   SIDECAR_AUTH_TOKEN    required (script aborts early without it)
+ *   SUI_RPC_URL           optional fullnode override
+ *
+ * Usage:
+ *   tsx backfill-end-epoch.ts                              # dry-run, all owners
+ *   tsx backfill-end-epoch.ts --apply --limit 50           # apply, capped
+ *   tsx backfill-end-epoch.ts --apply --owner 0xabc...     # one wallet
+ */
+
+import postgres from "postgres";
+import { WalrusClient } from "@mysten/walrus";
+import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
+
+// ── CLI args ──────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const APPLY = args.includes("--apply");
+
+// Reject a flag whose value is missing or is itself another `--flag` rather
+// than silently mis-scoping the run — `--owner` with no value would otherwise
+// scan ALL owners, and `--limit` with no value would parse as NaN.
+function flagValue(name: string): string | null {
+    const i = args.indexOf(name);
+    if (i < 0) return null;
+    const v = args[i + 1];
+    if (v === undefined || v.startsWith("--")) {
+        console.error(`[backfill] FATAL: ${name} requires a value`);
+        process.exit(1);
+    }
+    return v;
+}
+const ONLY_OWNER = flagValue("--owner");
+const limitStr = flagValue("--limit");
+let ROW_LIMIT: number | null = null;
+if (limitStr !== null) {
+    const n = parseInt(limitStr, 10);
+    if (!Number.isInteger(n) || n < 1) {
+        console.error(`[backfill] FATAL: --limit must be a positive integer (got "${limitStr}")`);
+        process.exit(1);
+    }
+    ROW_LIMIT = n;
+}
+
+// ── Env ───────────────────────────────────────────────────────────────────
+function requireEnv(name: string): string {
+    const v = process.env[name];
+    if (!v) {
+        console.error(`[backfill] FATAL: ${name} not set`);
+        process.exit(1);
+    }
+    return v;
+}
+
+const DATABASE_URL = requireEnv("DATABASE_URL");
+const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
+const SIDECAR_URL = process.env.SIDECAR_URL || "http://127.0.0.1:9000";
+// The sidecar mandates auth; a missing token would 401 every owner and get
+// logged as a per-owner "resolve FAILED" — a run that looks successful but
+// wrote nothing. Require the token up front instead of degrading silently.
+const SIDECAR_AUTH_TOKEN = requireEnv("SIDECAR_AUTH_TOKEN");
+
+type LegacyRow = { id: string; owner: string; blob_id: string; object_id: string | null };
+type QueryBlob = { blobId: string; objectId: string };
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Catch the most plausible operator footgun before touching the DB: a
+// mismatched SUI_NETWORK env (testnet DB + mainnet env, or a SIDECAR_URL
+// pointing at the wrong sidecar) would silently make every owner's wallet
+// scan return zero blobs — every row left NULL, run looks like a clean
+// no-op but is actually miscoverage. The sidecar reports `suiNetwork` on the
+// current-epoch endpoint already; one call here and bail on mismatch.
+async function assertSidecarNetworkMatches(): Promise<void> {
+    const url = `${SIDECAR_URL}/walrus/current-epoch`;
+    let resp: Response;
+    try {
+        resp = await fetch(url, {
+            headers: { authorization: `Bearer ${SIDECAR_AUTH_TOKEN}` },
+        });
+    } catch (e: any) {
+        console.error(`[backfill] FATAL: sidecar unreachable at ${SIDECAR_URL}: ${e?.message || e}`);
+        process.exit(1);
+    }
+    if (resp.status === 401 || resp.status === 403) {
+        console.error(`[backfill] FATAL: sidecar rejected auth (${resp.status}) — check SIDECAR_AUTH_TOKEN`);
+        process.exit(1);
+    }
+    if (!resp.ok) {
+        console.error(`[backfill] FATAL: sidecar /walrus/current-epoch ${resp.status} ${await resp.text()}`);
+        process.exit(1);
+    }
+    const body = (await resp.json()) as { epoch: number; suiNetwork?: string };
+    if (body.suiNetwork && body.suiNetwork !== SUI_NETWORK) {
+        console.error(
+            `[backfill] FATAL: SUI_NETWORK env is "${SUI_NETWORK}" but sidecar at ${SIDECAR_URL} ` +
+                `reports network "${body.suiNetwork}". Refusing to run — this would silently miscover ` +
+                `every owner. Fix SUI_NETWORK or SIDECAR_URL and retry.`,
+        );
+        process.exit(1);
+    }
+    console.log(`[backfill] sidecar check ok: network=${body.suiNetwork ?? "?"}, current_epoch=${body.epoch}`);
+}
+
+// Per-owner pacing + retry config, overridable via env. A per-owner wallet
+// scan is several getOwnedObjects pages; firing many back-to-back trips the
+// RPC's 429 limit (observed in practice). A small inter-owner delay plus
+// exponential backoff on 429/503 keeps a one-shot run within the limits
+// without losing rows — the script is re-runnable, so any owner we still
+// can't resolve is just picked up next pass.
+const OWNER_DELAY_MS = Number(process.env.BACKFILL_OWNER_DELAY_MS || 1500);
+const MAX_RETRIES = Number(process.env.BACKFILL_MAX_RETRIES || 5);
+
+// ── Sidecar resolver: blob_id → object_id, per owner ────────────────────────
+// The sidecar returns each blob's `blobId` already converted to base64url
+// (matching what vector_entries.blob_id stores), so the map keys line up with
+// the DB directly — no conversion on this side.
+
+// Distinct error class so the per-owner catch can re-throw auth failures up to
+// main(). An auth misconfig affects every owner; logging it per-owner as a
+// "resolve FAILED" would mislead the operator into thinking it's recoverable.
+class SidecarAuthError extends Error {}
+
+async function resolveOwnerBlobMap(owner: string): Promise<Map<string, string>> {
+    const url = `${SIDECAR_URL}/walrus/query-blobs`;
+    let attempt = 0;
+    for (;;) {
+        const resp = await fetch(url, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${SIDECAR_AUTH_TOKEN}`,
+            },
+            // NO `limit` field — the sidecar has a fast path that activates
+            // when limit>0 and caps at 100 candidates (newest first), which
+            // would silently miss older blobs on a heavy wallet. We want
+            // the exhaustive getOwnedObjects scan.
+            body: JSON.stringify({ owner }),
+        });
+        if (resp.ok) {
+            const data = (await resp.json()) as { blobs: QueryBlob[]; total: number };
+            const map = new Map<string, string>();
+            for (const b of data.blobs) {
+                if (b.blobId && b.objectId) map.set(b.blobId, b.objectId);
+            }
+            return map;
+        }
+        // Auth rejection is global, not per-owner — fail the whole run loudly.
+        if (resp.status === 401 || resp.status === 403) {
+            throw new SidecarAuthError(
+                `sidecar rejected auth (${resp.status}) — check SIDECAR_AUTH_TOKEN`,
+            );
+        }
+        const bodyText = await resp.text();
+        // The sidecar wraps upstream RPC 429/503 in a 500 whose body carries the
+        // real status, so check both the HTTP code and the body text.
+        const rateLimited = resp.status === 429 || resp.status === 503 ||
+            /\b(429|503)\b/.test(bodyText);
+        if (rateLimited && attempt < MAX_RETRIES) {
+            const backoff = Math.min(30_000, 1000 * 2 ** attempt) + Math.floor(Math.random() * 500);
+            console.warn(`[backfill] owner=${short(owner)} rate-limited (attempt ${attempt + 1}/${MAX_RETRIES}); backoff ${backoff}ms`);
+            await sleep(backoff);
+            attempt++;
+            continue;
+        }
+        throw new Error(`query-blobs failed for owner=${owner}: ${resp.status} ${bodyText}`);
+    }
+}
+
+async function main() {
+    console.log(
+        `[backfill] start network=${SUI_NETWORK} apply=${APPLY} ` +
+            `owner=${ONLY_OWNER ?? "*"} limit=${ROW_LIMIT ?? "none"} sidecar=${SIDECAR_URL}`,
+    );
+    if (!APPLY) console.log("[backfill] DRY-RUN — no writes. Pass --apply to persist.");
+
+    // Cross-check the sidecar's network matches our SUI_NETWORK env BEFORE
+    // opening the DB pool / doing any work. Bails hard on mismatch.
+    await assertSidecarNetworkMatches();
+
+    const sql = postgres(DATABASE_URL, { max: 4 });
+
+    // Sanity-check: confirm migration 010 has been applied to this DB. Without
+    // the end_epoch + object_id columns the script can't run; without a clear
+    // up-front error the operator sees a raw "column does not exist" postgres
+    // stack from much further down. Catch it here and tell them why.
+    try {
+        const cols: { column_name: string }[] = await sql`
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'vector_entries'
+              AND column_name IN ('end_epoch', 'object_id')
+        `;
+        const have = new Set(cols.map((r) => r.column_name));
+        const missing = ["end_epoch", "object_id"].filter((c) => !have.has(c));
+        if (missing.length > 0) {
+            console.error(
+                `[backfill] FATAL: vector_entries is missing column(s) [${missing.join(", ")}] — ` +
+                    `migration 010 has not been applied to ${maskUrl(DATABASE_URL)}. ` +
+                    `Deploy the server (which auto-runs 010) before running the backfill.`,
+            );
+            await sql.end({ timeout: 5 });
+            process.exit(1);
+        }
+    } catch (e: any) {
+        console.error(`[backfill] FATAL: schema check failed: ${e?.message || e}`);
+        await sql.end({ timeout: 5 });
+        process.exit(1);
+    }
+    const suiClient = new SuiJsonRpcClient({
+        url: process.env.SUI_RPC_URL || getJsonRpcFullnodeUrl(SUI_NETWORK),
+        network: SUI_NETWORK,
+    });
+    const walrusClient = new WalrusClient({ network: SUI_NETWORK, suiClient: suiClient as any });
+
+    // Drain the pool on every exit path — including a re-thrown
+    // SidecarAuthError or an unexpected DB error mid-run.
+    try {
+    // Rows needing backfill: production only (plaintext IS NULL), not yet set.
+    const rows: LegacyRow[] = await sql`
+        SELECT id, owner, blob_id, object_id
+        FROM vector_entries
+        WHERE end_epoch IS NULL
+          AND plaintext IS NULL
+          ${ONLY_OWNER ? sql`AND owner = ${ONLY_OWNER}` : sql``}
+        ORDER BY owner, id
+        ${ROW_LIMIT ? sql`LIMIT ${ROW_LIMIT}` : sql``}
+    `;
+    console.log(`[backfill] ${rows.length} candidate row(s)`);
+
+    // Group by owner so each owner's expensive blob scan runs once.
+    const byOwner = new Map<string, LegacyRow[]>();
+    for (const r of rows) {
+        const list = byOwner.get(r.owner) ?? [];
+        list.push(r);
+        byOwner.set(r.owner, list);
+    }
+
+    const stats = { set: 0, markedGone: 0, leftNull: 0, skippedHaveObjId: 0, errors: 0 };
+
+    let ownerIdx = 0;
+    for (const [owner, ownerRows] of byOwner) {
+        // Pace owners apart so consecutive wallet scans don't trip the RPC
+        // 429 limit. Skipped before the first owner.
+        if (ownerIdx > 0 && OWNER_DELAY_MS > 0) await sleep(OWNER_DELAY_MS);
+        ownerIdx++;
+
+        // Build the blob_id → object_id map for rows that don't already carry it.
+        let ownerMap: Map<string, string> | null = null;
+        const needResolve = ownerRows.some((r) => !r.object_id);
+        if (needResolve) {
+            try {
+                ownerMap = await resolveOwnerBlobMap(owner);
+                console.log(`[backfill] owner=${short(owner)} resolved ${ownerMap.size} blob(s) on-chain`);
+            } catch (e: any) {
+                // Auth failure is global config, not a per-owner transient —
+                // abort the whole run so it's not mistaken for a partial success.
+                if (e instanceof SidecarAuthError) throw e;
+                console.error(`[backfill] owner=${short(owner)} resolve FAILED (leaving rows NULL for re-run): ${e?.message || e}`);
+                stats.errors += ownerRows.length;
+                stats.leftNull += ownerRows.length;
+                continue;
+            }
+        }
+
+        for (const row of ownerRows) {
+            const objectId = row.object_id ?? ownerMap?.get(row.blob_id) ?? null;
+            if (row.object_id) stats.skippedHaveObjId++;
+
+            if (!objectId) {
+                // Object id unresolvable. The blob isn't owned by this wallet
+                // anymore (transferred away) or never appeared in the scan.
+                // We can't confirm it's gone, so DON'T guess — leave NULL.
+                console.warn(`[backfill] row=${row.id} blob=${short(row.blob_id)} owner=${short(owner)} unresolved → leave NULL`);
+                stats.leftNull++;
+                continue;
+            }
+
+            let endEpoch: number | null = null;
+            try {
+                const blobObj = await walrusClient.getBlobObject(objectId);
+                const raw = (blobObj as any)?.storage?.end_epoch;
+                endEpoch = typeof raw === "number" ? raw : Number(raw);
+                if (!Number.isFinite(endEpoch)) endEpoch = null;
+            } catch (e: any) {
+                // Asymmetric, IRREVERSIBLE decision: distinguish "the blob is
+                // genuinely gone" (write end_epoch=0 ⇒ filtered from recall
+                // forever; the re-run guard `WHERE end_epoch IS NULL` will
+                // never revisit it) from "transient failure" (leave NULL ⇒
+                // safe, picked up on the next pass).
+                //
+                // We classify on the SDK's structured error code, not on the
+                // error message text. @mysten/sui throws `ObjectError` with
+                // `.code ∈ {notExists, deleted, dynamicFieldNotFound,
+                // displayError, unknown}` — only `notExists` and `deleted`
+                // are unambiguously "gone". Everything else (transport
+                // 429/503, unknown, display errors) is treated as transient.
+                // The message regex is a fallback for non-ObjectError throws
+                // and even then only fires on the two confirmed phrasings.
+                const code: string | undefined =
+                    typeof e?.code === "string" ? e.code : undefined;
+                const msg = String(e?.message || e);
+                const goneByCode = code === "notExists" || code === "deleted";
+                const goneByMessage =
+                    code === undefined &&
+                    /\bobject\b.*\b(does not exist|has been deleted)\b/i.test(msg);
+                if (goneByCode || goneByMessage) {
+                    endEpoch = 0;
+                    console.warn(`[backfill] row=${row.id} blob GONE (${code ?? "by-message"}) → end_epoch=0`);
+                } else {
+                    console.error(`[backfill] row=${row.id} getBlobObject error (leave NULL, retry later) code=${code ?? "-"}: ${msg}`);
+                    stats.errors++;
+                    stats.leftNull++;
+                    continue;
+                }
+            }
+
+            if (endEpoch === null) {
+                console.warn(`[backfill] row=${row.id} blobObject had no usable end_epoch → leave NULL`);
+                stats.leftNull++;
+                continue;
+            }
+
+            if (endEpoch === 0) stats.markedGone++;
+            else stats.set++;
+
+            const verb = endEpoch === 0 ? "GONE→0" : `end_epoch=${endEpoch}`;
+            console.log(`[backfill] ${APPLY ? "SET " : "WOULD "}row=${row.id} obj=${short(objectId)} ${verb}`);
+
+            if (APPLY) {
+                // Re-runnable guard: only fill if still NULL (never clobber a
+                // value Part B wrote since this run started).
+                await sql`
+                    UPDATE vector_entries
+                    SET end_epoch = ${endEpoch}, object_id = COALESCE(object_id, ${objectId})
+                    WHERE id = ${row.id} AND end_epoch IS NULL
+                `;
+            }
+        }
+    }
+
+    console.log(
+        `[backfill] done. set=${stats.set} markedGone=${stats.markedGone} ` +
+            `leftNull=${stats.leftNull} alreadyHadObjId=${stats.skippedHaveObjId} errors=${stats.errors}` +
+            (APPLY ? "" : "  (dry-run — nothing written)"),
+    );
+    } finally {
+        await sql.end({ timeout: 5 });
+    }
+}
+
+function short(s: string): string {
+    return s.length > 12 ? `${s.slice(0, 6)}…${s.slice(-4)}` : s;
+}
+
+// Hide the password in a DB URL for log/error output ("postgres://u:***@h:p/db").
+function maskUrl(url: string): string {
+    return url.replace(/(:\/\/[^:/@]+:)[^@]+(@)/, "$1***$2");
+}
+
+main().catch((e) => {
+    console.error("[backfill] FATAL:", e);
+    process.exit(1);
+});

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -973,6 +973,28 @@ function extractBlobObjectId(blob: any): string | null {
     return null;
 }
 
+// Pull the storage-lease end epoch out of the `writeBlobFlow` getBlob() result.
+// The `blobObject` here is the SDK's decoded shape (object id is at the top
+// level, lease state lives under `storage`) — different from the on-chain
+// content shape returned by getOwnedObjects/multiGetObjects (see
+// `endEpochFromBlobFields` below for that variant).
+// Returns null on a missing/unparseable field so the response can omit it
+// rather than fail — the server then stores NULL and the row is always-served.
+function extractBlobEndEpoch(blob: any): number | null {
+    const raw = blob?.blobObject?.storage?.end_epoch;
+    if (typeof raw === "number" && Number.isFinite(raw)) {
+        return raw;
+    }
+    // Some BCS decoders surface u32 as a string; tolerate that.
+    if (typeof raw === "string" && raw.trim() !== "") {
+        const n = Number(raw);
+        if (Number.isFinite(n)) {
+            return n;
+        }
+    }
+    return null;
+}
+
 async function setMetadataAndTransferBlobs(
     signer: Ed25519Keypair,
     blobs: MetadataTransferBlob[],
@@ -1046,6 +1068,31 @@ async function setMetadataAndTransferBlobs(
     await suiClient.waitForTransaction({ digest });
     return digest;
 }
+
+// Current Walrus epoch lookup for the recall expiry filter. Lives on the
+// sidecar because the Walrus SDK does — reading `stakingState()` from Rust
+// would mean reimplementing the staking-object decoding by hand. The Rust
+// side hits this endpoint once per recall window (cached behind Redis with
+// a long TTL), so per-recall cost is effectively zero.
+app.get("/walrus/current-epoch", async (_req: Request, res: Response) => {
+    try {
+        refreshWalrusClientIfStale();
+        const staking = await walrusClient.stakingState();
+        const epoch = staking?.epoch;
+        if (typeof epoch !== "number" || !Number.isFinite(epoch)) {
+            return res
+                .status(502)
+                .json({ error: "walrus stakingState returned no usable epoch" });
+        }
+        return res.json({ epoch, suiNetwork: SUI_NETWORK });
+    } catch (err: any) {
+        const message = err?.message || String(err);
+        console.error(`[walrus/current-epoch] failed: ${message}`);
+        // The caller (Rust recall path) treats any failure as fail-open
+        // (don't filter), so a 502 here never hides live memories.
+        return res.status(502).json({ error: `current-epoch lookup failed: ${message}` });
+    }
+});
 
 // HIGH-13: /walrus/upload receives a base64-encoded SEAL ciphertext which can
 // be up to ~87 KiB per 64 KiB plaintext (SEAL overhead + base64 ≈ 1.37×).
@@ -1175,6 +1222,9 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         const blob = await flow.getBlob();
 
         const blobObjectId = extractBlobObjectId(blob);
+        // Same object the id came from already carries the lease state, so
+        // grab it now — the Rust write path stamps it onto the new row.
+        const blobEndEpoch = extractBlobEndEpoch(blob);
 
         // Set on-chain metadata + transfer blob to user in a single transaction
         if (!deferTransfer && owner && owner !== signerAddress && blobObjectId) {
@@ -1216,6 +1266,7 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         console.log(`[walrus/upload] [${traceId}] ok ${JSON.stringify({
             blobId: blob.blobId,
             objectId: blobObjectId,
+            endEpoch: blobEndEpoch,
             transferStatus: deferTransfer ? "deferred" : "ok",
             keyIndex,
             bytes: blobBytesForLog,
@@ -1223,6 +1274,7 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         res.json({
             blobId: blob.blobId,
             objectId: blobObjectId,
+            endEpoch: blobEndEpoch,
             transferStatus: deferTransfer ? "deferred" : "ok",
         });
     } catch (err: any) {
@@ -1458,8 +1510,25 @@ type RecentBlobCandidate = {
 type RawBlobObj = {
     objectId: string;
     rawBlobId: string | number | null;
+    endEpoch: number | null;
     timestampMs?: string | null;
 };
+
+// Pull `storage.end_epoch` out of an on-chain Blob object's decoded
+// `content.fields` — the shape returned by getOwnedObjects/multiGetObjects.
+// This differs from `extractBlobEndEpoch` (which reads the writeBlobFlow
+// result): here the storage resource is a nested Move struct, hence the
+// `fields.storage.fields.end_epoch` path with a fallback for the flattened
+// variant some SDK versions produce.
+function endEpochFromBlobFields(fields: any): number | null {
+    const raw = fields?.storage?.fields?.end_epoch ?? fields?.storage?.end_epoch;
+    if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+    if (typeof raw === "string" && raw.trim() !== "") {
+        const n = Number(raw);
+        if (Number.isFinite(n)) return n;
+    }
+    return null;
+}
 
 /**
  * Query newest transactions that transferred Walrus Blob objects to the owner.
@@ -1551,7 +1620,12 @@ async function fetchRawBlobObjects(candidates: RecentBlobCandidate[]): Promise<R
             if (typeof objectId !== "string" || !content || content.dataType !== "moveObject") return null;
             const fields = content.fields;
             const rawBlobId = fields?.blob_id ?? fields?.blobId ?? null;
-            return { objectId, rawBlobId, timestampMs: timestampByObject.get(objectId) ?? null };
+            return {
+                objectId,
+                rawBlobId,
+                endEpoch: endEpochFromBlobFields(fields),
+                timestampMs: timestampByObject.get(objectId) ?? null,
+            };
         })
         .filter((obj: RawBlobObj | null): obj is RawBlobObj => obj !== null);
 }
@@ -1650,7 +1724,11 @@ app.post("/walrus/query-blobs", express.json({ limit: JSON_LIMIT_METADATA }), as
                     const fields = (obj.data.content as any).fields;
                     if (!fields) continue;
                     const rawBlobId = fields.blob_id ?? fields.blobId ?? null;
-                    rawObjs.push({ objectId: obj.data.objectId, rawBlobId });
+                    rawObjs.push({
+                        objectId: obj.data.objectId,
+                        rawBlobId,
+                        endEpoch: endEpochFromBlobFields(fields),
+                    });
                 }
 
                 hasMore = result.hasNextPage;
@@ -1669,6 +1747,7 @@ app.post("/walrus/query-blobs", express.json({ limit: JSON_LIMIT_METADATA }), as
         type BlobMeta = {
             objectId: string;
             rawBlobId: string | number | null;
+            endEpoch: number | null;
             blobNamespace: string;
             blobOwner: string;
             blobPackageId: string;
@@ -1708,7 +1787,7 @@ app.post("/walrus/query-blobs", express.json({ limit: JSON_LIMIT_METADATA }), as
         });
 
         // Step 3: Filter + convert blob IDs
-        const blobs: { blobId: string; objectId: string; namespace: string; packageId: string; agentId: string }[] = [];
+        const blobs: { blobId: string; objectId: string; endEpoch: number | null; namespace: string; packageId: string; agentId: string }[] = [];
 
         for (const meta of metas) {
             // Filter by namespace if specified
@@ -1720,7 +1799,7 @@ app.post("/walrus/query-blobs", express.json({ limit: JSON_LIMIT_METADATA }), as
                 // blob_id from chain is a big integer (U256); convert to base64url (little-endian).
                 const blobIdStr = blobIdFromRaw(meta.rawBlobId);
                 if (blobIdStr) {
-                    blobs.push({ blobId: blobIdStr, objectId: meta.objectId, namespace: meta.blobNamespace, packageId: meta.blobPackageId, agentId: meta.blobAgentId });
+                    blobs.push({ blobId: blobIdStr, objectId: meta.objectId, endEpoch: meta.endEpoch, namespace: meta.blobNamespace, packageId: meta.blobPackageId, agentId: meta.blobAgentId });
                 }
             }
         }

--- a/services/server/src/engine/walrus_seal.rs
+++ b/services/server/src/engine/walrus_seal.rs
@@ -257,7 +257,18 @@ impl MemoryEngine for WalrusSealEngine {
         )
         .await?;
         let blob_id = upload.blob_id;
-        tracing::info!("engine.store_blob: walrus upload ok blob_id={}", blob_id);
+        // Capture before the upload struct is dropped. u64→i64 cast is safe:
+        // chain epochs are u32 (max ~4.3e9 ≪ i64::MAX). If either is None the
+        // row stores NULL, which the recall filter treats as always-served —
+        // the deliberate safe default for rows whose lease state we don't
+        // (yet) know.
+        let end_epoch = upload.end_epoch.map(|e| e as i64);
+        let object_id = upload.object_id;
+        tracing::info!(
+            "engine.store_blob: walrus upload ok blob_id={}, end_epoch={:?}",
+            blob_id,
+            end_epoch
+        );
 
         // MEM-37: warm the Redis blob cache with the just-uploaded ciphertext
         // so the first recall of this blob hits the cache instead of round-
@@ -270,7 +281,15 @@ impl MemoryEngine for WalrusSealEngine {
         let blob_size = bytes.len() as i64;
         self.db
             .insert_vector(
-                &id, owner, namespace, &blob_id, vector, blob_size, importance,
+                &id,
+                owner,
+                namespace,
+                &blob_id,
+                vector,
+                blob_size,
+                importance,
+                end_epoch,
+                object_id.as_deref(),
             )
             .await?;
 

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -415,6 +415,13 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
             blob_size_bytes,
             importance,
         } => {
+            // Deferred metadata-transfer recovery: the original upload result
+            // is long gone, so end_epoch isn't on hand — but we DO have the
+            // blob object id (we're about to set its metadata). Persist that;
+            // the backfill can read end_epoch later from this object id
+            // without re-running the expensive per-owner wallet scan. NULL
+            // end_epoch is the safe default — the row stays always-served.
+            let recovery_object_id = blob_object_id.clone();
             let result = execute_set_metadata_and_transfer(
                 state,
                 enqueued_wallet_index,
@@ -438,6 +445,8 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                             &vector,
                             blob_size_bytes,
                             importance,
+                            None,
+                            Some(recovery_object_id.as_str()),
                             enqueued_wallet_index,
                         )
                         .await
@@ -510,6 +519,11 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
             blob_size_bytes,
             importance,
         } => {
+            // Index-only retry after a finalization failure. The job variant
+            // doesn't carry the lease state, so end_epoch + object_id go in
+            // NULL — the row stays always-served until the backfill picks it
+            // up (the safe direction; a real expired row will still 404 and
+            // be cleaned up by the recall backstop).
             insert_vector_and_mark_remember_done(
                 state,
                 remember_job_id.as_deref(),
@@ -519,6 +533,8 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                 &vector,
                 blob_size_bytes,
                 importance,
+                None,
+                None,
                 enqueued_wallet_index,
             )
             .await
@@ -588,6 +604,9 @@ async fn insert_vector_and_mark_remember_done(
     vector: &[f32],
     blob_size_bytes: i64,
     importance: f32,
+    // Lease state from the upload (None on recovery paths that lack it).
+    end_epoch: Option<i64>,
+    object_id: Option<&str>,
     wallet_index: usize,
 ) -> Result<(), WalletJobError> {
     let vector_id = remember_job_id
@@ -604,6 +623,8 @@ async fn insert_vector_and_mark_remember_done(
             vector,
             blob_size_bytes,
             importance,
+            end_epoch,
+            object_id,
         )
         .await
     {
@@ -839,6 +860,10 @@ async fn execute_upload_and_transfer(
         }
     };
     let blob_id = upload.blob_id.clone();
+    // Lease state from the upload — chain epoch is u32, so the i64 cast is
+    // lossless for any value Walrus will ever produce.
+    let end_epoch = upload.end_epoch.map(|e| e as i64);
+    let object_id = upload.object_id.clone();
 
     warm_blob_cache_after_upload(state, &blob_id, &encrypted).await;
 
@@ -863,6 +888,8 @@ async fn execute_upload_and_transfer(
         &vector,
         encrypted.len() as i64,
         importance,
+        end_epoch,
+        object_id.as_deref(),
         wallet_index,
     )
     .await
@@ -1132,6 +1159,10 @@ pub async fn execute_remember(
         Err(UploadBlobError::App(e)) => fail!(format!("walrus upload failed: {}", e)),
     };
     let blob_id = upload.blob_id.clone();
+    // Lease state from the upload (see `insert_vector_and_mark_remember_done`
+    // for the u64→i64 rationale).
+    let end_epoch = upload.end_epoch.map(|e| e as i64);
+    let object_id = upload.object_id.clone();
 
     warm_blob_cache_after_upload(state, &blob_id, &encrypted).await;
 
@@ -1152,6 +1183,8 @@ pub async fn execute_remember(
             // new requests go through WalletOperation::UploadAndTransfer
             // which carries importance through end-to-end.
             crate::services::extractor::IMPORTANCE_STANDARD,
+            end_epoch,
+            object_id.as_deref(),
         )
         .await
     {

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -209,9 +209,13 @@ pub async fn ask(
 
     // Step 1: Recall relevant memories
     let query_vector = state.embedder.embed(&body.question).await?;
+    // /api/ask hydrates the hits exactly like /api/recall, so it needs the
+    // same expiry filter — otherwise an expired blob in the top-K either
+    // wastes a Walrus 404 or feeds an empty memory to the LLM.
+    let current_epoch = super::recall::current_epoch_cached(&state).await;
     let hits = state
         .db
-        .search_similar(&query_vector, owner, namespace, limit)
+        .search_similar(&query_vector, owner, namespace, limit, current_epoch)
         .await?;
 
     // Hydrate the hits through the storage engine, concurrently — same
@@ -444,6 +448,20 @@ pub async fn restore(
         .map(|b| (b.blob_id.clone(), b.package_id.clone()))
         .collect();
 
+    // Restore is the one path that re-inserts existing blobs without a fresh
+    // upload result. The on-chain query already returns the object id + lease
+    // end epoch for each blob we're about to restore, so persist them — leaving
+    // them NULL would mean a near-expiry blob gets re-indexed as always-served
+    // (until the backfill caught up) and force a redundant on-chain re-scan.
+    let blob_object_ids: std::collections::HashMap<String, String> = on_chain_blobs
+        .iter()
+        .map(|b| (b.blob_id.clone(), b.object_id.clone()))
+        .collect();
+    let blob_end_epochs: std::collections::HashMap<String, i64> = on_chain_blobs
+        .iter()
+        .filter_map(|b| b.end_epoch.map(|e| (b.blob_id.clone(), e as i64)))
+        .collect();
+
     if total == 0 {
         return Ok(Json(RestoreResponse {
             restored: 0,
@@ -659,6 +677,11 @@ pub async fn restore(
                 // neutral "standard" bucket so restored memories rank as
                 // average — neither boosted nor penalized.
                 crate::services::extractor::IMPORTANCE_STANDARD,
+                // Lease state captured above from the on-chain query. end_epoch
+                // may be None if an older sidecar didn't surface it — that's
+                // still safe (NULL = always-served until the backfill fills it).
+                blob_end_epochs.get(blob_id).copied(),
+                blob_object_ids.get(blob_id).map(String::as_str),
             )
             .await?;
     }

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -194,6 +194,11 @@ pub async fn analyze(
         match input_vector_opt {
             None => Vec::new(),
             Some(input_vector) => {
+                // Apply the blob-expiry filter here too: pre-extraction context
+                // feeds the LLM, and surfacing a dead blob's row would either
+                // waste a fetch on the 404 path or (worse) bias the extractor on
+                // content that's about to vanish. Cached + fail-open.
+                let current_epoch = super::recall::current_epoch_cached(&state).await;
                 let search_t = std::time::Instant::now();
                 let search_result = tokio::time::timeout(
                     std::time::Duration::from_millis(SEARCH_TIMEOUT_MS),
@@ -202,6 +207,7 @@ pub async fn analyze(
                         owner,
                         namespace,
                         PRE_EXTRACTION_CONTEXT_LIMIT,
+                        current_epoch,
                     ),
                 )
                 .await;

--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -68,6 +68,89 @@ async fn generate_recall_embedding_cached(
 }
 
 // ============================================================
+// Current Walrus epoch cache (Redis)
+// ============================================================
+//
+// The blob-expiry filter in `search_similar` needs the current Walrus epoch.
+// Reading it on every recall would mean one chain round-trip per request via
+// the sidecar — wasteful, since epochs advance roughly daily on testnet and
+// every ~2 weeks on mainnet. So we cache it with a long positive TTL.
+//
+// Failures must NOT block recall: returning None tells `search_similar` to
+// fail open (serve everything; the 404 cleanup backstop still catches actual
+// dead blobs). A short negative-cache on failure prevents every concurrent
+// request from independently hammering the sidecar during an outage.
+
+/// Network-scoped key so a testnet↔mainnet switch can't surface a stale
+/// cross-network value. The `:v1:` segment matches the `memwal:…:v1` convention
+/// used elsewhere, leaving room to bump without a flush.
+fn current_epoch_cache_key(config: &Config) -> String {
+    format!("memwal:walrus:current_epoch:v1:{}", config.sui_network)
+}
+
+/// Positive-cache TTL. Epochs change roughly daily (testnet) or every ~2 weeks
+/// (mainnet), so an hour-stale value is at most a fraction of an epoch — and
+/// the 404 backstop still catches a blob whose lease ended within the window.
+const CURRENT_EPOCH_TTL_SECS: u64 = 3600;
+
+/// Negative-cache TTL. When a lookup fails we briefly cache a sentinel so a
+/// sidecar/RPC outage doesn't have every concurrent recall stampede the
+/// sidecar with the same failing call. 30s is short enough that the filter
+/// rearms promptly once the sidecar recovers.
+const CURRENT_EPOCH_NEG_TTL_SECS: u64 = 30;
+
+/// Sentinel meaning "lookup failed recently, stay fail-open". Real epochs are
+/// always ≥ 0, so any negative value is an unambiguous marker.
+const CURRENT_EPOCH_FAILED_SENTINEL: i64 = -1;
+
+/// Returns the current Walrus epoch for the expiry filter, or `None` to mean
+/// "fail open — don't filter". The caller (`search_similar`) MUST treat None
+/// as "serve everything"; that's what makes any transient chain/sidecar issue
+/// safe by construction (it can never hide a live memory, and the 404 path
+/// still catches truly-dead blobs).
+pub(crate) async fn current_epoch_cached(state: &AppState) -> Option<i64> {
+    let cache_key = current_epoch_cache_key(&state.config);
+    let mut redis = state.redis.clone();
+
+    match redis.get::<_, Option<i64>>(&cache_key).await {
+        // Negative-cache hit: a recent lookup failed; keep failing open without
+        // calling the sidecar again until the short negative-TTL expires.
+        Ok(Some(v)) if v < 0 => return None,
+        Ok(Some(epoch)) => return Some(epoch),
+        Ok(None) => {}
+        Err(e) => tracing::warn!("current-epoch cache get failed: {}", e),
+    }
+
+    let epoch = match crate::storage::walrus::get_current_epoch(
+        &state.http_client,
+        &state.config.sidecar_url,
+        state.config.sidecar_secret.as_deref(),
+    )
+    .await
+    {
+        Ok(e) => e as i64,
+        Err(e) => {
+            // Best-effort negative-cache so the next N seconds of recalls skip
+            // the failing sidecar call. Failing to set is harmless: we just
+            // miss again next time.
+            tracing::warn!("current-epoch lookup failed (fail-open, not filtering): {}", e);
+            let _: redis::RedisResult<()> = redis
+                .set_ex(&cache_key, CURRENT_EPOCH_FAILED_SENTINEL, CURRENT_EPOCH_NEG_TTL_SECS)
+                .await;
+            return None;
+        }
+    };
+
+    let result: redis::RedisResult<()> =
+        redis.set_ex(&cache_key, epoch, CURRENT_EPOCH_TTL_SECS).await;
+    if let Err(e) = result {
+        tracing::warn!("current-epoch cache set failed: {}", e);
+    }
+
+    Some(epoch)
+}
+
+// ============================================================
 // Shared ranking for manual recall (ENG-1785)
 // ============================================================
 
@@ -182,10 +265,15 @@ pub async fn recall(
     // MED-3 fix: Cap limit to prevent unbounded DB scans / memory use.
     // Without this, an attacker could send limit=999999 to scan the entire DB.
     let limit = body.limit.min(100);
+    // Read the current epoch ONCE per recall — `search_similar` uses it to
+    // filter out rows whose Walrus blob lease has ended before hydration even
+    // starts (the cache below is downstream and would otherwise serve dead
+    // ciphertext for the rest of its TTL).
+    let current_epoch = current_epoch_cached(&state).await;
     let t1 = std::time::Instant::now();
     let hits = state
         .db
-        .search_similar(&query_vector, owner, namespace, limit)
+        .search_similar(&query_vector, owner, namespace, limit, current_epoch)
         .await?;
     let vsearch_ms = t1.elapsed().as_millis();
     let hit_count = hits.len();
@@ -342,9 +430,13 @@ pub async fn recall_manual(
     // Search Vector DB — blob IDs + distances (+ created_at + importance).
     // MED-3 fix: Cap limit on recall_manual as well.
     let limit = body.limit.min(100);
+    // Manual recall hands the blob_ids back to the client to fetch themselves,
+    // so the expiry filter matters here too: returning a dead blob's id is just
+    // a guaranteed 404 on the client side.
+    let current_epoch = current_epoch_cached(&state).await;
     let hits = state
         .db
-        .search_similar(&body.vector, owner, namespace, limit)
+        .search_similar(&body.vector, owner, namespace, limit, current_epoch)
         .await?;
 
     // Apply the shared CompositeRanker so manual ordering matches

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -25,41 +25,87 @@ impl VectorDb {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to connect to database: {}", e)))?;
 
-        // Run migrations
+        // Serialize migrations across concurrent app boots via a session-level
+        // advisory lock on a single dedicated connection. Two instances booting
+        // together can otherwise both pass an `IF NOT EXISTS` check and race —
+        // `CREATE INDEX` in particular is not idempotent against a concurrent
+        // creator and crash-loops the loser with "already exists". Holding the
+        // lock makes the second boot wait until the first finishes, at which
+        // point its migrations are clean no-ops. Session-level (not xact)
+        // because some DDL can't be wrapped in one transaction; we release
+        // explicitly in every exit path.
+        const MIGRATION_LOCK_KEY: i64 = 0x454E47_31373838;
+        let mut conn = pool
+            .acquire()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to acquire migration conn: {}", e)))?;
+        sqlx::query("SELECT pg_advisory_lock($1)")
+            .bind(MIGRATION_LOCK_KEY)
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to acquire migration lock: {}", e)))?;
+
+        let migration_result = Self::run_migrations(&mut conn).await;
+
+        // Release before returning the connection to the pool. A leaked session
+        // lock would block every subsequent boot on this same physical
+        // connection; logging on failure surfaces that fact (the conn drop
+        // below would force-release on disconnect anyway).
+        if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
+            .bind(MIGRATION_LOCK_KEY)
+            .execute(&mut *conn)
+            .await
+        {
+            tracing::warn!("Failed to release migration advisory lock (will be released on conn drop): {}", e);
+        }
+        drop(conn);
+        migration_result?;
+
+        tracing::info!("database connected and migrations applied");
+
+        Ok(Self { pool })
+    }
+
+    /// Run all schema migrations on a single connection (held under the boot
+    /// advisory lock — see `new`). Each migration is `IF NOT EXISTS`-guarded, so
+    /// re-running every boot is a cheap no-op once applied.
+    async fn run_migrations(
+        conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
+    ) -> Result<(), AppError> {
         let migration_001 = include_str!("../../migrations/001_init.sql");
         sqlx::raw_sql(migration_001)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 001: {}", e)))?;
 
         let migration_002 = include_str!("../../migrations/002_add_namespace.sql");
         sqlx::raw_sql(migration_002)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 002: {}", e)))?;
 
         let migration_003 = include_str!("../../migrations/003_rate_limiter.sql");
         sqlx::raw_sql(migration_003)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 003: {}", e)))?;
 
         let migration_004 = include_str!("../../migrations/004_delegate_key_cache_expires.sql");
         sqlx::raw_sql(migration_004)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 004: {}", e)))?;
 
         let migration_005 = include_str!("../../migrations/005_remember_jobs.sql");
         sqlx::raw_sql(migration_005)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 005: {}", e)))?;
 
         // ENG-1408: composite index on (owner, status, updated_at DESC) for bulk poll
         let migration_006 = include_str!("../../migrations/006_bulk_remember.sql");
         sqlx::raw_sql(migration_006)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 006: {}", e)))?;
 
@@ -69,7 +115,7 @@ impl VectorDb {
         // wallet + retry handling is sufficient.
         let migration_007 = include_str!("../../migrations/007_collapse_wallet_queues.sql");
         sqlx::raw_sql(migration_007)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 007: {}", e)))?;
 
@@ -79,20 +125,26 @@ impl VectorDb {
         // with MEM-35's 007_collapse_wallet_queues.sql.
         let migration_008 = include_str!("../../migrations/008_benchmark_plaintext.sql");
         sqlx::raw_sql(migration_008)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 008: {}", e)))?;
 
         // MEM-54: importance signal column on vector_entries.
         let migration_009 = include_str!("../../migrations/009_importance_signal.sql");
         sqlx::raw_sql(migration_009)
-            .execute(&pool)
+            .execute(&mut **conn)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 009: {}", e)))?;
 
-        tracing::info!("database connected and migrations applied");
+        // Blob-expiry tracking: end_epoch + object_id columns. Additive +
+        // nullable; the recall filter treats NULL as always-served.
+        let migration_010 = include_str!("../../migrations/010_blob_end_epoch.sql");
+        sqlx::raw_sql(migration_010)
+            .execute(&mut **conn)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 010: {}", e)))?;
 
-        Ok(Self { pool })
+        Ok(())
     }
 
     /// Expose a reference to the underlying `PgPool` so job handlers
@@ -118,20 +170,31 @@ impl VectorDb {
         vector: &[f32],
         blob_size_bytes: i64,
         importance: f32,
+        // Lease state for the Walrus blob, captured from the upload result.
+        // Either being `None` writes NULL — the recall filter treats NULL as
+        // always-served, so a missing value is the safe direction (never
+        // wrongly hides a memory; backfill resolves it later).
+        end_epoch: Option<i64>,
+        object_id: Option<&str>,
     ) -> Result<(), AppError> {
         let embedding = Vector::from(vector.to_vec());
 
         let started = std::time::Instant::now();
         let result = sqlx::query(
-            "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, importance)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, importance, end_epoch, object_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
              ON CONFLICT (id) DO UPDATE SET
                 owner = EXCLUDED.owner,
                 namespace = EXCLUDED.namespace,
                 blob_id = EXCLUDED.blob_id,
                 embedding = EXCLUDED.embedding,
                 blob_size_bytes = EXCLUDED.blob_size_bytes,
-                importance = EXCLUDED.importance",
+                importance = EXCLUDED.importance,
+                -- COALESCE the lease columns so a recovery/restore upsert
+                -- bearing NULL can't overwrite a previously-recorded value.
+                -- A real new value (fresh upload) still overwrites.
+                end_epoch = COALESCE(EXCLUDED.end_epoch, vector_entries.end_epoch),
+                object_id = COALESCE(EXCLUDED.object_id, vector_entries.object_id)",
         )
         .bind(id)
         .bind(owner)
@@ -140,6 +203,8 @@ impl VectorDb {
         .bind(embedding)
         .bind(blob_size_bytes)
         .bind(importance)
+        .bind(end_epoch)
+        .bind(object_id)
         .execute(&self.pool)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)));
@@ -260,6 +325,12 @@ impl VectorDb {
         owner: &str,
         namespace: &str,
         limit: usize,
+        // Current Walrus epoch for the expiry filter. `None` means the
+        // sidecar/cache lookup failed; we fail open by binding a sentinel
+        // (`i64::MIN`) that never excludes any row, instead of branching the
+        // SQL. The 404 backstop in the hydration path still guards against
+        // serving a blob Walrus has actually GC'd.
+        current_epoch: Option<i64>,
     ) -> Result<Vec<SearchHit>, AppError> {
         let embedding = Vector::from(query_vector.to_vec());
 
@@ -268,12 +339,20 @@ impl VectorDb {
         // without a second round-trip. Both NOT NULL (migration 001 for
         // created_at, 009 for importance) so the row tuple types are
         // non-Option.
+        //
+        // Expiry filter `end_epoch IS NULL OR end_epoch > $5` runs INSIDE the
+        // WHERE so dead rows can't take up LIMIT slots. NULL always passes —
+        // benchmark rows and any row not yet backfilled stay always-served,
+        // which is the safe direction (a row can only be wrongly hidden if
+        // its end_epoch was explicitly set, never by NULL).
+        let epoch_threshold = current_epoch.unwrap_or(i64::MIN);
         let started = std::time::Instant::now();
         let result: Result<Vec<(String, f64, chrono::DateTime<chrono::Utc>, f32)>, AppError> =
             sqlx::query_as(
                 "SELECT blob_id, (embedding <=> $1)::float8 AS distance, created_at, importance
              FROM vector_entries
              WHERE owner = $2 AND namespace = $3
+               AND (end_epoch IS NULL OR end_epoch > $5)
              ORDER BY embedding <=> $1
              LIMIT $4",
             )
@@ -281,6 +360,7 @@ impl VectorDb {
             .bind(owner)
             .bind(namespace)
             .bind(limit as i64)
+            .bind(epoch_threshold)
             .fetch_all(&self.pool)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to search vectors: {}", e)));

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -5,14 +5,21 @@ use std::time::Duration;
 
 const SIDECAR_WALRUS_TIMEOUT: Duration = Duration::from_secs(180);
 const WALRUS_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
+/// Current-epoch lookup is on the recall hot path and the caller already fails
+/// open, so it gets a tight timeout — not the long upload budget.
+const CURRENT_EPOCH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Result of a Walrus blob upload
 pub struct UploadResult {
     /// Walrus content-addressed blob ID (base64url)
     pub blob_id: String,
     /// Sui object ID of the Blob object (hex, e.g. "0x...")
-    #[allow(dead_code)]
     pub object_id: Option<String>,
+    /// Storage lease end epoch (`blobObject.storage.end_epoch`), read from
+    /// the upload result with no extra chain call. `None` if the sidecar
+    /// didn't surface it (older sidecar, or a code path that doesn't expose
+    /// it); persisted as NULL, which the recall filter treats as always-served.
+    pub end_epoch: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -66,6 +73,11 @@ pub struct OnChainBlob {
     /// Walrus Memory package ID from on-chain metadata
     #[serde(rename = "packageId", default)]
     pub package_id: String,
+    /// Storage lease end epoch — read by the sidecar from the on-chain object's
+    /// `storage.end_epoch` during the query, with no extra chain call. Lets
+    /// restore persist the real lease state instead of relying on the backfill.
+    #[serde(rename = "endEpoch", default)]
+    pub end_epoch: Option<u64>,
 }
 
 /// Response from sidecar query-blobs endpoint
@@ -73,6 +85,67 @@ pub struct OnChainBlob {
 struct QueryBlobsResponse {
     blobs: Vec<OnChainBlob>,
     total: usize,
+}
+
+/// Response from the sidecar `/walrus/current-epoch` endpoint.
+#[derive(Debug, serde::Deserialize)]
+struct CurrentEpochResponse {
+    epoch: u64,
+}
+
+/// Read the current Walrus epoch from the sidecar, which owns the Walrus SDK
+/// client. Callers cache the result (the per-recall Redis cache lives in the
+/// recall route) — this performs the actual uncached chain read. On any
+/// failure the caller treats it as fail-open (serve everything), so an `Err`
+/// here can never wrongly hide a live memory.
+pub async fn get_current_epoch(
+    client: &reqwest::Client,
+    sidecar_url: &str,
+    sidecar_secret: Option<&str>,
+) -> Result<u64, AppError> {
+    let url = format!("{}/walrus/current-epoch", sidecar_url);
+
+    // Tight timeout — this is on the recall hot path and the caller already
+    // fails open, so we'd rather give up fast than ride the shared client's
+    // 30s default while the sidecar is hung.
+    let mut req = client.get(&url).timeout(CURRENT_EPOCH_TIMEOUT);
+    if let Some(secret) = sidecar_secret {
+        req = req.header("authorization", format!("Bearer {}", secret));
+    }
+    let req = crate::observability::apply_request_id_header(req);
+    let started = std::time::Instant::now();
+    let resp = req.send().await.map_err(|e| {
+        crate::observability::observe_external(
+            "sidecar",
+            "walrus_current_epoch",
+            "transport_error",
+            started.elapsed(),
+        );
+        crate::observability::record_sidecar_failure("walrus_current_epoch", "transport_error");
+        AppError::Internal(format!("Sidecar walrus/current-epoch failed: {}", e))
+    })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "walrus_current_epoch",
+        &status_label,
+        started.elapsed(),
+    );
+
+    if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("walrus_current_epoch", "http_error");
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Internal(format!(
+            "walrus current-epoch failed: {}",
+            body
+        )));
+    }
+
+    let result: CurrentEpochResponse = resp.json().await.map_err(|e| {
+        AppError::Internal(format!("Failed to parse current-epoch response: {}", e))
+    })?;
+
+    Ok(result.epoch)
 }
 
 /// Request/response types for sidecar HTTP API
@@ -97,6 +170,11 @@ struct WalrusUploadResponse {
     object_id: Option<String>,
     #[serde(default)]
     transfer_status: Option<String>,
+    /// Storage lease end epoch from the on-chain Blob object. `#[serde(default)]`
+    /// so an older sidecar that omits the field parses as `None` rather than
+    /// erroring (forwards-compatible deploy).
+    #[serde(default)]
+    end_epoch: Option<u64>,
 }
 
 #[derive(serde::Deserialize)]
@@ -293,6 +371,7 @@ async fn upload_blob_inner(
     Ok(UploadResult {
         blob_id: result.blob_id,
         object_id: result.object_id,
+        end_epoch: result.end_epoch,
     })
 }
 


### PR DESCRIPTION
## Summary

### Why

Walrus blobs don't live forever. Each blob has a **storage lease** purchased at upload time, and once the lease ends Walrus is free to garbage-collect the blob — at which point any attempt to fetch it returns 404.

Auto-recall didn't know about this. When a user asked a question, recall would do its vector search, return the top-K blob IDs, and try to hydrate them. Two things would go wrong with blobs whose lease had expired:

**1. 404 on hydration.** The most visible symptom. Recall returns a blob_id, the engine goes to Walrus, Walrus says "gone", the memory is dropped and `dropped_count` ticks up. User sees fewer results than they should, and a dead memory burned a top-K slot that could have gone to a live one further down the list.

**2. Worse — the Redis blob cache silently masking expiry.** This is the part that's easy to miss. The ciphertext cache has a 14-day TTL, but on testnet Walrus leases run only ~5 days. So a blob that expired five days ago can still be sitting in the cache, getting served to recall as if it were alive, for **another nine days past its real lease end**. The user gets back what looks like a valid memory, decrypts it, uses it — but the underlying blob has been GC'd. Any operation that has to round-trip Walrus (e.g. a cache miss) breaks; the system has been lying about what's available.

Why can't we fix this with a timestamp heuristic? Walrus leases are denominated in **epochs**, not wall-clock seconds. Epochs advance via on-chain events (a validator quorum), not a fixed clock — so the duration drifts. A formula like `created_at + epochs_bought × nominal_duration` drifts in both directions: too late and we serve dead blobs (the bug we're fixing); too early and we wrongly hide memories that are still alive. The only correct way to ask "is this blob expired?" is to read the **actual** end-of-lease epoch off the on-chain Blob object and compare it to the **actual** current Walrus epoch.

So that's what this change does — and crucially, it does the comparison **at the SQL level, before the cache gets involved**, so the cache can't paper over expiry.

### What

- New migration `010` adds two nullable columns to `vector_entries`: `end_epoch` (the blob's on-chain lease end) and `object_id` (the Sui object id the lease lives on). NULL means "no lease state tracked" — handled as always-served, so adding the columns changes no behavior until a row actually has values.
- New sidecar endpoint `GET /walrus/current-epoch` returns the live Walrus epoch (from the SDK's `stakingState()`). Rust caches the result in Redis with a 1h positive TTL and a 30s negative-cache on failure, so this costs effectively one chain read per recall window per replica.
- Sidecar `/walrus/upload` and `/walrus/query-blobs` now include `endEpoch` per blob, read off the on-chain object that's already being fetched — zero extra chain calls in either path.
- `search_similar` gains an expiry filter: `AND (end_epoch IS NULL OR end_epoch > $current_epoch)`. Applied to `/api/recall`, `/api/recall/manual`, `/api/ask`, and the analyze pre-extraction context search. Expired rows never become a blob_id we'd try to hydrate.
- Write path threads `end_epoch` + `object_id` from the upload result into `insert_vector`, so every memory written after deploy is correctly marked. All five existing call sites updated (including the deferred-transfer recovery paths and the restore flow).
- Migration runner now serializes concurrent app boots under a session `pg_advisory_lock` so a rolling deploy can't crash-loop a replica that loses a `CREATE INDEX IF NOT EXISTS` race.
- `scripts/backfill-end-epoch.ts` (new, manual-run): fills `end_epoch` for legacy rows by reading each blob's `storage.end_epoch` straight from chain. Dry-run by default; `--apply` writes; `--limit` / `--owner` scope it.

### Solution

A few design decisions worth calling out, because they're load-bearing:

**Filter in the SQL `WHERE`, not at hydration.** This is the one that makes the cache bug above unfixable any other way. The blob cache reads happen *after* `search_similar` returns; if we filter at hydration, we've already retrieved (and potentially served from cache) a row whose lease ended weeks ago. Putting the filter in the SQL `WHERE` means expired rows never become a blob_id passed to `cache_get`. As a side benefit it also fixes top-K quality — `LIMIT $K` now returns up to K **live** rows, instead of letting expired rows squat in slots that should have gone to the next-best memory.

**NULL means "always-served" everywhere.** Three concrete categories of row write NULL: benchmark rows (no Walrus blob), recovery paths that lack a fresh upload result, and any row not yet backfilled. All are handled identically — the filter passes them. That makes the entire change *safe* by construction: it's structurally impossible to wrongly hide a memory unless a real `end_epoch` value was deliberately written. The migration is purely additive, and behavior is identical to today's for every row until a real value lands.

**Fail-open on the current-epoch lookup.** If Redis is unreachable, the sidecar 502s, the chain RPC times out, or anything else goes wrong — `current_epoch_cached` returns `None` and the SQL binds `i64::MIN` as the threshold, which every real `end_epoch` is greater than. Effect: the filter is silently disabled and recall serves everything. Pre-existing 404 cleanup still catches truly-dead blobs on the hydration path. Recall stays available no matter what's broken upstream; safety doesn't depend on the sidecar being healthy.

**The backfill is the only thing that can wrongly hide a memory, so it's the most conservative piece of code in the change.** Writing `end_epoch=0` ("blob is gone, filter forever") is the one irreversible operation in this whole PR — the script's own re-run guard (`WHERE end_epoch IS NULL`) will never revisit a row that has that value. So we classify "gone" only on the SDK's structured `ObjectError.code` (`notExists` / `deleted`). Anything else — transport 429, transient RPC error, unknown SDK error, anything message-based — leaves the row NULL for the next pass. We never write 0 on a guess.

**Migration is non-blocking, runs at boot, doesn't rewrite the table.** Two `ADD COLUMN IF NOT EXISTS` (catalog-only changes; no row rewrite) plus a `DROP INDEX IF EXISTS` to clean up a partial index from an earlier draft. The boot-time advisory lock prevents concurrent rolling-deploy replicas from racing on the `IF NOT EXISTS` checks, which would otherwise let one replica crash-loop on "already exists".

**Operator safety on the backfill script.** Three startup guards because this is the one piece of code that writes to a real DB: `SUI_NETWORK` is cross-checked against the sidecar's reported network (otherwise a misconfigured run silently miscovers every owner); the schema is checked for the new columns (friendly error if migration hasn't run yet); `SIDECAR_AUTH_TOKEN` is required up front (a missing token would otherwise 401 every owner and produce a clean-looking no-op).

## Types of Changes

<!-- What types of changes does your code introduce? Put an x in all the boxes that apply -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

## Testing

Validated end-to-end on a complete clone of the Neon dev DB (785 production rows / 18 distinct owners), pulled via `pg_dump` v18 and restored into a local pg17 container.

**Migration 010 on the clone:** both columns added (nullable), `DROP INDEX IF EXISTS` no-ops cleanly on fresh DBs, re-running the whole migration is a clean no-op (every statement guarded with `IF NOT EXISTS`).

**SQL filter behaviour with seeded `end_epoch` values** (current_epoch=100):
- `end_epoch=0` (chain-confirmed gone) → filtered
- `end_epoch=99` and `=100` (boundary) → filtered (correct: `>` matches the "expired = `end_epoch ≤ current`" definition)
- `end_epoch=101` and `=999999` → served
- `end_epoch IS NULL` → served
- Fail-open sentinel (`i64::MIN`) → all rows served

**Live sidecar/chain integration:** booted the new sidecar locally, `GET /walrus/current-epoch` returned `{"epoch":409,"suiNetwork":"testnet"}` against testnet; 401 without token.

**Full-clone backfill:** `--apply` converged at `set=665 markedGone=0 leftNull=120` in one pass; subsequent passes mopped up stragglers (the `WHERE end_epoch IS NULL` re-run guard verified idempotent — never clobbers a value written between passes). At the live epoch 409 the post-backfill filter split the 785 rows as 291 served / 494 filtered / 17 untracked NULL. An earlier full run produced 438 alive / 346 expired / 1 unresolvable, which confirms the precise-classification path was necessary — a "mark legacy expired" shortcut would have wrongly hidden 438 live memories.

**Operator-error guards on the backfill script:**
- `SUI_NETWORK=mainnet` against a testnet sidecar → FATAL before any DB work.
- Missing migration 010 → FATAL with a friendly schema-check message (URL password masked).
- Missing `SIDECAR_AUTH_TOKEN` → FATAL up front.
- `--limit` with no value → FATAL (no silent cap-at-1).

**Build/type:** `cargo check` clean. Both new/touched TS files (`backfill-end-epoch.ts`, `sidecar-server.ts`) type-check clean. (3 pre-existing errors in `mcp/tools/*.ts` are unrelated — already present on `origin/dev`.)

- [x] I have tested this code locally
- [x] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

## Checklist

<!-- Go over all the following points, and put an x in all the boxes that apply -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Additional Notes

**Merge sequence (manual, post-merge):**

1. Merge this PR into `dev`.
2. Wait for the dev deploy. Migration 010 auto-runs at server boot.
3. Verify the new columns exist on the dev DB (`\d vector_entries` shows `end_epoch` + `object_id`).
4. Verify the write path is recording lease state — a fresh `/api/remember` on dev should land a row with a non-NULL `end_epoch` and `object_id`.
5. **Back up the dev DB** — `pg_dump` v18 → restore into a local throwaway in the Docker container. (Mainnet backup location is a separate, infra-owned decision; out of scope here.)
6. Run `scripts/backfill-end-epoch.ts` — dry-run first (no `--apply`), inspect the `WOULD SET` lines, then `--apply`. Expect testnet 429s; the script is re-runnable so each pass mops up the previous one's stragglers.

**Boundary asymmetry worth knowing:** filtering at `end_epoch ≤ current` may briefly hide a blob whose lease has technically ended but whose ciphertext Walrus hasn't GC'd yet. The opposite direction (we serve, Walrus has already GC'd) is covered by the existing 404 cleanup backstop. Both are acceptable trade-offs.

**Performance note:** intentionally no dedicated `end_epoch` index. EXPLAIN confirms the recall filter rides the existing `(owner, namespace)` index from migration 002; `end_epoch` is a cheap recheck on that already-narrow per-owner row set. A partial `WHERE end_epoch IS NOT NULL` index can't satisfy the `OR end_epoch IS NULL` branch and would only add write-maintenance cost — see the inline comment in 010 for the full reasoning. If a prune is ever added (`DELETE WHERE end_epoch <= current`), a tuned index can come with it.

**Backfill script is committed for review + reproducibility + audit trail** — but is manual-run only (no scheduler, no CI hook, `--apply` defaults off). The operator invokes it deliberately post-deploy.

**Mainnet pre-rollout work (out of scope for this PR):**
- Decide on a dedicated DB-backup location (the local-Docker pattern used here is testnet-only).
- Add a `--confirm` prompt on `--apply` to catch a same-shape wrong-DB paste.
- Re-measure the per-row / convergence timing on mainnet's actual owner count + RPC limits.
