### PR TITLE
feat: add Slack alert for exhausted Walrus uploads

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -32,6 +32,7 @@ These are not all enforced at boot, but most real deployments need them.
 | `PORT` | `8000` | Relayer port |
 | `RUST_LOG` | `memwal_server=info,tower_http=info` | Rust tracing filter for relayer logs |
 | `LOG_FORMAT` | pretty text | Set to `json` for machine-parseable structured logs |
+| `ALERT_TO_SLACK` | none | Slack incoming webhook URL. When set, the relayer posts an alert after a Walrus upload job exhausts all 5 wallet attempts without producing a blob |
 | `SIDECAR_URL` | `http://localhost:9000` | Sidecar HTTP endpoint |
 | `OPENAI_API_BASE` | `https://api.openai.com/v1` | OpenAI-compatible base URL |
 | `SUI_NETWORK` | `mainnet` | Picks the fallback RPC URL and network-driven service defaults |

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -8,6 +8,9 @@ SIDECAR_AUTH_TOKEN=replace-with-32-byte-random-secret
 # so request_id, route, status, and latency fields are machine-parseable.
 RUST_LOG=memwal_server=info,tower_http=info
 LOG_FORMAT=pretty
+# Optional Slack incoming webhook URL. When set, the relayer alerts after a
+# Walrus upload job exhausts all 5 wallet attempts without producing a blob.
+# ALERT_TO_SLACK=https://hooks.slack.com/services/...
 
 # Database (PostgreSQL + pgvector)
 DATABASE_URL=postgresql://memwal:memwal_secret@localhost:5432/memwal

--- a/services/server/deploy/nautilus/runtime.env.example
+++ b/services/server/deploy/nautilus/runtime.env.example
@@ -7,6 +7,8 @@ RUST_LOG=memwal_server=info,tower_http=info
 LOG_FORMAT=json
 BENCHMARK_MODE=false
 ALLOWED_ORIGINS=https://your-app.example.com
+# Optional Slack incoming webhook URL for terminal Walrus upload failures.
+# ALERT_TO_SLACK=https://hooks.slack.com/services/...
 
 # Database and Redis
 DATABASE_URL=postgresql://memwal:<password>@postgres.example.com:5432/memwal?sslmode=require

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -1,0 +1,245 @@
+use serde::Serialize;
+
+const ALERT_TO_SLACK_ENV: &str = "ALERT_TO_SLACK";
+const MAX_SLACK_ERROR_LEN: usize = 1_500;
+
+#[derive(Clone, Debug)]
+pub struct AlertManager {
+    slack: Option<SlackNotifier>,
+}
+
+impl AlertManager {
+    pub fn from_env(http_client: reqwest::Client) -> Self {
+        let slack = std::env::var(ALERT_TO_SLACK_ENV)
+            .ok()
+            .and_then(|raw| SlackNotifier::from_env_value(http_client, &raw));
+
+        Self { slack }
+    }
+
+    pub fn slack_enabled(&self) -> bool {
+        self.slack.is_some()
+    }
+
+    pub async fn notify_walrus_upload_exhausted(
+        &self,
+        alert: WalrusUploadExhaustedAlert,
+    ) -> Result<(), AlertError> {
+        let Some(slack) = &self.slack else {
+            return Ok(());
+        };
+
+        slack.send(&alert).await
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SlackNotifier {
+    http_client: reqwest::Client,
+    webhook_url: String,
+}
+
+impl SlackNotifier {
+    fn from_env_value(http_client: reqwest::Client, raw: &str) -> Option<Self> {
+        let value = raw.trim();
+        if value.is_empty() || is_disabled_env_value(value) {
+            return None;
+        }
+
+        Some(Self {
+            http_client,
+            webhook_url: value.to_string(),
+        })
+    }
+
+    async fn send(&self, alert: &WalrusUploadExhaustedAlert) -> Result<(), AlertError> {
+        let payload = SlackPayload::for_walrus_upload_exhausted(alert);
+        let resp = self
+            .http_client
+            .post(&self.webhook_url)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| AlertError::Transport(err.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AlertError::HttpStatus {
+                status: status.as_u16(),
+                body: truncate(&body, 500),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WalrusUploadExhaustedAlert {
+    pub remember_job_id: Option<String>,
+    pub owner: String,
+    pub namespace: String,
+    pub attempt: usize,
+    pub max_attempts: usize,
+    pub wallet_index: usize,
+    pub configured_wallets: usize,
+    pub sui_network: String,
+    pub error: String,
+}
+
+#[derive(Debug)]
+pub enum AlertError {
+    Transport(String),
+    HttpStatus { status: u16, body: String },
+}
+
+impl std::fmt::Display for AlertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AlertError::Transport(err) => write!(f, "alert transport error: {}", err),
+            AlertError::HttpStatus { status, body } => {
+                write!(f, "alert webhook returned HTTP {}: {}", status, body)
+            }
+        }
+    }
+}
+
+impl std::error::Error for AlertError {}
+
+#[derive(Serialize)]
+struct SlackPayload {
+    text: String,
+    blocks: Vec<SlackBlock>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum SlackBlock {
+    #[serde(rename = "header")]
+    Header { text: SlackText },
+    #[serde(rename = "section")]
+    Section { text: SlackText },
+}
+
+#[derive(Serialize)]
+struct SlackText {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: String,
+}
+
+impl SlackPayload {
+    fn for_walrus_upload_exhausted(alert: &WalrusUploadExhaustedAlert) -> Self {
+        let job = alert.remember_job_id.as_deref().unwrap_or("-");
+        let title = "MemWal Walrus upload exhausted retries".to_string();
+        let summary = format!(
+            "Walrus upload failed after {}/{} wallet attempt(s) for job {}.",
+            alert.attempt, alert.max_attempts, job
+        );
+        let details = format!(
+            "*Job:* `{}`\n*Owner:* `{}`\n*Namespace:* `{}`\n*Network:* `{}`\n*Wallet index:* `{}`\n*Configured wallets:* `{}`\n*Error:* ```{}```",
+            job,
+            short_address(&alert.owner),
+            alert.namespace,
+            alert.sui_network,
+            alert.wallet_index,
+            alert.configured_wallets,
+            truncate(&alert.error, MAX_SLACK_ERROR_LEN),
+        );
+
+        Self {
+            text: summary.clone(),
+            blocks: vec![
+                SlackBlock::Header {
+                    text: plain_text(title),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(summary),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(details),
+                },
+            ],
+        }
+    }
+}
+
+fn plain_text(text: String) -> SlackText {
+    SlackText {
+        kind: "plain_text",
+        text,
+    }
+}
+
+fn mrkdwn(text: String) -> SlackText {
+    SlackText {
+        kind: "mrkdwn",
+        text,
+    }
+}
+
+fn is_disabled_env_value(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+fn short_address(address: &str) -> String {
+    if address.len() <= 18 {
+        return address.to_string();
+    }
+    format!("{}...{}", &address[..10], &address[address.len() - 6..])
+}
+
+fn truncate(value: &str, max_len: usize) -> String {
+    if value.chars().count() <= max_len {
+        return value.to_string();
+    }
+
+    format!("{}...", value.chars().take(max_len).collect::<String>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_env_values_do_not_enable_slack() {
+        let client = reqwest::Client::new();
+        for raw in ["", "0", "false", "no", "off"] {
+            assert!(SlackNotifier::from_env_value(client.clone(), raw).is_none());
+        }
+    }
+
+    #[test]
+    fn webhook_env_value_enables_slack() {
+        let client = reqwest::Client::new();
+        let notifier =
+            SlackNotifier::from_env_value(client, "https://hooks.slack.com/services/T/B/C");
+        assert!(notifier.is_some());
+    }
+
+    #[test]
+    fn slack_payload_contains_upload_context() {
+        let payload = SlackPayload::for_walrus_upload_exhausted(&WalrusUploadExhaustedAlert {
+            remember_job_id: Some("job-1".into()),
+            owner: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".into(),
+            namespace: "default".into(),
+            attempt: 5,
+            max_attempts: 5,
+            wallet_index: 4,
+            configured_wallets: 5,
+            sui_network: "mainnet".into(),
+            error: "walrus upload failed".into(),
+        });
+
+        assert!(payload.text.contains("5/5"));
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("job-1"));
+        assert!(json.contains("default"));
+        assert!(json.contains("mainnet"));
+        assert!(json.contains("walrus upload failed"));
+    }
+}

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -19,6 +19,7 @@ use redis::AsyncCommands;
 
 use serde::{Deserialize, Serialize};
 
+use crate::alerts::WalrusUploadExhaustedAlert;
 use crate::storage::walrus::{SetMetadataBatchEntry, UploadBlobError};
 use crate::types::{configured_walrus_storage_epochs, AppState, BLOB_CACHE_KEY_PREFIX};
 
@@ -332,17 +333,53 @@ pub async fn execute_meta_transfer(
 }
 
 // ============================================================
-// Retry policy (Tower middleware)
+// Retry constants
 // ============================================================
 
 /// Maximum number of attempts (1 initial + N-1 retries).
 #[allow(dead_code)]
-pub const MAX_ATTEMPTS: u32 = 3;
+pub const MAX_ATTEMPTS: u32 = 5;
 
-/// Exponential back-off: attempt 1→2s, 2→4s, 3→8s.
+/// Exponential back-off: attempt 1→2s, 2→4s, 3→8s, 4→16s, 5→32s.
 #[allow(dead_code)]
 pub fn backoff_duration(attempt: u32) -> std::time::Duration {
     std::time::Duration::from_secs(2u64.pow(attempt))
+}
+
+pub(crate) fn wallet_job_request(
+    job: WalletJob,
+) -> Request<WalletJob, apalis_sql::context::SqlContext> {
+    let mut context = apalis_sql::context::SqlContext::new();
+    context.set_max_attempts(MAX_ATTEMPTS as i32);
+    Request::new_with_ctx(job, context)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WalletJobAttemptInfo {
+    current: usize,
+    max: usize,
+}
+
+impl WalletJobAttemptInfo {
+    fn exhausted_by(&self, error: &WalletJobError) -> bool {
+        !error.is_permanent() && self.current >= self.max
+    }
+}
+
+impl FromRequest<Request<WalletJob, apalis_sql::context::SqlContext>> for WalletJobAttemptInfo {
+    fn from_request(
+        req: &Request<WalletJob, apalis_sql::context::SqlContext>,
+    ) -> Result<Self, Error> {
+        let mut max =
+            usize::try_from(req.parts.context.max_attempts()).unwrap_or(MAX_ATTEMPTS as usize);
+        if max == 0 {
+            max = MAX_ATTEMPTS as usize;
+        }
+        Ok(Self {
+            current: req.parts.attempt.current(),
+            max,
+        })
+    }
 }
 
 // ============================================================
@@ -355,7 +392,11 @@ pub fn backoff_duration(attempt: u32) -> std::time::Duration {
 /// queue. Upload jobs select a fresh wallet index at execution time; legacy
 /// metadata-transfer jobs keep their pinned wallet because the blob object is
 /// owned by the wallet that registered/certified it.
-pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Result<(), Error> {
+pub(crate) async fn execute_wallet_job(
+    job: WalletJob,
+    ctx: Data<Arc<AppState>>,
+    attempt_info: WalletJobAttemptInfo,
+) -> Result<(), Error> {
     let state: &AppState = &ctx;
     let enqueued_wallet_index = job.wallet_index;
 
@@ -400,6 +441,7 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                 agent_public_key,
                 remember_job_id,
                 epochs,
+                attempt_info,
             )
             .await
         }
@@ -654,7 +696,7 @@ async fn enqueue_finalize_uploaded_blob(
 ) -> Result<(), WalletJobError> {
     let mut storage = state.wallet_storage.clone();
     storage
-        .push(WalletJob {
+        .push_request(wallet_job_request(WalletJob {
             wallet_index,
             operation: WalletOperation::FinalizeUploadedBlob {
                 owner,
@@ -665,7 +707,7 @@ async fn enqueue_finalize_uploaded_blob(
                 blob_size_bytes,
                 importance,
             },
-        })
+        }))
         .await
         .map_err(|e| {
             WalletJobError::Transient(format!(
@@ -693,6 +735,7 @@ async fn execute_upload_and_transfer(
     agent_public_key: Option<String>,
     remember_job_id: Option<String>,
     epochs: u32,
+    attempt_info: WalletJobAttemptInfo,
 ) -> Result<(), WalletJobError> {
     // ── Mark running ───────────────────────────────────────────
     if let Some(ref jid) = remember_job_id {
@@ -779,7 +822,7 @@ async fn execute_upload_and_transfer(
             let recovery_remember_job_id = remember_job_id.clone();
             let mut storage = state.wallet_storage.clone();
             if let Err(e) = storage
-                .push(WalletJob {
+                .push_request(wallet_job_request(WalletJob {
                     wallet_index,
                     operation: WalletOperation::SetMetadataAndTransfer {
                         blob_object_id: object_id,
@@ -793,7 +836,7 @@ async fn execute_upload_and_transfer(
                         blob_size_bytes: Some(encrypted.len() as i64),
                         importance,
                     },
-                })
+                }))
                 .await
             {
                 let classified = classify_wallet_remember_handoff_failure(
@@ -821,6 +864,17 @@ async fn execute_upload_and_transfer(
         Err(UploadBlobError::App(e)) => {
             let msg = format!("walrus upload failed: {}", e);
             let classified = WalletJobError::classify_sidecar_error(&msg);
+            maybe_alert_walrus_upload_exhausted(
+                state,
+                &classified,
+                attempt_info,
+                remember_job_id.as_deref(),
+                &owner,
+                &namespace,
+                wallet_index,
+                &msg,
+            )
+            .await;
             update_remember_job_after_wallet_error(
                 state,
                 remember_job_id.as_deref(),
@@ -866,6 +920,40 @@ async fn execute_upload_and_transfer(
         wallet_index,
     )
     .await
+}
+
+async fn maybe_alert_walrus_upload_exhausted(
+    state: &AppState,
+    error: &WalletJobError,
+    attempt_info: WalletJobAttemptInfo,
+    remember_job_id: Option<&str>,
+    owner: &str,
+    namespace: &str,
+    wallet_index: usize,
+    msg: &str,
+) {
+    if !attempt_info.exhausted_by(error) {
+        return;
+    }
+
+    let alert = WalrusUploadExhaustedAlert {
+        remember_job_id: remember_job_id.map(str::to_owned),
+        owner: owner.to_string(),
+        namespace: namespace.to_string(),
+        attempt: attempt_info.current,
+        max_attempts: attempt_info.max,
+        wallet_index,
+        configured_wallets: state.key_pool.len(),
+        sui_network: state.config.sui_network.clone(),
+        error: msg.to_string(),
+    };
+
+    if let Err(err) = state.alerts.notify_walrus_upload_exhausted(alert).await {
+        tracing::warn!(
+            "[wallet-job:upload] failed to send Slack alert for exhausted Walrus upload retries: {}",
+            err
+        );
+    }
 }
 
 // ============================================================
@@ -1093,7 +1181,7 @@ pub async fn execute_remember(
 
             let mut storage = state.wallet_storage.clone();
             if let Err(e) = storage
-                .push(WalletJob {
+                .push_request(wallet_job_request(WalletJob {
                     wallet_index: key_index,
                     operation: WalletOperation::SetMetadataAndTransfer {
                         blob_object_id: object_id,
@@ -1112,7 +1200,7 @@ pub async fn execute_remember(
                         // importance through end-to-end.
                         importance: crate::services::extractor::IMPORTANCE_STANDARD,
                     },
-                })
+                }))
                 .await
             {
                 let msg = format!("failed to enqueue metadata/transfer recovery job: {}", e);
@@ -1272,7 +1360,7 @@ pub async fn execute_bulk_remember(
         let namespace = item.namespace.clone();
         let wallet_index = item.wallet_index;
         storage
-            .push(WalletJob {
+            .push_request(wallet_job_request(WalletJob {
                 wallet_index,
                 operation: WalletOperation::UploadAndTransfer {
                     encrypted_b64: item.encrypted_b64,
@@ -1285,7 +1373,7 @@ pub async fn execute_bulk_remember(
                     remember_job_id: Some(job_id.clone()),
                     epochs: job.epochs,
                 },
-            })
+            }))
             .await
             .map_err(|e| {
                 BulkRememberError::Internal(format!(
@@ -1314,7 +1402,8 @@ mod tests {
     use sqlx::postgres::PgPoolOptions;
 
     use super::{
-        classify_wallet_remember_handoff_failure, mark_remember_job_failed, WalletJobError,
+        classify_wallet_remember_handoff_failure, mark_remember_job_failed, wallet_job_request,
+        WalletJob, WalletJobAttemptInfo, WalletJobError, WalletOperation, MAX_ATTEMPTS,
     };
 
     static DB_SETUP_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -1423,6 +1512,37 @@ mod tests {
     fn transient_errors_remain_retryable() {
         let error = WalletJobError::Transient("timeout".to_string()).into_apalis_error();
         assert!(matches!(error, apalis::prelude::Error::Failed(_)));
+    }
+
+    #[test]
+    fn alert_gate_only_opens_on_final_transient_attempt() {
+        let transient = WalletJobError::Transient("timeout".to_string());
+        assert!(!WalletJobAttemptInfo { current: 4, max: 5 }.exhausted_by(&transient));
+        assert!(WalletJobAttemptInfo { current: 5, max: 5 }.exhausted_by(&transient));
+    }
+
+    #[test]
+    fn alert_gate_stays_closed_for_permanent_errors() {
+        let permanent = WalletJobError::Permanent("move abort".to_string());
+        assert!(!WalletJobAttemptInfo { current: 5, max: 5 }.exhausted_by(&permanent));
+    }
+
+    #[test]
+    fn wallet_job_request_sets_explicit_max_attempts() {
+        let req = wallet_job_request(WalletJob {
+            wallet_index: 0,
+            operation: WalletOperation::FinalizeUploadedBlob {
+                owner: "0xowner".to_string(),
+                namespace: "default".to_string(),
+                remember_job_id: None,
+                blob_id: "blob".to_string(),
+                vector: vec![],
+                blob_size_bytes: 0,
+                importance: crate::services::extractor::IMPORTANCE_STANDARD,
+            },
+        });
+
+        assert_eq!(req.parts.context.max_attempts(), MAX_ATTEMPTS as i32);
     }
 
     #[tokio::test]

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1,3 +1,4 @@
+mod alerts;
 mod auth;
 mod compatibility;
 mod engine;
@@ -24,6 +25,7 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 use apalis::prelude::*;
 use apalis_sql::postgres::PostgresStorage;
 
+use alerts::AlertManager;
 use engine::{MemoryEngine, PlaintextEngine, WalrusSealEngine};
 use jobs::{
     execute_bulk_remember, execute_wallet_job, BulkRememberJob, MetaTransferJob, RememberJob,
@@ -328,12 +330,15 @@ async fn main() {
     // CompositeRanker is stateless — one shared instance is fine.
     let ranker: Arc<dyn Ranker> = Arc::new(CompositeRanker);
 
+    let alerts = Arc::new(AlertManager::from_env(http_client.clone()));
+
     // Shared application state
     let state = Arc::new(AppState {
         db,
         config: Arc::clone(&config),
         http_client,
         key_pool,
+        alerts,
         engine,
         embedder,
         extractor,
@@ -347,6 +352,15 @@ async fn main() {
         blob_cache_max_bytes,
         embedding_cache_ttl,
     });
+
+    tracing::info!(
+        "  alerts: Slack {} via ALERT_TO_SLACK",
+        if state.alerts.slack_enabled() {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
 
     // Worker 1: MetaTransferJob (legacy — backward compat with existing DB rows)
     {

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -32,7 +32,7 @@ pub use sponsor::{sponsor_execute_proxy, sponsor_proxy};
 
 use futures::stream::{self, StreamExt};
 
-use crate::jobs::{WalletJob, WalletOperation};
+use crate::jobs::{wallet_job_request, WalletJob, WalletOperation};
 use crate::storage::db::VectorDb;
 use crate::types::*;
 
@@ -54,10 +54,10 @@ pub async fn enqueue_wallet_job(
 ) -> Result<usize, AppError> {
     let mut storage = state.wallet_storage.clone();
     storage
-        .push(WalletJob {
+        .push_request(wallet_job_request(WalletJob {
             wallet_index,
             operation,
-        })
+        }))
         .await
         .map_err(|e| AppError::Internal(format!("Failed to enqueue WalletJob: {}", e)))?;
     Ok(wallet_index)

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use crate::alerts::AlertManager;
 use crate::engine::MemoryEngine;
 use crate::jobs::{BulkRememberJobStorage, RememberJobStorage, WalletJobStorage};
 use crate::rate_limit::RateLimitConfig;
@@ -62,6 +63,9 @@ pub struct AppState {
     /// `Arc` so the engine + handlers share one immutable config.
     pub config: Arc<Config>,
     pub http_client: reqwest::Client,
+    /// Alert dispatchers for operational notifications. Individual alert
+    /// paths decide when failures are terminal enough to notify.
+    pub alerts: Arc<AlertManager>,
     /// Round-robin pool of Sui private keys for parallel Walrus uploads.
     /// `Arc` so the engine's `store_blob` can draw from the same pool.
     pub key_pool: Arc<KeyPool>,


### PR DESCRIPTION
## Summary
- Add an alert module with Slack incoming webhook support via `ALERT_TO_SLACK`.
- Send a Slack alert only when a Walrus upload job exhausts all 5 wallet attempts without producing a blob.
- Set WalletJob max attempts explicitly to 5 and document the new env var.

## Verification
- `cargo check --manifest-path services/server/Cargo.toml`
- `cargo test --manifest-path services/server/Cargo.toml --all-targets --no-run`
- `services/server/target/debug/deps/memwal_server-3ca590097b62dd48 alerts::tests jobs::tests::alert_gate jobs::tests::wallet_job_request_sets_explicit_max_attempts`