### PR TITLE
feat(relayer): add WALM-52 upload relay tip metrics

### DIFF
--- a/docs/relayer/grafana/walm-52-upload-relay-cost.json
+++ b/docs/relayer/grafana/walm-52-upload-relay-cost.json
@@ -1,0 +1,317 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping MemWal relayer /metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "WALM-52 canary dashboard comparing public Walrus upload-relay tip spend with self-hosted no-tip relay spend.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "decimals": 6,
+          "unit": "sui"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) * 3600 / 1e9",
+          "legendFormat": "{{host}} send_tip={{send_tip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Relay Tip Burn Rate (SUI/hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "decimals": 2,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (host, send_tip) (rate(walrus_upload_relay_uploads_total[1h])) * 3600",
+          "legendFormat": "{{host}} send_tip={{send_tip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Register-Confirmed Upload Attempts (per hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "decimals": 9,
+          "unit": "sui"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) / sum by (host, send_tip) (rate(walrus_upload_relay_uploads_total[1h])) / 1e9",
+          "legendFormat": "{{host}} send_tip={{send_tip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Relay Tip per Register-Confirmed Attempt (SUI)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "decimals": 4,
+          "unit": "sui"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) * 86400 / 1e9",
+          "legendFormat": "{{host}} send_tip={{send_tip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Projected Relay Tip Burn (SUI/day)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "mirror down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "mirror ok"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "memwal_sidecar_walrus_metrics_scrape_success",
+          "legendFormat": "mirror",
+          "refId": "A"
+        }
+      ],
+      "title": "WALM Metrics Mirror",
+      "type": "stat"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "memwal",
+    "walm-52",
+    "walrus"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "WALM-52 Upload Relay Cost Canary",
+  "uid": "walm-52-upload-relay-cost",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/relayer/observability.md
+++ b/docs/relayer/observability.md
@@ -124,3 +124,71 @@ If your APM supports custom spans, map `memwal_external_request_duration_seconds
 - `sidecar / seal_decrypt_batch`
 - `sidecar / walrus_upload`
 - `walrus / download_blob`
+
+## WALM-52: Upload-Relay Tip Spend
+
+The sidecar emits two Prometheus counters that track SUI MIST paid as Walrus upload-relay tip. Use these to decide whether self-hosting the upload relay reduces pool burn (Henry's hypothesis is "at high usage, self-host wins"). Gas for register/certify is Enoki-sponsored separately and is **not** part of this metric.
+
+### Scrape
+
+The counters are exposed in Prometheus text format at `GET <SIDECAR_URL>/metrics/walrus` — separate from the JSON `/metrics/wallet` endpoint and reachable without the sidecar bearer token (same posture as `/metrics/wallet`). Add a second scrape target:
+
+```yaml
+scrape_configs:
+  - job_name: memwal-sidecar-walrus
+    metrics_path: /metrics/walrus
+    static_configs:
+      - targets: ["sidecar.example.com:9000"]
+```
+
+### Metrics
+
+| Metric | Labels | Notes |
+| --- | --- | --- |
+| `walrus_upload_relay_uploads_total` | `host`, `send_tip` | Successful uploads since sidecar start. `host` is the parsed hostname from `WALRUS_UPLOAD_RELAY_URL`. `send_tip` is `"true"` / `"false"` from `WALRUS_UPLOAD_RELAY_SEND_TIP`. |
+| `walrus_upload_relay_tip_mist_total` | `host`, `send_tip` | Sum of MIST attributed to the relay tip recipient in register-tx balance changes. Increments by 0 in no-tip mode. |
+
+Each sidecar process emits a single label combination (the config is per-instance), so multi-instance comparison is by **deploy**, not by relabeling — i.e. run a canary sidecar with a different `WALRUS_UPLOAD_RELAY_URL` / `WALRUS_UPLOAD_RELAY_SEND_TIP` to get a second label combination in Grafana.
+
+### Panels
+
+All PromQL examples below are copy-paste valid for Prometheus / Grafana — aggregation operators (`sum by`) wrap the `rate(...)` calls so labels are explicit, and division aggregates each side before dividing.
+
+| Panel | PromQL |
+| --- | --- |
+| Tip burn rate per host | `sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h]))` |
+| Upload rate per host | `sum by (host, send_tip) (rate(walrus_upload_relay_uploads_total[1h]))` |
+| Tip per upload (MIST) | `sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) / sum by (host, send_tip) (rate(walrus_upload_relay_uploads_total[1h]))` |
+| Daily SUI projection | `sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) * 86400 / 1e9` |
+
+### Alerts
+
+| Alert | Condition |
+| --- | --- |
+| Public relay tip spike | `sum(rate(walrus_upload_relay_tip_mist_total{send_tip="true"}[1h])) > 2 * quantile_over_time(0.5, sum(rate(walrus_upload_relay_tip_mist_total{send_tip="true"}[1h]))[7d:1h])` for 30m |
+| Canary tip non-zero | `sum(rate(walrus_upload_relay_tip_mist_total{send_tip="false"}[5m])) > 0` (means a misconfigured self-hosted relay is still charging a tip) |
+
+### Independent on-chain audit
+
+The Prometheus counter is an observed proxy. For ground truth (and for one-off reporting like Henry's "2.67 SUI in 12h" measurement), run the standalone audit. The relay tip recipient is configurable per relay and can change — always fetch it from `<relay>/v1/tip-config` rather than hardcoding:
+
+```bash
+# 1. Fetch the live tip recipient (per network; verify before each audit).
+TIP_ADDR=$(curl -s https://upload-relay.mainnet.walrus.space/v1/tip-config | jq -r '.send_tip.address')
+echo "$TIP_ADDR"  # e.g. 0x765a6ff2c13b47e2603416d0b5a156df498a5c51bc8085be3838e43e06086256
+
+# 2. Run the audit against the pool wallets for the window of interest.
+npx tsx services/server/scripts/walrus-tip-audit.ts \
+  --pool-address 0x<pool-wallet-1> --pool-address 0x<pool-wallet-2> \
+  --relay-tip-address "$TIP_ADDR" \
+  --from 2026-05-24T05:00:00Z --to 2026-05-25T05:00:00Z
+```
+
+Current known recipients (verify with the `curl` above — they are not part of any static config):
+
+| Network | Relay tip address (as of this writing) |
+| --- | --- |
+| mainnet | `0x765a6ff2c13b47e2603416d0b5a156df498a5c51bc8085be3838e43e06086256` |
+| testnet | `0x4b6a7439159cf10533147fc3d678cf10b714f2bc998f6cb1f1b0b9594cdc52b6` |
+
+Output is CSV: `date,pool_address,relay_tip_mist,relay_tip_sui,upload_count_estimate,other_mist`. The script queries Sui RPC directly and does not depend on the sidecar. See [WALM-52 Canary](/relayer/walm-52-canary) for the trial procedure.

--- a/docs/relayer/observability.md
+++ b/docs/relayer/observability.md
@@ -131,7 +131,19 @@ The sidecar emits two Prometheus counters that track SUI MIST paid as Walrus upl
 
 ### Scrape
 
-The counters are exposed in Prometheus text format at `GET <SIDECAR_URL>/metrics/walrus` — separate from the JSON `/metrics/wallet` endpoint and reachable without the sidecar bearer token (same posture as `/metrics/wallet`). Add a second scrape target:
+The TypeScript sidecar exposes the source counters in Prometheus text format at `GET <SIDECAR_URL>/metrics/walrus`. The Rust relayer also mirrors those counters into its existing `GET /metrics` output on every scrape when the sidecar is reachable, so existing relayer scrape jobs pick up WALM-52 without a second target.
+
+Existing scrape path:
+
+```yaml
+scrape_configs:
+  - job_name: memwal-relayer
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["relayer.example.com"]
+```
+
+Optional direct sidecar scrape:
 
 ```yaml
 scrape_configs:
@@ -145,8 +157,9 @@ scrape_configs:
 
 | Metric | Labels | Notes |
 | --- | --- | --- |
-| `walrus_upload_relay_uploads_total` | `host`, `send_tip` | Successful uploads since sidecar start. `host` is the parsed hostname from `WALRUS_UPLOAD_RELAY_URL`. `send_tip` is `"true"` / `"false"` from `WALRUS_UPLOAD_RELAY_SEND_TIP`. |
+| `walrus_upload_relay_uploads_total` | `host`, `send_tip` | Register-confirmed upload-relay attempts since sidecar start. `host` is the parsed hostname from `WALRUS_UPLOAD_RELAY_URL`. `send_tip` is `"true"` / `"false"` from `WALRUS_UPLOAD_RELAY_SEND_TIP`. |
 | `walrus_upload_relay_tip_mist_total` | `host`, `send_tip` | Sum of MIST attributed to the relay tip recipient in register-tx balance changes. Increments by 0 in no-tip mode. |
+| `memwal_sidecar_walrus_metrics_scrape_success` | none | `1` when the relayer successfully mirrored `/metrics/walrus` into `/metrics` on the latest scrape; `0` if the sidecar scrape failed/timed out. |
 
 Each sidecar process emits a single label combination (the config is per-instance), so multi-instance comparison is by **deploy**, not by relabeling — i.e. run a canary sidecar with a different `WALRUS_UPLOAD_RELAY_URL` / `WALRUS_UPLOAD_RELAY_SEND_TIP` to get a second label combination in Grafana.
 
@@ -157,7 +170,7 @@ All PromQL examples below are copy-paste valid for Prometheus / Grafana — aggr
 | Panel | PromQL |
 | --- | --- |
 | Tip burn rate per host | `sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h]))` |
-| Upload rate per host | `sum by (host, send_tip) (rate(walrus_upload_relay_uploads_total[1h]))` |
+| Register-confirmed upload-attempt rate per host | `sum by (host, send_tip) (rate(walrus_upload_relay_uploads_total[1h]))` |
 | Tip per upload (MIST) | `sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) / sum by (host, send_tip) (rate(walrus_upload_relay_uploads_total[1h]))` |
 | Daily SUI projection | `sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) * 86400 / 1e9` |
 
@@ -167,6 +180,9 @@ All PromQL examples below are copy-paste valid for Prometheus / Grafana — aggr
 | --- | --- |
 | Public relay tip spike | `sum(rate(walrus_upload_relay_tip_mist_total{send_tip="true"}[1h])) > 2 * quantile_over_time(0.5, sum(rate(walrus_upload_relay_tip_mist_total{send_tip="true"}[1h]))[7d:1h])` for 30m |
 | Canary tip non-zero | `sum(rate(walrus_upload_relay_tip_mist_total{send_tip="false"}[5m])) > 0` (means a misconfigured self-hosted relay is still charging a tip) |
+| WALM metric mirror down | `memwal_sidecar_walrus_metrics_scrape_success == 0` for 10m |
+
+Grafana dashboard JSON for these panels lives at `docs/relayer/grafana/walm-52-upload-relay-cost.json`. Prometheus alert rules live at `docs/relayer/prometheus/walm-52-upload-relay-alerts.yml`.
 
 ### Independent on-chain audit
 

--- a/docs/relayer/prometheus/walm-52-upload-relay-alerts.yml
+++ b/docs/relayer/prometheus/walm-52-upload-relay-alerts.yml
@@ -1,0 +1,29 @@
+groups:
+  - name: walm-52-upload-relay-cost
+    rules:
+      - alert: Walm52PublicRelayTipSpike
+        expr: sum(rate(walrus_upload_relay_tip_mist_total{send_tip="true"}[1h])) > 2 * quantile_over_time(0.5, sum(rate(walrus_upload_relay_tip_mist_total{send_tip="true"}[1h]))[7d:1h])
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Public Walrus relay tip burn is more than 2x trailing 7-day median"
+          description: "Pool-funded public relay tips are burning faster than the recent baseline. Check upload volume and decide whether to expand the self-hosted relay canary or request more pool funding."
+
+      - alert: Walm52CanaryTipNonZero
+        expr: sum(rate(walrus_upload_relay_tip_mist_total{send_tip="false"}[5m])) > 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Self-hosted no-tip relay canary is still paying relay tips"
+          description: "A sidecar labeled send_tip=false emitted non-zero relay tip spend. Verify WALRUS_UPLOAD_RELAY_SEND_TIP=false and that WALRUS_UPLOAD_RELAY_URL points at a no-tip self-hosted relay."
+
+      - alert: Walm52WalrusMetricsMirrorDown
+        expr: memwal_sidecar_walrus_metrics_scrape_success == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Relayer cannot mirror WALM-52 sidecar metrics"
+          description: "The relayer /metrics endpoint could not fetch sidecar /metrics/walrus. Existing relayer metrics are still served, but WALM-52 tip-spend panels may be stale or missing."

--- a/docs/relayer/walm-52-canary.md
+++ b/docs/relayer/walm-52-canary.md
@@ -12,7 +12,7 @@ Pool wallets fund only the relay tip. Gas for register/certify is sponsored by E
 
 - Self-hosted `walrus-upload-relay` reachable from at least one MemWal sidecar host (config: `tip_config: !no_tip`).
 - Existing public-relay sidecar(s) continue running as the **control**.
-- Prometheus scraping the sidecar `/metrics/walrus` endpoint (see [Observability](/relayer/observability#walm-52-upload-relay-tip-spend)).
+- Prometheus scraping relayer `/metrics`, which mirrors sidecar `/metrics/walrus` when the sidecar is reachable (see [Observability](/relayer/observability#walm-52-upload-relay-tip-spend)).
 
 ## Canary env
 
@@ -56,7 +56,7 @@ Run the canary for **24-48h** before flipping the remaining instances. Compare c
 | Signal | Canary expectation | PromQL |
 | --- | --- | --- |
 | Tip burn rate | drops to **0 SUI/hr** | `rate(walrus_upload_relay_tip_mist_total{send_tip="false"}[1h])` |
-| Upload success rate | matches control within noise | `rate(walrus_upload_relay_uploads_total[1h])` by `host` vs sidecar error logs |
+| Register-confirmed upload-attempt rate | matches control within noise | `rate(walrus_upload_relay_uploads_total[1h])` by `host` vs sidecar error logs |
 | Upload p50 / p95 latency | no material regression vs control | existing `memwal_external_request_duration_seconds{service="sidecar",operation="walrus_upload"}` |
 | Self-hosted relay CPU / bandwidth | within operating budget | infra-side metrics on the relay box |
 

--- a/docs/relayer/walm-52-canary.md
+++ b/docs/relayer/walm-52-canary.md
@@ -1,0 +1,107 @@
+---
+title: "WALM-52 Canary"
+---
+
+WALM-52 is a cost-reduction trial: run our own `walrus-upload-relay` with `tip_config: !no_tip` and measure whether it materially reduces SUI pool burn against the public Walrus team relay. This page is the operator runbook.
+
+<Note>
+Pool wallets fund only the relay tip. Gas for register/certify is sponsored by Enoki separately and is not in scope for this trial. Walrus storage / WAL is a third bucket and is also out of scope.
+</Note>
+
+## Prerequisites
+
+- Self-hosted `walrus-upload-relay` reachable from at least one MemWal sidecar host (config: `tip_config: !no_tip`).
+- Existing public-relay sidecar(s) continue running as the **control**.
+- Prometheus scraping the sidecar `/metrics/walrus` endpoint (see [Observability](/relayer/observability#walm-52-upload-relay-tip-spend)).
+
+## Canary env
+
+On the canary sidecar instance only:
+
+```bash
+WALRUS_UPLOAD_RELAY_URL=http://<internal-relay-host>:<port>
+WALRUS_UPLOAD_RELAY_SEND_TIP=false
+# Optional: tighten the SDK-side max (defensive; should never trigger in no-tip mode)
+# WALRUS_UPLOAD_RELAY_TIP_MAX_MIST=0
+```
+
+Restart the sidecar. The other (control) sidecars keep their existing `WALRUS_UPLOAD_RELAY_URL` and do not need `WALRUS_UPLOAD_RELAY_SEND_TIP` set — the default is `true`.
+
+## Verify the canary is on the new path
+
+Check the sidecar startup log for the `sidecar_ready` event — its `state` block now includes:
+
+```json
+{
+  "uploadRelayHost": "<internal-relay-host>:<port>",
+  "uploadRelaySendTip": false,
+  "uploadRelayTipMaxMist": null
+}
+```
+
+Confirm each upload is taking the no-tip path by tailing for the `register_sponsor` line:
+
+```bash
+journalctl -u memwal-sidecar -f | grep register_sponsor
+```
+
+The canary should emit `"sendTip":false,"tipRecipient":null`. The control should emit `"sendTip":true,"tipRecipient":"0x765a6ff2...086256"` on mainnet (`sidecar-server.ts` `shortAddress()` truncates the full mainnet tip-recipient `0x765a6ff2c13b47e2603416d0b5a156df498a5c51bc8085be3838e43e06086256`; testnet is `0x4b6a7439...dc52b6`). These are the current values — the Walrus team can rotate them, so confirm with `curl <relay>/v1/tip-config | jq .send_tip.address` before treating any specific prefix as canonical.
+
+After a successful upload, the canary's `ok` log line carries `"registerTipMist":"0"`; the control's should carry a small non-zero value like `"registerTipMist":"4500000"`.
+
+## Success criteria
+
+Run the canary for **24-48h** before flipping the remaining instances. Compare canary vs control on:
+
+| Signal | Canary expectation | PromQL |
+| --- | --- | --- |
+| Tip burn rate | drops to **0 SUI/hr** | `rate(walrus_upload_relay_tip_mist_total{send_tip="false"}[1h])` |
+| Upload success rate | matches control within noise | `rate(walrus_upload_relay_uploads_total[1h])` by `host` vs sidecar error logs |
+| Upload p50 / p95 latency | no material regression vs control | existing `memwal_external_request_duration_seconds{service="sidecar",operation="walrus_upload"}` |
+| Self-hosted relay CPU / bandwidth | within operating budget | infra-side metrics on the relay box |
+
+Flip the remaining instances only if **all four** hold.
+
+## Validate the metric against on-chain truth
+
+Before trusting the Prometheus counter for the funding decision, cross-check it against the audit script for the same window. **Always fetch the tip recipient from the live relay** — it is per-relay config, not a static constant, and the Walrus team can rotate it without warning:
+
+```bash
+# 1. Fetch the live tip recipient for the network you're auditing.
+TIP_ADDR=$(curl -s https://upload-relay.mainnet.walrus.space/v1/tip-config | jq -r '.send_tip.address')
+# (testnet equivalent: https://upload-relay.testnet.walrus.space/v1/tip-config)
+
+# 2. Run the audit.
+npx tsx services/server/scripts/walrus-tip-audit.ts \
+  --pool-address 0x<pool-wallet-1> --pool-address 0x<pool-wallet-2> \
+  --relay-tip-address "$TIP_ADDR" \
+  --from <ISO> --to <ISO>
+```
+
+Current known values (as of this writing — verify with the `curl` above):
+
+| Network | Relay tip address |
+| --- | --- |
+| mainnet | `0x765a6ff2c13b47e2603416d0b5a156df498a5c51bc8085be3838e43e06086256` |
+| testnet | `0x4b6a7439159cf10533147fc3d678cf10b714f2bc998f6cb1f1b0b9594cdc52b6` |
+
+Sum the `relay_tip_sui` column across pool wallets — it should match what Grafana reports for the same window (within rounding from RPC pagination boundaries).
+
+The audit script is the figure to hand to Daniel for the funding ask; Prometheus is for ongoing monitoring.
+
+## Rollback
+
+Per-instance:
+
+```bash
+unset WALRUS_UPLOAD_RELAY_URL          # falls back to public mainnet/testnet defaults
+unset WALRUS_UPLOAD_RELAY_SEND_TIP     # falls back to true
+```
+
+Restart the sidecar. Within one restart cycle the instance is back on the public relay path and paying tips again. No code change or redeploy is required for rollback.
+
+## Stakeholder map
+
+- **Trial owner**: Henry Nguyen (WALM-52).
+- **Engineering**: Harry Phan.
+- **Funding decision**: Daniel Lam — waiting on the trial outcome before approving (or declining) the next SUI top-up of the pool wallets.

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -79,6 +79,13 @@ MEMWAL_REGISTRY_ID=0x...
 
 # Walrus upload relay (auto-detected from SUI_NETWORK if not set)
 # WALRUS_UPLOAD_RELAY_URL=https://upload-relay.mainnet.walrus.space
+# WALM-52: set to "false" when WALRUS_UPLOAD_RELAY_URL points at a self-hosted
+# walrus-upload-relay configured with `tip_config: !no_tip`. The sidecar will
+# skip the /v1/tip-config fetch and omit sendTip from the Walrus client config,
+# so no relay tip is ever included in the register tx. Default: true (public relay).
+# WALRUS_UPLOAD_RELAY_SEND_TIP=true
+# Max acceptable relay tip in MIST when sendTip is enabled (default 10_000_000 = 0.01 SUI).
+# WALRUS_UPLOAD_RELAY_TIP_MAX_MIST=10000000
 # Number of Walrus storage epochs requested for new uploads.
 # Mainnet default is 3; sidecar caps this at 5 to avoid accidental large spends.
 # WALRUS_STORAGE_EPOCHS=3

--- a/services/server/scripts/__tests__/walm52-tip-metrics.test.ts
+++ b/services/server/scripts/__tests__/walm52-tip-metrics.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    SUI_COIN_TYPE,
+    type SuiBalanceChange,
+    escapePromLabel,
+    extractTipMistFromBalanceChanges,
+    relayHostLabel,
+    renderWalmTipMetrics,
+} from "../walm52-tip-metrics.js";
+
+const RELAY_TIP_ADDR = "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77";
+const SIGNER_ADDR = "0xaaaa000000000000000000000000000000000000000000000000000000000001";
+
+function change(amount: string, ownerAddr: string, coinType: string = SUI_COIN_TYPE): SuiBalanceChange {
+    return { amount, coinType, owner: { AddressOwner: ownerAddr } };
+}
+
+test("extractTipMistFromBalanceChanges sums positive SUI deltas addressed to tipRecipient", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [
+            change("-5000000", SIGNER_ADDR),
+            change("4500000", RELAY_TIP_ADDR),
+        ],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 4_500_000n);
+});
+
+test("returns 0n when tipRecipient is null (no-tip mode)", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [change("4500000", RELAY_TIP_ADDR)],
+        null,
+    );
+    assert.equal(result, 0n);
+});
+
+test("returns 0n when balance changes are null or empty (RPC returned no data)", () => {
+    assert.equal(extractTipMistFromBalanceChanges(null, RELAY_TIP_ADDR), 0n);
+    assert.equal(extractTipMistFromBalanceChanges(undefined, RELAY_TIP_ADDR), 0n);
+    assert.equal(extractTipMistFromBalanceChanges([], RELAY_TIP_ADDR), 0n);
+});
+
+test("ignores non-SUI coin types even when addressed to tipRecipient", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [change("4500000", RELAY_TIP_ADDR, "0x2::wal::WAL")],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 0n);
+});
+
+test("ignores negative deltas addressed to tipRecipient (defensive: tip never withdraws)", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [change("-4500000", RELAY_TIP_ADDR)],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 0n);
+});
+
+test("ignores AddressOwner mismatch (tip going to a different relay)", () => {
+    const otherRelay = "0x" + "ff".repeat(32);
+    const result = extractTipMistFromBalanceChanges(
+        [change("4500000", otherRelay)],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 0n);
+});
+
+test("ignores ObjectOwner / Shared / Immutable owners (only AddressOwner counts)", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [
+            { amount: "4500000", coinType: SUI_COIN_TYPE, owner: { ObjectOwner: RELAY_TIP_ADDR } },
+            { amount: "4500000", coinType: SUI_COIN_TYPE, owner: { Shared: { initial_shared_version: "1" } } },
+            { amount: "4500000", coinType: SUI_COIN_TYPE, owner: "Immutable" as unknown },
+        ] as SuiBalanceChange[],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 0n);
+});
+
+test("sums multiple positive entries for the same tipRecipient (defensive: usually one, support N)", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [
+            change("1000000", RELAY_TIP_ADDR),
+            change("2000000", RELAY_TIP_ADDR),
+        ],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 3_000_000n);
+});
+
+test("address comparison is case-insensitive (Sui addresses are hex; SDK may return mixed case)", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [change("4500000", RELAY_TIP_ADDR.toUpperCase().replace(/^0X/, "0x"))],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 4_500_000n);
+});
+
+test("malformed amount string contributes 0 (does not crash)", () => {
+    const result = extractTipMistFromBalanceChanges(
+        [
+            { amount: "not-a-number", coinType: SUI_COIN_TYPE, owner: { AddressOwner: RELAY_TIP_ADDR } },
+            change("123", RELAY_TIP_ADDR),
+        ],
+        RELAY_TIP_ADDR,
+    );
+    assert.equal(result, 123n);
+});
+
+test("relayHostLabel returns hostname without protocol/path", () => {
+    assert.equal(relayHostLabel("https://upload-relay.mainnet.walrus.space"), "upload-relay.mainnet.walrus.space");
+    assert.equal(relayHostLabel("http://internal-relay:9180/v1"), "internal-relay:9180");
+});
+
+test("relayHostLabel falls back to raw value on parse failure", () => {
+    assert.equal(relayHostLabel("not a url"), "not a url");
+});
+
+test("escapePromLabel escapes backslash, quote, and newline", () => {
+    assert.equal(escapePromLabel('a\\b"c\nd'), 'a\\\\b\\"c\\nd');
+});
+
+test("renderWalmTipMetrics emits both counters with host + send_tip labels", () => {
+    const out = renderWalmTipMetrics(
+        { uploadsTotal: 7, tipMistTotal: 31_500_000n },
+        { host: "upload-relay.mainnet.walrus.space", sendTip: true },
+    );
+    assert.match(out, /^# HELP walrus_upload_relay_uploads_total/m);
+    assert.match(out, /^# TYPE walrus_upload_relay_uploads_total counter$/m);
+    assert.match(out, /^walrus_upload_relay_uploads_total\{host="upload-relay\.mainnet\.walrus\.space",send_tip="true"\} 7$/m);
+    assert.match(out, /^# HELP walrus_upload_relay_tip_mist_total/m);
+    assert.match(out, /^# TYPE walrus_upload_relay_tip_mist_total counter$/m);
+    assert.match(out, /^walrus_upload_relay_tip_mist_total\{host="upload-relay\.mainnet\.walrus\.space",send_tip="true"\} 31500000$/m);
+});
+
+test("renderWalmTipMetrics encodes send_tip=false (canary no-tip mode)", () => {
+    const out = renderWalmTipMetrics(
+        { uploadsTotal: 0, tipMistTotal: 0n },
+        { host: "internal-relay:9180", sendTip: false },
+    );
+    assert.match(out, /send_tip="false"/);
+    assert.match(out, /walrus_upload_relay_uploads_total\{[^}]+\} 0$/m);
+    assert.match(out, /walrus_upload_relay_tip_mist_total\{[^}]+\} 0$/m);
+});

--- a/services/server/scripts/__tests__/walm52-tip-metrics.test.ts
+++ b/services/server/scripts/__tests__/walm52-tip-metrics.test.ts
@@ -10,8 +10,8 @@ import {
     renderWalmTipMetrics,
 } from "../walm52-tip-metrics.js";
 
-const RELAY_TIP_ADDR = "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77";
-const SIGNER_ADDR = "0xaaaa000000000000000000000000000000000000000000000000000000000001";
+const RELAY_TIP_ADDR = `0x${"22".repeat(32)}`;
+const SIGNER_ADDR = `0x${"aa".repeat(32)}`;
 
 function change(amount: string, ownerAddr: string, coinType: string = SUI_COIN_TYPE): SuiBalanceChange {
     return { amount, coinType, owner: { AddressOwner: ownerAddr } };

--- a/services/server/scripts/__tests__/walrus-tip-audit.test.ts
+++ b/services/server/scripts/__tests__/walrus-tip-audit.test.ts
@@ -19,8 +19,8 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = resolve(HERE, "..", "walrus-tip-audit.ts");
 
 const POOL = "0x1111111111111111111111111111111111111111111111111111111111111111";
-const TIP_A = "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77";
-const TIP_B = "0xd84704c17fc870b8764832c535aa6b11f21a95cd6f5bb38a9b07d2cf42220c66";
+const TIP_A = `0x${"22".repeat(32)}`;
+const TIP_B = `0x${"33".repeat(32)}`;
 const TIPS: ReadonlySet<string> = new Set([TIP_A, TIP_B].map((a) => a.toLowerCase()));
 
 function change(amount: string, ownerAddr: string, coinType: string = SUI_COIN_TYPE): SuiBalanceChange {

--- a/services/server/scripts/__tests__/walrus-tip-audit.test.ts
+++ b/services/server/scripts/__tests__/walrus-tip-audit.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import {
+    type DailyBucket,
+    bucketKey,
+    classifyTx,
+    dateStem,
+    emitCsv,
+    isCliEntrypoint,
+    parseWindow,
+} from "../walrus-tip-audit.js";
+import { SUI_COIN_TYPE, type SuiBalanceChange } from "../walm52-tip-metrics.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(HERE, "..", "walrus-tip-audit.ts");
+
+const POOL = "0x1111111111111111111111111111111111111111111111111111111111111111";
+const TIP_A = "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77";
+const TIP_B = "0xd84704c17fc870b8764832c535aa6b11f21a95cd6f5bb38a9b07d2cf42220c66";
+const TIPS: ReadonlySet<string> = new Set([TIP_A, TIP_B].map((a) => a.toLowerCase()));
+
+function change(amount: string, ownerAddr: string, coinType: string = SUI_COIN_TYPE): SuiBalanceChange {
+    return { amount, coinType, owner: { AddressOwner: ownerAddr } };
+}
+
+test("parseWindow defaults --from to 24h before --to", () => {
+    const now = new Date("2026-05-26T12:00:00Z");
+    const w = parseWindow(undefined, undefined, now);
+    assert.equal(w.toMs, now.getTime());
+    assert.equal(w.toMs - w.fromMs, 24 * 60 * 60 * 1000);
+});
+
+test("parseWindow honors explicit --from / --to", () => {
+    const w = parseWindow("2026-05-24T05:00:00Z", "2026-05-25T05:00:00Z");
+    assert.equal(dateStem(w.fromMs), "2026-05-24");
+    assert.equal(dateStem(w.toMs), "2026-05-25");
+});
+
+test("parseWindow rejects invalid dates and inverted windows", () => {
+    assert.throws(() => parseWindow("not-a-date", undefined));
+    assert.throws(() => parseWindow(undefined, "not-a-date"));
+    assert.throws(() => parseWindow("2026-05-25T00:00:00Z", "2026-05-24T00:00:00Z"));
+});
+
+test("classifyTx attributes tip + pool outflow correctly when tip is paid", () => {
+    const cls = classifyTx(
+        [
+            change("-12000000", POOL),       // pool spends 0.012 SUI (tip + dust)
+            change("10000000", TIP_A),       // tip A receives 0.010 SUI
+            change("2000000", "0xdead"),     // other transfer receives 0.002 SUI
+        ],
+        POOL,
+        TIPS,
+    );
+    assert.equal(cls.relayTipMist, 10_000_000n);
+    assert.equal(cls.poolOutflowMist, 12_000_000n);
+    assert.equal(cls.hadRelayTip, true);
+});
+
+test("classifyTx records zero tip when no known tip recipient is in balance changes", () => {
+    const cls = classifyTx(
+        [
+            change("-5000000", POOL),
+            change("5000000", "0xdead"),
+        ],
+        POOL,
+        TIPS,
+    );
+    assert.equal(cls.relayTipMist, 0n);
+    assert.equal(cls.poolOutflowMist, 5_000_000n);
+    assert.equal(cls.hadRelayTip, false);
+});
+
+test("classifyTx sums tips across multiple known tip recipients", () => {
+    const cls = classifyTx(
+        [
+            change("-9000000", POOL),
+            change("4000000", TIP_A),
+            change("5000000", TIP_B),
+        ],
+        POOL,
+        TIPS,
+    );
+    assert.equal(cls.relayTipMist, 9_000_000n);
+    assert.equal(cls.poolOutflowMist, 9_000_000n);
+});
+
+test("classifyTx ignores non-SUI coin changes and the wrong sender", () => {
+    const cls = classifyTx(
+        [
+            change("-1000000", "0xnotpool"),               // different sender
+            change("1000000", TIP_A, "0x2::wal::WAL"),     // wrong coin
+        ],
+        POOL,
+        TIPS,
+    );
+    assert.equal(cls.relayTipMist, 0n);
+    assert.equal(cls.poolOutflowMist, 0n);
+});
+
+test("emitCsv writes header + per-bucket rows with mist/sui/upload count", () => {
+    const buckets: DailyBucket[] = [
+        { date: "2026-05-25", poolAddress: POOL, relayTipMist: 2_670_000_000n, poolOutflowMist: 2_700_000_000n, uploadCount: 540 },
+        { date: "2026-05-24", poolAddress: POOL, relayTipMist: 1_000_000_000n, poolOutflowMist: 1_000_000_000n, uploadCount: 200 },
+    ];
+    const csv = emitCsv(buckets);
+    const lines = csv.trim().split("\n");
+    assert.equal(lines[0], "date,pool_address,relay_tip_mist,relay_tip_sui,upload_count_estimate,other_mist");
+    // Sorted ascending by date.
+    assert.match(lines[1], /^2026-05-24,/);
+    assert.match(lines[2], /^2026-05-25,/);
+    // SUI conversion (mist / 1e9), 6 dp.
+    assert.match(lines[2], /,2\.670000,/);
+    // other_mist = pool_outflow - relay_tip.
+    assert.match(lines[2], /,30000000$/);
+});
+
+test("bucketKey is stable for case variants of the same address", () => {
+    assert.equal(
+        bucketKey("2026-05-25", POOL.toUpperCase().replace(/^0X/, "0x")),
+        bucketKey("2026-05-25", POOL.toLowerCase()),
+    );
+});
+
+test("isCliEntrypoint matches the URL-encoded form when invoked via tsx with a spaces-in-path argv[1]", () => {
+    // Repro the original P1 #2 bug: argv[1] is a raw FS path with spaces;
+    // import.meta.url is URL-encoded. Naive `file://${argv[1]}` comparison fails.
+    const pathWithSpace = "/tmp/some dir/walrus-tip-audit.ts";
+    const argv1 = pathWithSpace;
+    const metaUrl = pathToFileURL(pathWithSpace).href;
+    assert.equal(isCliEntrypoint(metaUrl, argv1), true);
+});
+
+test("isCliEntrypoint returns false when argv[1] points elsewhere", () => {
+    const metaUrl = pathToFileURL("/a/walrus-tip-audit.ts").href;
+    assert.equal(isCliEntrypoint(metaUrl, "/b/other.ts"), false);
+});
+
+test("isCliEntrypoint returns false when argv[1] is missing", () => {
+    assert.equal(isCliEntrypoint("file:///irrelevant", undefined), false);
+});
+
+test("CLI --help actually fires under tsx and exits 0 with usage text", () => {
+    const result = spawnSync("npx", ["tsx", SCRIPT, "--help"], {
+        encoding: "utf8",
+        timeout: 30_000,
+    });
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}; stderr=${result.stderr}`);
+    // Help text is written to stderr (so it doesn't pollute CSV stdout).
+    assert.match(result.stderr, /walrus-tip-audit/);
+    assert.match(result.stderr, /Usage:/);
+    assert.match(result.stderr, /--pool-address/);
+});
+
+test("CLI errors clearly when required flags are missing", () => {
+    const result = spawnSync("npx", ["tsx", SCRIPT], {
+        encoding: "utf8",
+        timeout: 30_000,
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--pool-address/);
+});

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -21,6 +21,11 @@ import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
 import { WalrusClient } from "@mysten/walrus";
 import { mountMcpRoutes, shutdownMcpSessions } from "./mcp/index.js";
 import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-config.js";
+import {
+    extractTipMistFromBalanceChanges,
+    relayHostLabel,
+    renderWalmTipMetrics,
+} from "./walm52-tip-metrics.js";
 
 // ============================================================
 // Shared clients (initialized once at boot — the whole point!)
@@ -72,6 +77,16 @@ const WALRUS_UPLOAD_RELAY_URL = process.env.WALRUS_UPLOAD_RELAY_URL || (
         ? "https://upload-relay.testnet.walrus.space"
         : "https://upload-relay.mainnet.walrus.space"
 );
+// WALM-52: explicit opt-out of relay tipping for self-hosted no-tip relays.
+// Default true keeps the public Walrus relay path unchanged.
+const WALRUS_UPLOAD_RELAY_SEND_TIP = (() => {
+    const raw = (process.env.WALRUS_UPLOAD_RELAY_SEND_TIP ?? "true").trim().toLowerCase();
+    return raw !== "0" && raw !== "false" && raw !== "no";
+})();
+const WALRUS_UPLOAD_RELAY_TIP_MAX_MIST = (() => {
+    const parsed = Number.parseInt(process.env.WALRUS_UPLOAD_RELAY_TIP_MAX_MIST || "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 10_000_000;
+})();
 
 const MAX_WALRUS_EPOCHS = 5;
 const DEFAULT_WALRUS_EPOCHS = (() => {
@@ -99,10 +114,14 @@ function createWalrusClient(): WalrusClient {
     return new WalrusClient({
         network: SUI_NETWORK,
         suiClient: suiClient as any,
-        uploadRelay: {
-            host: WALRUS_UPLOAD_RELAY_URL,
-            sendTip: { max: 10_000_000 },
-        },
+        uploadRelay: WALRUS_UPLOAD_RELAY_SEND_TIP
+            ? {
+                host: WALRUS_UPLOAD_RELAY_URL,
+                sendTip: { max: WALRUS_UPLOAD_RELAY_TIP_MAX_MIST },
+            }
+            : {
+                host: WALRUS_UPLOAD_RELAY_URL,
+            },
     });
 }
 
@@ -196,6 +215,15 @@ const sidecarMetrics = {
     walletSubmittedTotal: 0,
     walletLockErrorsTotal: 0,
     walletPermanentFailuresTotal: 0,
+};
+
+// WALM-52: per-process counters for upload-relay tip outflow. Single host +
+// send-tip mode per sidecar instance, so no per-label aggregation is needed —
+// labels are emitted at scrape time from the static config values below.
+const WALRUS_UPLOAD_RELAY_HOST_LABEL = relayHostLabel(WALRUS_UPLOAD_RELAY_URL);
+const walmTipMetrics = {
+    uploadsTotal: 0,
+    tipMistTotal: 0n,
 };
 
 let uploadRelayTipAddressCache: string | null | undefined = undefined;
@@ -336,6 +364,9 @@ function sidecarStateSnapshot(): Record<string, unknown> {
         walletSubmittedTotal: sidecarMetrics.walletSubmittedTotal,
         walletLockErrorsTotal: sidecarMetrics.walletLockErrorsTotal,
         walletPermanentFailuresTotal: sidecarMetrics.walletPermanentFailuresTotal,
+        uploadRelayHost: WALRUS_UPLOAD_RELAY_URL,
+        uploadRelaySendTip: WALRUS_UPLOAD_RELAY_SEND_TIP,
+        uploadRelayTipMaxMist: WALRUS_UPLOAD_RELAY_SEND_TIP ? WALRUS_UPLOAD_RELAY_TIP_MAX_MIST : null,
         uploadRelayTipCache:
             uploadRelayTipAddressCache === undefined
                 ? "uninitialized"
@@ -653,6 +684,18 @@ app.get("/metrics/wallet", (_req: Request, res: Response) => {
         enokiEnabled: !!enokiApiKey,
         suiNetwork: SUI_NETWORK,
     });
+});
+
+// WALM-52: Prometheus text-exposition endpoint for upload-relay tip outflow.
+// Kept above the bearer auth middleware so prometheus can scrape without the
+// SIDECAR_AUTH_TOKEN (matches /metrics/wallet posture).
+app.get("/metrics/walrus", (_req: Request, res: Response) => {
+    res.type("text/plain; version=0.0.4").send(
+        renderWalmTipMetrics(walmTipMetrics, {
+            host: WALRUS_UPLOAD_RELAY_HOST_LABEL,
+            sendTip: WALRUS_UPLOAD_RELAY_SEND_TIP,
+        }),
+    );
 });
 
 // Shared-secret authentication — protects all routes registered after this point.
@@ -1058,6 +1101,9 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
     let namespaceForLog: unknown;
     let signerAddressForLog: string | undefined;
     let blobBytesForLog: number | undefined;
+    // WALM-52: hoisted so `finally` can await the counter-update side effect even
+    // when upload/certify fails after register-confirm.
+    let tipMistPromise: Promise<bigint> = Promise.resolve(0n);
     activeWalrusUploads += 1;
     try {
         const {
@@ -1145,13 +1191,18 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         // Enoki rejects GasCoin as tx argument, but relay requires the tip.
         // After patching, signer pays tip from own SUI; Enoki sponsors gas.
         patchGasCoinIntents(registerTx);
-        const tipRecipient = await getUploadRelayTipAddress();
+        // WALM-52: skip tip-config fetch entirely in no-tip mode so a misconfigured
+        // self-hosted relay can't silently leak tips back into the tx.
+        const tipRecipient = WALRUS_UPLOAD_RELAY_SEND_TIP
+            ? await getUploadRelayTipAddress()
+            : null;
         const registerAllowedAddresses = dedupeAddresses([signerAddress, tipRecipient]);
         phase = "register_sponsor";
         console.log(`[walrus/upload] [${traceId}] register_sponsor ${JSON.stringify({
             keyIndex,
             signer: shortAddress(signerAddress),
             tipRecipient: shortAddress(tipRecipient),
+            sendTip: WALRUS_UPLOAD_RELAY_SEND_TIP,
             allowedAddresses: registerAllowedAddresses.map(shortAddress),
         })}`);
         const registerDigest = await submitWalletTransaction(
@@ -1161,6 +1212,32 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         );
         phase = "register_wait";
         await suiClient.waitForTransaction({ digest: registerDigest });
+
+        // WALM-52: the relay tip is paid inside the register tx. Once register is
+        // confirmed, the SUI is already gone — counters MUST reflect that even if
+        // upload/certify/metadata fail downstream. We launch this IIFE here (after
+        // register_wait) and let it run in parallel with the sliver upload. The
+        // IIFE owns the counter mutation, so the increment fires regardless of
+        // whether the caller ever awaits the resulting MIST value. The `finally`
+        // block awaits the promise to guarantee the microtask completes before
+        // the request ends.
+        tipMistPromise = (async (): Promise<bigint> => {
+            let mist = 0n;
+            if (WALRUS_UPLOAD_RELAY_SEND_TIP && tipRecipient) {
+                try {
+                    const txResp = await suiClient.getTransactionBlock({
+                        digest: registerDigest,
+                        options: { showBalanceChanges: true },
+                    });
+                    mist = extractTipMistFromBalanceChanges(txResp.balanceChanges, tipRecipient);
+                } catch (tipErr: any) {
+                    console.warn(`[walm-52] [${traceId}] tip-mist fetch failed digest=${registerDigest}: ${tipErr?.message || tipErr}`);
+                }
+            }
+            walmTipMetrics.uploadsTotal += 1;
+            walmTipMetrics.tipMistTotal += mist;
+            return mist;
+        })();
 
         phase = "upload_blob";
         await flow.upload({ digest: registerDigest });
@@ -1213,12 +1290,20 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         }
 
         phase = "respond";
+        // WALM-52: counter mutation lives inside tipMistPromise so it fires on
+        // register-confirm regardless of downstream success. Here we only read
+        // the resolved value for the success log.
+        const registerTipMist = await tipMistPromise;
         console.log(`[walrus/upload] [${traceId}] ok ${JSON.stringify({
             blobId: blob.blobId,
             objectId: blobObjectId,
             transferStatus: deferTransfer ? "deferred" : "ok",
             keyIndex,
             bytes: blobBytesForLog,
+            uploadRelayHost: WALRUS_UPLOAD_RELAY_HOST_LABEL,
+            uploadRelaySendTip: WALRUS_UPLOAD_RELAY_SEND_TIP,
+            tipRecipient: shortAddress(tipRecipient),
+            registerTipMist: registerTipMist.toString(),
         })}`);
         res.json({
             blobId: blob.blobId,
@@ -1254,6 +1339,9 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         });
         res.status(500).json({ error: message, traceId });
     } finally {
+        // WALM-52: ensure the register-tip IIFE settles before the request ends,
+        // so the counter increment is never lost to a dangling microtask.
+        try { await tipMistPromise; } catch { /* counter mutation already swallowed errors */ }
         activeWalrusUploads = Math.max(0, activeWalrusUploads - 1);
     }
 });

--- a/services/server/scripts/walm52-tip-metrics.ts
+++ b/services/server/scripts/walm52-tip-metrics.ts
@@ -1,0 +1,108 @@
+/**
+ * WALM-52: pure helpers for extracting Walrus upload-relay tip outflow from
+ * Sui register-tx balance changes. Kept in a standalone module so unit tests
+ * can exercise the parsing without spinning up the sidecar.
+ */
+
+export type SuiBalanceChangeOwner =
+    | { AddressOwner: string }
+    | { ObjectOwner: string }
+    | { Shared: unknown }
+    | "Immutable"
+    | unknown;
+
+export interface SuiBalanceChange {
+    amount: string;
+    coinType: string;
+    owner: SuiBalanceChangeOwner;
+}
+
+export const SUI_COIN_TYPE = "0x2::sui::SUI";
+
+function normalizeSuiAddress(addr: string): string {
+    return addr.trim().toLowerCase();
+}
+
+/**
+ * Returns the positive SUI MIST amount transferred to `tipRecipient` in the
+ * given balance changes. Returns 0n when:
+ *   - tipRecipient is null/empty (no-tip mode)
+ *   - changes is null/empty (RPC returned no balance changes)
+ *   - no positive SUI change is addressed to tipRecipient
+ *
+ * Negative deltas, non-SUI coin types, and non-AddressOwner entries are ignored.
+ */
+export function extractTipMistFromBalanceChanges(
+    changes: SuiBalanceChange[] | null | undefined,
+    tipRecipient: string | null | undefined,
+): bigint {
+    if (!tipRecipient || !changes || changes.length === 0) return 0n;
+    const target = normalizeSuiAddress(tipRecipient);
+    let total = 0n;
+    for (const change of changes) {
+        if (change.coinType !== SUI_COIN_TYPE) continue;
+        const owner = change.owner as { AddressOwner?: unknown };
+        if (typeof owner?.AddressOwner !== "string") continue;
+        if (normalizeSuiAddress(owner.AddressOwner) !== target) continue;
+        let amount: bigint;
+        try {
+            amount = BigInt(change.amount);
+        } catch {
+            continue;
+        }
+        if (amount > 0n) total += amount;
+    }
+    return total;
+}
+
+/**
+ * Extract a stable, low-cardinality host label from a relay URL for Prometheus
+ * labels. Falls back to the raw value if URL parsing fails.
+ */
+export function relayHostLabel(rawUrl: string): string {
+    try {
+        return new URL(rawUrl).host;
+    } catch {
+        return rawUrl;
+    }
+}
+
+/**
+ * Escape a label value per the Prometheus text exposition format:
+ *   backslash, double-quote, and newline must be escaped.
+ */
+export function escapePromLabel(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+export interface WalmTipMetricsState {
+    uploadsTotal: number;
+    tipMistTotal: bigint;
+}
+
+export interface WalmTipMetricsLabels {
+    host: string;
+    sendTip: boolean;
+}
+
+/**
+ * Render the two WALM-52 counters in Prometheus 0.0.4 text exposition format.
+ * Single instance, single label set per process — no per-label aggregation.
+ */
+export function renderWalmTipMetrics(
+    state: WalmTipMetricsState,
+    labels: WalmTipMetricsLabels,
+): string {
+    const host = escapePromLabel(labels.host);
+    const sendTip = labels.sendTip ? "true" : "false";
+    const labelSet = `{host="${host}",send_tip="${sendTip}"}`;
+    return [
+        "# HELP walrus_upload_relay_uploads_total Successful Walrus upload-relay register flows since sidecar start.",
+        "# TYPE walrus_upload_relay_uploads_total counter",
+        `walrus_upload_relay_uploads_total${labelSet} ${state.uploadsTotal}`,
+        "# HELP walrus_upload_relay_tip_mist_total SUI MIST paid as upload-relay tip since sidecar start (parsed from register-tx balance changes).",
+        "# TYPE walrus_upload_relay_tip_mist_total counter",
+        `walrus_upload_relay_tip_mist_total${labelSet} ${state.tipMistTotal.toString()}`,
+        "",
+    ].join("\n");
+}

--- a/services/server/scripts/walm52-tip-metrics.ts
+++ b/services/server/scripts/walm52-tip-metrics.ts
@@ -97,7 +97,7 @@ export function renderWalmTipMetrics(
     const sendTip = labels.sendTip ? "true" : "false";
     const labelSet = `{host="${host}",send_tip="${sendTip}"}`;
     return [
-        "# HELP walrus_upload_relay_uploads_total Successful Walrus upload-relay register flows since sidecar start.",
+        "# HELP walrus_upload_relay_uploads_total Register-confirmed Walrus upload-relay attempts since sidecar start.",
         "# TYPE walrus_upload_relay_uploads_total counter",
         `walrus_upload_relay_uploads_total${labelSet} ${state.uploadsTotal}`,
         "# HELP walrus_upload_relay_tip_mist_total SUI MIST paid as upload-relay tip since sidecar start (parsed from register-tx balance changes).",

--- a/services/server/scripts/walrus-tip-audit.ts
+++ b/services/server/scripts/walrus-tip-audit.ts
@@ -1,0 +1,293 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * WALM-52: on-chain audit of upload-relay tip outflow from pool wallets.
+ *
+ * Independent of any metric the sidecar emits — queries Sui RPC directly so it
+ * can validate (or contradict) the `walrus_upload_relay_tip_mist_total` counter
+ * and reproduce Henry's "2.67 SUI in 12h" measurement.
+ *
+ * Output: CSV to stdout —
+ *   date,pool_address,relay_tip_mist,relay_tip_sui,upload_count_estimate,other_mist
+ *
+ * Inputs:
+ *   --pool-address <0x...> (repeatable) OR env WALRUS_TIP_POOL_ADDRESSES (comma-sep)
+ *   --relay-tip-address <0x...> (repeatable) OR env WALRUS_RELAY_TIP_ADDRESSES (comma-sep)
+ *   --from <ISO-8601>   default: now - 24h
+ *   --to   <ISO-8601>   default: now
+ *   --network <mainnet|testnet>   default: mainnet
+ *   --rpc-url <url>     optional override of Sui RPC URL
+ *   --page-size <n>     default: 50 (RPC max is typically 50)
+ *
+ * Example:
+ *   # 1. Get the current relay tip recipient (it's per-relay config, not static).
+ *   curl -s https://upload-relay.mainnet.walrus.space/v1/tip-config | jq '.send_tip.address'
+ *   # 2. Run the audit with that address (today's mainnet value shown; verify before use).
+ *   npx tsx walrus-tip-audit.ts \
+ *     --pool-address 0xaaa... --pool-address 0xbbb... \
+ *     --relay-tip-address 0x765a6ff2c13b47e2603416d0b5a156df498a5c51bc8085be3838e43e06086256 \
+ *     --from 2026-05-24T05:00:00Z --to 2026-05-25T05:00:00Z
+ *
+ * Current known relay-tip recipients (curl /v1/tip-config to confirm — they can change):
+ *   mainnet: 0x765a6ff2c13b47e2603416d0b5a156df498a5c51bc8085be3838e43e06086256
+ *   testnet: 0x4b6a7439159cf10533147fc3d678cf10b714f2bc998f6cb1f1b0b9594cdc52b6
+ */
+
+import { resolve as resolvePath } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
+
+import {
+    SUI_COIN_TYPE,
+    extractTipMistFromBalanceChanges,
+    type SuiBalanceChange,
+} from "./walm52-tip-metrics.js";
+
+// ============================================================
+// Pure helpers (testable without Sui RPC)
+// ============================================================
+
+export interface AuditWindow {
+    fromMs: number;
+    toMs: number;
+}
+
+export function parseWindow(
+    fromArg: string | undefined,
+    toArg: string | undefined,
+    now: Date = new Date(),
+): AuditWindow {
+    const toMs = toArg ? Date.parse(toArg) : now.getTime();
+    if (Number.isNaN(toMs)) throw new Error(`--to is not a valid ISO date: ${toArg}`);
+    const defaultFrom = toMs - 24 * 60 * 60 * 1000;
+    const fromMs = fromArg ? Date.parse(fromArg) : defaultFrom;
+    if (Number.isNaN(fromMs)) throw new Error(`--from is not a valid ISO date: ${fromArg}`);
+    if (fromMs >= toMs) throw new Error(`--from (${fromArg}) must be earlier than --to (${toArg})`);
+    return { fromMs, toMs };
+}
+
+export function dateStem(ms: number): string {
+    return new Date(ms).toISOString().slice(0, 10);
+}
+
+export interface AuditTxClassification {
+    relayTipMist: bigint;
+    poolOutflowMist: bigint;
+    hadRelayTip: boolean;
+}
+
+/**
+ * Classify a single tx's contribution from one pool address's perspective:
+ *   - relayTipMist:  positive SUI delta to any known tip recipient
+ *   - poolOutflowMist:  magnitude of negative SUI delta owned by poolAddress
+ *   - hadRelayTip:  true iff this tx paid a non-zero tip (= 1 upload)
+ *
+ * "other" outflow is derived at aggregation time as poolOutflow - relayTip.
+ */
+export function classifyTx(
+    balanceChanges: SuiBalanceChange[] | null | undefined,
+    poolAddress: string,
+    relayTipAddresses: ReadonlySet<string>,
+): AuditTxClassification {
+    let relayTipMist = 0n;
+    for (const tipAddr of relayTipAddresses) {
+        relayTipMist += extractTipMistFromBalanceChanges(balanceChanges, tipAddr);
+    }
+    let poolOutflowMist = 0n;
+    if (balanceChanges) {
+        const target = poolAddress.trim().toLowerCase();
+        for (const change of balanceChanges) {
+            if (change.coinType !== SUI_COIN_TYPE) continue;
+            const owner = change.owner as { AddressOwner?: unknown };
+            if (typeof owner?.AddressOwner !== "string") continue;
+            if (owner.AddressOwner.trim().toLowerCase() !== target) continue;
+            let amount: bigint;
+            try { amount = BigInt(change.amount); } catch { continue; }
+            if (amount < 0n) poolOutflowMist += -amount;
+        }
+    }
+    return { relayTipMist, poolOutflowMist, hadRelayTip: relayTipMist > 0n };
+}
+
+export interface DailyBucket {
+    date: string;
+    poolAddress: string;
+    relayTipMist: bigint;
+    poolOutflowMist: bigint;
+    uploadCount: number;
+}
+
+export function bucketKey(date: string, poolAddress: string): string {
+    return `${date}\t${poolAddress.toLowerCase()}`;
+}
+
+export function emitCsv(buckets: Iterable<DailyBucket>): string {
+    const header = "date,pool_address,relay_tip_mist,relay_tip_sui,upload_count_estimate,other_mist";
+    const rows: string[] = [header];
+    const sorted = [...buckets].sort((a, b) => a.date.localeCompare(b.date) || a.poolAddress.localeCompare(b.poolAddress));
+    for (const b of sorted) {
+        const otherMist = b.poolOutflowMist > b.relayTipMist ? b.poolOutflowMist - b.relayTipMist : 0n;
+        const tipSui = (Number(b.relayTipMist) / 1e9).toFixed(6);
+        rows.push([b.date, b.poolAddress.toLowerCase(), b.relayTipMist.toString(), tipSui, b.uploadCount.toString(), otherMist.toString()].join(","));
+    }
+    return rows.join("\n") + "\n";
+}
+
+// ============================================================
+// CLI parsing
+// ============================================================
+
+interface CliArgs {
+    poolAddresses: string[];
+    relayTipAddresses: string[];
+    from?: string;
+    to?: string;
+    network: "mainnet" | "testnet";
+    rpcUrl?: string;
+    pageSize: number;
+}
+
+const HELP_TEXT = `walrus-tip-audit — on-chain audit of WALM-52 upload-relay tip outflow.
+
+Usage:
+  npx tsx services/server/scripts/walrus-tip-audit.ts \\
+    --pool-address 0x<addr> [--pool-address 0x<addr>...] \\
+    --relay-tip-address 0x<addr> [--relay-tip-address 0x<addr>...] \\
+    [--from <ISO-8601>] [--to <ISO-8601>] \\
+    [--network mainnet|testnet] [--rpc-url <url>] [--page-size <1-50>]
+
+Required:
+  --pool-address          Sui address of a pool wallet (repeatable).
+                          Env fallback: WALRUS_TIP_POOL_ADDRESSES (comma-sep).
+  --relay-tip-address     Sui address of a known relay tip recipient (repeatable).
+                          Env fallback: WALRUS_RELAY_TIP_ADDRESSES (comma-sep).
+
+Optional:
+  --from / --to           ISO timestamps. Default: last 24h.
+  --network               mainnet (default) or testnet.
+  --rpc-url               Override the Sui JSON-RPC URL.
+  --page-size             Sui RPC page size, 1..50 (default 50).
+  -h, --help              Print this help and exit.
+
+Output: CSV to stdout with header
+  date,pool_address,relay_tip_mist,relay_tip_sui,upload_count_estimate,other_mist
+`;
+
+function splitEnvList(name: string): string[] {
+    const v = process.env[name];
+    return v ? v.split(",").map((s) => s.trim()).filter(Boolean) : [];
+}
+
+function parseCliArgs(argv: string[]): CliArgs {
+    const poolAddresses: string[] = [];
+    const relayTipAddresses: string[] = [];
+    let from: string | undefined;
+    let to: string | undefined;
+    let network: "mainnet" | "testnet" = "mainnet";
+    let rpcUrl: string | undefined;
+    let pageSize = 50;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        switch (a) {
+            case "--pool-address": poolAddresses.push(argv[++i]); break;
+            case "--relay-tip-address": relayTipAddresses.push(argv[++i]); break;
+            case "--from": from = argv[++i]; break;
+            case "--to": to = argv[++i]; break;
+            case "--network": network = argv[++i] as "mainnet" | "testnet"; break;
+            case "--rpc-url": rpcUrl = argv[++i]; break;
+            case "--page-size": pageSize = Number.parseInt(argv[++i], 10); break;
+            case "-h":
+            case "--help":
+                process.stderr.write(HELP_TEXT);
+                process.exit(0);
+            default:
+                throw new Error(`Unknown arg: ${a}`);
+        }
+    }
+    for (const addr of splitEnvList("WALRUS_TIP_POOL_ADDRESSES")) {
+        if (!poolAddresses.includes(addr)) poolAddresses.push(addr);
+    }
+    for (const addr of splitEnvList("WALRUS_RELAY_TIP_ADDRESSES")) {
+        if (!relayTipAddresses.includes(addr)) relayTipAddresses.push(addr);
+    }
+    if (poolAddresses.length === 0) {
+        throw new Error("at least one --pool-address (or WALRUS_TIP_POOL_ADDRESSES) is required");
+    }
+    if (relayTipAddresses.length === 0) {
+        throw new Error("at least one --relay-tip-address (or WALRUS_RELAY_TIP_ADDRESSES) is required");
+    }
+    if (network !== "mainnet" && network !== "testnet") {
+        throw new Error(`--network must be mainnet or testnet, got: ${network}`);
+    }
+    if (!(pageSize > 0 && pageSize <= 50)) {
+        throw new Error(`--page-size must be in (0, 50], got: ${pageSize}`);
+    }
+    return { poolAddresses, relayTipAddresses, from, to, network, rpcUrl, pageSize };
+}
+
+// ============================================================
+// Main — walk Sui RPC and emit CSV
+// ============================================================
+
+async function main(): Promise<void> {
+    const args = parseCliArgs(process.argv.slice(2));
+    const window = parseWindow(args.from, args.to);
+    const url = args.rpcUrl || getJsonRpcFullnodeUrl(args.network);
+    const client = new SuiJsonRpcClient({ url, network: args.network });
+    const relayTipSet: ReadonlySet<string> = new Set(args.relayTipAddresses.map((a) => a.trim().toLowerCase()));
+    const buckets = new Map<string, DailyBucket>();
+
+    for (const poolAddress of args.poolAddresses) {
+        let cursor: string | null | undefined = undefined;
+        let stop = false;
+        while (!stop) {
+            const page = await client.queryTransactionBlocks({
+                filter: { FromAddress: poolAddress },
+                options: { showBalanceChanges: true },
+                order: "descending",
+                limit: args.pageSize,
+                cursor: cursor ?? null,
+            });
+            for (const tx of page.data) {
+                const ts = tx.timestampMs ? Number(tx.timestampMs) : 0;
+                if (ts === 0) continue;
+                if (ts < window.fromMs) { stop = true; break; }
+                if (ts > window.toMs) continue;
+                const cls = classifyTx(tx.balanceChanges as unknown as SuiBalanceChange[] | null, poolAddress, relayTipSet);
+                const date = dateStem(ts);
+                const key = bucketKey(date, poolAddress);
+                let bucket = buckets.get(key);
+                if (!bucket) {
+                    bucket = { date, poolAddress, relayTipMist: 0n, poolOutflowMist: 0n, uploadCount: 0 };
+                    buckets.set(key, bucket);
+                }
+                bucket.relayTipMist += cls.relayTipMist;
+                bucket.poolOutflowMist += cls.poolOutflowMist;
+                if (cls.hadRelayTip) bucket.uploadCount += 1;
+            }
+            if (!page.hasNextPage || !page.nextCursor) break;
+            cursor = page.nextCursor;
+        }
+    }
+
+    process.stdout.write(emitCsv(buckets.values()));
+}
+
+// Main-guard: import.meta.url is URL-encoded (e.g. file:///path%20with%20space/...)
+// while process.argv[1] is the raw filesystem path. `pathToFileURL` does the
+// same encoding so the comparison works for paths with spaces or unicode.
+export function isCliEntrypoint(metaUrl: string, argv1: string | undefined): boolean {
+    if (!argv1) return false;
+    try {
+        return metaUrl === pathToFileURL(resolvePath(argv1)).href;
+    } catch {
+        return false;
+    }
+}
+
+if (isCliEntrypoint(import.meta.url, process.argv[1])) {
+    main().catch((err) => {
+        console.error(`walrus-tip-audit error: ${err?.message || err}`);
+        process.exit(1);
+    });
+}

--- a/services/server/scripts/walrus-upload.ts
+++ b/services/server/scripts/walrus-upload.ts
@@ -96,6 +96,13 @@ async function main() {
             ? "https://upload-relay.testnet.walrus.space"
             : "https://upload-relay.mainnet.walrus.space"
     );
+    // WALM-52: keep parity with sidecar so this CLI honors the same no-tip toggle.
+    const sendTipRaw = (process.env.WALRUS_UPLOAD_RELAY_SEND_TIP ?? "true").trim().toLowerCase();
+    const WALRUS_UPLOAD_RELAY_SEND_TIP = sendTipRaw !== "0" && sendTipRaw !== "false" && sendTipRaw !== "no";
+    const tipMaxParsed = Number.parseInt(process.env.WALRUS_UPLOAD_RELAY_TIP_MAX_MIST || "", 10);
+    const WALRUS_UPLOAD_RELAY_TIP_MAX_MIST = Number.isFinite(tipMaxParsed) && tipMaxParsed > 0
+        ? tipMaxParsed
+        : 10_000_000;
 
     // Create Sui JSON-RPC client
     const suiClient = new SuiJsonRpcClient({
@@ -107,10 +114,14 @@ async function main() {
     const walrusClient = new WalrusClient({
         network: SUI_NETWORK,
         suiClient: suiClient as any,
-        uploadRelay: {
-            host: WALRUS_UPLOAD_RELAY_URL,
-            sendTip: { max: 10_000_000 },
-        },
+        uploadRelay: WALRUS_UPLOAD_RELAY_SEND_TIP
+            ? {
+                host: WALRUS_UPLOAD_RELAY_URL,
+                sendTip: { max: WALRUS_UPLOAD_RELAY_TIP_MAX_MIST },
+            }
+            : {
+                host: WALRUS_UPLOAD_RELAY_URL,
+            },
     });
 
     // writeBlobFlow is a stateful object — each step stores results internally

--- a/services/server/src/observability.rs
+++ b/services/server/src/observability.rs
@@ -109,6 +109,14 @@ static SIDECAR_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("register memwal_sidecar_failures_total")
 });
 
+static SIDECAR_WALRUS_METRICS_SCRAPE_SUCCESS: LazyLock<IntGauge> = LazyLock::new(|| {
+    prometheus::register_int_gauge!(
+        "memwal_sidecar_walrus_metrics_scrape_success",
+        "Whether the relayer was able to mirror WALM-52 sidecar Walrus metrics into /metrics on the latest scrape."
+    )
+    .expect("register memwal_sidecar_walrus_metrics_scrape_success")
+});
+
 static DB_QUERY_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus::register_histogram_vec!(
         HistogramOpts::new(
@@ -213,21 +221,94 @@ pub async fn request_context_middleware(mut request: Request, next: Next) -> Res
 }
 
 pub async fn metrics(State(state): State<Arc<AppState>>) -> Response {
+    let sidecar_walrus_metrics = scrape_sidecar_walrus_metrics(&state).await;
     update_db_pool_metrics(state.db.pool());
 
     let encoder = prometheus::TextEncoder::new();
     let mut buffer = Vec::new();
     match encoder.encode(&prometheus::gather(), &mut buffer) {
-        Ok(()) => Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, encoder.format_type())
-            .body(Body::from(buffer))
-            .expect("build metrics response"),
+        Ok(()) => {
+            if let Some(sidecar_text) = sidecar_walrus_metrics {
+                buffer.extend_from_slice(b"\n");
+                buffer.extend_from_slice(sidecar_text.as_bytes());
+            }
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, encoder.format_type())
+                .body(Body::from(buffer))
+                .expect("build metrics response")
+        }
         Err(err) => Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
             .body(Body::from(format!("failed to encode metrics: {}", err)))
             .expect("build metrics error response"),
+    }
+}
+
+async fn scrape_sidecar_walrus_metrics(state: &AppState) -> Option<String> {
+    let url = format!(
+        "{}/metrics/walrus",
+        state.config.sidecar_url.trim_end_matches('/')
+    );
+    let started = Instant::now();
+    let request = state.http_client.get(&url);
+    match tokio::time::timeout(Duration::from_secs(2), request.send()).await {
+        Ok(Ok(resp)) => {
+            let status = resp.status();
+            observe_external(
+                "sidecar",
+                "metrics_walrus",
+                &status.as_u16().to_string(),
+                started.elapsed(),
+            );
+            if !status.is_success() {
+                SIDECAR_WALRUS_METRICS_SCRAPE_SUCCESS.set(0);
+                record_sidecar_failure("metrics_walrus", "http_error");
+                tracing::warn!(
+                    status = status.as_u16(),
+                    "sidecar WALM-52 metrics scrape returned non-success"
+                );
+                return None;
+            }
+            match tokio::time::timeout(Duration::from_secs(2), resp.text()).await {
+                Ok(Ok(text)) => {
+                    SIDECAR_WALRUS_METRICS_SCRAPE_SUCCESS.set(1);
+                    Some(text)
+                }
+                Ok(Err(err)) => {
+                    SIDECAR_WALRUS_METRICS_SCRAPE_SUCCESS.set(0);
+                    record_sidecar_failure("metrics_walrus", "body_error");
+                    tracing::warn!(error = %err, "sidecar WALM-52 metrics body read failed");
+                    None
+                }
+                Err(_) => {
+                    SIDECAR_WALRUS_METRICS_SCRAPE_SUCCESS.set(0);
+                    record_sidecar_failure("metrics_walrus", "body_timeout");
+                    tracing::warn!("sidecar WALM-52 metrics body read timed out");
+                    None
+                }
+            }
+        }
+        Ok(Err(err)) => {
+            observe_external(
+                "sidecar",
+                "metrics_walrus",
+                "transport_error",
+                started.elapsed(),
+            );
+            SIDECAR_WALRUS_METRICS_SCRAPE_SUCCESS.set(0);
+            record_sidecar_failure("metrics_walrus", "transport_error");
+            tracing::warn!(error = %err, "sidecar WALM-52 metrics scrape failed");
+            None
+        }
+        Err(_) => {
+            observe_external("sidecar", "metrics_walrus", "timeout", started.elapsed());
+            SIDECAR_WALRUS_METRICS_SCRAPE_SUCCESS.set(0);
+            record_sidecar_failure("metrics_walrus", "timeout");
+            tracing::warn!("sidecar WALM-52 metrics scrape timed out");
+            None
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds WALM-52 monitoring for Walrus upload relay cost canary.

We are self-hosting the Walrus upload relay to verify whether it reduces pool-funded relay-tip spend compared with the Walrus team public relay. The core spend we care about is relay tips, not gas, because gas is sponsored separately and is not deducted from pool wallets.

## Changes

- Add sidecar Prometheus metrics:
  - `walrus_upload_relay_uploads_total{host,send_tip}`
  - `walrus_upload_relay_tip_mist_total{host,send_tip}`
- Track tip spend from register transaction balance changes.
- Support self-host no-tip mode via:
  - `WALRUS_UPLOAD_RELAY_URL`
  - `WALRUS_UPLOAD_RELAY_SEND_TIP=false`
  - `WALRUS_UPLOAD_RELAY_TIP_MAX_MIST`
- Add structured upload log fields for canary validation:
  - relay host
  - send-tip mode
  - tip recipient
  - register tip MIST
- Add `/metrics/walrus` endpoint for Prometheus scraping.
- Add standalone audit script:
  - `services/server/scripts/walrus-tip-audit.ts`
  - fetches/categorizes pool-wallet relay tip spend over a time window
- Update docs with:
  - WALM-52 observability panels and alerts
  - self-host canary setup
  - public relay comparison procedure
  - rollback steps

## Monitoring

Primary decision metric:

```promql
sum by (host, send_tip) (rate(walrus_upload_relay_tip_mist_total[1h])) * 3600 / 1e9
```

This reports SUI/hour relay-tip burn.

Expected canary outcome:

public relay + send_tip=true => nonzero tip spend
self-host relay + send_tip=false => near-zero pool tip spend

