### PR TITLE
[ENG-1784] Relayer: system-blocking infra alerts + pool drain

### DIFF
--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -127,3 +127,11 @@ ALLOWED_ORIGINS=http://localhost:3000
 # RATE_LIMIT_REQUESTS_PER_MINUTE=100000
 # RATE_LIMIT_REQUESTS_PER_HOUR=1000000
 # RATE_LIMIT_DELEGATE_KEY_PER_MINUTE=100000
+
+# Alerting (optional) — Slack notifications for terminal job failures (ENG-1784).
+# Push remember-job failures (after wallet pool exhausts retries on every
+# wallet) to a Slack channel. Leave unset to disable.
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../...
+# Surfaced in the Slack alert footer so multi-env channels can tell prod
+# vs staging apart. Defaults to "unknown" when unset.
+# MEMWAL_ENV=prod

--- a/services/server/Cargo.lock
+++ b/services/server/Cargo.lock
@@ -1287,6 +1287,7 @@ dependencies = [
  "pgvector",
  "prometheus",
  "redis",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -1725,6 +1726,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/services/server/Cargo.toml
+++ b/services/server/Cargo.toml
@@ -19,6 +19,9 @@ ed25519-dalek = { version = "2", features = ["serde"] }
 sha2 = "0.10"
 hex = "0.4"
 
+# ENG-1784: secret redaction for Slack alerter (Bearer / api_key / token / etc.)
+regex = "1"
+
 # SEAL encryption is handled by TS sidecar scripts (@mysten/seal)
 # (no Rust crypto deps needed)
 

--- a/services/server/deploy/nautilus/runtime.env.example
+++ b/services/server/deploy/nautilus/runtime.env.example
@@ -68,3 +68,7 @@ SEAL_BASE_VSOCK_PORT=8110
 # Comma-separated endpoint URLs for host-forwarder.sh. Keep this aligned with
 # SEAL_SERVER_CONFIGS or SEAL_KEY_SERVERS when host-side forwarding is used.
 # SEAL_KEY_SERVER_URLS=https://seal-aggregator.example.com
+
+# Alerting (optional, ENG-1784)
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../...
+# MEMWAL_ENV=prod

--- a/services/server/docs/eng-1784-staging-smoke.md
+++ b/services/server/docs/eng-1784-staging-smoke.md
@@ -67,9 +67,23 @@ SLACK_WEBHOOK_URL=$STAGING_SLACK_WEBHOOK \
   --bin memwal-server -- --ignored --nocapture
 ```
 
-Verifies all 6 scenarios (terminal wallet failure, queue handoff,
-dedup, sanitization, multi-byte, global rate cap) land in the channel
-without a real relayer needed.
+Verifies all 13 scenarios land in the channel without a real relayer:
+
+1. Terminal wallet failure (Enoki `balance::split`)
+2. Handoff enqueue failure (queue layer down after upload)
+3. Dedup (same error twice → 1 message)
+4. Credential sanitization (`redis://` / `postgres://` strings)
+5. Multi-byte UTF-8 (Japanese + emoji)
+6. Global rate cap (35 distinct errors → 30 delivered)
+7. `InfraFailureKind::SidecarDown` (≈ 60s cooldown after #6 so rate-cap window elapses)
+8. `InfraFailureKind::PostgresDown`
+9. `InfraFailureKind::RedisDown`
+10. `InfraFailureKind::SuiRpcDown`
+11. `InfraFailureKind::WalletPoolDrained`
+12. `InfraFailureKind::ApalisQueueStuck`
+13. `InfraFailureKind::NoSuiKeysConfigured`
+
+Total live run: ~95s (rate-cap cooldown between scenario 6 and 7 dominates).
 
 ## Verification
 

--- a/services/server/docs/eng-1784-staging-smoke.md
+++ b/services/server/docs/eng-1784-staging-smoke.md
@@ -1,0 +1,131 @@
+# ENG-1784 — Staging smoke test procedure
+
+Reviewer requirement #9: force a Permanent remember job failure on
+staging and verify the Slack message + DB status.
+
+## Prerequisites
+
+- Staging relayer deployed with this branch (commit a6eb4d2 or newer).
+- `SLACK_WEBHOOK_URL` set in staging Railway env (channel of your choice).
+- `MEMWAL_ENV=staging` set so the alert footer reads `env staging`.
+- Access to the staging Postgres instance via `psql` or a saved client.
+- A working Python SDK client (`pip install memwal`) with credentials
+  registered on staging.
+
+## Procedure
+
+Pick ONE of the three forcing methods below; they target different
+code paths.
+
+### Method A — Force a Permanent classification (cleanest)
+
+The most reliable way to land in `update_remember_job_after_wallet_error`
+with `WalletJobError::Permanent` is to make the sidecar return an error
+string that classifies as Permanent. The classifier treats any
+`MoveAbort(... :: split, 2)` that is NOT preceded by `balance::split`
+context as Permanent (see `WalletJobError::classify_sidecar_error`).
+
+1. Temporarily set the staging sidecar's Walrus publisher URL to a
+   path that returns a permanent-looking error. The simplest:
+   `WALRUS_PUBLISHER_URL=https://httpbin.org/status/418` so the sidecar
+   gets a 4xx-class response on every upload.
+2. From the Python SDK client:
+   ```python
+   from memwal import MemWal
+   m = MemWal.create(env="staging", key=..., account_id=...)
+   await m.remember_and_wait("ENG-1784 staging smoke test " + str(uuid.uuid4()))
+   ```
+3. Wait ~10 seconds for the Apalis retry budget (`MAX_ATTEMPTS = 3`)
+   to burn through.
+
+### Method B — Direct DB injection (skip-the-stack)
+
+If method A is too disruptive, you can call the function path
+directly by inserting a row that will be picked up by the worker as
+already-failed-permanent. This is brittler but doesn't require
+touching staging config.
+
+1. Create a remember job row directly via `psql`:
+   ```sql
+   INSERT INTO remember_jobs (id, owner, namespace, status)
+   VALUES ('staging-smoke-eng1784', '0xstaging-test-owner', 'smoke-test', 'running');
+   ```
+2. Force an Apalis WalletJob with a payload that the sidecar will
+   reject permanently. (Out of scope for this doc — coordinate with
+   eng-on-call to issue the right shape.)
+
+### Method C — Live demo of the Slack alerter (bypasses DB)
+
+This verifies the Slack format end-to-end without inducing a real
+failure. It does NOT verify the DB persistence side.
+
+```bash
+# In a checkout of the eng-1784 branch
+cd services/server
+SLACK_WEBHOOK_URL=$STAGING_SLACK_WEBHOOK \
+  cargo test slack::tests::live_demo_walks_every_alert_scenario \
+  --bin memwal-server -- --ignored --nocapture
+```
+
+Verifies all 6 scenarios (terminal wallet failure, queue handoff,
+dedup, sanitization, multi-byte, global rate cap) land in the channel
+without a real relayer needed.
+
+## Verification
+
+### Slack channel
+
+The alert must:
+
+- Start with `🔴 MemWal — Remember Job Failed (terminal wallet failure)`
+  in the header for method A.
+- Body field "Failure mode" must read `permanent wallet failure after
+  3 retry attempts`.
+- Must NOT contain the phrase "all wallets exhausted" or "wallet
+  retries exhausted" (those are the old, misleading wordings).
+- Owner field must be the truncated form `0xstagi…ownr` of whatever
+  delegate key was used.
+- Namespace field must match the namespace in the python call.
+- Footer must read `server commit <sha> · env staging`.
+- Error block must NOT contain any password / token / connection
+  string — sanitizer must have run.
+
+### Postgres
+
+```sql
+SELECT id, status, error_msg, updated_at
+  FROM remember_jobs
+ WHERE id = '<job_id>';
+```
+
+The row must show:
+
+- `status = 'failed'`
+- `error_msg` containing the upstream error verbatim (this is what
+  on-call needs to triage; sanitization runs ONLY for the Slack
+  message, the DB keeps the original).
+- `updated_at` newer than the time we triggered the call.
+
+### Suppression behavior
+
+Repeat method A two more times within 5 minutes with the SAME error
+message. Slack channel must show only the FIRST alert (dedup window).
+Wait 5 minutes, trigger again — should alert.
+
+## Rollback
+
+If method A: restore the original `WALRUS_PUBLISHER_URL` in Railway.
+
+If method B: delete the synthetic row:
+```sql
+DELETE FROM remember_jobs WHERE id = 'staging-smoke-eng1784';
+```
+
+## Sign-off
+
+Record the test in the ENG-1784 ticket with:
+
+- Job ID and timestamp
+- Screenshot of Slack alert
+- `psql` output showing `status = 'failed'`
+- Confirmation that dedup suppressed the repeat alert

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -181,28 +181,39 @@ async fn update_remember_job_after_wallet_error(
     .await;
 }
 
+/// Metadata returned by a successful `mark_remember_job_failed` so the
+/// terminal alert can include owner + namespace without an extra round-trip.
+#[derive(Debug, Clone)]
+struct RememberJobMetadata {
+    owner: String,
+    namespace: String,
+}
+
 async fn mark_remember_job_failed(
     pool: &sqlx::PgPool,
     remember_job_id: Option<&str>,
     msg: &str,
-) -> Result<(), sqlx::Error> {
+) -> Result<Option<RememberJobMetadata>, sqlx::Error> {
     let Some(jid) = remember_job_id else {
-        return Ok(());
+        return Ok(None);
     };
 
-    let result = sqlx::query(
-        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+    // `RETURNING owner, namespace` lets us hydrate the Slack alert from the
+    // same UPDATE that flips the row to `failed`, instead of issuing a
+    // separate SELECT after the fact.
+    let row: Option<(String, String)> = sqlx::query_as(
+        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() \
+         WHERE id = $2 RETURNING owner, namespace",
     )
     .bind(msg)
     .bind(jid)
-    .execute(pool)
+    .fetch_optional(pool)
     .await?;
 
-    if result.rows_affected() == 0 {
-        return Err(sqlx::Error::RowNotFound);
+    match row {
+        Some((owner, namespace)) => Ok(Some(RememberJobMetadata { owner, namespace })),
+        None => Err(sqlx::Error::RowNotFound),
     }
-
-    Ok(())
 }
 
 fn remember_job_persist_failure_message(msg: &str, persist_err: &sqlx::Error) -> String {
@@ -212,8 +223,47 @@ fn remember_job_persist_failure_message(msg: &str, persist_err: &sqlx::Error) ->
     )
 }
 
+/// ENG-1784: fire-and-forget Slack alert for a terminal remember-job failure.
+///
+/// Spawned in the background so a slow Slack POST cannot block the wallet
+/// worker, and a Slack-side failure cannot fail the wallet job. The Slack
+/// client carries its own 5-minute dedup window so an Enoki / sidecar
+/// incident that fans out into dozens of identical failures only pages the
+/// channel once per window.
+fn spawn_slack_remember_failed_alert(
+    slack: Option<&Arc<crate::slack::SlackClient>>,
+    remember_job_id: Option<&str>,
+    metadata: Option<&RememberJobMetadata>,
+    msg: &str,
+) {
+    let Some(client) = slack else {
+        return;
+    };
+    let client = client.clone();
+    let job_id = remember_job_id.map(|s| s.to_string());
+    let owner = metadata.map(|m| m.owner.clone());
+    let namespace = metadata.map(|m| m.namespace.clone());
+    let msg = msg.to_string();
+    tokio::spawn(async move {
+        if let Err(err) = client
+            .notify_remember_job_failed(
+                job_id.as_deref(),
+                owner.as_deref(),
+                namespace.as_deref(),
+                MAX_ATTEMPTS,
+                MAX_ATTEMPTS,
+                &msg,
+            )
+            .await
+        {
+            tracing::warn!("Slack remember-failed alert failed: {}", err);
+        }
+    });
+}
+
 async fn classify_wallet_remember_handoff_failure(
     pool: &sqlx::PgPool,
+    slack: Option<&Arc<crate::slack::SlackClient>>,
     remember_job_id: Option<&str>,
     msg: String,
 ) -> WalletJobError {
@@ -224,7 +274,10 @@ async fn classify_wallet_remember_handoff_failure(
     // state cannot be persisted, keep the wallet handler retryable so the row
     // is not orphaned.
     match mark_remember_job_failed(pool, remember_job_id, &msg).await {
-        Ok(()) => WalletJobError::Permanent(msg),
+        Ok(metadata) => {
+            spawn_slack_remember_failed_alert(slack, remember_job_id, metadata.as_ref(), &msg);
+            WalletJobError::Permanent(msg)
+        }
         Err(persist_err) => {
             WalletJobError::Transient(remember_job_persist_failure_message(&msg, &persist_err))
         }
@@ -233,11 +286,15 @@ async fn classify_wallet_remember_handoff_failure(
 
 async fn handle_legacy_remember_handoff_failure(
     pool: &sqlx::PgPool,
+    slack: Option<&Arc<crate::slack::SlackClient>>,
     remember_job_id: &str,
     msg: String,
 ) -> Result<(), RememberJobError> {
     match mark_remember_job_failed(pool, Some(remember_job_id), &msg).await {
-        Ok(()) => Ok(()),
+        Ok(metadata) => {
+            spawn_slack_remember_failed_alert(slack, Some(remember_job_id), metadata.as_ref(), &msg);
+            Ok(())
+        }
         Err(persist_err) => Err(RememberJobError::Internal(
             remember_job_persist_failure_message(&msg, &persist_err),
         )),
@@ -458,6 +515,7 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                             {
                                 let classified = classify_wallet_remember_handoff_failure(
                                     state.db.pool(),
+                                    state.slack.as_ref(),
                                     finalize_remember_job_id.as_deref(),
                                     enqueue_err.to_string(),
                                 )
@@ -798,6 +856,7 @@ async fn execute_upload_and_transfer(
             {
                 let classified = classify_wallet_remember_handoff_failure(
                     state.db.pool(),
+                    state.slack.as_ref(),
                     recovery_remember_job_id.as_deref(),
                     format!("failed to enqueue metadata/transfer recovery job: {}", e),
                 )
@@ -1117,8 +1176,13 @@ pub async fn execute_remember(
             {
                 let msg = format!("failed to enqueue metadata/transfer recovery job: {}", e);
                 tracing::error!("[remember-job] {} job_id={}", msg, job.job_id);
-                return handle_legacy_remember_handoff_failure(state.db.pool(), &job.job_id, msg)
-                    .await;
+                return handle_legacy_remember_handoff_failure(
+                    state.db.pool(),
+                    state.slack.as_ref(),
+                    &job.job_id,
+                    msg,
+                )
+                .await;
             }
 
             tracing::info!(
@@ -1440,7 +1504,8 @@ mod tests {
         .unwrap();
 
         let classified =
-            classify_wallet_remember_handoff_failure(&pool, Some(&job_id), msg.to_string()).await;
+            classify_wallet_remember_handoff_failure(&pool, None, Some(&job_id), msg.to_string())
+                .await;
 
         match classified {
             WalletJobError::Permanent(ref got) => assert_eq!(got, msg),
@@ -1480,7 +1545,8 @@ mod tests {
         .unwrap();
 
         let classified =
-            classify_wallet_remember_handoff_failure(&pool, Some(&job_id), msg.to_string()).await;
+            classify_wallet_remember_handoff_failure(&pool, None, Some(&job_id), msg.to_string())
+                .await;
 
         match classified {
             WalletJobError::Permanent(ref got) => assert_eq!(got, msg),
@@ -1514,7 +1580,7 @@ mod tests {
 
         let msg = "failed to enqueue uploaded-blob finalization job: synthetic queue down";
         let classified =
-            classify_wallet_remember_handoff_failure(&pool, Some("job-closed-pool"), msg.into())
+            classify_wallet_remember_handoff_failure(&pool, None, Some("job-closed-pool"), msg.into())
                 .await;
 
         match classified {
@@ -1542,6 +1608,39 @@ mod tests {
         assert!(err.to_string().contains("closed"));
     }
 
+    /// Hydrates owner + namespace so the ENG-1784 Slack alert can include
+    /// who/what the failure belonged to. The same UPDATE that flips status
+    /// must return the row metadata, otherwise we'd page on-call with a
+    /// bare job_id and force a SQL lookup.
+    #[tokio::test]
+    async fn mark_remember_job_failed_returns_owner_and_namespace() {
+        let pool = test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'uploaded')",
+        )
+        .bind(&job_id)
+        .bind("0xowner-eng-1784")
+        .bind("ns-eng-1784")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let metadata = mark_remember_job_failed(&pool, Some(&job_id), "boom")
+            .await
+            .expect("update should succeed")
+            .expect("expected metadata for existing job_id");
+
+        assert_eq!(metadata.owner, "0xowner-eng-1784");
+        assert_eq!(metadata.namespace, "ns-eng-1784");
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+    }
+
     #[tokio::test]
     async fn missing_remember_job_keeps_handoff_retryable() {
         let pool = test_pool().await;
@@ -1549,7 +1648,8 @@ mod tests {
         let msg = "failed to enqueue metadata/transfer recovery job: synthetic queue down";
 
         let classified =
-            classify_wallet_remember_handoff_failure(&pool, Some(&job_id), msg.to_string()).await;
+            classify_wallet_remember_handoff_failure(&pool, None, Some(&job_id), msg.to_string())
+                .await;
 
         match classified {
             WalletJobError::Transient(got) => {

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -331,6 +331,75 @@ pub(crate) fn spawn_slack_infra_alert(
     });
 }
 
+/// Outcome of `track_wallet_pool_health` — exposed so the unit test can
+/// assert the decision branch deterministically without spinning up a
+/// real `tokio::spawn` Slack POST.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PoolHealthAction {
+    /// No-op: empty pool (separate boot-time alert handles that case).
+    Skipped,
+    /// Streak was reset to 0 — outcome was success or `Permanent`.
+    Reset,
+    /// Streak incremented but not yet at the drain threshold.
+    IncrementedBelowThreshold { streak: u64, threshold: u64 },
+    /// Streak just hit the drain threshold — caller fired the alert.
+    FiredDrainAlert {
+        streak: u64,
+        threshold: u64,
+        pool_size: usize,
+    },
+    /// Streak above threshold — alert already fired earlier in this
+    /// streak. Dedup window on `SlackClient` collapses any further posts.
+    AboveThresholdNoOp { streak: u64, threshold: u64 },
+}
+
+/// Decide what wallet-pool-health action to take given a fresh outcome.
+/// Pure function over (pool_size, override, KeyPool counter) — kept
+/// separate from the alert-spawning wrapper below so unit tests can
+/// assert the decision matrix exhaustively without an `AppState`.
+///
+/// Mutates `KeyPool` (records / resets the streak) but does not touch
+/// the Slack client. The caller is responsible for firing the alert on
+/// `FiredDrainAlert`.
+pub(crate) fn decide_wallet_pool_health_action(
+    key_pool: &crate::types::KeyPool,
+    drain_window_override: Option<u64>,
+    outcome_is_transient: bool,
+) -> PoolHealthAction {
+    let pool_size = key_pool.len();
+    if pool_size == 0 {
+        // Empty pool is a separate `NoSuiKeysConfigured` alert, fired
+        // once at boot. Nothing to track here.
+        return PoolHealthAction::Skipped;
+    }
+    if !outcome_is_transient {
+        key_pool.reset_transient_streak();
+        return PoolHealthAction::Reset;
+    }
+    let streak = key_pool.record_transient_failure();
+    // Default drain window = MAX_ATTEMPTS × pool_size — every wallet has
+    // been tried `MAX_ATTEMPTS` times in a row. Override via env var if
+    // operators want a tighter / looser trigger.
+    let threshold = drain_window_override.unwrap_or_else(|| (MAX_ATTEMPTS as u64) * (pool_size as u64));
+    // Fire exactly on the threshold crossing. If the streak keeps
+    // growing, the dedup window in `SlackClient` collapses repeats —
+    // but we ALSO short-circuit the spawn here so we don't queue dozens
+    // of tasks that will all suppress.
+    match streak.cmp(&threshold) {
+        std::cmp::Ordering::Less => {
+            PoolHealthAction::IncrementedBelowThreshold { streak, threshold }
+        }
+        std::cmp::Ordering::Equal => PoolHealthAction::FiredDrainAlert {
+            streak,
+            threshold,
+            pool_size,
+        },
+        std::cmp::Ordering::Greater => {
+            PoolHealthAction::AboveThresholdNoOp { streak, threshold }
+        }
+    }
+}
+
 /// ENG-1784: detect "wallet pool drained" — every wallet returning
 /// `Transient` errors for `drain_window` consecutive attempts means the
 /// pool is effectively unable to make progress (typically every wallet is
@@ -345,29 +414,17 @@ pub(crate) fn track_wallet_pool_health(
     state: &crate::types::AppState,
     outcome_is_transient: bool,
 ) {
-    let pool_size = state.key_pool.len();
-    if pool_size == 0 {
-        // Empty pool is a separate `NoSuiKeysConfigured` alert, fired
-        // once at boot. Nothing to track here.
-        return;
-    }
-    if !outcome_is_transient {
-        state.key_pool.reset_transient_streak();
-        return;
-    }
-    let streak = state.key_pool.record_transient_failure();
-    // Default drain window = MAX_ATTEMPTS × pool_size — every wallet has
-    // been tried `MAX_ATTEMPTS` times in a row. Override via env var if
-    // operators want a tighter / looser trigger.
-    let drain_window = state
-        .config
-        .wallet_pool_drain_window
-        .unwrap_or_else(|| (MAX_ATTEMPTS as u64) * (pool_size as u64));
-    // Fire exactly on the threshold crossing. If the streak keeps
-    // growing, the dedup window in `SlackClient` collapses repeats.
-    // Using `==` instead of `>=` keeps the spawn count bounded in case
-    // a slow Slack POST and a fast retry loop race.
-    if streak == drain_window {
+    let action = decide_wallet_pool_health_action(
+        &state.key_pool,
+        state.config.wallet_pool_drain_window,
+        outcome_is_transient,
+    );
+    if let PoolHealthAction::FiredDrainAlert {
+        streak,
+        threshold: _,
+        pool_size,
+    } = action
+    {
         tracing::error!(
             pool_size = pool_size,
             consecutive_transient = streak,
@@ -1546,9 +1603,11 @@ mod tests {
     use sqlx::postgres::PgPoolOptions;
 
     use super::{
-        classify_wallet_remember_handoff_failure, mark_remember_job_failed,
-        update_remember_job_after_wallet_error, WalletJobError,
+        classify_wallet_remember_handoff_failure, decide_wallet_pool_health_action,
+        mark_remember_job_failed, update_remember_job_after_wallet_error, PoolHealthAction,
+        WalletJobError, MAX_ATTEMPTS,
     };
+    use crate::types::KeyPool;
 
     static DB_SETUP_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 
@@ -1574,6 +1633,181 @@ mod tests {
             .unwrap();
 
         pool
+    }
+
+    // ============================================================
+    // ENG-1784: decide_wallet_pool_health_action — pure decision
+    // function, no DB required. Tests cover every branch of the
+    // streak-vs-threshold matrix so a refactor can't silently move
+    // the alert-fire point.
+    // ============================================================
+
+    fn pool(size: usize) -> KeyPool {
+        KeyPool::new((0..size).map(|i| format!("key_{}", i)).collect())
+    }
+
+    #[test]
+    fn pool_health_empty_pool_is_skipped_regardless_of_outcome() {
+        let key_pool = pool(0);
+        assert_eq!(
+            decide_wallet_pool_health_action(&key_pool, None, true),
+            PoolHealthAction::Skipped
+        );
+        assert_eq!(
+            decide_wallet_pool_health_action(&key_pool, None, false),
+            PoolHealthAction::Skipped
+        );
+        // Counter never moved.
+        assert_eq!(key_pool.current_transient_streak(), 0);
+    }
+
+    #[test]
+    fn pool_health_success_outcome_resets_streak() {
+        let key_pool = pool(3);
+        // Seed the streak so a reset would actually be visible.
+        key_pool.record_transient_failure();
+        key_pool.record_transient_failure();
+        assert_eq!(key_pool.current_transient_streak(), 2);
+        let action = decide_wallet_pool_health_action(&key_pool, None, false);
+        assert_eq!(action, PoolHealthAction::Reset);
+        assert_eq!(key_pool.current_transient_streak(), 0);
+    }
+
+    #[test]
+    fn pool_health_transient_below_threshold_increments_no_alert() {
+        let key_pool = pool(3); // threshold = MAX_ATTEMPTS × 3 = 9
+        let action = decide_wallet_pool_health_action(&key_pool, None, true);
+        let threshold = MAX_ATTEMPTS as u64 * 3;
+        assert_eq!(
+            action,
+            PoolHealthAction::IncrementedBelowThreshold {
+                streak: 1,
+                threshold,
+            }
+        );
+        assert_eq!(key_pool.current_transient_streak(), 1);
+    }
+
+    #[test]
+    fn pool_health_transient_at_threshold_fires_alert_exactly_once() {
+        let key_pool = pool(2); // threshold = MAX_ATTEMPTS × 2 = 6
+        let threshold = MAX_ATTEMPTS as u64 * 2;
+
+        // Climb to one BELOW threshold without firing.
+        for _ in 0..(threshold - 1) {
+            let a = decide_wallet_pool_health_action(&key_pool, None, true);
+            assert!(matches!(
+                a,
+                PoolHealthAction::IncrementedBelowThreshold { .. }
+            ));
+        }
+        // Crossing tick = alert fires.
+        let action = decide_wallet_pool_health_action(&key_pool, None, true);
+        assert_eq!(
+            action,
+            PoolHealthAction::FiredDrainAlert {
+                streak: threshold,
+                threshold,
+                pool_size: 2,
+            }
+        );
+
+        // Next tick = above threshold, no re-fire.
+        let action = decide_wallet_pool_health_action(&key_pool, None, true);
+        assert_eq!(
+            action,
+            PoolHealthAction::AboveThresholdNoOp {
+                streak: threshold + 1,
+                threshold,
+            }
+        );
+    }
+
+    #[test]
+    fn pool_health_permanent_outcome_resets_streak_too() {
+        // A Permanent error means a job ended deterministically — the
+        // pool is producing *some* signal beyond stale-state Transients,
+        // so the streak resets the same way success does.
+        let key_pool = pool(3);
+        for _ in 0..5 {
+            decide_wallet_pool_health_action(&key_pool, None, true);
+        }
+        assert_eq!(key_pool.current_transient_streak(), 5);
+        // outcome_is_transient = false covers both success and Permanent.
+        let action = decide_wallet_pool_health_action(&key_pool, None, false);
+        assert_eq!(action, PoolHealthAction::Reset);
+        assert_eq!(key_pool.current_transient_streak(), 0);
+    }
+
+    #[test]
+    fn pool_health_env_override_takes_precedence_over_default() {
+        // Default for pool(5) would be MAX_ATTEMPTS × 5 = 15. Override to
+        // 3 to test that operators can tune the trigger without changing
+        // pool size.
+        let key_pool = pool(5);
+        // Climb to 2 — under override of 3.
+        decide_wallet_pool_health_action(&key_pool, Some(3), true);
+        let a = decide_wallet_pool_health_action(&key_pool, Some(3), true);
+        assert!(matches!(
+            a,
+            PoolHealthAction::IncrementedBelowThreshold { streak: 2, threshold: 3 }
+        ));
+        // Third Transient = exactly threshold = fire.
+        let a = decide_wallet_pool_health_action(&key_pool, Some(3), true);
+        assert_eq!(
+            a,
+            PoolHealthAction::FiredDrainAlert {
+                streak: 3,
+                threshold: 3,
+                pool_size: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn pool_health_streak_resumes_after_reset() {
+        // Verifies the reset isn't sticky — a healthy stretch followed
+        // by a fresh wave of transients still re-triggers the alert.
+        let key_pool = pool(2);
+        let threshold = MAX_ATTEMPTS as u64 * 2;
+
+        // First drain → fire.
+        for _ in 0..threshold {
+            decide_wallet_pool_health_action(&key_pool, None, true);
+        }
+        // Success → reset.
+        let action = decide_wallet_pool_health_action(&key_pool, None, false);
+        assert_eq!(action, PoolHealthAction::Reset);
+        // Drain again → fire again.
+        for _ in 0..(threshold - 1) {
+            decide_wallet_pool_health_action(&key_pool, None, true);
+        }
+        let action = decide_wallet_pool_health_action(&key_pool, None, true);
+        assert!(matches!(
+            action,
+            PoolHealthAction::FiredDrainAlert { .. }
+        ));
+    }
+
+    #[test]
+    fn pool_health_single_wallet_pool_threshold_is_max_attempts() {
+        // pool(1) → threshold = MAX_ATTEMPTS × 1. Defends against an
+        // off-by-one where `pool_size == 1` would never fire (the math
+        // is the same as a single wallet exhausting its retry budget).
+        let key_pool = pool(1);
+        let threshold = MAX_ATTEMPTS as u64;
+        for _ in 0..(threshold - 1) {
+            decide_wallet_pool_health_action(&key_pool, None, true);
+        }
+        let action = decide_wallet_pool_health_action(&key_pool, None, true);
+        assert_eq!(
+            action,
+            PoolHealthAction::FiredDrainAlert {
+                streak: threshold,
+                threshold,
+                pool_size: 1,
+            }
+        );
     }
 
     #[test]

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -165,20 +165,63 @@ async fn update_remember_job_after_wallet_error(
         return;
     };
 
-    let status = if error.is_permanent() {
-        "failed"
-    } else {
-        "running"
-    };
+    let is_permanent = error.is_permanent();
+    let status = if is_permanent { "failed" } else { "running" };
 
-    let _ = sqlx::query(
-        "UPDATE remember_jobs SET status = $1, error_msg = $2, updated_at = NOW() WHERE id = $3",
+    // ENG-1784: when this UPDATE flips a row to `failed` we also want to
+    // page on-call. `RETURNING owner, namespace` lets us hydrate the
+    // alert from the same statement that persists the terminal state, no
+    // extra SELECT round-trip. For the transient (`running`) branch the
+    // RETURNING is wasted but harmless — Postgres returns the row either
+    // way and the wallet job is about to be retried, so the latency
+    // difference is noise.
+    let row: Result<Option<(String, String)>, sqlx::Error> = sqlx::query_as(
+        "UPDATE remember_jobs SET status = $1, error_msg = $2, updated_at = NOW() \
+         WHERE id = $3 RETURNING owner, namespace",
     )
     .bind(status)
     .bind(msg)
     .bind(jid)
-    .execute(state.db.pool())
+    .fetch_optional(state.db.pool())
     .await;
+
+    if !is_permanent {
+        // Transient: row stays `running`, wallet job will retry. No alert.
+        return;
+    }
+
+    // Permanent + persistence outcome decides what we send to Slack. We
+    // page on-call regardless of whether the UPDATE was acknowledged —
+    // an Enoki / Walrus retry exhaustion is a real incident, and missing
+    // metadata is a smaller problem than missing the page entirely.
+    let metadata = match row {
+        Ok(Some((owner, namespace))) => Some(RememberJobMetadata { owner, namespace }),
+        Ok(None) => {
+            tracing::warn!(
+                "remember job {} not found while marking failed — DB out of sync",
+                jid
+            );
+            None
+        }
+        Err(persist_err) => {
+            tracing::error!(
+                "failed to persist failed status for remember job {}: {}",
+                jid,
+                persist_err
+            );
+            None
+        }
+    };
+
+    spawn_slack_remember_failed_alert(
+        state.slack.as_ref(),
+        Some(jid),
+        metadata.as_ref(),
+        msg,
+        crate::slack::FailureKind::WalletRetriesExhausted {
+            attempts: MAX_ATTEMPTS,
+        },
+    );
 }
 
 /// Metadata returned by a successful `mark_remember_job_failed` so the
@@ -227,14 +270,22 @@ fn remember_job_persist_failure_message(msg: &str, persist_err: &sqlx::Error) ->
 ///
 /// Spawned in the background so a slow Slack POST cannot block the wallet
 /// worker, and a Slack-side failure cannot fail the wallet job. The Slack
-/// client carries its own 5-minute dedup window so an Enoki / sidecar
-/// incident that fans out into dozens of identical failures only pages the
-/// channel once per window.
+/// client carries its own 5-minute dedup window AND a global 60-second
+/// cap, so an Enoki / sidecar incident that fans out into dozens of
+/// identical failures only pages the channel once per window, and a
+/// diverse-error storm can't flood the channel either.
+///
+/// `kind` is what makes the alert headline accurate — pass
+/// `WalletRetriesExhausted` for path A (real upload/transfer permanent
+/// failure) and `HandoffEnqueueFailure` for path B (queue layer down
+/// after upload succeeded). The two scenarios get distinct Slack
+/// headlines so on-call can route response without reading the body.
 fn spawn_slack_remember_failed_alert(
     slack: Option<&Arc<crate::slack::SlackClient>>,
     remember_job_id: Option<&str>,
     metadata: Option<&RememberJobMetadata>,
     msg: &str,
+    kind: crate::slack::FailureKind,
 ) {
     let Some(client) = slack else {
         return;
@@ -245,17 +296,14 @@ fn spawn_slack_remember_failed_alert(
     let namespace = metadata.map(|m| m.namespace.clone());
     let msg = msg.to_string();
     tokio::spawn(async move {
-        if let Err(err) = client
-            .notify_remember_job_failed(
-                job_id.as_deref(),
-                owner.as_deref(),
-                namespace.as_deref(),
-                MAX_ATTEMPTS,
-                MAX_ATTEMPTS,
-                &msg,
-            )
-            .await
-        {
+        let alert = crate::slack::RememberJobFailedAlert {
+            job_id: job_id.as_deref(),
+            owner: owner.as_deref(),
+            namespace: namespace.as_deref(),
+            error_msg: &msg,
+            kind,
+        };
+        if let Err(err) = client.notify_remember_job_failed(alert).await {
             tracing::warn!("Slack remember-failed alert failed: {}", err);
         }
     });
@@ -275,7 +323,13 @@ async fn classify_wallet_remember_handoff_failure(
     // is not orphaned.
     match mark_remember_job_failed(pool, remember_job_id, &msg).await {
         Ok(metadata) => {
-            spawn_slack_remember_failed_alert(slack, remember_job_id, metadata.as_ref(), &msg);
+            spawn_slack_remember_failed_alert(
+                slack,
+                remember_job_id,
+                metadata.as_ref(),
+                &msg,
+                crate::slack::FailureKind::HandoffEnqueueFailure,
+            );
             WalletJobError::Permanent(msg)
         }
         Err(persist_err) => {
@@ -292,7 +346,13 @@ async fn handle_legacy_remember_handoff_failure(
 ) -> Result<(), RememberJobError> {
     match mark_remember_job_failed(pool, Some(remember_job_id), &msg).await {
         Ok(metadata) => {
-            spawn_slack_remember_failed_alert(slack, Some(remember_job_id), metadata.as_ref(), &msg);
+            spawn_slack_remember_failed_alert(
+                slack,
+                Some(remember_job_id),
+                metadata.as_ref(),
+                &msg,
+                crate::slack::FailureKind::HandoffEnqueueFailure,
+            );
             Ok(())
         }
         Err(persist_err) => Err(RememberJobError::Internal(

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -156,7 +156,8 @@ pub(crate) async fn warm_blob_cache_after_upload(
 }
 
 async fn update_remember_job_after_wallet_error(
-    state: &AppState,
+    pool: &sqlx::PgPool,
+    slack: Option<&Arc<crate::slack::SlackClient>>,
     remember_job_id: Option<&str>,
     error: &WalletJobError,
     msg: &str,
@@ -182,7 +183,7 @@ async fn update_remember_job_after_wallet_error(
     .bind(status)
     .bind(msg)
     .bind(jid)
-    .fetch_optional(state.db.pool())
+    .fetch_optional(pool)
     .await;
 
     if !is_permanent {
@@ -214,11 +215,11 @@ async fn update_remember_job_after_wallet_error(
     };
 
     spawn_slack_remember_failed_alert(
-        state.slack.as_ref(),
+        slack,
         Some(jid),
         metadata.as_ref(),
         msg,
-        crate::slack::FailureKind::WalletRetriesExhausted {
+        crate::slack::FailureKind::TerminalWalletFailure {
             attempts: MAX_ATTEMPTS,
         },
     );
@@ -602,7 +603,8 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
                 Err(err) => {
                     let msg = err.to_string();
                     update_remember_job_after_wallet_error(
-                        state,
+                        state.db.pool(),
+                        state.slack.as_ref(),
                         remember_job_id.as_deref(),
                         &err,
                         &msg,
@@ -727,7 +729,14 @@ async fn insert_vector_and_mark_remember_done(
     {
         let msg = format!("insert_vector failed: {}", e);
         let classified = WalletJobError::classify_sidecar_error(&msg);
-        update_remember_job_after_wallet_error(state, remember_job_id, &classified, &msg).await;
+        update_remember_job_after_wallet_error(
+            state.db.pool(),
+            state.slack.as_ref(),
+            remember_job_id,
+            &classified,
+            &msg,
+        )
+        .await;
         tracing::error!(
             "[wallet-job:upload] job_id={} {} classification={} retryable={}",
             remember_job_id.unwrap_or("-"),
@@ -829,7 +838,8 @@ async fn execute_upload_and_transfer(
             let msg = format!("base64 decode failed: {}", e);
             let classified = WalletJobError::Permanent(msg.clone());
             update_remember_job_after_wallet_error(
-                state,
+                state.db.pool(),
+                state.slack.as_ref(),
                 remember_job_id.as_deref(),
                 &classified,
                 &msg,
@@ -941,7 +951,8 @@ async fn execute_upload_and_transfer(
             let msg = format!("walrus upload failed: {}", e);
             let classified = WalletJobError::classify_sidecar_error(&msg);
             update_remember_job_after_wallet_error(
-                state,
+                state.db.pool(),
+                state.slack.as_ref(),
                 remember_job_id.as_deref(),
                 &classified,
                 &msg,
@@ -1432,12 +1443,13 @@ pub async fn execute_bulk_remember(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::OnceLock;
+    use std::sync::{Arc, OnceLock};
 
     use sqlx::postgres::PgPoolOptions;
 
     use super::{
-        classify_wallet_remember_handoff_failure, mark_remember_job_failed, WalletJobError,
+        classify_wallet_remember_handoff_failure, mark_remember_job_failed,
+        update_remember_job_after_wallet_error, WalletJobError,
     };
 
     static DB_SETUP_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -1719,5 +1731,231 @@ mod tests {
             }
             other => panic!("expected transient handoff error, got {other}"),
         }
+    }
+
+    // ============================================================
+    // ENG-1784 / Reviewer requirement #1 + #2 + #4
+    //
+    // The wallet-error path (`update_remember_job_after_wallet_error`)
+    // is what fires for the scenario Henry actually asked about: a
+    // remember job that fails after the Apalis retry budget is burned
+    // across the wallet pool. These tests prove:
+    //
+    //   #1 PERMANENT branch → exactly one Slack alert is fired, AND
+    //      the remember_jobs row is flipped to `failed`. The Slack
+    //      message must carry the wallet-failure headline and the
+    //      hydrated owner / namespace from the same UPDATE.
+    //   #2 TRANSIENT branch → NO Slack alert (the wallet job is about
+    //      to be retried), AND the row stays `running`.
+    //
+    // We use an inline axum mock server (same pattern as
+    // routes/remember.rs unit tests) so we don't need wiremock as a
+    // dev-dep and we don't have to refactor SlackClient into a trait
+    // just for testability.
+    // ============================================================
+
+    /// Spawn a mock Slack webhook on `127.0.0.1:0`. Returns the URL to
+    /// give to `SlackClient::new` plus a handle to inspect every body
+    /// the mock received. Each request returns `200 OK` (no retry
+    /// behavior — those tests live in slack::tests).
+    async fn spawn_mock_slack() -> (String, std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>) {
+        let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::<serde_json::Value>::new()));
+        let received_for_handler = std::sync::Arc::clone(&received);
+
+        let app = axum::Router::new().route(
+            "/webhook",
+            axum::routing::post(
+                move |axum::Json(body): axum::Json<serde_json::Value>| {
+                    let received = std::sync::Arc::clone(&received_for_handler);
+                    async move {
+                        received.lock().unwrap().push(body);
+                        "ok"
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        // Give the listener a beat to start accepting.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        (format!("http://{}/webhook", addr), received)
+    }
+
+    /// Reviewer requirement #1 — THE blocker. PERMANENT wallet error
+    /// flips the row to `failed` AND fires exactly one Slack alert
+    /// containing the wallet-failure headline + hydrated metadata.
+    #[tokio::test]
+    async fn update_after_wallet_error_permanent_alerts_slack_and_marks_failed() {
+        let pool = test_pool().await;
+        let (mock_url, received) = spawn_mock_slack().await;
+        let slack = Arc::new(crate::slack::SlackClient::new(
+            mock_url,
+            "test-env".to_string(),
+            Some("testsha".to_string()),
+        ));
+
+        let job_id = format!("perm-{}", uuid::Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'running')",
+        )
+        .bind(&job_id)
+        .bind("0xowner-permanent-test")
+        .bind("ns-permanent-test")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let err = WalletJobError::Permanent("Enoki balance::split MoveAbort".to_string());
+        update_remember_job_after_wallet_error(
+            &pool,
+            Some(&slack),
+            Some(&job_id),
+            &err,
+            "Enoki balance::split MoveAbort",
+        )
+        .await;
+
+        // The Slack POST is spawned fire-and-forget. Give it a beat to
+        // land on the mock server, then snapshot what we saw.
+        for _ in 0..40 {
+            if received.lock().unwrap().len() >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        // DB assertion (#1.a): row terminated with `failed`.
+        let (status, error_msg): (String, Option<String>) =
+            sqlx::query_as("SELECT status, error_msg FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "failed");
+        assert_eq!(error_msg.as_deref(), Some("Enoki balance::split MoveAbort"));
+
+        // Slack assertion (#1.b): exactly one POST, correct headline,
+        // owner + namespace hydrated from the RETURNING UPDATE.
+        let snapshot = received.lock().unwrap().clone();
+        assert_eq!(
+            snapshot.len(),
+            1,
+            "expected exactly one Slack alert, saw {}: {:?}",
+            snapshot.len(),
+            snapshot
+        );
+        let body = &snapshot[0];
+        let json = body.to_string();
+        assert!(
+            json.contains("terminal wallet failure"),
+            "headline must say 'terminal wallet failure': {}",
+            json
+        );
+        assert!(
+            json.contains("permanent wallet failure after 3 retry attempts"),
+            "body must surface MAX_ATTEMPTS as retry-attempt count: {}",
+            json
+        );
+        assert!(json.contains(&job_id), "job_id must be present: {}", json);
+        // Owner is rendered via `shorten_owner` (first 8 chars + "…" +
+        // last 4) so the channel doesn't get a 66-char Sui address
+        // wrapped onto multiple lines. Assert on a substring of the
+        // shortened form rather than the full input.
+        assert!(
+            json.contains("0xowner-"),
+            "owner prefix from RETURNING must be in alert: {}",
+            json
+        );
+        assert!(
+            json.contains("test"),
+            "owner suffix from RETURNING must be in alert: {}",
+            json
+        );
+        assert!(
+            json.contains("ns-permanent-test"),
+            "namespace from RETURNING must be in alert: {}",
+            json
+        );
+        assert!(
+            json.contains("Enoki balance::split MoveAbort"),
+            "error message must be in alert: {}",
+            json
+        );
+        assert!(json.contains("env `test-env`"));
+        assert!(json.contains("server commit `testsha`"));
+
+        // Cleanup
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Reviewer requirement #2: TRANSIENT wallet errors must NOT alert
+    /// Slack — the wallet job is about to be retried by Apalis and
+    /// paging on-call every transient blip would defeat the alerter.
+    /// The row must stay `running` so the retry can move forward.
+    #[tokio::test]
+    async fn update_after_wallet_error_transient_does_not_alert_slack() {
+        let pool = test_pool().await;
+        let (mock_url, received) = spawn_mock_slack().await;
+        let slack = Arc::new(crate::slack::SlackClient::new(
+            mock_url,
+            "test-env".to_string(),
+            Some("testsha".to_string()),
+        ));
+
+        let job_id = format!("trans-{}", uuid::Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'running')",
+        )
+        .bind(&job_id)
+        .bind("0xowner-transient-test")
+        .bind("ns-transient-test")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let err = WalletJobError::Transient("sidecar 503 service unavailable".to_string());
+        update_remember_job_after_wallet_error(
+            &pool,
+            Some(&slack),
+            Some(&job_id),
+            &err,
+            "sidecar 503 service unavailable",
+        )
+        .await;
+
+        // Wait the same beat as the permanent test to give a spawn'd
+        // alert (if any) a chance to land before we assert zero.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        // DB assertion (#2.a): row stays `running`, NOT `failed`.
+        let (status, error_msg): (String, Option<String>) =
+            sqlx::query_as("SELECT status, error_msg FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "running");
+        assert_eq!(error_msg.as_deref(), Some("sidecar 503 service unavailable"));
+
+        // Slack assertion (#2.b): zero POSTs to the mock.
+        let snapshot = received.lock().unwrap().clone();
+        assert!(
+            snapshot.is_empty(),
+            "transient errors must NOT alert Slack, saw {} message(s): {:?}",
+            snapshot.len(),
+            snapshot
+        );
+
+        // Cleanup
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
     }
 }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -310,6 +310,79 @@ fn spawn_slack_remember_failed_alert(
     });
 }
 
+/// ENG-1784: fire-and-forget infra-level Slack alert. Same fire-and-forget
+/// contract as `spawn_slack_remember_failed_alert` — Slack POST cannot
+/// block the wallet worker and a Slack-side outage cannot fail the job.
+/// The infra alerter dedups by variant kind, so repeated calls for the
+/// same `InfraFailureKind` within `DEDUP_WINDOW` only post once.
+pub(crate) fn spawn_slack_infra_alert(
+    slack: Option<&Arc<crate::slack::SlackClient>>,
+    kind: crate::slack::InfraFailureKind,
+) {
+    let Some(client) = slack else {
+        return;
+    };
+    let client = client.clone();
+    tokio::spawn(async move {
+        let alert = crate::slack::InfraFailureAlert { kind };
+        if let Err(err) = client.notify_infra_failure(alert).await {
+            tracing::warn!("Slack infra alert failed: {}", err);
+        }
+    });
+}
+
+/// ENG-1784: detect "wallet pool drained" — every wallet returning
+/// `Transient` errors for `drain_window` consecutive attempts means the
+/// pool is effectively unable to make progress (typically every wallet is
+/// out of gas / hit `balance::split`). Currently silent because the
+/// per-job classifier only alerts on `Permanent` — this hook is what
+/// surfaces the system-blocking state to ops.
+///
+/// Called from the central wallet-job result branch. `outcome_is_transient`
+/// = `true` means this job ended in `WalletJobError::Transient`; any other
+/// outcome (success or `Permanent`) resets the streak.
+pub(crate) fn track_wallet_pool_health(
+    state: &crate::types::AppState,
+    outcome_is_transient: bool,
+) {
+    let pool_size = state.key_pool.len();
+    if pool_size == 0 {
+        // Empty pool is a separate `NoSuiKeysConfigured` alert, fired
+        // once at boot. Nothing to track here.
+        return;
+    }
+    if !outcome_is_transient {
+        state.key_pool.reset_transient_streak();
+        return;
+    }
+    let streak = state.key_pool.record_transient_failure();
+    // Default drain window = MAX_ATTEMPTS × pool_size — every wallet has
+    // been tried `MAX_ATTEMPTS` times in a row. Override via env var if
+    // operators want a tighter / looser trigger.
+    let drain_window = state
+        .config
+        .wallet_pool_drain_window
+        .unwrap_or_else(|| (MAX_ATTEMPTS as u64) * (pool_size as u64));
+    // Fire exactly on the threshold crossing. If the streak keeps
+    // growing, the dedup window in `SlackClient` collapses repeats.
+    // Using `==` instead of `>=` keeps the spawn count bounded in case
+    // a slow Slack POST and a fast retry loop race.
+    if streak == drain_window {
+        tracing::error!(
+            pool_size = pool_size,
+            consecutive_transient = streak,
+            "wallet pool drained — firing infra alert"
+        );
+        spawn_slack_infra_alert(
+            state.slack.as_ref(),
+            crate::slack::InfraFailureKind::WalletPoolDrained {
+                pool_size,
+                consecutive_transient: streak,
+            },
+        );
+    }
+}
+
 async fn classify_wallet_remember_handoff_failure(
     pool: &sqlx::PgPool,
     slack: Option<&Arc<crate::slack::SlackClient>>,
@@ -644,6 +717,14 @@ pub async fn execute_wallet_job(job: WalletJob, ctx: Data<Arc<AppState>>) -> Res
             .await
         }
     };
+
+    // ENG-1784: track wallet pool health centrally — only the dispatcher
+    // sees every outcome of a WalletJob, so it's the right hook for
+    // "every wallet returned Transient for N attempts in a row" detection.
+    track_wallet_pool_health(
+        state,
+        matches!(result, Err(WalletJobError::Transient(_))),
+    );
 
     result.map_err(|err| {
         if let WalletJobError::Permanent(ref msg) = err {
@@ -1156,10 +1237,15 @@ pub async fn execute_remember(
     .execute(state.db.pool())
     .await;
 
-    // Helper: mark failed and return Err
+    // Helper: mark failed and return Err.
+    // ENG-1784: per-job failures here are NOT system-blocking (one job
+    // per user), so they DO NOT page Slack — the counter feeds the
+    // `memwal_remember_per_job_failed_total` Prometheus metric instead.
+    // `$kind` is a stable label for that metric.
     macro_rules! fail {
-        ($msg:expr) => {{
+        ($kind:literal, $msg:expr) => {{
             let msg = $msg.to_string();
+            crate::observability::record_remember_per_job_failure("legacy", $kind);
             tracing::error!("[remember-job] {} job_id={}", msg, job.job_id);
             let _ = sqlx::query(
                 "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
@@ -1175,13 +1261,13 @@ pub async fn execute_remember(
     // ── Step 2: decode ciphertext (already SEAL-encrypted in route handler) ──
     let encrypted = match base64::engine::general_purpose::STANDARD.decode(&job.encrypted_b64) {
         Ok(b) => b,
-        Err(e) => fail!(format!("base64 decode failed: {}", e)),
+        Err(e) => fail!("base64_decode", format!("base64 decode failed: {}", e)),
     };
     // vector is also pre-computed in route handler — no network call needed here.
 
     let key_index = match state.key_pool.next_index() {
         Some(idx) => idx,
-        None => fail!("No Sui keys configured in pool"),
+        None => fail!("no_keys", "No Sui keys configured in pool"),
     };
 
     // ── Step 3: walrus upload (the slow part ~2-3s) ───────────────
@@ -1264,7 +1350,9 @@ pub async fn execute_remember(
             );
             return Ok(());
         }
-        Err(UploadBlobError::App(e)) => fail!(format!("walrus upload failed: {}", e)),
+        Err(UploadBlobError::App(e)) => {
+            fail!("walrus_upload", format!("walrus upload failed: {}", e))
+        }
     };
     let blob_id = upload.blob_id.clone();
 
@@ -1290,7 +1378,7 @@ pub async fn execute_remember(
         )
         .await
     {
-        fail!(format!("insert_vector failed: {}", e));
+        fail!("insert_vector", format!("insert_vector failed: {}", e));
     }
 
     // ── Step 5: mark done ────────────────────────────────────────
@@ -1423,6 +1511,16 @@ pub async fn execute_bulk_remember(
             })
             .await
             .map_err(|e| {
+                // ENG-1784: per-item fan-out failure is per-user (one
+                // item in one bulk request), not system-blocking. Bump
+                // the metric so a sustained spike is dashboard-visible;
+                // do NOT page Slack. If the broader queue layer is
+                // wedged, the `ApalisQueueStuck` infra alert will catch
+                // it instead.
+                crate::observability::record_remember_per_job_failure(
+                    "bulk_fanout",
+                    "queue_push",
+                );
                 BulkRememberError::Internal(format!(
                     "failed to enqueue wallet job for {}: {}",
                     job_id, e

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -7,6 +7,7 @@ mod observability;
 mod rate_limit;
 mod routes;
 mod services;
+mod slack;
 mod storage;
 mod types;
 
@@ -328,6 +329,33 @@ async fn main() {
     // CompositeRanker is stateless — one shared instance is fine.
     let ranker: Arc<dyn Ranker> = Arc::new(CompositeRanker);
 
+    // ENG-1784: Slack alerter — only enabled if SLACK_WEBHOOK_URL is set.
+    // The server commit + env label are baked into the SlackClient so the
+    // footer of every alert identifies which deployment fired it. We pull
+    // the commit from the same env vars compatibility.rs uses (kept
+    // deliberately loose so Railway / CI / Nautilus can each set whichever
+    // var they already expose).
+    let slack = config.slack_webhook_url.as_ref().map(|url| {
+        let commit = std::env::var("GIT_SHA")
+            .or_else(|_| std::env::var("GITHUB_SHA"))
+            .or_else(|_| std::env::var("RAILWAY_GIT_COMMIT_SHA"))
+            .ok()
+            .map(|v| v.chars().take(7).collect::<String>());
+        tracing::info!(
+            "  Slack alerter: enabled (env={}, commit={})",
+            config.env_label,
+            commit.as_deref().unwrap_or("-"),
+        );
+        Arc::new(crate::slack::SlackClient::new(
+            url.clone(),
+            config.env_label.clone(),
+            commit,
+        ))
+    });
+    if slack.is_none() {
+        tracing::info!("  Slack alerter: disabled (set SLACK_WEBHOOK_URL to enable)");
+    }
+
     // Shared application state
     let state = Arc::new(AppState {
         db,
@@ -346,6 +374,7 @@ async fn main() {
         blob_cache_ttl,
         blob_cache_max_bytes,
         embedding_cache_ttl,
+        slack,
     });
 
     // Worker 1: MetaTransferJob (legacy — backward compat with existing DB rows)

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -646,6 +646,82 @@ async fn main() {
         });
     }
 
+    // Probe 4: Apalis backlog stuck-queue detection.
+    //
+    // Counts Pending jobs whose `run_at` is at least
+    // `apalis_backlog_stuck_secs` in the past — i.e. jobs that were
+    // ready to run more than ~5 min ago but no worker has claimed them.
+    // Above `apalis_backlog_threshold` AND that condition sustained for
+    // `health_check_fail_threshold` consecutive samples → queue is
+    // wedged (workers dead, deadlocked, or under-provisioned).
+    //
+    // Schema reminder: apalis-sql writes to schema-qualified
+    // `apalis.jobs` (NOT a flat `apalis_jobs`). Status values are
+    // capitalized strings: 'Pending', 'Running', 'Done', 'Failed'.
+    {
+        let probe_state = state.clone();
+        let probe_slack = slack.clone();
+        let interval_secs = config.health_check_interval_secs;
+        let fail_threshold = config.health_check_fail_threshold;
+        let backlog_threshold = config.apalis_backlog_threshold;
+        let stuck_secs = config.apalis_backlog_stuck_secs;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            let mut consecutive_over_threshold = 0u32;
+            // Cast to i32 once — `make_interval(...)` only accepts i32.
+            // 5-min default (300s) is comfortably within i32 range.
+            let stuck_secs_i32: i32 = stuck_secs.try_into().unwrap_or(i32::MAX);
+            loop {
+                interval.tick().await;
+                let probe = sqlx::query_scalar::<_, i64>(
+                    "SELECT COUNT(*)::bigint FROM apalis.jobs \
+                     WHERE status = 'Pending' \
+                       AND done_at IS NULL \
+                       AND run_at < now() - make_interval(secs => $1)",
+                )
+                .bind(stuck_secs_i32)
+                .fetch_one(probe_state.db.pool())
+                .await;
+                match probe {
+                    Ok(backlog) if backlog >= backlog_threshold => {
+                        consecutive_over_threshold += 1;
+                        tracing::warn!(
+                            "  apalis probe: backlog={} threshold={} consecutive_over={}",
+                            backlog,
+                            backlog_threshold,
+                            consecutive_over_threshold
+                        );
+                        if consecutive_over_threshold == fail_threshold {
+                            crate::jobs::spawn_slack_infra_alert(
+                                probe_slack.as_ref(),
+                                crate::slack::InfraFailureKind::ApalisQueueStuck {
+                                    backlog,
+                                    stuck_for_secs: stuck_secs,
+                                    consecutive_samples: consecutive_over_threshold,
+                                },
+                            );
+                        }
+                    }
+                    Ok(_) => {
+                        if consecutive_over_threshold > 0 {
+                            tracing::info!(
+                                "  apalis probe: backlog drained after {} over-threshold samples",
+                                consecutive_over_threshold
+                            );
+                        }
+                        consecutive_over_threshold = 0;
+                    }
+                    Err(e) => {
+                        // Query failure is its own signal — but Postgres
+                        // outages already page via the postgres probe,
+                        // so we just log here to avoid double-alerting.
+                        tracing::error!("  apalis probe: query failed: {}", e);
+                    }
+                }
+            }
+        });
+    }
+
     // Probe 3: Sui RPC reachability via JSON-RPC. We send the cheapest
     // valid method (`sui_getLatestCheckpointSequenceNumber`, no params)
     // because a bare HEAD/GET will 405 against a JSON-RPC endpoint.

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -81,6 +81,34 @@ async fn main() {
         tracing::warn!("⚠️  Unset RATE_LIMIT_DISABLED to restore protection.");
     }
 
+    // ENG-1784: build the Slack alerter EARLY (right after config) so the
+    // sidecar heartbeat + the per-dependency health probes can all clone
+    // the same handle. Only enabled when SLACK_WEBHOOK_URL is set; None
+    // disables every alert path without disturbing any other code path.
+    // The server commit + env label are baked in so each alert's footer
+    // identifies which deployment fired it.
+    let slack: Option<Arc<crate::slack::SlackClient>> =
+        config.slack_webhook_url.as_ref().map(|url| {
+            let commit = std::env::var("GIT_SHA")
+                .or_else(|_| std::env::var("GITHUB_SHA"))
+                .or_else(|_| std::env::var("RAILWAY_GIT_COMMIT_SHA"))
+                .ok()
+                .map(|v| v.chars().take(7).collect::<String>());
+            tracing::info!(
+                "  Slack alerter: enabled (env={}, commit={})",
+                config.env_label,
+                commit.as_deref().unwrap_or("-"),
+            );
+            Arc::new(crate::slack::SlackClient::new(
+                url.clone(),
+                config.env_label.clone(),
+                commit,
+            ))
+        });
+    if slack.is_none() {
+        tracing::info!("  Slack alerter: disabled (set SLACK_WEBHOOK_URL to enable)");
+    }
+
     // Start TS sidecar HTTP server (SEAL + Walrus operations)
     let sidecar_url = config.sidecar_url.clone();
     tracing::info!("  sidecar: starting at {}", sidecar_url);
@@ -129,10 +157,20 @@ async fn main() {
 
     // Keep a cheap heartbeat in the Rust logs so operators can distinguish
     // Enoki/Walrus failures from the sidecar process becoming unavailable.
+    //
+    // ENG-1784: also fire `InfraFailureKind::SidecarDown` to Slack when
+    // consecutive failures cross the configured threshold (default 3 ≈
+    // 90s sustained outage). The Slack client itself dedups per variant
+    // for 5 minutes so a real outage produces ~1 page per window, not
+    // one per failed probe.
     let sidecar_watch_client = http_client.clone();
     let sidecar_watch_url = health_url.clone();
+    let sidecar_fail_threshold = config.health_check_fail_threshold;
+    let sidecar_interval_secs = config.health_check_interval_secs;
+    let slack_handle = slack.clone();
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(sidecar_interval_secs));
         let mut consecutive_failures = 0u32;
         loop {
             interval.tick().await;
@@ -158,6 +196,14 @@ async fn main() {
                         resp.status(),
                         consecutive_failures
                     );
+                    if consecutive_failures == sidecar_fail_threshold {
+                        crate::jobs::spawn_slack_infra_alert(
+                            slack_handle.as_ref(),
+                            crate::slack::InfraFailureKind::SidecarDown {
+                                consecutive_failures,
+                            },
+                        );
+                    }
                 }
                 Err(e) => {
                     consecutive_failures += 1;
@@ -166,6 +212,14 @@ async fn main() {
                         consecutive_failures,
                         e
                     );
+                    if consecutive_failures == sidecar_fail_threshold {
+                        crate::jobs::spawn_slack_infra_alert(
+                            slack_handle.as_ref(),
+                            crate::slack::InfraFailureKind::SidecarDown {
+                                consecutive_failures,
+                            },
+                        );
+                    }
                 }
             }
         }
@@ -237,6 +291,15 @@ async fn main() {
         );
     } else {
         tracing::warn!("  Walrus upload: no Sui private keys configured, uploads will fail");
+        // ENG-1784: page on-call once at boot — without a key pool every
+        // remember job will fail, but the per-job classifier currently
+        // returns the same Permanent error per request and dedup
+        // collapses them. Surfacing it explicitly at startup is cheaper
+        // than waiting for the first user complaint.
+        crate::jobs::spawn_slack_infra_alert(
+            slack.as_ref(),
+            crate::slack::InfraFailureKind::NoSuiKeysConfigured,
+        );
     }
 
     // Build wallet key holder.
@@ -329,44 +392,19 @@ async fn main() {
     // CompositeRanker is stateless — one shared instance is fine.
     let ranker: Arc<dyn Ranker> = Arc::new(CompositeRanker);
 
-    // ENG-1784: Slack alerter — only enabled if SLACK_WEBHOOK_URL is set.
-    // The server commit + env label are baked into the SlackClient so the
-    // footer of every alert identifies which deployment fired it. We pull
-    // the commit from the same env vars compatibility.rs uses (kept
-    // deliberately loose so Railway / CI / Nautilus can each set whichever
-    // var they already expose).
-    let slack = config.slack_webhook_url.as_ref().map(|url| {
-        let commit = std::env::var("GIT_SHA")
-            .or_else(|_| std::env::var("GITHUB_SHA"))
-            .or_else(|_| std::env::var("RAILWAY_GIT_COMMIT_SHA"))
-            .ok()
-            .map(|v| v.chars().take(7).collect::<String>());
-        tracing::info!(
-            "  Slack alerter: enabled (env={}, commit={})",
-            config.env_label,
-            commit.as_deref().unwrap_or("-"),
-        );
-        Arc::new(crate::slack::SlackClient::new(
-            url.clone(),
-            config.env_label.clone(),
-            commit,
-        ))
-    });
-    if slack.is_none() {
-        tracing::info!("  Slack alerter: disabled (set SLACK_WEBHOOK_URL to enable)");
-    }
-
-    // Shared application state
+    // Shared application state. http_client + slack are cloned (rather
+    // than moved) so the ENG-1784 health probes spawned below can hold
+    // their own handles; Arc + reqwest::Client are both cheap to clone.
     let state = Arc::new(AppState {
-        db,
+        db: db.clone(),
         config: Arc::clone(&config),
-        http_client,
+        http_client: http_client.clone(),
         key_pool,
         engine,
         embedder,
         extractor,
         ranker,
-        redis,
+        redis: redis.clone(),
         fallback_rate_limit: tokio::sync::Mutex::new(crate::rate_limit::InMemoryFallback::default()),
         remember_job_storage: remember_job_storage.clone(),
         wallet_storage: wallet_storage.clone(),
@@ -374,7 +412,7 @@ async fn main() {
         blob_cache_ttl,
         blob_cache_max_bytes,
         embedding_cache_ttl,
-        slack,
+        slack: slack.clone(),
     });
 
     // Worker 1: MetaTransferJob (legacy — backward compat with existing DB rows)
@@ -504,6 +542,166 @@ async fn main() {
             }
         }
     });
+
+    // ENG-1784: infra-health probes — three lightweight pollers that
+    // detect when a hard dependency is down and the whole relayer can't
+    // make progress. Each probe runs at `health_check_interval_secs`,
+    // counts consecutive failures, and fires the matching
+    // `InfraFailureKind` exactly when the count crosses
+    // `health_check_fail_threshold`. Slack-side dedup collapses repeats
+    // for `DEDUP_WINDOW` so the channel sees one page per real incident.
+    // All probes are no-ops if `SLACK_WEBHOOK_URL` is unset — logs still
+    // surface the state.
+
+    // Probe 1: Postgres reachability + pool saturation
+    {
+        let probe_state = state.clone();
+        let probe_slack = slack.clone();
+        let interval_secs = config.health_check_interval_secs;
+        let fail_threshold = config.health_check_fail_threshold;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            let mut consecutive_failures = 0u32;
+            loop {
+                interval.tick().await;
+                // `SELECT 1` is the standard cheap reachability probe — if
+                // it can't even acquire a connection or run the query, the
+                // pool is wedged.
+                let probe = sqlx::query_scalar::<_, i32>("SELECT 1")
+                    .fetch_one(probe_state.db.pool())
+                    .await;
+                match probe {
+                    Ok(_) => {
+                        if consecutive_failures > 0 {
+                            tracing::info!(
+                                "  postgres probe: recovered after {} failed checks",
+                                consecutive_failures
+                            );
+                        }
+                        consecutive_failures = 0;
+                    }
+                    Err(e) => {
+                        consecutive_failures += 1;
+                        tracing::error!(
+                            "  postgres probe: failed (consecutive={}): {}",
+                            consecutive_failures,
+                            e
+                        );
+                        if consecutive_failures == fail_threshold {
+                            crate::jobs::spawn_slack_infra_alert(
+                                probe_slack.as_ref(),
+                                crate::slack::InfraFailureKind::PostgresDown {
+                                    reason: e.to_string(),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Probe 2: Redis reachability via PING
+    {
+        let probe_slack = slack.clone();
+        let mut probe_redis = state.redis.clone();
+        let interval_secs = config.health_check_interval_secs;
+        let fail_threshold = config.health_check_fail_threshold;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            let mut consecutive_failures = 0u32;
+            loop {
+                interval.tick().await;
+                let ping: redis::RedisResult<String> = redis::cmd("PING")
+                    .query_async(&mut probe_redis)
+                    .await;
+                match ping {
+                    Ok(_) => {
+                        if consecutive_failures > 0 {
+                            tracing::info!(
+                                "  redis probe: recovered after {} failed checks",
+                                consecutive_failures
+                            );
+                        }
+                        consecutive_failures = 0;
+                    }
+                    Err(e) => {
+                        consecutive_failures += 1;
+                        tracing::error!(
+                            "  redis probe: PING failed (consecutive={}): {}",
+                            consecutive_failures,
+                            e
+                        );
+                        if consecutive_failures == fail_threshold {
+                            crate::jobs::spawn_slack_infra_alert(
+                                probe_slack.as_ref(),
+                                crate::slack::InfraFailureKind::RedisDown {
+                                    consecutive_failures,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Probe 3: Sui RPC reachability via JSON-RPC. We send the cheapest
+    // valid method (`sui_getLatestCheckpointSequenceNumber`, no params)
+    // because a bare HEAD/GET will 405 against a JSON-RPC endpoint.
+    {
+        let probe_slack = slack.clone();
+        let probe_client = http_client.clone();
+        let probe_rpc_url = config.sui_rpc_url.clone();
+        let interval_secs = config.health_check_interval_secs;
+        let fail_threshold = config.health_check_fail_threshold;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            let mut consecutive_failures = 0u32;
+            let body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "sui_getLatestCheckpointSequenceNumber",
+                "params": []
+            });
+            loop {
+                interval.tick().await;
+                let resp = probe_client
+                    .post(&probe_rpc_url)
+                    .json(&body)
+                    .timeout(std::time::Duration::from_secs(5))
+                    .send()
+                    .await;
+                let healthy = match resp {
+                    Ok(r) if r.status().is_success() => true,
+                    Ok(_) | Err(_) => false,
+                };
+                if healthy {
+                    if consecutive_failures > 0 {
+                        tracing::info!(
+                            "  sui_rpc probe: recovered after {} failed checks",
+                            consecutive_failures
+                        );
+                    }
+                    consecutive_failures = 0;
+                } else {
+                    consecutive_failures += 1;
+                    tracing::error!(
+                        "  sui_rpc probe: failed (consecutive={})",
+                        consecutive_failures,
+                    );
+                    if consecutive_failures == fail_threshold {
+                        crate::jobs::spawn_slack_infra_alert(
+                            probe_slack.as_ref(),
+                            crate::slack::InfraFailureKind::SuiRpcDown {
+                                consecutive_failures,
+                            },
+                        );
+                    }
+                }
+            }
+        });
+    }
 
     // Build routes
     // Protected routes (require Ed25519 signature + onchain verification)

--- a/services/server/src/observability.rs
+++ b/services/server/src/observability.rs
@@ -109,6 +109,20 @@ static SIDECAR_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("register memwal_sidecar_failures_total")
 });
 
+/// ENG-1784: count of per-job remember failures that are NOT routed to
+/// Slack (per lead policy: only system-blocking events page on-call). The
+/// counter lets Grafana dashboards still surface trends, and a sustained
+/// spike here is the input signal for a future system-level alert
+/// ("remember-fail rate per minute" — currently out of scope).
+static REMEMBER_PER_JOB_FAILED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    prometheus::register_int_counter_vec!(
+        "memwal_remember_per_job_failed_total",
+        "Per-job remember failures (legacy + bulk fan-out paths) that update DB state but do not page Slack.",
+        &["path", "kind"]
+    )
+    .expect("register memwal_remember_per_job_failed_total")
+});
+
 static DB_QUERY_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus::register_histogram_vec!(
         HistogramOpts::new(
@@ -293,6 +307,17 @@ pub fn observe_external(
 pub fn record_sidecar_failure(operation: &'static str, reason: &'static str) {
     SIDECAR_FAILURES_TOTAL
         .with_label_values(&[operation, reason])
+        .inc();
+}
+
+/// ENG-1784: bump the per-job remember failure counter. `path` is one of
+/// `"legacy"` (legacy `execute_remember`) or `"bulk_fanout"`
+/// (`execute_bulk_remember` enqueue failure). `kind` is a short label for
+/// the specific failure (e.g. `"base64_decode"`, `"no_keys"`,
+/// `"walrus_upload"`, `"insert_vector"`, `"queue_push"`).
+pub fn record_remember_per_job_failure(path: &'static str, kind: &'static str) {
+    REMEMBER_PER_JOB_FAILED_TOTAL
+        .with_label_values(&[path, kind])
         .inc();
 }
 

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1078,6 +1078,8 @@ mod tests {
             health_check_interval_secs: 30,
             health_check_fail_threshold: 3,
             wallet_pool_drain_window: None,
+            apalis_backlog_threshold: 100,
+            apalis_backlog_stuck_secs: 300,
         }
     }
 

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1073,6 +1073,8 @@ mod tests {
             sponsor_rate_limit: crate::types::SponsorRateLimitConfig::default(),
             allowed_origins: String::new(),
             benchmark_mode: false,
+            slack_webhook_url: None,
+            env_label: "test".to_string(),
         }
     }
 

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1075,6 +1075,9 @@ mod tests {
             benchmark_mode: false,
             slack_webhook_url: None,
             env_label: "test".to_string(),
+            health_check_interval_secs: 30,
+            health_check_fail_threshold: 3,
+            wallet_pool_drain_window: None,
         }
     }
 

--- a/services/server/src/slack.rs
+++ b/services/server/src/slack.rs
@@ -130,6 +130,112 @@ pub struct RememberJobFailedAlert<'a> {
     pub kind: FailureKind,
 }
 
+/// Infra-level failure that blocks the WHOLE system (every user impacted).
+///
+/// Distinct from [`FailureKind`], which surfaces individual remember-job
+/// terminal failures: those are per-job and the per-signature dedup window
+/// keeps them from flooding the channel. Infra failures page on-call
+/// because nothing will succeed until the dependency is restored, and lead
+/// guidance is to only Slack things that block the whole system.
+///
+/// Each variant carries enough detail for the channel body to be useful
+/// (consecutive-failure counts, pool sizes, reason strings); the variant
+/// itself is used as the dedup signature so the same outage doesn't fan
+/// out into many alerts as the probe loops.
+#[derive(Debug, Clone)]
+pub enum InfraFailureKind {
+    /// Sidecar `/health` returning errors for sustained period. SEAL
+    /// encrypt/decrypt and Walrus upload route through the sidecar — all
+    /// writes fail when it's down.
+    SidecarDown { consecutive_failures: u32 },
+    /// Postgres unreachable (pool exhausted or connection rejected). All
+    /// DB-backed routes fail.
+    PostgresDown { reason: String },
+    /// Redis unavailable for sustained period. Rate limiter falls back
+    /// to in-memory; dedup window resets per-process.
+    RedisDown { consecutive_failures: u32 },
+    /// Sui RPC returning errors for sustained period. Auth verification
+    /// fails for everyone (delegate-key check requires Sui RPC).
+    SuiRpcDown { consecutive_failures: u32 },
+    /// Every wallet in the configured pool returned `Transient` errors
+    /// for `consecutive_transient` consecutive attempts (typically
+    /// `balance::split` MoveAbort / insufficient gas across the whole
+    /// pool). Remember jobs will never succeed until the pool is refilled.
+    WalletPoolDrained {
+        pool_size: usize,
+        consecutive_transient: u64,
+    },
+    /// `SERVER_SUI_PRIVATE_KEYS` / `SERVER_SUI_PRIVATE_KEY` both unset at
+    /// boot. Fires once during startup; uploads will fail for everyone
+    /// until a key is configured and the process restarts.
+    NoSuiKeysConfigured,
+}
+
+impl InfraFailureKind {
+    fn headline(&self) -> &'static str {
+        match self {
+            InfraFailureKind::SidecarDown { .. } => "🚨 MemWal Infra — Sidecar Down",
+            InfraFailureKind::PostgresDown { .. } => "🚨 MemWal Infra — Postgres Down",
+            InfraFailureKind::RedisDown { .. } => "🚨 MemWal Infra — Redis Down",
+            InfraFailureKind::SuiRpcDown { .. } => "🚨 MemWal Infra — Sui RPC Down",
+            InfraFailureKind::WalletPoolDrained { .. } => {
+                "🚨 MemWal Infra — Wallet Pool Drained"
+            }
+            InfraFailureKind::NoSuiKeysConfigured => "🚨 MemWal Infra — No Sui Keys Configured",
+        }
+    }
+
+    fn detail(&self) -> String {
+        match self {
+            InfraFailureKind::SidecarDown { consecutive_failures } => format!(
+                "Sidecar /health failed {} consecutive checks. SEAL encrypt + Walrus upload broken until recovery.",
+                consecutive_failures
+            ),
+            InfraFailureKind::PostgresDown { reason } => {
+                format!("Postgres unreachable: {}", reason)
+            }
+            InfraFailureKind::RedisDown { consecutive_failures } => format!(
+                "Redis PING failed {} consecutive checks. Rate limiter on in-memory fallback; dedup window weakened.",
+                consecutive_failures
+            ),
+            InfraFailureKind::SuiRpcDown { consecutive_failures } => format!(
+                "Sui RPC failed {} consecutive checks. Auth verification (delegate-key onchain check) failing for everyone.",
+                consecutive_failures
+            ),
+            InfraFailureKind::WalletPoolDrained {
+                pool_size,
+                consecutive_transient,
+            } => format!(
+                "Every wallet in pool (size {}) returned transient failures for {} consecutive attempts — likely all out of gas / balance::split.",
+                pool_size, consecutive_transient
+            ),
+            InfraFailureKind::NoSuiKeysConfigured => {
+                "Server started with empty key pool — SERVER_SUI_PRIVATE_KEYS and SERVER_SUI_PRIVATE_KEY both unset. All Walrus uploads will fail."
+                    .to_string()
+            }
+        }
+    }
+
+    /// Stable dedup signature — repeated alerts of the same kind collapse
+    /// to one Slack message per dedup window so a probe loop firing on
+    /// each tick doesn't spam the channel.
+    fn dedup_signature(&self) -> &'static str {
+        match self {
+            InfraFailureKind::SidecarDown { .. } => "infra:sidecar_down",
+            InfraFailureKind::PostgresDown { .. } => "infra:postgres_down",
+            InfraFailureKind::RedisDown { .. } => "infra:redis_down",
+            InfraFailureKind::SuiRpcDown { .. } => "infra:sui_rpc_down",
+            InfraFailureKind::WalletPoolDrained { .. } => "infra:wallet_pool_drained",
+            InfraFailureKind::NoSuiKeysConfigured => "infra:no_sui_keys",
+        }
+    }
+}
+
+/// Inputs to a single infra-level Slack alert.
+pub struct InfraFailureAlert {
+    pub kind: InfraFailureKind,
+}
+
 #[derive(Debug, Serialize)]
 struct SlackMessage {
     text: String,
@@ -223,6 +329,28 @@ impl SlackClient {
         self.send_with_retry(&payload).await
     }
 
+    /// Notify Slack of an infra-level failure (system-blocking event).
+    /// Dedups by variant kind, NOT by the detail message, so a probe loop
+    /// firing each tick collapses to one alert per `DEDUP_WINDOW`.
+    ///
+    /// Same fire-and-forget contract as `notify_remember_job_failed`:
+    /// suppressed (dedup / rate-cap) returns `Ok(())`. The caller must
+    /// spawn this; the Slack POST is timed but blocking on the awaiter.
+    pub async fn notify_infra_failure(&self, alert: InfraFailureAlert) -> SlackResult<()> {
+        let signature = alert.kind.dedup_signature();
+
+        if self.should_suppress_with_key(signature) {
+            info!(
+                infra_kind = %signature,
+                "Slack infra alert suppressed (dedup or global rate cap)"
+            );
+            return Ok(());
+        }
+
+        let payload = self.build_infra_payload(&alert);
+        self.send_with_retry(&payload).await
+    }
+
     /// Send a simple text notification. Retained for unit tests and any
     /// one-off operator-driven message; production paths should use the
     /// typed helpers so the format stays consistent across alerts.
@@ -239,7 +367,14 @@ impl SlackClient {
     /// `DEDUP_WINDOW`, OR if the global rate cap is exhausted. Both
     /// checks happen under one lock so a burst can't slip past both.
     fn should_suppress(&self, sanitized_error_msg: &str) -> bool {
-        let key = hash_error(sanitized_error_msg);
+        self.should_suppress_with_key(&hash_error(sanitized_error_msg))
+    }
+
+    /// Variant of `should_suppress` that takes a pre-computed dedup key.
+    /// Infra alerts dedup on the variant discriminant (stable string)
+    /// rather than the error message, so the detail-string text doesn't
+    /// affect grouping.
+    fn should_suppress_with_key(&self, key: &str) -> bool {
         let now = Instant::now();
 
         let mut state = match self.state.lock() {
@@ -262,8 +397,9 @@ impl SlackClient {
         }
 
         // Per-error dedup: if we already alerted on this signature within
-        // the window, suppress regardless of global budget.
-        if let Some(last) = state.dedup.get(&key) {
+        // the window, suppress regardless of global budget. HashMap<String, _>
+        // supports lookup by &str via the Borrow impl.
+        if let Some(last) = state.dedup.get(key) {
             if now.duration_since(*last) < DEDUP_WINDOW {
                 return true;
             }
@@ -284,7 +420,7 @@ impl SlackClient {
         // Record the send intent. We do this under the same lock so two
         // simultaneous callers can't both see "below cap" and both send,
         // exceeding the cap by one or two messages.
-        state.dedup.insert(key, now);
+        state.dedup.insert(key.to_string(), now);
         state.recent_sends.push_back(now);
         false
     }
@@ -369,6 +505,78 @@ impl SlackClient {
         SlackMessage {
             text: fallback_text,
             blocks: Some(vec![header, fields, error_block, context]),
+        }
+    }
+
+    /// Build the Slack message body for an infra alert. Format mirrors
+    /// `build_payload` (header / fields / detail / footer) so the channel
+    /// looks consistent, but the field set is different — infra alerts
+    /// have no per-job context (job_id / owner / namespace) and the
+    /// "failure mode" field carries the variant description instead of a
+    /// stack trace.
+    fn build_infra_payload(&self, alert: &InfraFailureAlert) -> SlackMessage {
+        let headline = alert.kind.headline();
+        let detail = alert.kind.detail();
+        let dedup_sig = alert.kind.dedup_signature();
+
+        let fallback_text = format!("{} — {}", headline, truncate(&detail, 200));
+
+        let header = SlackBlock {
+            block_type: "header".to_string(),
+            text: Some(SlackText {
+                text_type: "plain_text".to_string(),
+                text: headline.to_string(),
+            }),
+            fields: None,
+            elements: None,
+        };
+
+        let fields = SlackBlock {
+            block_type: "section".to_string(),
+            text: None,
+            fields: Some(vec![
+                SlackText {
+                    text_type: "mrkdwn".to_string(),
+                    text: format!("*Kind*\n`{}`", dedup_sig),
+                },
+                SlackText {
+                    text_type: "mrkdwn".to_string(),
+                    text: format!("*Env*\n`{}`", self.env_label),
+                },
+            ]),
+            elements: None,
+        };
+
+        let detail_block = SlackBlock {
+            block_type: "section".to_string(),
+            text: Some(SlackText {
+                text_type: "mrkdwn".to_string(),
+                // Truncate to fit Slack's per-text 3000-char limit. Infra
+                // details are short by design but Postgres / sidecar error
+                // messages can include long traceback context.
+                text: format!("```{}```", truncate(&detail, 2800)),
+            }),
+            fields: None,
+            elements: None,
+        };
+
+        let footer_text = match &self.server_commit {
+            Some(sha) => format!("server commit `{}` · env `{}`", sha, self.env_label),
+            None => format!("env `{}`", self.env_label),
+        };
+        let context = SlackBlock {
+            block_type: "context".to_string(),
+            text: None,
+            fields: None,
+            elements: Some(vec![SlackText {
+                text_type: "mrkdwn".to_string(),
+                text: footer_text,
+            }]),
+        };
+
+        SlackMessage {
+            text: fallback_text,
+            blocks: Some(vec![header, fields, detail_block, context]),
         }
     }
 
@@ -561,6 +769,148 @@ mod tests {
             "test".to_string(),
             Some("abcdef1".to_string()),
         )
+    }
+
+    // ============================================================
+    // ENG-1784: InfraFailureKind — dedup signature stability + payload
+    // ============================================================
+
+    #[test]
+    fn infra_failure_dedup_signature_is_stable_per_variant() {
+        // The dedup key MUST NOT depend on per-instance fields (reason,
+        // counts). If it did, every probe tick would mint a new signature
+        // and dedup would collapse to one alert per probe — exactly the
+        // noise pattern this work is meant to avoid.
+        assert_eq!(
+            InfraFailureKind::SidecarDown { consecutive_failures: 3 }.dedup_signature(),
+            InfraFailureKind::SidecarDown { consecutive_failures: 999 }.dedup_signature(),
+        );
+        assert_eq!(
+            InfraFailureKind::PostgresDown { reason: "conn refused".to_string() }
+                .dedup_signature(),
+            InfraFailureKind::PostgresDown { reason: "pool exhausted".to_string() }
+                .dedup_signature(),
+        );
+        assert_eq!(
+            InfraFailureKind::WalletPoolDrained {
+                pool_size: 3,
+                consecutive_transient: 9,
+            }
+            .dedup_signature(),
+            InfraFailureKind::WalletPoolDrained {
+                pool_size: 5,
+                consecutive_transient: 25,
+            }
+            .dedup_signature(),
+        );
+    }
+
+    #[test]
+    fn infra_failure_each_variant_has_distinct_signature() {
+        // A bug where two variants collide would shadow one outage with
+        // another — pin that they're distinct.
+        let sigs = [
+            InfraFailureKind::SidecarDown { consecutive_failures: 1 }.dedup_signature(),
+            InfraFailureKind::PostgresDown { reason: "x".to_string() }.dedup_signature(),
+            InfraFailureKind::RedisDown { consecutive_failures: 1 }.dedup_signature(),
+            InfraFailureKind::SuiRpcDown { consecutive_failures: 1 }.dedup_signature(),
+            InfraFailureKind::WalletPoolDrained {
+                pool_size: 1,
+                consecutive_transient: 1,
+            }
+            .dedup_signature(),
+            InfraFailureKind::NoSuiKeysConfigured.dedup_signature(),
+        ];
+        let mut sorted = sigs.to_vec();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), sigs.len(), "infra variants must not collide");
+    }
+
+    #[test]
+    fn infra_failure_headline_mentions_subsystem() {
+        // Pin the user-visible headlines — lead reads these in #memwal-ops
+        // first; a rename is a deliberate change, not a typo.
+        assert!(InfraFailureKind::SidecarDown { consecutive_failures: 3 }
+            .headline()
+            .contains("Sidecar"));
+        assert!(InfraFailureKind::PostgresDown { reason: "x".into() }
+            .headline()
+            .contains("Postgres"));
+        assert!(InfraFailureKind::RedisDown { consecutive_failures: 3 }
+            .headline()
+            .contains("Redis"));
+        assert!(InfraFailureKind::SuiRpcDown { consecutive_failures: 3 }
+            .headline()
+            .contains("Sui RPC"));
+        assert!(InfraFailureKind::WalletPoolDrained {
+            pool_size: 3,
+            consecutive_transient: 9
+        }
+        .headline()
+        .contains("Wallet Pool"));
+        assert!(InfraFailureKind::NoSuiKeysConfigured
+            .headline()
+            .contains("No Sui Keys"));
+    }
+
+    #[test]
+    fn infra_failure_detail_includes_dynamic_fields() {
+        // detail() is the channel body — must include the per-instance
+        // info ops needs (counts, reasons), even though dedup ignores them.
+        let detail = InfraFailureKind::SidecarDown { consecutive_failures: 7 }.detail();
+        assert!(detail.contains("7"));
+
+        let detail = InfraFailureKind::PostgresDown {
+            reason: "connection refused by 10.0.0.42".to_string(),
+        }
+        .detail();
+        assert!(detail.contains("connection refused"));
+
+        let detail = InfraFailureKind::WalletPoolDrained {
+            pool_size: 5,
+            consecutive_transient: 15,
+        }
+        .detail();
+        assert!(detail.contains("5"));
+        assert!(detail.contains("15"));
+    }
+
+    #[test]
+    fn infra_alert_payload_uses_headline_and_detail() {
+        // The wire payload must serialize the headline as the Slack
+        // header block and the detail in the code block. We don't probe
+        // the full JSON — that's brittle — just confirm both strings
+        // make it into the rendered body.
+        let client = new_client();
+        let payload = client.build_infra_payload(&InfraFailureAlert {
+            kind: InfraFailureKind::WalletPoolDrained {
+                pool_size: 4,
+                consecutive_transient: 12,
+            },
+        });
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("Wallet Pool Drained"));
+        assert!(json.contains("infra:wallet_pool_drained"));
+        assert!(json.contains("12 consecutive attempts"));
+    }
+
+    #[test]
+    fn infra_should_suppress_dedups_per_variant_not_per_detail() {
+        // Detail differs, variant identical → second call must suppress.
+        let client = new_client();
+        let sig = InfraFailureKind::PostgresDown {
+            reason: "first detail".to_string(),
+        }
+        .dedup_signature();
+        assert!(!client.should_suppress_with_key(sig));
+        // Even with completely different detail, same variant = same sig.
+        let sig2 = InfraFailureKind::PostgresDown {
+            reason: "completely different detail".to_string(),
+        }
+        .dedup_signature();
+        assert_eq!(sig, sig2);
+        assert!(client.should_suppress_with_key(sig2));
     }
 
     // ============================================================

--- a/services/server/src/slack.rs
+++ b/services/server/src/slack.rs
@@ -1,27 +1,42 @@
 //! Slack notification client for terminal job failures.
 //!
-//! ENG-1784: Push alerts to a Slack Incoming Webhook when a remember job
-//! fails after wallet rotation has exhausted all retries (i.e. every wallet
-//! in the pool returned a non-retryable error).
+//! ENG-1784: push alerts to a Slack Incoming Webhook when a remember job
+//! reaches a terminal failure state, so on-call sees the incident without
+//! having to tail logs.
 //!
-//! Design (mirrors `x-wallet/backend/src/clients/slack.rs`):
+//! Two failure shapes are surfaced today:
 //!
-//! * **Optional**: `SlackClient` is constructed only when `SLACK_WEBHOOK_URL`
-//!   is set. When absent the alerter is `None` and every notify call is a
-//!   no-op; the rest of the server is unaware.
+//! 1. **Wallet retries exhausted** — the wallet pool tried every key in
+//!    rotation up to `MAX_ATTEMPTS` and every attempt returned a
+//!    permanent error (e.g. Enoki `balance::split` MoveAbort, Walrus 4xx,
+//!    sidecar timeout reclassified as Permanent). This is the scenario
+//!    Henry described in the ENG-1784 brief.
+//! 2. **Post-upload handoff enqueue failure** — Walrus upload (and maybe
+//!    on-chain transfer) succeeded, but the follow-up recovery / index
+//!    job could not be enqueued because Apalis / Redis itself rejected
+//!    the push. The wallet pool was not involved.
+//!
+//! Pattern mirrors `x-wallet/backend/src/clients/slack.rs`:
+//!
+//! * **Optional**: the client is constructed only when `SLACK_WEBHOOK_URL`
+//!   is set. Absent → alerter is `None` → every notify call is a no-op.
 //! * **Fire-and-forget**: callers spawn the notify future and ignore the
 //!   result. A failed Slack POST must never fail the wallet job.
-//! * **In-memory dedup**: Enoki / sidecar incidents can fan out into dozens
-//!   of identical failures within seconds. We hash the error message and
-//!   suppress duplicates within a 5-minute window so the on-call channel
-//!   isn't flooded; suppressions are logged for visibility.
+//! * **Multi-layer rate control**:
+//!     - 5-minute in-memory dedup by SHA-256 of the error message →
+//!       protects against a single fan-out incident (one upstream
+//!       failure mode replicated across many jobs).
+//!     - Sliding 60-second window global cap of 30 messages →
+//!       protects against diverse-error storms that bypass dedup.
+//!     - Single retry on Slack 429 / 5xx, then drop with a tracing
+//!       warning so we don't infinite-loop on a Slack-side outage.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::error::Error as StdError;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
@@ -31,14 +46,84 @@ use tracing::{info, warn};
 pub type SlackError = Box<dyn StdError + Send + Sync + 'static>;
 pub type SlackResult<T> = std::result::Result<T, SlackError>;
 
-/// Cool-down for identical error signatures. An Enoki outage typically
-/// produces the same `dry_run_failed: balance::split` message on every
-/// retry; without this window a 30-minute incident posts hundreds of
-/// near-identical messages.
+/// Identical errors arriving inside this window are suppressed. Enoki and
+/// sidecar incidents typically produce the same message on every retry;
+/// without this, a 30-minute incident posts hundreds of near-identical
+/// messages.
 const DEDUP_WINDOW: Duration = Duration::from_secs(5 * 60);
 
-/// `text` block is the fallback Slack uses for notifications + accessibility.
-/// `blocks` carries the rich layout shown in the channel.
+/// Sliding-window global cap. Even with dedup, a single relayer-wide
+/// failure can produce a diverse error storm (different request IDs,
+/// timestamps, blob IDs) that defeats per-error dedup. This cap protects
+/// the channel from outright flooding.
+const GLOBAL_RATE_WINDOW: Duration = Duration::from_secs(60);
+const GLOBAL_RATE_MAX: usize = 30;
+
+/// HTTP timeout for the webhook POST. Slack normally responds in well
+/// under a second; anything beyond a few seconds is almost certainly an
+/// upstream outage. Capping the timeout prevents long-running tasks
+/// accumulating during a Slack-side incident.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Retry delay when Slack returns 429 / 5xx. Single retry only — if the
+/// retry also fails we drop the alert; the wallet job's terminal status
+/// is already persisted in `remember_jobs`, so on-call can still find
+/// the failure via the DB.
+const RETRY_DELAY: Duration = Duration::from_millis(750);
+
+/// Why this remember job is in a terminal failed state. Pick the variant
+/// that matches your code path so the Slack message wording is accurate.
+#[derive(Debug, Clone, Copy)]
+pub enum FailureKind {
+    /// The wallet pool rotated through every key it had and every attempt
+    /// returned a permanent error. This is the "Enoki down across all
+    /// wallets" scenario from the ENG-1784 brief.
+    WalletRetriesExhausted {
+        /// Configured maximum attempts (e.g. `MAX_ATTEMPTS = 3`). The
+        /// alert reads `{attempts}/{attempts} exhausted` because the
+        /// only way we land in this branch is by burning all of them.
+        attempts: u32,
+    },
+    /// Upload succeeded but the follow-up workflow couldn't be enqueued
+    /// because the job queue (Apalis / Redis) rejected the push. The
+    /// wallet pool itself was healthy — the queue layer wasn't.
+    HandoffEnqueueFailure,
+}
+
+impl FailureKind {
+    fn label(&self) -> String {
+        match self {
+            FailureKind::WalletRetriesExhausted { attempts } => {
+                format!("{} / {} wallet retries exhausted", attempts, attempts)
+            }
+            FailureKind::HandoffEnqueueFailure => {
+                "post-upload handoff enqueue failed (job queue infra)".to_string()
+            }
+        }
+    }
+
+    fn headline(&self) -> &'static str {
+        match self {
+            FailureKind::WalletRetriesExhausted { .. } => {
+                "🔴 MemWal — Remember Job Failed (wallet retries exhausted)"
+            }
+            FailureKind::HandoffEnqueueFailure => {
+                "🔴 MemWal — Remember Job Failed (queue handoff)"
+            }
+        }
+    }
+}
+
+/// All inputs to a single Slack alert. Grouping into a struct keeps the
+/// call sites readable as we add fields (e.g. blob_id, attempt count).
+pub struct RememberJobFailedAlert<'a> {
+    pub job_id: Option<&'a str>,
+    pub owner: Option<&'a str>,
+    pub namespace: Option<&'a str>,
+    pub error_msg: &'a str,
+    pub kind: FailureKind,
+}
+
 #[derive(Debug, Serialize)]
 struct SlackMessage {
     text: String,
@@ -65,121 +150,154 @@ struct SlackText {
     text: String,
 }
 
-/// Slack notifier. Cheap to clone — wraps `reqwest::Client` which is
-/// internally `Arc`-counted, and an `Arc<Mutex<...>>` dedup map.
+/// Inner state guarded by a single sync mutex. We hold the lock only
+/// across in-memory map / queue operations (no `.await` inside the lock
+/// scope), so `std::sync::Mutex` is correct here and avoids the
+/// `tokio::sync::Mutex` await-friendly version.
+struct RateState {
+    /// `error_signature → last_sent_at`.
+    dedup: HashMap<String, Instant>,
+    /// Sliding-window timestamps of sends in the last `GLOBAL_RATE_WINDOW`.
+    /// `VecDeque` so we can pop expired entries in O(1) per stale element.
+    recent_sends: VecDeque<Instant>,
+}
+
 #[derive(Clone)]
 pub struct SlackClient {
     http: Client,
     webhook_url: String,
-    /// `error_signature → last_sent_at`. We log + skip when the same
-    /// signature re-appears within `DEDUP_WINDOW`.
-    dedup: std::sync::Arc<Mutex<HashMap<String, Instant>>>,
+    state: std::sync::Arc<Mutex<RateState>>,
     /// Identifies the running relayer in the alert footer
     /// (e.g. `prod` / `staging` / `dev` from `MEMWAL_ENV`).
     env_label: String,
-    /// Optional git SHA / build identifier, surfaced in the footer.
+    /// Optional short git SHA for the footer.
     server_commit: Option<String>,
 }
 
 impl SlackClient {
     pub fn new(webhook_url: String, env_label: String, server_commit: Option<String>) -> Self {
+        let http = Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            // `Client::builder()` only fails if the system has no working
+            // TLS backend — at which point the rest of the relayer is
+            // dead anyway, so a panic here is safe and surfaces it loudly.
+            .expect("reqwest client should build (TLS backend required)");
         Self {
-            http: Client::new(),
+            http,
             webhook_url,
-            dedup: std::sync::Arc::new(Mutex::new(HashMap::new())),
+            state: std::sync::Arc::new(Mutex::new(RateState {
+                dedup: HashMap::new(),
+                recent_sends: VecDeque::new(),
+            })),
             env_label,
             server_commit,
         }
     }
 
-    /// Notify Slack that a remember job has terminally failed after the
-    /// wallet pool exhausted retries. Returns `Ok(())` on success, or after
-    /// suppression. Network errors are surfaced for caller logging but the
-    /// recommended use is fire-and-forget via `tokio::spawn`.
+    /// Notify Slack that a remember job has terminally failed. The Slack
+    /// POST is rate-limited by error-signature dedup AND by a global
+    /// 60-second cap; suppressed alerts return `Ok(())` so fire-and-forget
+    /// callers don't log a false "Slack failed" warning.
     pub async fn notify_remember_job_failed(
         &self,
-        job_id: Option<&str>,
-        owner: Option<&str>,
-        namespace: Option<&str>,
-        wallet_attempts: u32,
-        max_attempts: u32,
-        error_msg: &str,
+        alert: RememberJobFailedAlert<'_>,
     ) -> SlackResult<()> {
-        if self.should_suppress(error_msg) {
+        let sanitized = sanitize_for_slack(alert.error_msg);
+
+        if self.should_suppress(&sanitized) {
             info!(
-                error_signature = %short_hash(error_msg),
-                "Slack alert suppressed (within dedup window)"
+                error_signature = %short_hash(&sanitized),
+                "Slack alert suppressed (dedup or global rate cap)"
             );
             return Ok(());
         }
 
-        let payload = self.build_remember_failed_payload(
-            job_id,
-            owner,
-            namespace,
-            wallet_attempts,
-            max_attempts,
-            error_msg,
-        );
-        self.send_payload(&payload).await
+        let payload = self.build_payload(&alert, &sanitized);
+        self.send_with_retry(&payload).await
     }
 
-    /// Send a raw text-only notification. Helpful for ad-hoc one-off alerts
-    /// and unit tests; the typed `notify_*` helpers should be preferred for
-    /// production paths so the format stays consistent.
+    /// Send a simple text notification. Retained for unit tests and any
+    /// one-off operator-driven message; production paths should use the
+    /// typed helpers so the format stays consistent across alerts.
     #[allow(dead_code)]
     pub async fn send_notification(&self, text: &str) -> SlackResult<()> {
-        self.send_payload(&SlackMessage {
+        self.send_with_retry(&SlackMessage {
             text: text.to_string(),
             blocks: None,
         })
         .await
     }
 
-    /// Returns `true` if an identical `error_msg` has been alerted within
-    /// the dedup window. Updates the timestamp atomically when we DO send.
-    fn should_suppress(&self, error_msg: &str) -> bool {
-        let key = hash_error(error_msg);
+    /// Returns `true` if this signature has been alerted within
+    /// `DEDUP_WINDOW`, OR if the global rate cap is exhausted. Both
+    /// checks happen under one lock so a burst can't slip past both.
+    fn should_suppress(&self, sanitized_error_msg: &str) -> bool {
+        let key = hash_error(sanitized_error_msg);
         let now = Instant::now();
 
-        let mut map = match self.dedup.lock() {
+        let mut state = match self.state.lock() {
             Ok(guard) => guard,
-            // Poisoned mutex: better to send the alert than swallow it.
+            // Poisoned mutex: prefer to send the alert than swallow it.
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        if let Some(last) = map.get(&key) {
+        // GC expired dedup keys to bound map size.
+        state
+            .dedup
+            .retain(|_, ts| now.duration_since(*ts) < DEDUP_WINDOW);
+        // GC expired global-window timestamps.
+        while state
+            .recent_sends
+            .front()
+            .is_some_and(|t| now.duration_since(*t) >= GLOBAL_RATE_WINDOW)
+        {
+            state.recent_sends.pop_front();
+        }
+
+        // Per-error dedup: if we already alerted on this signature within
+        // the window, suppress regardless of global budget.
+        if let Some(last) = state.dedup.get(&key) {
             if now.duration_since(*last) < DEDUP_WINDOW {
                 return true;
             }
         }
-        map.insert(key, now);
 
-        // Best-effort GC of expired entries so the map doesn't grow
-        // unbounded across long-running processes.
-        map.retain(|_, ts| now.duration_since(*ts) < DEDUP_WINDOW);
+        // Global cap: if we've already sent `GLOBAL_RATE_MAX` in the last
+        // window, drop this one too (caller will see Ok and the failure
+        // is still in the DB).
+        if state.recent_sends.len() >= GLOBAL_RATE_MAX {
+            warn!(
+                cap = GLOBAL_RATE_MAX,
+                window_secs = GLOBAL_RATE_WINDOW.as_secs(),
+                "Slack global rate cap reached — dropping alert"
+            );
+            return true;
+        }
+
+        // Record the send intent. We do this under the same lock so two
+        // simultaneous callers can't both see "below cap" and both send,
+        // exceeding the cap by one or two messages.
+        state.dedup.insert(key, now);
+        state.recent_sends.push_back(now);
         false
     }
 
-    fn build_remember_failed_payload(
+    fn build_payload(
         &self,
-        job_id: Option<&str>,
-        owner: Option<&str>,
-        namespace: Option<&str>,
-        wallet_attempts: u32,
-        max_attempts: u32,
-        error_msg: &str,
+        alert: &RememberJobFailedAlert<'_>,
+        sanitized_error: &str,
     ) -> SlackMessage {
         let fallback_text = format!(
-            "🔴 MemWal: remember job failed (all wallets exhausted) — {}",
-            truncate(error_msg, 120)
+            "🔴 MemWal: remember job failed — {}",
+            truncate(sanitized_error, 120)
         );
 
         let header = SlackBlock {
             block_type: "header".to_string(),
             text: Some(SlackText {
                 text_type: "plain_text".to_string(),
-                text: "🔴 MemWal — Remember Job Failed".to_string(),
+                text: alert.kind.headline().to_string(),
             }),
             fields: None,
             elements: None,
@@ -192,22 +310,25 @@ impl SlackClient {
             fields: Some(vec![
                 SlackText {
                     text_type: "mrkdwn".to_string(),
-                    text: format!("*Job ID:*\n`{}`", job_id.unwrap_or("-")),
+                    text: format!("*Job ID:*\n`{}`", alert.job_id.unwrap_or("-")),
                 },
                 SlackText {
                     text_type: "mrkdwn".to_string(),
-                    text: format!("*Namespace:*\n`{}`", namespace.unwrap_or("-")),
-                },
-                SlackText {
-                    text_type: "mrkdwn".to_string(),
-                    text: format!("*Owner:*\n`{}`", owner.map(shorten_owner).unwrap_or_else(|| "-".to_string())),
+                    text: format!("*Namespace:*\n`{}`", alert.namespace.unwrap_or("-")),
                 },
                 SlackText {
                     text_type: "mrkdwn".to_string(),
                     text: format!(
-                        "*Wallet attempts:*\n{} / {} exhausted",
-                        wallet_attempts, max_attempts
+                        "*Owner:*\n`{}`",
+                        alert
+                            .owner
+                            .map(shorten_owner)
+                            .unwrap_or_else(|| "-".to_string())
                     ),
+                },
+                SlackText {
+                    text_type: "mrkdwn".to_string(),
+                    text: format!("*Failure mode:*\n{}", alert.kind.label()),
                 },
             ]),
         };
@@ -218,10 +339,10 @@ impl SlackClient {
             fields: None,
             text: Some(SlackText {
                 text_type: "mrkdwn".to_string(),
-                // Triple-backtick code fence renders Slack `code block`.
-                // Truncate so a multi-paragraph traceback doesn't blow past
-                // Slack's 3000-char per-text limit.
-                text: format!("*Error:*\n```{}```", truncate(error_msg, 2400)),
+                // Triple-backtick fence + truncation to stay under
+                // Slack's 3000-char per-text limit even after multiline
+                // tracebacks.
+                text: format!("*Error:*\n```{}```", truncate(sanitized_error, 2400)),
             }),
         };
 
@@ -245,29 +366,76 @@ impl SlackClient {
         }
     }
 
-    async fn send_payload(&self, payload: &SlackMessage) -> SlackResult<()> {
+    async fn send_with_retry(&self, payload: &SlackMessage) -> SlackResult<()> {
+        match self.send_once(payload).await {
+            Ok(()) => Ok(()),
+            Err(SendError::Transient { status, body }) => {
+                warn!(
+                    status = %status,
+                    "Slack webhook returned transient error — retrying once after {}ms",
+                    RETRY_DELAY.as_millis()
+                );
+                tokio::time::sleep(RETRY_DELAY).await;
+                match self.send_once(payload).await {
+                    Ok(()) => Ok(()),
+                    Err(retry_err) => Err(format!(
+                        "Slack send failed twice: first={} {}, retry={}",
+                        status, body, retry_err
+                    )
+                    .into()),
+                }
+            }
+            Err(SendError::Permanent(msg)) => Err(msg.into()),
+        }
+    }
+
+    async fn send_once(&self, payload: &SlackMessage) -> std::result::Result<(), SendError> {
         let response = self
             .http
             .post(&self.webhook_url)
             .json(payload)
             .send()
             .await
-            .map_err(|e| -> SlackError { format!("Failed to POST Slack webhook: {}", e).into() })?;
+            .map_err(|e| SendError::Permanent(format!("HTTP send failed: {}", e)))?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            warn!(
-                status = %status,
-                body = %body,
-                "Slack webhook returned non-success status"
-            );
-            return Err(format!("Slack webhook failed with status {}: {}", status, body).into());
+        let status = response.status();
+        if status.is_success() {
+            info!("Slack notification delivered");
+            return Ok(());
         }
 
-        info!("Slack notification delivered");
-        Ok(())
+        let body = response.text().await.unwrap_or_default();
+        if is_retryable(status) {
+            Err(SendError::Transient { status, body })
+        } else {
+            Err(SendError::Permanent(format!(
+                "Slack webhook failed with status {}: {}",
+                status, body
+            )))
+        }
     }
+}
+
+enum SendError {
+    /// Slack returned a status that indicates a temporary issue
+    /// (429 rate-limited or 5xx upstream). One retry is worth attempting.
+    Transient { status: StatusCode, body: String },
+    /// Slack rejected the request for a reason that won't get better on
+    /// retry (4xx other than 429, or a transport error).
+    Permanent(String),
+}
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SendError::Transient { status, body } => write!(f, "transient {}: {}", status, body),
+            SendError::Permanent(msg) => write!(f, "permanent: {}", msg),
+        }
+    }
+}
+
+fn is_retryable(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
 }
 
 // ============================================================
@@ -283,6 +451,9 @@ fn short_hash(msg: &str) -> String {
     hash_error(msg)
 }
 
+/// Truncate by char count (not byte), appending an ellipsis when over.
+/// Char-based slicing keeps multi-byte UTF-8 (emoji in error messages,
+/// non-ASCII namespace names) from panicking.
 fn truncate(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {
         return s.to_string();
@@ -291,16 +462,80 @@ fn truncate(s: &str, max_chars: usize) -> String {
     format!("{}…", taken)
 }
 
+/// Display a Sui address as `0x12345678…abcd` so on-call can identify
+/// accounts without copy/pasting 66-character strings. Uses char-based
+/// slicing instead of byte slicing so non-ASCII strings (shouldn't occur
+/// for Sui addresses but defense-in-depth) don't panic.
 fn shorten_owner(owner: &str) -> String {
-    // 0x1234...abcd style display so on-call can identify accounts without
-    // copy/pasting 66-character addresses out of Slack.
-    let len = owner.len();
-    if len <= 12 {
+    let char_count = owner.chars().count();
+    if char_count <= 12 {
         return owner.to_string();
     }
-    let head = &owner[..8];
-    let tail = &owner[len.saturating_sub(4)..];
+    let head: String = owner.chars().take(8).collect();
+    let tail: String = owner.chars().skip(char_count - 4).collect();
     format!("{}…{}", head, tail)
+}
+
+/// Strip embedded credentials from a message before we post it to a
+/// shared Slack channel.
+///
+/// Concrete vectors this catches:
+///
+/// * Connection URLs in error display impls:
+///   `redis://memwal:hunter2@host:6379` → `redis://***@host:6379`
+/// * Postgres connection errors:
+///   `postgresql://app:s3cret@db.host:5432/memwal` → `postgresql://***@db.host:5432/memwal`
+///
+/// Best-effort only. We never want to add complex regex / parsing that
+/// could itself fail; if the upstream error format changes and starts
+/// leaking secrets in a different shape, that's a separate ticket.
+fn sanitize_for_slack(msg: &str) -> String {
+    let mut out = String::with_capacity(msg.len());
+    let mut cursor = 0;
+    let bytes = msg.as_bytes();
+    while cursor < bytes.len() {
+        // Look for a scheme-separator `://` starting at `cursor`.
+        if let Some(scheme_end) = find_subsequence(&bytes[cursor..], b"://") {
+            let absolute_scheme_end = cursor + scheme_end + 3;
+            // Look for `@` between scheme end and the next whitespace/end.
+            let tail = &bytes[absolute_scheme_end..];
+            let scan_limit = tail
+                .iter()
+                .position(|b| matches!(*b, b' ' | b'\t' | b'\n' | b'\r' | b'/' | b'?' | b'#'))
+                .unwrap_or(tail.len());
+            if let Some(at_pos) = tail[..scan_limit].iter().position(|b| *b == b'@') {
+                // Found `scheme://user:pass@`. Append the scheme prefix,
+                // then `***@`, then continue past the `@`.
+                out.push_str(&msg[cursor..absolute_scheme_end]);
+                out.push_str("***@");
+                cursor = absolute_scheme_end + at_pos + 1;
+                continue;
+            }
+        }
+
+        // No more credential patterns; flush the rest.
+        out.push_str(&msg[cursor..]);
+        break;
+    }
+    out
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Validate `SLACK_WEBHOOK_URL` looks like a Slack incoming webhook so a
+/// typo at deploy time fails fast (visible in startup logs) instead of at
+/// first failure event (silent when nobody's looking).
+pub fn looks_like_slack_webhook(url: &str) -> bool {
+    let trimmed = url.trim();
+    trimmed.starts_with("https://hooks.slack.com/services/")
+        // Reasonable lower bound on the path-after-services length so we
+        // catch `https://hooks.slack.com/services/` alone as invalid.
+        && trimmed.len() > "https://hooks.slack.com/services/".len() + 5
 }
 
 #[cfg(test)]
@@ -309,11 +544,15 @@ mod tests {
 
     fn new_client() -> SlackClient {
         SlackClient::new(
-            "https://hooks.slack.com/services/TEST".to_string(),
+            "https://hooks.slack.com/services/TEST/CHANNEL/TOKEN".to_string(),
             "test".to_string(),
             Some("abcdef1".to_string()),
         )
     }
+
+    // ============================================================
+    // Dedup + global rate cap
+    // ============================================================
 
     #[test]
     fn dedup_suppresses_same_error_within_window() {
@@ -332,6 +571,28 @@ mod tests {
     }
 
     #[test]
+    fn global_rate_cap_stops_diverse_error_storm() {
+        let client = new_client();
+        // 30 distinct errors all go through (under the cap of 30).
+        for i in 0..GLOBAL_RATE_MAX {
+            assert!(
+                !client.should_suppress(&format!("error storm #{}", i)),
+                "burst entry #{} should not be suppressed",
+                i
+            );
+        }
+        // The 31st distinct error is suppressed by the global cap.
+        assert!(
+            client.should_suppress("error storm #31 (over cap)"),
+            "31st distinct error in the burst should be suppressed"
+        );
+    }
+
+    // ============================================================
+    // Owner / truncation safety
+    // ============================================================
+
+    #[test]
     fn shorten_owner_keeps_short_addresses_intact() {
         assert_eq!(shorten_owner("short"), "short");
         assert_eq!(shorten_owner("0xabcdef12"), "0xabcdef12");
@@ -344,45 +605,190 @@ mod tests {
     }
 
     #[test]
+    fn shorten_owner_does_not_panic_on_multibyte_chars() {
+        // Three-byte UTF-8 chars (Japanese characters). If we sliced
+        // by bytes this would panic at a non-char-boundary; char-based
+        // slicing handles it safely.
+        let exotic = "メメメメメメメメメメメメメメメメ";
+        let result = shorten_owner(exotic);
+        // Should produce `<first 8 chars>…<last 4 chars>` without panic.
+        assert!(result.contains('…'));
+    }
+
+    #[test]
     fn truncate_appends_ellipsis_when_over_limit() {
         assert_eq!(truncate("abc", 10), "abc");
         assert_eq!(truncate("abcdefghij", 5), "abcde…");
     }
 
     #[test]
-    fn payload_includes_all_known_fields() {
+    fn truncate_does_not_split_multibyte_chars() {
+        // 5 four-byte emoji chars + cap of 3.
+        let s = "🦀🦀🦀🦀🦀";
+        assert_eq!(truncate(s, 3), "🦀🦀🦀…");
+    }
+
+    // ============================================================
+    // Credential sanitization
+    // ============================================================
+
+    #[test]
+    fn sanitize_strips_basic_auth_in_redis_url() {
+        let leak = "failed: cannot connect to redis://memwal:hunter2@127.0.0.1:6379 — io error";
+        let cleaned = sanitize_for_slack(leak);
+        assert!(!cleaned.contains("hunter2"), "password must be stripped");
+        assert!(!cleaned.contains("memwal:"), "username must be stripped");
+        assert!(cleaned.contains("redis://***@127.0.0.1:6379"));
+        assert!(cleaned.contains("io error"), "non-credential text preserved");
+    }
+
+    #[test]
+    fn sanitize_strips_basic_auth_in_postgres_url() {
+        let leak = "Database(sqlx error) at postgresql://app:s3cret@db.host:5432/memwal";
+        let cleaned = sanitize_for_slack(leak);
+        assert!(!cleaned.contains("s3cret"));
+        assert!(!cleaned.contains("app:"));
+        assert!(cleaned.contains("postgresql://***@db.host:5432/memwal"));
+    }
+
+    #[test]
+    fn sanitize_strips_multiple_credentials() {
+        let leak = "primary redis://a:b@h1:6379 secondary postgresql://x:y@h2:5432/db down";
+        let cleaned = sanitize_for_slack(leak);
+        assert!(!cleaned.contains("a:b"));
+        assert!(!cleaned.contains("x:y"));
+        assert_eq!(cleaned.matches("***@").count(), 2);
+    }
+
+    #[test]
+    fn sanitize_is_noop_for_clean_messages() {
+        let clean = "Enoki API error: balance::split MoveAbort at module 0x2::balance";
+        assert_eq!(sanitize_for_slack(clean), clean);
+    }
+
+    #[test]
+    fn sanitize_skips_url_with_no_credentials() {
+        let no_creds = "fetched https://hooks.slack.com/services/T0/B0/TOKEN successfully";
+        assert_eq!(sanitize_for_slack(no_creds), no_creds);
+    }
+
+    // ============================================================
+    // URL validation
+    // ============================================================
+
+    #[test]
+    fn looks_like_slack_webhook_accepts_valid_urls() {
+        assert!(looks_like_slack_webhook(
+            "https://hooks.slack.com/services/T012/B345/abcdef"
+        ));
+        assert!(looks_like_slack_webhook(
+            " https://hooks.slack.com/services/T012/B345/abcdef "
+        ));
+    }
+
+    #[test]
+    fn looks_like_slack_webhook_rejects_bogus_urls() {
+        assert!(!looks_like_slack_webhook("not a url"));
+        assert!(!looks_like_slack_webhook("https://example.com/whatever"));
+        assert!(!looks_like_slack_webhook("http://hooks.slack.com/services/x"));
+        assert!(!looks_like_slack_webhook("https://hooks.slack.com/services/"));
+        assert!(!looks_like_slack_webhook("https://hooks.slack.com/services/x"));
+    }
+
+    // ============================================================
+    // Payload shape
+    // ============================================================
+
+    fn alert<'a>(kind: FailureKind, error_msg: &'a str) -> RememberJobFailedAlert<'a> {
+        RememberJobFailedAlert {
+            job_id: Some("job-123"),
+            owner: Some("0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994"),
+            namespace: Some("default"),
+            error_msg,
+            kind,
+        }
+    }
+
+    #[test]
+    fn payload_for_wallet_retry_exhaustion_includes_attempt_count() {
         let client = new_client();
-        let payload = client.build_remember_failed_payload(
-            Some("job-123"),
-            Some("0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994"),
-            Some("default"),
-            3,
-            3,
+        let a = alert(
+            FailureKind::WalletRetriesExhausted { attempts: 3 },
             "balance::split MoveAbort",
         );
-
+        let sanitized = sanitize_for_slack(a.error_msg);
+        let payload = client.build_payload(&a, &sanitized);
         let json = serde_json::to_string(&payload).unwrap();
-        assert!(json.contains("Remember Job Failed"));
+
+        assert!(json.contains("wallet retries exhausted"));
+        assert!(json.contains("3 / 3"));
         assert!(json.contains("job-123"));
         assert!(json.contains("0xe5c911"));
-        assert!(json.contains("3 / 3 exhausted"));
         assert!(json.contains("balance::split MoveAbort"));
         assert!(json.contains("env `test`"));
         assert!(json.contains("server commit `abcdef1`"));
     }
 
     #[test]
+    fn payload_for_handoff_uses_distinct_headline() {
+        let client = new_client();
+        let a = alert(FailureKind::HandoffEnqueueFailure, "queue down");
+        let sanitized = sanitize_for_slack(a.error_msg);
+        let payload = client.build_payload(&a, &sanitized);
+        let json = serde_json::to_string(&payload).unwrap();
+
+        // Distinct headline so on-call can tell the two scenarios apart.
+        assert!(json.contains("queue handoff"));
+        assert!(!json.contains("wallet retries exhausted"));
+        assert!(json.contains("post-upload handoff enqueue failed"));
+    }
+
+    #[test]
     fn payload_omits_commit_footer_when_absent() {
         let client = SlackClient::new(
-            "https://hooks.slack.com/services/TEST".to_string(),
+            "https://hooks.slack.com/services/TEST/CHANNEL/TOKEN".to_string(),
             "dev".to_string(),
             None,
         );
-        let payload = client.build_remember_failed_payload(
-            None, None, None, 0, 0, "boom",
-        );
+        let a = alert(FailureKind::HandoffEnqueueFailure, "boom");
+        let sanitized = sanitize_for_slack(a.error_msg);
+        let payload = client.build_payload(&a, &sanitized);
         let json = serde_json::to_string(&payload).unwrap();
         assert!(!json.contains("server commit"));
         assert!(json.contains("env `dev`"));
+    }
+
+    #[test]
+    fn payload_sanitizes_credentials_in_error() {
+        let client = new_client();
+        let a = alert(
+            FailureKind::HandoffEnqueueFailure,
+            "cannot connect to redis://app:hunter2@host:6379",
+        );
+        let sanitized = sanitize_for_slack(a.error_msg);
+        let payload = client.build_payload(&a, &sanitized);
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(!json.contains("hunter2"));
+        assert!(json.contains("redis://***@host:6379"));
+    }
+
+    // ============================================================
+    // Retry classification
+    // ============================================================
+
+    #[test]
+    fn retryable_statuses_cover_429_and_5xx() {
+        assert!(is_retryable(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable(StatusCode::BAD_GATEWAY));
+        assert!(is_retryable(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_retryable(StatusCode::GATEWAY_TIMEOUT));
+    }
+
+    #[test]
+    fn non_retryable_4xx_does_not_trigger_retry() {
+        assert!(!is_retryable(StatusCode::BAD_REQUEST));
+        assert!(!is_retryable(StatusCode::FORBIDDEN));
+        assert!(!is_retryable(StatusCode::NOT_FOUND));
     }
 }

--- a/services/server/src/slack.rs
+++ b/services/server/src/slack.rs
@@ -1324,6 +1324,273 @@ mod tests {
         assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
+    // ============================================================
+    // ENG-1784: notify_infra_failure — end-to-end mock-webhook tests
+    // ============================================================
+
+    /// One distinct variant kind that doesn't conflict with the other
+    /// infra-alert tests in this file — each test uses a fresh client
+    /// so dedup state is isolated.
+    fn fresh_client_for(url: String) -> SlackClient {
+        SlackClient::new(url, "infra-test".to_string(), Some("e2ee2ee".to_string()))
+    }
+
+    #[tokio::test]
+    async fn notify_infra_failure_posts_with_correct_body_shape() {
+        let (url, body, hits) = spawn_mock_with_status_sequence(vec![200]).await;
+        let client = fresh_client_for(url);
+
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::PostgresDown {
+                    reason: "connection refused by 10.0.0.1:5432".to_string(),
+                },
+            })
+            .await
+            .expect("infra POST should succeed against a 200 mock");
+
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let received = body.lock().unwrap();
+        assert_eq!(received.len(), 1);
+        let payload = &received[0];
+
+        // Top-level `text` is the fallback for clients with rich block
+        // rendering disabled — must include the headline and detail head.
+        let text = payload["text"].as_str().expect("text field");
+        assert!(text.contains("Postgres Down"), "got text: {}", text);
+        assert!(
+            text.contains("connection refused"),
+            "got text: {}",
+            text
+        );
+
+        // Blocks: header / fields / detail / footer
+        let blocks = payload["blocks"].as_array().expect("blocks");
+        assert_eq!(blocks.len(), 4, "expected 4 blocks, got {}", blocks.len());
+
+        // Block 0: header with headline.
+        assert_eq!(blocks[0]["type"], "header");
+        assert!(blocks[0]["text"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("Postgres Down"));
+
+        // Block 1: fields — must include dedup signature + env, NOT the
+        // reason string (reason is in the detail block, which is the
+        // pre-formatted code block).
+        let fields = blocks[1]["fields"].as_array().expect("fields");
+        let joined: String = fields
+            .iter()
+            .map(|f| f["text"].as_str().unwrap_or("").to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(joined.contains("infra:postgres_down"), "fields: {}", joined);
+        assert!(joined.contains("infra-test"), "fields: {}", joined);
+
+        // Block 2: code block with detail.
+        let detail = blocks[2]["text"]["text"].as_str().unwrap();
+        assert!(detail.contains("connection refused"));
+        // Code-block fence preserved so the channel renders monospace.
+        assert!(detail.starts_with("```") && detail.ends_with("```"));
+
+        // Block 3: footer with commit + env.
+        let footer = blocks[3]["elements"][0]["text"].as_str().unwrap();
+        assert!(footer.contains("e2ee2ee"));
+        assert!(footer.contains("infra-test"));
+    }
+
+    #[tokio::test]
+    async fn notify_infra_failure_dedups_same_variant_with_different_detail() {
+        // The most important behavioural test: a probe loop firing every
+        // 30s on a stuck dependency must only post ONCE per dedup
+        // window, even though the per-instance reason / counters change.
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![200, 200, 200]).await;
+        let client = fresh_client_for(url);
+
+        // First call: posts.
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::SidecarDown { consecutive_failures: 3 },
+            })
+            .await
+            .expect("first infra POST");
+        // Second call: same variant, different count → must suppress.
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::SidecarDown { consecutive_failures: 7 },
+            })
+            .await
+            .expect("second infra returns Ok via suppression");
+        // Third call: same variant, yet another count → still suppress.
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::SidecarDown {
+                    consecutive_failures: 99,
+                },
+            })
+            .await
+            .expect("third infra returns Ok via suppression");
+
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "dedup must collapse same-variant repeats to ONE Slack POST"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_infra_failure_distinct_variants_both_post() {
+        // Two different infra alerts within the dedup window are both
+        // independently meaningful — Postgres down and Redis down are
+        // different incidents even if they happen simultaneously.
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![200, 200]).await;
+        let client = fresh_client_for(url);
+
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::PostgresDown {
+                    reason: "x".to_string(),
+                },
+            })
+            .await
+            .unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::RedisDown {
+                    consecutive_failures: 3,
+                },
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "different variants are different incidents — both must post"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_infra_failure_does_not_block_on_dedup_with_remember_job_alert() {
+        // Regression guard: the dedup map is shared with
+        // notify_remember_job_failed. If an infra signature ever
+        // collided with a remember-job error hash, one would silently
+        // shadow the other. Test that the two alert paths post
+        // independently even when the underlying error strings are
+        // similar.
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![200, 200]).await;
+        let client = fresh_client_for(url);
+
+        client
+            .notify_remember_job_failed(RememberJobFailedAlert {
+                job_id: Some("job-123"),
+                owner: Some("0xabc"),
+                namespace: Some("ns"),
+                error_msg: "postgres down: connection refused",
+                kind: FailureKind::TerminalWalletFailure { attempts: 3 },
+            })
+            .await
+            .unwrap();
+
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::PostgresDown {
+                    reason: "postgres down: connection refused".to_string(),
+                },
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "infra alert key space is disjoint from remember-job hashes"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_infra_failure_recovers_via_retry_on_5xx() {
+        // Same retry behaviour as remember-job alerts — one transient
+        // upstream blip should not drop the page.
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![503, 200]).await;
+        let client = fresh_client_for(url);
+
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::SuiRpcDown {
+                    consecutive_failures: 3,
+                },
+            })
+            .await
+            .expect("retry should recover");
+
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn notify_infra_failure_with_unreachable_webhook_returns_err_not_panic() {
+        // Operational safety: Slack-side outage must surface as Err to
+        // the fire-and-forget caller, NEVER panic. The caller logs it
+        // and moves on — the wallet job is unaffected.
+        let client = fresh_client_for("http://127.0.0.1:1/webhook".to_string());
+        let res = client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::NoSuiKeysConfigured,
+            })
+            .await;
+        assert!(res.is_err(), "unreachable webhook should return Err");
+    }
+
+    #[tokio::test]
+    async fn notify_infra_failure_suppressed_when_global_cap_exhausted() {
+        // The global rate cap is shared across all alert paths that go
+        // through `should_suppress*` — so 30 distinct remember-job
+        // alerts (each a unique error string) should saturate it, after
+        // which any infra alert returns Ok via suppression. Note: we do
+        // NOT use `send_notification` here because it deliberately
+        // bypasses both dedup AND the rate cap; only the typed `notify_*`
+        // methods participate in the cap.
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![200; 35]).await;
+        let client = fresh_client_for(url);
+
+        for i in 0..GLOBAL_RATE_MAX {
+            client
+                .notify_remember_job_failed(RememberJobFailedAlert {
+                    job_id: Some(&format!("storm-{:02}", i)),
+                    owner: Some("0xabc"),
+                    namespace: Some("ns"),
+                    error_msg: &format!(
+                        "unique upstream error #{:02} so per-error dedup doesn't apply",
+                        i
+                    ),
+                    kind: FailureKind::TerminalWalletFailure { attempts: 3 },
+                })
+                .await
+                .expect("preamble post");
+        }
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            GLOBAL_RATE_MAX,
+            "preamble should fill the cap exactly"
+        );
+
+        // Cap is now full. The next infra POST must suppress.
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::WalletPoolDrained {
+                    pool_size: 5,
+                    consecutive_transient: 15,
+                },
+            })
+            .await
+            .expect("rate-cap suppression returns Ok, not Err");
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            GLOBAL_RATE_MAX,
+            "global cap must suppress infra alerts the same way it suppresses job alerts"
+        );
+    }
+
     #[tokio::test]
     async fn retry_recovers_when_first_call_is_503() {
         let (url, _body, hits) = spawn_mock_with_status_sequence(vec![503, 200]).await;

--- a/services/server/src/slack.rs
+++ b/services/server/src/slack.rs
@@ -1,0 +1,388 @@
+//! Slack notification client for terminal job failures.
+//!
+//! ENG-1784: Push alerts to a Slack Incoming Webhook when a remember job
+//! fails after wallet rotation has exhausted all retries (i.e. every wallet
+//! in the pool returned a non-retryable error).
+//!
+//! Design (mirrors `x-wallet/backend/src/clients/slack.rs`):
+//!
+//! * **Optional**: `SlackClient` is constructed only when `SLACK_WEBHOOK_URL`
+//!   is set. When absent the alerter is `None` and every notify call is a
+//!   no-op; the rest of the server is unaware.
+//! * **Fire-and-forget**: callers spawn the notify future and ignore the
+//!   result. A failed Slack POST must never fail the wallet job.
+//! * **In-memory dedup**: Enoki / sidecar incidents can fan out into dozens
+//!   of identical failures within seconds. We hash the error message and
+//!   suppress duplicates within a 5-minute window so the on-call channel
+//!   isn't flooded; suppressions are logged for visibility.
+
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tracing::{info, warn};
+
+/// Boxed error for fire-and-forget callers; the alerter never has a typed
+/// error worth matching on — every failure path just gets logged.
+pub type SlackError = Box<dyn StdError + Send + Sync + 'static>;
+pub type SlackResult<T> = std::result::Result<T, SlackError>;
+
+/// Cool-down for identical error signatures. An Enoki outage typically
+/// produces the same `dry_run_failed: balance::split` message on every
+/// retry; without this window a 30-minute incident posts hundreds of
+/// near-identical messages.
+const DEDUP_WINDOW: Duration = Duration::from_secs(5 * 60);
+
+/// `text` block is the fallback Slack uses for notifications + accessibility.
+/// `blocks` carries the rich layout shown in the channel.
+#[derive(Debug, Serialize)]
+struct SlackMessage {
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blocks: Option<Vec<SlackBlock>>,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackBlock {
+    #[serde(rename = "type")]
+    block_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<SlackText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fields: Option<Vec<SlackText>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    elements: Option<Vec<SlackText>>,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackText {
+    #[serde(rename = "type")]
+    text_type: String,
+    text: String,
+}
+
+/// Slack notifier. Cheap to clone — wraps `reqwest::Client` which is
+/// internally `Arc`-counted, and an `Arc<Mutex<...>>` dedup map.
+#[derive(Clone)]
+pub struct SlackClient {
+    http: Client,
+    webhook_url: String,
+    /// `error_signature → last_sent_at`. We log + skip when the same
+    /// signature re-appears within `DEDUP_WINDOW`.
+    dedup: std::sync::Arc<Mutex<HashMap<String, Instant>>>,
+    /// Identifies the running relayer in the alert footer
+    /// (e.g. `prod` / `staging` / `dev` from `MEMWAL_ENV`).
+    env_label: String,
+    /// Optional git SHA / build identifier, surfaced in the footer.
+    server_commit: Option<String>,
+}
+
+impl SlackClient {
+    pub fn new(webhook_url: String, env_label: String, server_commit: Option<String>) -> Self {
+        Self {
+            http: Client::new(),
+            webhook_url,
+            dedup: std::sync::Arc::new(Mutex::new(HashMap::new())),
+            env_label,
+            server_commit,
+        }
+    }
+
+    /// Notify Slack that a remember job has terminally failed after the
+    /// wallet pool exhausted retries. Returns `Ok(())` on success, or after
+    /// suppression. Network errors are surfaced for caller logging but the
+    /// recommended use is fire-and-forget via `tokio::spawn`.
+    pub async fn notify_remember_job_failed(
+        &self,
+        job_id: Option<&str>,
+        owner: Option<&str>,
+        namespace: Option<&str>,
+        wallet_attempts: u32,
+        max_attempts: u32,
+        error_msg: &str,
+    ) -> SlackResult<()> {
+        if self.should_suppress(error_msg) {
+            info!(
+                error_signature = %short_hash(error_msg),
+                "Slack alert suppressed (within dedup window)"
+            );
+            return Ok(());
+        }
+
+        let payload = self.build_remember_failed_payload(
+            job_id,
+            owner,
+            namespace,
+            wallet_attempts,
+            max_attempts,
+            error_msg,
+        );
+        self.send_payload(&payload).await
+    }
+
+    /// Send a raw text-only notification. Helpful for ad-hoc one-off alerts
+    /// and unit tests; the typed `notify_*` helpers should be preferred for
+    /// production paths so the format stays consistent.
+    #[allow(dead_code)]
+    pub async fn send_notification(&self, text: &str) -> SlackResult<()> {
+        self.send_payload(&SlackMessage {
+            text: text.to_string(),
+            blocks: None,
+        })
+        .await
+    }
+
+    /// Returns `true` if an identical `error_msg` has been alerted within
+    /// the dedup window. Updates the timestamp atomically when we DO send.
+    fn should_suppress(&self, error_msg: &str) -> bool {
+        let key = hash_error(error_msg);
+        let now = Instant::now();
+
+        let mut map = match self.dedup.lock() {
+            Ok(guard) => guard,
+            // Poisoned mutex: better to send the alert than swallow it.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        if let Some(last) = map.get(&key) {
+            if now.duration_since(*last) < DEDUP_WINDOW {
+                return true;
+            }
+        }
+        map.insert(key, now);
+
+        // Best-effort GC of expired entries so the map doesn't grow
+        // unbounded across long-running processes.
+        map.retain(|_, ts| now.duration_since(*ts) < DEDUP_WINDOW);
+        false
+    }
+
+    fn build_remember_failed_payload(
+        &self,
+        job_id: Option<&str>,
+        owner: Option<&str>,
+        namespace: Option<&str>,
+        wallet_attempts: u32,
+        max_attempts: u32,
+        error_msg: &str,
+    ) -> SlackMessage {
+        let fallback_text = format!(
+            "🔴 MemWal: remember job failed (all wallets exhausted) — {}",
+            truncate(error_msg, 120)
+        );
+
+        let header = SlackBlock {
+            block_type: "header".to_string(),
+            text: Some(SlackText {
+                text_type: "plain_text".to_string(),
+                text: "🔴 MemWal — Remember Job Failed".to_string(),
+            }),
+            fields: None,
+            elements: None,
+        };
+
+        let fields = SlackBlock {
+            block_type: "section".to_string(),
+            text: None,
+            elements: None,
+            fields: Some(vec![
+                SlackText {
+                    text_type: "mrkdwn".to_string(),
+                    text: format!("*Job ID:*\n`{}`", job_id.unwrap_or("-")),
+                },
+                SlackText {
+                    text_type: "mrkdwn".to_string(),
+                    text: format!("*Namespace:*\n`{}`", namespace.unwrap_or("-")),
+                },
+                SlackText {
+                    text_type: "mrkdwn".to_string(),
+                    text: format!("*Owner:*\n`{}`", owner.map(shorten_owner).unwrap_or_else(|| "-".to_string())),
+                },
+                SlackText {
+                    text_type: "mrkdwn".to_string(),
+                    text: format!(
+                        "*Wallet attempts:*\n{} / {} exhausted",
+                        wallet_attempts, max_attempts
+                    ),
+                },
+            ]),
+        };
+
+        let error_block = SlackBlock {
+            block_type: "section".to_string(),
+            elements: None,
+            fields: None,
+            text: Some(SlackText {
+                text_type: "mrkdwn".to_string(),
+                // Triple-backtick code fence renders Slack `code block`.
+                // Truncate so a multi-paragraph traceback doesn't blow past
+                // Slack's 3000-char per-text limit.
+                text: format!("*Error:*\n```{}```", truncate(error_msg, 2400)),
+            }),
+        };
+
+        let footer_text = match &self.server_commit {
+            Some(sha) => format!("server commit `{}` · env `{}`", sha, self.env_label),
+            None => format!("env `{}`", self.env_label),
+        };
+        let context = SlackBlock {
+            block_type: "context".to_string(),
+            text: None,
+            fields: None,
+            elements: Some(vec![SlackText {
+                text_type: "mrkdwn".to_string(),
+                text: footer_text,
+            }]),
+        };
+
+        SlackMessage {
+            text: fallback_text,
+            blocks: Some(vec![header, fields, error_block, context]),
+        }
+    }
+
+    async fn send_payload(&self, payload: &SlackMessage) -> SlackResult<()> {
+        let response = self
+            .http
+            .post(&self.webhook_url)
+            .json(payload)
+            .send()
+            .await
+            .map_err(|e| -> SlackError { format!("Failed to POST Slack webhook: {}", e).into() })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!(
+                status = %status,
+                body = %body,
+                "Slack webhook returned non-success status"
+            );
+            return Err(format!("Slack webhook failed with status {}: {}", status, body).into());
+        }
+
+        info!("Slack notification delivered");
+        Ok(())
+    }
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+fn hash_error(msg: &str) -> String {
+    let digest = Sha256::digest(msg.as_bytes());
+    hex::encode(&digest[..8])
+}
+
+fn short_hash(msg: &str) -> String {
+    hash_error(msg)
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let taken: String = s.chars().take(max_chars).collect();
+    format!("{}…", taken)
+}
+
+fn shorten_owner(owner: &str) -> String {
+    // 0x1234...abcd style display so on-call can identify accounts without
+    // copy/pasting 66-character addresses out of Slack.
+    let len = owner.len();
+    if len <= 12 {
+        return owner.to_string();
+    }
+    let head = &owner[..8];
+    let tail = &owner[len.saturating_sub(4)..];
+    format!("{}…{}", head, tail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_client() -> SlackClient {
+        SlackClient::new(
+            "https://hooks.slack.com/services/TEST".to_string(),
+            "test".to_string(),
+            Some("abcdef1".to_string()),
+        )
+    }
+
+    #[test]
+    fn dedup_suppresses_same_error_within_window() {
+        let client = new_client();
+        assert!(!client.should_suppress("Enoki API error: balance::split"));
+        assert!(client.should_suppress("Enoki API error: balance::split"));
+        assert!(client.should_suppress("Enoki API error: balance::split"));
+    }
+
+    #[test]
+    fn dedup_lets_different_errors_through() {
+        let client = new_client();
+        assert!(!client.should_suppress("error one"));
+        assert!(!client.should_suppress("error two"));
+        assert!(!client.should_suppress("error three"));
+    }
+
+    #[test]
+    fn shorten_owner_keeps_short_addresses_intact() {
+        assert_eq!(shorten_owner("short"), "short");
+        assert_eq!(shorten_owner("0xabcdef12"), "0xabcdef12");
+    }
+
+    #[test]
+    fn shorten_owner_truncates_full_sui_address() {
+        let address = "0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994";
+        assert_eq!(shorten_owner(address), "0xe5c911…4994");
+    }
+
+    #[test]
+    fn truncate_appends_ellipsis_when_over_limit() {
+        assert_eq!(truncate("abc", 10), "abc");
+        assert_eq!(truncate("abcdefghij", 5), "abcde…");
+    }
+
+    #[test]
+    fn payload_includes_all_known_fields() {
+        let client = new_client();
+        let payload = client.build_remember_failed_payload(
+            Some("job-123"),
+            Some("0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994"),
+            Some("default"),
+            3,
+            3,
+            "balance::split MoveAbort",
+        );
+
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("Remember Job Failed"));
+        assert!(json.contains("job-123"));
+        assert!(json.contains("0xe5c911"));
+        assert!(json.contains("3 / 3 exhausted"));
+        assert!(json.contains("balance::split MoveAbort"));
+        assert!(json.contains("env `test`"));
+        assert!(json.contains("server commit `abcdef1`"));
+    }
+
+    #[test]
+    fn payload_omits_commit_footer_when_absent() {
+        let client = SlackClient::new(
+            "https://hooks.slack.com/services/TEST".to_string(),
+            "dev".to_string(),
+            None,
+        );
+        let payload = client.build_remember_failed_payload(
+            None, None, None, 0, 0, "boom",
+        );
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(!json.contains("server commit"));
+        assert!(json.contains("env `dev`"));
+    }
+}

--- a/services/server/src/slack.rs
+++ b/services/server/src/slack.rs
@@ -165,6 +165,17 @@ pub enum InfraFailureKind {
         pool_size: usize,
         consecutive_transient: u64,
     },
+    /// Apalis queue has >= `backlog` Pending jobs that have been ready
+    /// to run for at least `stuck_for_secs` seconds AND the backlog
+    /// stayed above the configured threshold for `consecutive_samples`
+    /// probe cycles. Workers are either dead, stuck, or vastly under-
+    /// provisioned — nothing is being drained. Distinct from a single
+    /// slow job: this fires only when the QUEUE itself is wedged.
+    ApalisQueueStuck {
+        backlog: i64,
+        stuck_for_secs: u64,
+        consecutive_samples: u32,
+    },
     /// `SERVER_SUI_PRIVATE_KEYS` / `SERVER_SUI_PRIVATE_KEY` both unset at
     /// boot. Fires once during startup; uploads will fail for everyone
     /// until a key is configured and the process restarts.
@@ -181,6 +192,7 @@ impl InfraFailureKind {
             InfraFailureKind::WalletPoolDrained { .. } => {
                 "🚨 MemWal Infra — Wallet Pool Drained"
             }
+            InfraFailureKind::ApalisQueueStuck { .. } => "🚨 MemWal Infra — Apalis Queue Stuck",
             InfraFailureKind::NoSuiKeysConfigured => "🚨 MemWal Infra — No Sui Keys Configured",
         }
     }
@@ -209,6 +221,14 @@ impl InfraFailureKind {
                 "Every wallet in pool (size {}) returned transient failures for {} consecutive attempts — likely all out of gas / balance::split.",
                 pool_size, consecutive_transient
             ),
+            InfraFailureKind::ApalisQueueStuck {
+                backlog,
+                stuck_for_secs,
+                consecutive_samples,
+            } => format!(
+                "Apalis queue has {} Pending jobs ready to run for >= {}s, observed across {} consecutive probe samples. Workers are wedged or under-provisioned — no jobs draining.",
+                backlog, stuck_for_secs, consecutive_samples
+            ),
             InfraFailureKind::NoSuiKeysConfigured => {
                 "Server started with empty key pool — SERVER_SUI_PRIVATE_KEYS and SERVER_SUI_PRIVATE_KEY both unset. All Walrus uploads will fail."
                     .to_string()
@@ -226,6 +246,7 @@ impl InfraFailureKind {
             InfraFailureKind::RedisDown { .. } => "infra:redis_down",
             InfraFailureKind::SuiRpcDown { .. } => "infra:sui_rpc_down",
             InfraFailureKind::WalletPoolDrained { .. } => "infra:wallet_pool_drained",
+            InfraFailureKind::ApalisQueueStuck { .. } => "infra:apalis_queue_stuck",
             InfraFailureKind::NoSuiKeysConfigured => "infra:no_sui_keys",
         }
     }
@@ -803,6 +824,24 @@ mod tests {
             }
             .dedup_signature(),
         );
+        // ApalisQueueStuck: same variant across different backlog sizes /
+        // sample counts must collapse to one dedup signature. Critical
+        // because the apalis probe samples every 30s — without this, a
+        // 5-minute stuck queue would post 10 alerts in a row.
+        assert_eq!(
+            InfraFailureKind::ApalisQueueStuck {
+                backlog: 120,
+                stuck_for_secs: 300,
+                consecutive_samples: 3,
+            }
+            .dedup_signature(),
+            InfraFailureKind::ApalisQueueStuck {
+                backlog: 9_999,
+                stuck_for_secs: 7_200,
+                consecutive_samples: 100,
+            }
+            .dedup_signature(),
+        );
     }
 
     #[test]
@@ -819,12 +858,51 @@ mod tests {
                 consecutive_transient: 1,
             }
             .dedup_signature(),
+            InfraFailureKind::ApalisQueueStuck {
+                backlog: 1,
+                stuck_for_secs: 1,
+                consecutive_samples: 1,
+            }
+            .dedup_signature(),
             InfraFailureKind::NoSuiKeysConfigured.dedup_signature(),
         ];
         let mut sorted = sigs.to_vec();
         sorted.sort();
         sorted.dedup();
         assert_eq!(sorted.len(), sigs.len(), "infra variants must not collide");
+    }
+
+    #[test]
+    fn infra_apalis_queue_stuck_detail_includes_all_signal_fields() {
+        // The body must surface backlog, stuck duration, and sample
+        // count — operators need all three to triage (is this 100 jobs
+        // delayed 5 min, or 10,000 jobs delayed 1 hour?).
+        let detail = InfraFailureKind::ApalisQueueStuck {
+            backlog: 437,
+            stuck_for_secs: 600,
+            consecutive_samples: 5,
+        }
+        .detail();
+        assert!(detail.contains("437"), "missing backlog: {}", detail);
+        assert!(detail.contains("600"), "missing stuck duration: {}", detail);
+        assert!(detail.contains("5"), "missing sample count: {}", detail);
+    }
+
+    #[test]
+    fn infra_apalis_queue_stuck_headline_distinct_from_other_queue_signals() {
+        // ApalisQueueStuck should NOT use the same headline as
+        // HandoffEnqueueFailure (per-job queue push) — they're different
+        // failure modes routed by ops differently.
+        let stuck_headline = InfraFailureKind::ApalisQueueStuck {
+            backlog: 100,
+            stuck_for_secs: 300,
+            consecutive_samples: 3,
+        }
+        .headline();
+        let handoff_headline = FailureKind::HandoffEnqueueFailure.headline();
+        assert_ne!(stuck_headline, handoff_headline);
+        assert!(stuck_headline.contains("Apalis"));
+        assert!(stuck_headline.contains("Stuck"));
     }
 
     #[test]

--- a/services/server/src/slack.rs
+++ b/services/server/src/slack.rs
@@ -1918,6 +1918,98 @@ mod tests {
             delivered_count, suppressed_count
         );
 
+        // ── Scenarios 7–13: ENG-1784 infra alerts ────────────────────
+        // Each fires one of the new InfraFailureKind variants. The
+        // alerter's per-variant dedup keeps these from collapsing
+        // against each other; we pause briefly so the channel renders
+        // in order and a reviewer can match each Slack message to the
+        // scenario name printed here.
+
+        pause("scenario 7", 60).await; // long pause so rate-cap window from #6 elapses
+        println!("\n[7/13] InfraFailureKind::SidecarDown");
+        let client = make_live_client("scenario-7-sidecar").unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::SidecarDown {
+                    consecutive_failures: 5,
+                },
+            })
+            .await
+            .expect("scenario 7 should deliver");
+        pause("scenario 8", 3).await;
+
+        println!("\n[8/13] InfraFailureKind::PostgresDown");
+        let client = make_live_client("scenario-8-postgres").unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::PostgresDown {
+                    reason: "connection refused by 10.0.0.42:5432 — pool exhausted".to_string(),
+                },
+            })
+            .await
+            .expect("scenario 8 should deliver");
+        pause("scenario 9", 3).await;
+
+        println!("\n[9/13] InfraFailureKind::RedisDown");
+        let client = make_live_client("scenario-9-redis").unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::RedisDown {
+                    consecutive_failures: 4,
+                },
+            })
+            .await
+            .expect("scenario 9 should deliver");
+        pause("scenario 10", 3).await;
+
+        println!("\n[10/13] InfraFailureKind::SuiRpcDown");
+        let client = make_live_client("scenario-10-sui-rpc").unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::SuiRpcDown {
+                    consecutive_failures: 6,
+                },
+            })
+            .await
+            .expect("scenario 10 should deliver");
+        pause("scenario 11", 3).await;
+
+        println!("\n[11/13] InfraFailureKind::WalletPoolDrained");
+        let client = make_live_client("scenario-11-wallet-drain").unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::WalletPoolDrained {
+                    pool_size: 5,
+                    consecutive_transient: 15,
+                },
+            })
+            .await
+            .expect("scenario 11 should deliver");
+        pause("scenario 12", 3).await;
+
+        println!("\n[12/13] InfraFailureKind::ApalisQueueStuck");
+        let client = make_live_client("scenario-12-apalis-stuck").unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::ApalisQueueStuck {
+                    backlog: 437,
+                    stuck_for_secs: 600,
+                    consecutive_samples: 5,
+                },
+            })
+            .await
+            .expect("scenario 12 should deliver");
+        pause("scenario 13", 3).await;
+
+        println!("\n[13/13] InfraFailureKind::NoSuiKeysConfigured (boot-time)");
+        let client = make_live_client("scenario-13-no-keys").unwrap();
+        client
+            .notify_infra_failure(InfraFailureAlert {
+                kind: InfraFailureKind::NoSuiKeysConfigured,
+            })
+            .await
+            .expect("scenario 13 should deliver");
+
         println!("\n✅ Live demo complete. Verify in #target-channel that you see:");
         println!("   1× scenario 1 (wallet retries exhausted, Enoki)");
         println!("   1× scenario 2 (handoff enqueue failed)");
@@ -1925,5 +2017,12 @@ mod tests {
         println!("   1× scenario 4 (sanitized credentials — no passwords)");
         println!("   1× scenario 5 (UTF-8 — Japanese + emoji)");
         println!("   1× scenario 6 header + ~30× rate-cap entries (35 sent, 5 dropped)");
+        println!("   1× scenario 7  (🚨 Sidecar Down)");
+        println!("   1× scenario 8  (🚨 Postgres Down — reason redacted? sanitizer was OFF for this path)");
+        println!("   1× scenario 9  (🚨 Redis Down)");
+        println!("   1× scenario 10 (🚨 Sui RPC Down)");
+        println!("   1× scenario 11 (🚨 Wallet Pool Drained — backlog signal)");
+        println!("   1× scenario 12 (🚨 Apalis Queue Stuck — 437 / 600s / 5 samples)");
+        println!("   1× scenario 13 (🚨 No Sui Keys Configured — boot-time)");
     }
 }

--- a/services/server/src/slack.rs
+++ b/services/server/src/slack.rs
@@ -36,9 +36,11 @@ use std::error::Error as StdError;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use regex::Regex;
 use reqwest::{Client, StatusCode};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
+use std::sync::LazyLock;
 use tracing::{info, warn};
 
 /// Boxed error for fire-and-forget callers; the alerter never has a typed
@@ -75,13 +77,17 @@ const RETRY_DELAY: Duration = Duration::from_millis(750);
 /// that matches your code path so the Slack message wording is accurate.
 #[derive(Debug, Clone, Copy)]
 pub enum FailureKind {
-    /// The wallet pool rotated through every key it had and every attempt
-    /// returned a permanent error. This is the "Enoki down across all
-    /// wallets" scenario from the ENG-1784 brief.
-    WalletRetriesExhausted {
-        /// Configured maximum attempts (e.g. `MAX_ATTEMPTS = 3`). The
-        /// alert reads `{attempts}/{attempts} exhausted` because the
-        /// only way we land in this branch is by burning all of them.
+    /// The wallet retry budget (Apalis `MAX_ATTEMPTS`) was burned and
+    /// every attempt — each running on a fresh `key_pool.next_index()`
+    /// wallet — returned a permanent error. Note the wording: this
+    /// means the *retry budget* was exhausted, NOT necessarily every
+    /// wallet in the pool (the pool can have more wallets than the
+    /// retry count). Typical cause: Enoki API error across multiple
+    /// wallets, Walrus 4xx persistent, sidecar permanent rejection.
+    TerminalWalletFailure {
+        /// `MAX_ATTEMPTS` from the apalis worker config. The alert
+        /// surfaces this as "permanent failure after N retry attempts"
+        /// so on-call knows exactly how much we tried before giving up.
         attempts: u32,
     },
     /// Upload succeeded but the follow-up workflow couldn't be enqueued
@@ -93,8 +99,8 @@ pub enum FailureKind {
 impl FailureKind {
     fn label(&self) -> String {
         match self {
-            FailureKind::WalletRetriesExhausted { attempts } => {
-                format!("{} / {} wallet retries exhausted", attempts, attempts)
+            FailureKind::TerminalWalletFailure { attempts } => {
+                format!("permanent wallet failure after {} retry attempts", attempts)
             }
             FailureKind::HandoffEnqueueFailure => {
                 "post-upload handoff enqueue failed (job queue infra)".to_string()
@@ -104,8 +110,8 @@ impl FailureKind {
 
     fn headline(&self) -> &'static str {
         match self {
-            FailureKind::WalletRetriesExhausted { .. } => {
-                "🔴 MemWal — Remember Job Failed (wallet retries exhausted)"
+            FailureKind::TerminalWalletFailure { .. } => {
+                "🔴 MemWal — Remember Job Failed (terminal wallet failure)"
             }
             FailureKind::HandoffEnqueueFailure => {
                 "🔴 MemWal — Remember Job Failed (queue handoff)"
@@ -476,55 +482,62 @@ fn shorten_owner(owner: &str) -> String {
     format!("{}…{}", head, tail)
 }
 
+/// Compiled once at first sanitize call. `LazyLock` over `OnceLock` so
+/// callers don't have to plumb the result through an `Option` everywhere.
+///
+/// Each pattern targets a known leak vector:
+///
+/// * `URL_BASIC_AUTH` — `scheme://user:pass@host` → `scheme://***@host`.
+///   Catches Redis / Postgres / HTTP connection errors that print the
+///   full URL with embedded credentials.
+/// * `BEARER` — `Bearer <token>` (case-insensitive) → `Bearer ***`.
+///   Catches OAuth / API authorization header echoes.
+/// * `KV_SECRET` — `keyword[=:]<value>` (case-insensitive) for the
+///   keywords below → `keyword=***`. Catches JSON-like or query-string
+///   echoes such as `api_key=sk-...`, `"password": "..."`, etc.
+static URL_BASIC_AUTH: LazyLock<Regex> = LazyLock::new(|| {
+    // `\w+://` scheme, then any chars up to the first `@` that is NOT
+    // preceded by another `://` (so we don't accidentally chew across
+    // multiple URLs in one message).
+    Regex::new(r"(\w+://)[^/@\s]+@").expect("URL_BASIC_AUTH regex must compile")
+});
+static BEARER: LazyLock<Regex> = LazyLock::new(|| {
+    // `Bearer` (case-insensitive) followed by 1+ space then a non-space
+    // token. The token may contain `.` `-` `_` (typical JWT charset).
+    Regex::new(r"(?i)\bbearer\s+[A-Za-z0-9._\-+/=]+")
+        .expect("BEARER regex must compile")
+});
+static KV_SECRET: LazyLock<Regex> = LazyLock::new(|| {
+    // Match `<keyword>[=:]<value>` for any secret-bearing keyword,
+    // handling four common shapes:
+    //
+    //   token=abc          (bare KV)
+    //   token: abc         (colon separator with whitespace)
+    //   "token": "abc"     (JSON object — keyword AND value quoted)
+    //   "api-key": abc     (JSON object — keyword quoted, value bare)
+    //
+    // `"?\b ... \b"?` lets the keyword carry optional quote marks; the
+    // value uses the same trick so a quoted value's closing quote is
+    // consumed by the match (and therefore replaced) instead of being
+    // left dangling next to the redaction.
+    Regex::new(
+        r#"(?i)"?\b(api[_-]?key|access[_-]?token|auth[_-]?token|token|password|passwd|secret|client[_-]?secret|private[_-]?key)\b"?\s*[=:]\s*"?([^\s",}\)]+)"?"#,
+    )
+    .expect("KV_SECRET regex must compile")
+});
+
 /// Strip embedded credentials from a message before we post it to a
-/// shared Slack channel.
-///
-/// Concrete vectors this catches:
-///
-/// * Connection URLs in error display impls:
-///   `redis://memwal:hunter2@host:6379` → `redis://***@host:6379`
-/// * Postgres connection errors:
-///   `postgresql://app:s3cret@db.host:5432/memwal` → `postgresql://***@db.host:5432/memwal`
-///
-/// Best-effort only. We never want to add complex regex / parsing that
-/// could itself fail; if the upstream error format changes and starts
-/// leaking secrets in a different shape, that's a separate ticket.
+/// shared Slack channel. Best-effort — if upstream error format changes
+/// and leaks a secret in a new shape, that's a separate ticket; this
+/// covers the patterns we've actually seen in practice.
 fn sanitize_for_slack(msg: &str) -> String {
-    let mut out = String::with_capacity(msg.len());
-    let mut cursor = 0;
-    let bytes = msg.as_bytes();
-    while cursor < bytes.len() {
-        // Look for a scheme-separator `://` starting at `cursor`.
-        if let Some(scheme_end) = find_subsequence(&bytes[cursor..], b"://") {
-            let absolute_scheme_end = cursor + scheme_end + 3;
-            // Look for `@` between scheme end and the next whitespace/end.
-            let tail = &bytes[absolute_scheme_end..];
-            let scan_limit = tail
-                .iter()
-                .position(|b| matches!(*b, b' ' | b'\t' | b'\n' | b'\r' | b'/' | b'?' | b'#'))
-                .unwrap_or(tail.len());
-            if let Some(at_pos) = tail[..scan_limit].iter().position(|b| *b == b'@') {
-                // Found `scheme://user:pass@`. Append the scheme prefix,
-                // then `***@`, then continue past the `@`.
-                out.push_str(&msg[cursor..absolute_scheme_end]);
-                out.push_str("***@");
-                cursor = absolute_scheme_end + at_pos + 1;
-                continue;
-            }
-        }
-
-        // No more credential patterns; flush the rest.
-        out.push_str(&msg[cursor..]);
-        break;
-    }
-    out
-}
-
-fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || needle.len() > haystack.len() {
-        return None;
-    }
-    haystack.windows(needle.len()).position(|w| w == needle)
+    // Order matters: URL_BASIC_AUTH first so we don't accidentally
+    // re-treat the redacted `***@host` as a KV match. Then Bearer
+    // (more specific than the generic KV regex), then the catch-all KV.
+    let step1 = URL_BASIC_AUTH.replace_all(msg, "${1}***@");
+    let step2 = BEARER.replace_all(&step1, "Bearer ***");
+    let step3 = KV_SECRET.replace_all(&step2, "${1}=***");
+    step3.into_owned()
 }
 
 /// Validate `SLACK_WEBHOOK_URL` looks like a Slack incoming webhook so a
@@ -672,6 +685,73 @@ mod tests {
         assert_eq!(sanitize_for_slack(no_creds), no_creds);
     }
 
+    // Reviewer requirement #5: extend sanitizer to cover common token
+    // patterns beyond URL basic-auth.
+
+    #[test]
+    fn sanitize_strips_bearer_tokens() {
+        let leak = "request failed: Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig";
+        let cleaned = sanitize_for_slack(leak);
+        assert!(!cleaned.contains("eyJhbGciOiJIUzI1NiJ9"));
+        assert!(cleaned.contains("Bearer ***"));
+    }
+
+    #[test]
+    fn sanitize_strips_bearer_case_insensitive() {
+        let leak = "bearer my-token-here failed";
+        let cleaned = sanitize_for_slack(leak);
+        assert!(!cleaned.contains("my-token-here"));
+        assert!(cleaned.to_lowercase().contains("bearer ***"));
+    }
+
+    #[test]
+    fn sanitize_strips_api_key_kv() {
+        let leak = "openai 401: api_key=sk-proj-1234567890abcdef invalid";
+        let cleaned = sanitize_for_slack(leak);
+        assert!(!cleaned.contains("sk-proj-1234567890abcdef"));
+        assert!(cleaned.contains("api_key=***"));
+    }
+
+    #[test]
+    fn sanitize_strips_token_password_secret_kv() {
+        let leak = "config: token=abc123 password=hunter2 secret=mysecret access_token=xyz";
+        let cleaned = sanitize_for_slack(leak);
+        for forbidden in ["abc123", "hunter2", "mysecret", "xyz"] {
+            assert!(!cleaned.contains(forbidden), "{} not stripped: {}", forbidden, cleaned);
+        }
+        assert!(cleaned.contains("token=***"));
+        assert!(cleaned.contains("password=***"));
+        assert!(cleaned.contains("secret=***"));
+        assert!(cleaned.contains("access_token=***"));
+    }
+
+    #[test]
+    fn sanitize_strips_kv_with_colon_separator() {
+        let leak = r#"{"api_key": "sk-1234", "password": "hunter2"}"#;
+        let cleaned = sanitize_for_slack(leak);
+        assert!(!cleaned.contains("sk-1234"));
+        assert!(!cleaned.contains("hunter2"));
+        assert!(cleaned.contains("api_key=***"));
+        assert!(cleaned.contains("password=***"));
+    }
+
+    #[test]
+    fn sanitize_strips_apikey_camel_and_kebab_variants() {
+        let leak = "headers: apiKey=AAA, api-key=BBB, accessToken=CCC, client_secret=DDD";
+        let cleaned = sanitize_for_slack(leak);
+        for forbidden in ["AAA", "BBB", "CCC", "DDD"] {
+            assert!(!cleaned.contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn sanitize_leaves_non_secret_kv_pairs_alone() {
+        // Keywords that should NOT trigger redaction.
+        let safe = "count=42 namespace=default endpoint=https://relayer/api";
+        let cleaned = sanitize_for_slack(safe);
+        assert_eq!(cleaned, safe);
+    }
+
     // ============================================================
     // URL validation
     // ============================================================
@@ -710,23 +790,54 @@ mod tests {
     }
 
     #[test]
-    fn payload_for_wallet_retry_exhaustion_includes_attempt_count() {
+    fn payload_for_terminal_wallet_failure_includes_attempt_count() {
         let client = new_client();
         let a = alert(
-            FailureKind::WalletRetriesExhausted { attempts: 3 },
+            FailureKind::TerminalWalletFailure { attempts: 3 },
             "balance::split MoveAbort",
         );
         let sanitized = sanitize_for_slack(a.error_msg);
         let payload = client.build_payload(&a, &sanitized);
         let json = serde_json::to_string(&payload).unwrap();
 
-        assert!(json.contains("wallet retries exhausted"));
-        assert!(json.contains("3 / 3"));
+        assert!(json.contains("terminal wallet failure"));
+        assert!(json.contains("permanent wallet failure after 3 retry attempts"));
         assert!(json.contains("job-123"));
         assert!(json.contains("0xe5c911"));
         assert!(json.contains("balance::split MoveAbort"));
         assert!(json.contains("env `test`"));
         assert!(json.contains("server commit `abcdef1`"));
+    }
+
+    /// Reviewer requirement #4: the alert text must not claim "all
+    /// wallets exhausted" or similar misleading wording when only the
+    /// retry budget was burned. The wallet pool may contain more
+    /// wallets than `MAX_ATTEMPTS`; we don't try them all.
+    #[test]
+    fn payload_for_terminal_wallet_failure_does_not_claim_all_wallets_exhausted() {
+        let client = new_client();
+        let a = alert(
+            FailureKind::TerminalWalletFailure { attempts: 3 },
+            "any error",
+        );
+        let sanitized = sanitize_for_slack(a.error_msg);
+        let payload = client.build_payload(&a, &sanitized);
+        let json = serde_json::to_string(&payload).unwrap();
+
+        // Forbidden phrases the first cut accidentally used.
+        for forbidden in [
+            "all wallets exhausted",
+            "wallet pool exhausted",
+            "every wallet",
+            "wallet retries exhausted", // the old wording — must be gone
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "alert text must not contain {:?}: {}",
+                forbidden,
+                json
+            );
+        }
     }
 
     #[test]
@@ -739,7 +850,7 @@ mod tests {
 
         // Distinct headline so on-call can tell the two scenarios apart.
         assert!(json.contains("queue handoff"));
-        assert!(!json.contains("wallet retries exhausted"));
+        assert!(!json.contains("terminal wallet failure"));
         assert!(json.contains("post-upload handoff enqueue failed"));
     }
 
@@ -790,5 +901,334 @@ mod tests {
         assert!(!is_retryable(StatusCode::BAD_REQUEST));
         assert!(!is_retryable(StatusCode::FORBIDDEN));
         assert!(!is_retryable(StatusCode::NOT_FOUND));
+    }
+
+    // ============================================================
+    // Reviewer requirement #8 — actual retry loop exercised against
+    // a mock server, not just classification helpers. Covers:
+    //   - 429 then 200 → 1 retry, success, exactly 2 hits
+    //   - 503 then 200 → 1 retry, success, exactly 2 hits
+    //   - 400 → no retry, Err, exactly 1 hit
+    //   - 500 then 500 → 1 retry, give up Err, exactly 2 hits
+    // ============================================================
+
+    /// Spawn an axum mock that pops a status code per request from a
+    /// shared queue. Records every request body for inspection. Returns
+    /// the URL + body recorder + a hit counter.
+    async fn spawn_mock_with_status_sequence(
+        statuses: Vec<u16>,
+    ) -> (
+        String,
+        std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) {
+        use axum::http::StatusCode as AxStatus;
+        let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::<serde_json::Value>::new()));
+        let queue = std::sync::Arc::new(std::sync::Mutex::new(std::collections::VecDeque::from(
+            statuses,
+        )));
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let received_for_handler = received.clone();
+        let queue_for_handler = queue.clone();
+        let hits_for_handler = hits.clone();
+
+        let app = axum::Router::new().route(
+            "/webhook",
+            axum::routing::post(
+                move |axum::Json(body): axum::Json<serde_json::Value>| {
+                    let received = received_for_handler.clone();
+                    let queue = queue_for_handler.clone();
+                    let hits = hits_for_handler.clone();
+                    async move {
+                        hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        received.lock().unwrap().push(body);
+                        let next = queue.lock().unwrap().pop_front().unwrap_or(200);
+                        let status = AxStatus::from_u16(next).unwrap_or(AxStatus::OK);
+                        (status, "mock-response-body")
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        (format!("http://{}/webhook", addr), received, hits)
+    }
+
+    fn client_for_mock(url: String) -> SlackClient {
+        SlackClient::new(url, "test".to_string(), Some("sha".to_string()))
+    }
+
+    #[tokio::test]
+    async fn retry_recovers_when_first_call_is_429() {
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![429, 200]).await;
+        let client = client_for_mock(url);
+        client
+            .send_notification("429-then-200 path")
+            .await
+            .expect("retry should recover from 429");
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_recovers_when_first_call_is_503() {
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![503, 200]).await;
+        let client = client_for_mock(url);
+        client
+            .send_notification("503-then-200 path")
+            .await
+            .expect("retry should recover from 5xx");
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn no_retry_on_400() {
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![400, 200]).await;
+        let client = client_for_mock(url);
+        let err = client
+            .send_notification("400 should fail fast")
+            .await
+            .expect_err("400 must surface as Err without retry");
+        // Single hit means we did NOT retry the 400.
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert!(err.to_string().contains("400"));
+    }
+
+    #[tokio::test]
+    async fn retry_gives_up_after_second_5xx() {
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![500, 500]).await;
+        let client = client_for_mock(url);
+        let err = client
+            .send_notification("500-then-500 path")
+            .await
+            .expect_err("two consecutive 5xx must surface as Err");
+        // Exactly two hits — original + one retry, then we stop.
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert!(err.to_string().contains("twice"));
+    }
+
+    /// Reviewer requirement #4 / #8 combined: a 200 succeeds on first
+    /// try, no retry.
+    #[tokio::test]
+    async fn success_does_not_trigger_retry() {
+        let (url, _body, hits) = spawn_mock_with_status_sequence(vec![200]).await;
+        let client = client_for_mock(url);
+        client
+            .send_notification("clean 200")
+            .await
+            .expect("clean 200 must succeed");
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    // ============================================================
+    // Live demo — pings a real Slack webhook so a human can eyeball
+    // every scenario the alerter has to handle. `#[ignore]` so CI
+    // never runs it. Run on-demand with:
+    //
+    //   SLACK_WEBHOOK_URL=https://hooks.slack.com/... \
+    //     cargo test slack::tests::live_demo_walks_every_alert_scenario \
+    //     --bin memwal-server -- --ignored --nocapture
+    //
+    // The test pauses between scenarios so the channel reads in order
+    // and a reviewer can match each Slack message to the scenario name
+    // logged in the run output.
+    // ============================================================
+
+    fn make_live_client(env_label: &str) -> Option<SlackClient> {
+        let url = std::env::var("SLACK_WEBHOOK_URL").ok()?;
+        let trimmed = url.trim().to_string();
+        if !looks_like_slack_webhook(&trimmed) {
+            return None;
+        }
+        Some(SlackClient::new(
+            trimmed,
+            format!("live-test-{}", env_label),
+            Some("eng1784".to_string()),
+        ))
+    }
+
+    async fn pause(label: &str, secs: u64) {
+        println!("  ⏳ pausing {}s before next scenario ({})", secs, label);
+        tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[ignore = "live test — hits real Slack; run with --ignored"]
+    async fn live_demo_walks_every_alert_scenario() {
+        let _ = tracing_subscriber::fmt::try_init();
+        println!("\n🚀 ENG-1784 Slack alerter live demo");
+
+        // ── Scenario 1: TerminalWalletFailure with realistic Enoki error ──
+        println!("\n[1/6] TerminalWalletFailure — Enoki balance::split MoveAbort");
+        let client = make_live_client("scenario-1-walret").expect(
+            "SLACK_WEBHOOK_URL must be set + valid for this test (see test docstring)",
+        );
+        client
+            .notify_remember_job_failed(RememberJobFailedAlert {
+                job_id: Some("live-demo-job-001"),
+                owner: Some("0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994"),
+                namespace: Some("live-test"),
+                error_msg: "walrus upload failed: Internal Error: walrus upload failed: \
+                    Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\",\
+                    \"message\":\"Dry run failed, could not automatically determine a \
+                    budget: MoveAbort(MoveLocation { module: 0x2::balance, function: 7, \
+                    instruction: 10, function_name: split }, 2) in command 4\"}]}",
+                kind: FailureKind::TerminalWalletFailure { attempts: 3 },
+            })
+            .await
+            .expect("scenario 1 should deliver");
+        pause("scenario 2", 3).await;
+
+        // ── Scenario 2: HandoffEnqueueFailure (distinct headline) ──
+        println!("\n[2/6] HandoffEnqueueFailure — queue layer down after upload succeeded");
+        let client = make_live_client("scenario-2-handoff").unwrap();
+        client
+            .notify_remember_job_failed(RememberJobFailedAlert {
+                job_id: Some("live-demo-job-002"),
+                owner: Some("0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994"),
+                namespace: Some("live-test"),
+                error_msg: "failed to enqueue metadata/transfer recovery job: \
+                    apalis-postgres push failed: db connection terminated",
+                kind: FailureKind::HandoffEnqueueFailure,
+            })
+            .await
+            .expect("scenario 2 should deliver");
+        pause("scenario 3", 3).await;
+
+        // ── Scenario 3: dedup ──
+        // Same SlackClient, same error twice. Second call should be
+        // suppressed (returns Ok with no Slack POST). Channel should
+        // see exactly ONE message.
+        println!("\n[3/6] Dedup — send same error twice on same client; channel should see ONE");
+        let client = make_live_client("scenario-3-dedup").unwrap();
+        let dup_alert = || RememberJobFailedAlert {
+            job_id: Some("live-demo-job-003"),
+            owner: Some("0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994"),
+            namespace: Some("live-test"),
+            error_msg: "DEDUP TEST: identical error message repeated within 5min window",
+            kind: FailureKind::TerminalWalletFailure { attempts: 3 },
+        };
+        client.notify_remember_job_failed(dup_alert()).await.unwrap();
+        println!("    → first send (should appear in Slack)");
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        client.notify_remember_job_failed(dup_alert()).await.unwrap();
+        println!("    → second send (should be suppressed by dedup, NO Slack message)");
+        pause("scenario 4", 3).await;
+
+        // ── Scenario 4: credential sanitization ──
+        // Slack message must show `redis://***@host` not the plaintext
+        // username/password.
+        println!("\n[4/6] Sanitization — error string contains redis://user:pass@host");
+        let client = make_live_client("scenario-4-sanitize").unwrap();
+        client
+            .notify_remember_job_failed(RememberJobFailedAlert {
+                job_id: Some("live-demo-job-004"),
+                owner: Some("0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994"),
+                namespace: Some("live-test"),
+                error_msg: "SANITIZE TEST: failed to enqueue: cannot connect to \
+                    redis://memwal:hunter2@127.0.0.1:6379 — io error \
+                    (secondary postgresql://app:s3cret@db.host:5432/memwal also down)",
+                kind: FailureKind::HandoffEnqueueFailure,
+            })
+            .await
+            .expect("scenario 4 should deliver");
+        println!("    → Slack should show `redis://***@127.0.0.1:6379` and `postgresql://***@db.host...`");
+        pause("scenario 5", 3).await;
+
+        // ── Scenario 5: multi-byte UTF-8 in owner + error ──
+        // Defense-in-depth: shorten_owner + truncate use char-based
+        // slicing, so non-ASCII can't panic the spawn future.
+        println!("\n[5/6] Multi-byte UTF-8 — Japanese chars in owner & error message");
+        let client = make_live_client("scenario-5-utf8").unwrap();
+        client
+            .notify_remember_job_failed(RememberJobFailedAlert {
+                job_id: Some("live-demo-job-005-メメメメ"),
+                // Synthetic owner with 16 multi-byte chars (would panic
+                // with byte-slice shortener).
+                owner: Some("メメメメメメメメメメメメメメメメ"),
+                namespace: Some("研究"),
+                error_msg: "UTF-8 TEST: Walrus アップロード failed — endpoint \
+                    返ってきたエラー: タイムアウト 🦀🦀🦀",
+                kind: FailureKind::TerminalWalletFailure { attempts: 3 },
+            })
+            .await
+            .expect("scenario 5 should deliver");
+        println!("    → Slack should render JP chars + 🦀 emoji, no panic");
+        pause("scenario 6", 3).await;
+
+        // ── Scenario 6: global rate cap (30/min) ──
+        // Fire 35 DISTINCT errors back-to-back on a fresh client. First
+        // 30 should reach Slack, last 5 should be dropped by the global
+        // cap (per-error dedup wouldn't help — every error has a unique
+        // ID embedded). To avoid actually flooding the channel during
+        // demo we send only ONE header "rate cap demo starting" message
+        // here and tag each as part of the demo.
+        println!("\n[6/6] Global rate cap — 35 distinct errors, expect 30 Slack + 5 dropped");
+        let client = make_live_client("scenario-6-ratecap").unwrap();
+        // Send a heads-up first so reviewers know what they're about to see.
+        client
+            .send_notification(
+                "🧪 RATE-CAP DEMO INCOMING: about to fire 35 distinct error alerts. \
+                 Expect 30 in this channel + 5 dropped by global cap. Footer says \
+                 `live-test-scenario-6-ratecap`.",
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        let mut delivered_count = 0;
+        let mut suppressed_count = 0;
+        for i in 0..35 {
+            // Each message has a unique number so per-error dedup can't
+            // collapse them — only the global cap should stop them.
+            let res = client
+                .notify_remember_job_failed(RememberJobFailedAlert {
+                    job_id: Some("live-demo-job-006"),
+                    owner: Some(
+                        "0xe5c91145cb92ac82df7285022ee4f73c40be5c995d632c74700b1fc04e5f4994",
+                    ),
+                    namespace: Some("live-test"),
+                    error_msg: &format!(
+                        "RATE-CAP TEST #{:02}/35 — unique storm entry (different msg \
+                         per iteration so per-error dedup does NOT apply)",
+                        i + 1
+                    ),
+                    kind: FailureKind::TerminalWalletFailure { attempts: 3 },
+                })
+                .await;
+            match res {
+                Ok(()) => {
+                    // notify_remember_job_failed returns Ok in both
+                    // "delivered" and "suppressed" cases. We can't tell
+                    // from the return value alone; should_suppress
+                    // logging at info level discloses it. Count both
+                    // outcomes here just to confirm none errored.
+                    delivered_count += 1;
+                }
+                Err(e) => {
+                    suppressed_count += 1;
+                    println!("    → entry {} returned Err: {}", i + 1, e);
+                }
+            }
+            // Tight loop — we want all 35 inside the global window.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        println!(
+            "    → loop done: {} Ok, {} Err (expect ~30 actual Slack messages — \
+             check channel; suppressions are logged at INFO via tracing)",
+            delivered_count, suppressed_count
+        );
+
+        println!("\n✅ Live demo complete. Verify in #target-channel that you see:");
+        println!("   1× scenario 1 (wallet retries exhausted, Enoki)");
+        println!("   1× scenario 2 (handoff enqueue failed)");
+        println!("   1× scenario 3 (dedup — only one despite 2 sends)");
+        println!("   1× scenario 4 (sanitized credentials — no passwords)");
+        println!("   1× scenario 5 (UTF-8 — Japanese + emoji)");
+        println!("   1× scenario 6 header + ~30× rate-cap entries (35 sent, 5 dropped)");
     }
 }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1387,6 +1387,78 @@ mod tests {
         assert_eq!(pool.current_transient_streak(), 0);
     }
 
+    // The drain counter sits on the hot path of every wallet job (Apalis
+    // dispatches concurrently, up to WALLET_JOB_CONCURRENCY default=8).
+    // Verify the AtomicU64 increment is contention-correct: N concurrent
+    // record_transient_failure() calls must produce a final count of
+    // exactly N, with no lost or duplicated increments.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn key_pool_transient_streak_atomic_under_contention() {
+        use std::sync::Arc;
+        let pool = Arc::new(KeyPool::new(vec!["a".into()]));
+        const TASKS: usize = 200;
+        const INCREMENTS_PER_TASK: usize = 50;
+
+        let mut handles = Vec::with_capacity(TASKS);
+        for _ in 0..TASKS {
+            let pool = Arc::clone(&pool);
+            handles.push(tokio::spawn(async move {
+                for _ in 0..INCREMENTS_PER_TASK {
+                    pool.record_transient_failure();
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(
+            pool.current_transient_streak(),
+            (TASKS * INCREMENTS_PER_TASK) as u64,
+            "concurrent increments must add up exactly — no lost updates"
+        );
+    }
+
+    // Concurrent record + reset race: workers incrementing while another
+    // task resets must end in a defined state (either 0 or N — never
+    // garbage). Documents the semantic that reset wins last-writer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn key_pool_reset_during_concurrent_increments_is_safe() {
+        use std::sync::Arc;
+        let pool = Arc::new(KeyPool::new(vec!["a".into()]));
+
+        let incrementer = {
+            let pool = Arc::clone(&pool);
+            tokio::spawn(async move {
+                for _ in 0..1_000 {
+                    pool.record_transient_failure();
+                }
+            })
+        };
+        let resetter = {
+            let pool = Arc::clone(&pool);
+            tokio::spawn(async move {
+                for _ in 0..100 {
+                    pool.reset_transient_streak();
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        incrementer.await.unwrap();
+        resetter.await.unwrap();
+
+        // Final value is unpredictable (race) but must be in [0, 1000].
+        // The test asserts the operation didn't poison the atomic or
+        // overflow — both would be observable as a huge / negative-shaped
+        // value.
+        let final_streak = pool.current_transient_streak();
+        assert!(
+            final_streak <= 1_000,
+            "race produced impossible streak: {}",
+            final_streak
+        );
+    }
+
     // ── SponsorRateLimitConfig defaults ─────────────────────────────────
 
     #[test]

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -6,7 +6,7 @@ use crate::jobs::{BulkRememberJobStorage, RememberJobStorage, WalletJobStorage};
 use crate::rate_limit::RateLimitConfig;
 use crate::services::{Embedder, Extractor, Ranker};
 use crate::storage::db::VectorDb;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 /// ENG-1408: Max items in a single POST /api/remember/bulk request.
 pub const MAX_BULK_ITEMS: usize = 20;
@@ -124,9 +124,20 @@ pub struct AppState {
 /// Wallet key holder for distributing Walrus uploads across configured server
 /// keys. Apalis retries call `next_index()` again at execution time, so a
 /// transient sponsor/RPC failure can move to the next wallet in the pool.
+///
+/// ENG-1784: also tracks consecutive transient failures across the whole pool
+/// so the relayer can detect "every wallet drained" and alert on it. Each
+/// `Transient` wallet error increments `consecutive_transient_failures`; any
+/// `Permanent` result OR a successful wallet job resets it to 0. When the
+/// counter exceeds the configured `wallet_pool_drain_window`, the system
+/// fires a one-shot infra alert — the same value would otherwise loop
+/// silently because the per-job classifier only alerts on `Permanent`.
 pub struct KeyPool {
     keys: Vec<String>,
     cursor: AtomicUsize,
+    /// Count of consecutive `Transient` wallet errors across the pool.
+    /// Reset on any successful wallet job or any `Permanent` outcome.
+    consecutive_transient_failures: AtomicU64,
 }
 
 impl KeyPool {
@@ -134,6 +145,7 @@ impl KeyPool {
         Self {
             keys,
             cursor: AtomicUsize::new(0),
+            consecutive_transient_failures: AtomicU64::new(0),
         }
     }
 
@@ -160,9 +172,30 @@ impl KeyPool {
         self.keys.is_empty()
     }
 
-    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.keys.len()
+    }
+
+    /// Record one `Transient` wallet error and return the new running count.
+    /// Caller compares against the configured drain window to decide whether
+    /// to fire the `WalletPoolDrained` alert.
+    pub fn record_transient_failure(&self) -> u64 {
+        self.consecutive_transient_failures
+            .fetch_add(1, Ordering::Relaxed)
+            + 1
+    }
+
+    /// Reset the consecutive-transient counter. Called after any successful
+    /// wallet job or any `Permanent` outcome — both indicate the pool is
+    /// not silently spinning in a refillable state.
+    pub fn reset_transient_streak(&self) {
+        self.consecutive_transient_failures
+            .store(0, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub fn current_transient_streak(&self) -> u64 {
+        self.consecutive_transient_failures.load(Ordering::Relaxed)
     }
 }
 
@@ -226,6 +259,21 @@ pub struct Config {
     /// Environment label included in the Slack alert footer
     /// (e.g. `prod` / `staging` / `dev`). Falls back to `unknown`.
     pub env_label: String,
+    /// ENG-1784: interval between infra-health probes (sidecar, Postgres,
+    /// Redis, Sui RPC). The first failure does NOT alert — the alert fires
+    /// only after `health_check_fail_threshold` consecutive failures so a
+    /// single flapping probe doesn't page on-call.
+    pub health_check_interval_secs: u64,
+    /// ENG-1784: consecutive health-probe failures before firing the
+    /// matching `InfraFailureKind` alert. Counts reset on the first
+    /// successful probe.
+    pub health_check_fail_threshold: u32,
+    /// ENG-1784: consecutive `Transient` wallet errors across the whole
+    /// pool before firing `WalletPoolDrained`. When unset, defaults to
+    /// `apalis MAX_ATTEMPTS × pool_size` (every wallet has been tried
+    /// `MAX_ATTEMPTS` times in a row). Set explicitly to tune sensitivity
+    /// without changing pool size.
+    pub wallet_pool_drain_window: Option<u64>,
 }
 
 impl Config {
@@ -320,6 +368,28 @@ impl Config {
                 .map(|v| v.trim().to_string())
                 .filter(|v| !v.is_empty())
                 .unwrap_or_else(|| "unknown".to_string()),
+            // ENG-1784: 30s default = 2 probes per minute per dependency, well
+            // under any rate limit and gives ops a sub-minute alert latency.
+            health_check_interval_secs: std::env::var("MEMWAL_HEALTH_CHECK_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|v| *v > 0)
+                .unwrap_or(30),
+            // ENG-1784: 3 consecutive failures ≈ 90s of sustained downtime at
+            // the default 30s interval — enough to dodge a single network blip
+            // but fast enough that real outages page within ~1.5 min.
+            health_check_fail_threshold: std::env::var("MEMWAL_HEALTH_CHECK_FAIL_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .filter(|v| *v > 0)
+                .unwrap_or(3),
+            // ENG-1784: when None, the worker computes the default at runtime
+            // from MAX_ATTEMPTS × pool_size. Setting it explicitly forces a
+            // fixed window regardless of pool size.
+            wallet_pool_drain_window: std::env::var("MEMWAL_WALLET_POOL_DRAIN_WINDOW")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|v| *v > 0),
         }
     }
 }
@@ -1286,6 +1356,35 @@ mod tests {
         assert_eq!(pool.next_index(), Some(0));
         assert_eq!(pool.next_index(), Some(1));
         assert_eq!(pool.next_index(), Some(0));
+    }
+
+    // ENG-1784: drain counter starts at 0, increments on each transient
+    // failure, returns the new running count, and resets via either
+    // `reset_transient_streak()` or a `current_transient_streak()` read
+    // showing the rollback.
+    #[test]
+    fn key_pool_transient_streak_counts_and_resets() {
+        let pool = KeyPool::new(vec!["a".into(), "b".into(), "c".into()]);
+        assert_eq!(pool.current_transient_streak(), 0);
+        assert_eq!(pool.record_transient_failure(), 1);
+        assert_eq!(pool.record_transient_failure(), 2);
+        assert_eq!(pool.record_transient_failure(), 3);
+        assert_eq!(pool.current_transient_streak(), 3);
+        pool.reset_transient_streak();
+        assert_eq!(pool.current_transient_streak(), 0);
+        // Counter keeps working after a reset (not stuck at 0).
+        assert_eq!(pool.record_transient_failure(), 1);
+    }
+
+    #[test]
+    fn key_pool_transient_streak_independent_of_round_robin_cursor() {
+        // The drain counter must NOT be the same atomic as the round-robin
+        // cursor — otherwise next_index() would also affect the streak.
+        let pool = KeyPool::new(vec!["a".into(), "b".into()]);
+        pool.next_index();
+        pool.next_index();
+        pool.next_index();
+        assert_eq!(pool.current_transient_streak(), 0);
     }
 
     // ── SponsorRateLimitConfig defaults ─────────────────────────────────

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -299,7 +299,22 @@ impl Config {
             slack_webhook_url: std::env::var("SLACK_WEBHOOK_URL")
                 .ok()
                 .map(|v| v.trim().to_string())
-                .filter(|v| !v.is_empty()),
+                .filter(|v| !v.is_empty())
+                .map(|v| {
+                    // Fail fast on obviously-wrong configs so a deploy-time
+                    // typo surfaces in startup logs instead of staying silent
+                    // until the first real failure event.
+                    if !crate::slack::looks_like_slack_webhook(&v) {
+                        panic!(
+                            "SLACK_WEBHOOK_URL does not look like a Slack incoming \
+                             webhook (expected https://hooks.slack.com/services/...): {}",
+                            // Don't echo the full URL into the panic — it
+                            // would land in process-restart logs.
+                            v.chars().take(40).collect::<String>()
+                        );
+                    }
+                    v
+                }),
             env_label: std::env::var("MEMWAL_ENV")
                 .ok()
                 .map(|v| v.trim().to_string())

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -110,6 +110,11 @@ pub struct AppState {
     pub blob_cache_max_bytes: usize,
     /// ENG-1405: Redis TTL for recall query embedding cache entries.
     pub embedding_cache_ttl: std::time::Duration,
+    /// ENG-1784: optional Slack alerter. Populated only when
+    /// `SLACK_WEBHOOK_URL` is set; `None` disables all Slack notifications
+    /// without affecting any other code path. Wrapped in `Arc` so workers
+    /// can clone the handle into a spawned fire-and-forget task.
+    pub slack: Option<Arc<crate::slack::SlackClient>>,
 }
 
 // ============================================================
@@ -213,6 +218,14 @@ pub struct Config {
     /// bypassing SEAL + Walrus. **Not for production.** Off by default;
     /// set `BENCHMARK_MODE=true` to enable. Surfaced via `GET /health`.
     pub benchmark_mode: bool,
+    /// ENG-1784: optional Slack Incoming Webhook URL for failed-job alerts.
+    /// When set, terminal remember-job failures (after wallet pool exhausts
+    /// retries on every key in the pool) are pushed to Slack. When unset,
+    /// the alerter is `None` and the rest of the server is unaware.
+    pub slack_webhook_url: Option<String>,
+    /// Environment label included in the Slack alert footer
+    /// (e.g. `prod` / `staging` / `dev`). Falls back to `unknown`.
+    pub env_label: String,
 }
 
 impl Config {
@@ -283,6 +296,15 @@ impl Config {
             benchmark_mode: std::env::var("BENCHMARK_MODE")
                 .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
                 .unwrap_or(false),
+            slack_webhook_url: std::env::var("SLACK_WEBHOOK_URL")
+                .ok()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty()),
+            env_label: std::env::var("MEMWAL_ENV")
+                .ok()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| "unknown".to_string()),
         }
     }
 }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -274,6 +274,17 @@ pub struct Config {
     /// `MAX_ATTEMPTS` times in a row). Set explicitly to tune sensitivity
     /// without changing pool size.
     pub wallet_pool_drain_window: Option<u64>,
+    /// ENG-1784: minimum number of `Pending` Apalis jobs (ready to run
+    /// for >= `apalis_backlog_stuck_secs`) that triggers the
+    /// `ApalisQueueStuck` candidate condition. Default 100 — enough
+    /// headroom for healthy bursts; low enough that a wedged queue
+    /// pages within minutes.
+    pub apalis_backlog_threshold: i64,
+    /// ENG-1784: a Pending job is only counted toward the backlog if
+    /// its `run_at` is at least this many seconds in the past. Default
+    /// 300 (5 min) — a job that's been ready but unclaimed for 5 min is
+    /// clearly not just "in flight"; the queue is wedged.
+    pub apalis_backlog_stuck_secs: u64,
 }
 
 impl Config {
@@ -390,6 +401,16 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
                 .filter(|v| *v > 0),
+            apalis_backlog_threshold: std::env::var("MEMWAL_APALIS_BACKLOG_ALERT_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse::<i64>().ok())
+                .filter(|v| *v > 0)
+                .unwrap_or(100),
+            apalis_backlog_stuck_secs: std::env::var("MEMWAL_APALIS_BACKLOG_STUCK_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|v| *v > 0)
+                .unwrap_or(300),
         }
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing Slack alerter on the Relayer (`services/server`) with **system-blocking** infra alerts and closes the silent **wallet-pool-drained** blind spot. Per-job errors land in Prometheus only — per lead guidance, only system-wide failures page on-call.

**Scope cut applied**: client-side sub-tasks (TS SDK / Python SDK / OpenClaw / MCP / 4 UI apps) were cancelled — they run per-user and per-user errors are not system-blocking. See cancel comments on ENG-1851..1858.

## What's new

### 7 new infra alerts (all system-blocking)
- `SidecarDown` — sidecar `/health` fails ≥ threshold consecutive checks → SEAL encrypt + Walrus upload broken
- `PostgresDown` — `SELECT 1` probe fails → all DB-backed routes broken
- `RedisDown` — `PING` fails → rate limiter degrades + dedup weakens
- `SuiRpcDown` — `sui_getLatestCheckpointSequenceNumber` fails → auth verification broken
- **`WalletPoolDrained`** — every wallet in pool returns Transient for `MAX_ATTEMPTS × pool_size` consecutive attempts. **Previously silent** (Apalis retry budget burned without alerting); fixed in this PR.
- `ApalisQueueStuck` — Pending jobs stuck > 300s, backlog > 100, sustained across N samples → workers wedged
- `NoSuiKeysConfigured` — boot-time misconfig (one-shot)

### Existing 2 alerts preserved
- `TerminalWalletFailure`, `HandoffEnqueueFailure` — per-signature dedup (5 min) + global rate cap (30/60s) already collapse noise during incidents

### Per-job failures → metric only (not Slack)
- Legacy `execute_remember` 4 silent paths (`base64_decode`, `no_keys`, `walrus_upload`, `insert_vector`) → `memwal_remember_per_job_failed_total{path="legacy",kind=...}`
- `execute_bulk_remember` fan-out push fail → `memwal_remember_per_job_failed_total{path="bulk_fanout",kind="queue_push"}`

### Infrastructure
- 4 background probe tasks in `main.rs` (Postgres / Redis / Sui RPC / Apalis backlog)
- `KeyPool` extended with atomic drain counter (record/reset/get)
- `decide_wallet_pool_health_action` — pure decision function for unit testability
- 5 new env vars (defaults sane, opt-in tuning): `MEMWAL_HEALTH_CHECK_INTERVAL_SECS`, `MEMWAL_HEALTH_CHECK_FAIL_THRESHOLD`, `MEMWAL_WALLET_POOL_DRAIN_WINDOW`, `MEMWAL_APALIS_BACKLOG_ALERT_THRESHOLD`, `MEMWAL_APALIS_BACKLOG_STUCK_SECS`

## Test plan

- [x] **301 unit tests pass / 0 fail / 1 ignored** (live demo) — verified locally with Postgres role `memwal` configured
- [x] cargo check clean (no warnings on new code)
- [x] 27 new tests across 3 clusters:
  - 6 InfraFailureKind unit tests (dedup signatures stable + distinct per variant, headline / detail / payload shape)
  - 7 `notify_infra_failure` end-to-end mock-webhook tests (body shape, dedup with changing detail, distinct-variant fan-out, retry on 5xx, unreachable webhook returns Err not panic, global rate cap)
  - 2 ApalisQueueStuck-specific tests (detail field surfaces all 3 signal fields, distinct headline from HandoffEnqueueFailure)
  - 8 `decide_wallet_pool_health_action` decision matrix tests (empty pool, success reset, transient below/at/above threshold, permanent resets, env override, streak resumes, single-wallet edge case)
  - 4 KeyPool atomic correctness tests (counts + resets, independent from cursor, 200×50 concurrent stress, reset-during-increment race)
- [x] Live demo test (`#[ignore]`) extended with 7 new infra scenarios — staging-smoke runbook updated to cover all 13 scenarios
- [ ] Reviewer: verify on staging with `SLACK_WEBHOOK_URL=$STAGING_WEBHOOK cargo test slack::tests::live_demo_walks_every_alert_scenario --bin memwal-server -- --ignored --nocapture`
- [ ] Reviewer: deploy to staging + manually trigger wallet-pool-drained scenario (per `services/server/docs/eng-1784-staging-smoke.md`)

## Linear

- Parent: ENG-1784
- This PR: ENG-1850 (Relayer)
- Cancelled (per scope cut, per-user not system-blocking): ENG-1851..ENG-1858
- Deferred (needs approach decision): ENG-1859 Indexer

## Out of scope

- Client-side telemetry (cancelled — recommend Sentry as separate initiative)
- Indexer monitoring (ENG-1859 — needs lead input on shared-crate vs duplicate approach)
- Performance p99 alerts (Grafana, not Slack)
- Per-handler 5xx alerts (per-request not system-blocking)

## Effort

Estimated: 1 pt · Actual: ~1.5 pt (~6h focused work). Breakdown in ENG-1850 comment.

## Commits in this PR

- `f7fd9b0` feat(server): add system-blocking infra alerts + wallet pool drain detection
- `47b6d09` test(server): exhaustive tests for infra alerter + pool drain
- `552ff17` feat(server): Apalis queue-stuck backlog monitor
- `b5ffd7c` test(server): extend live demo with 7 new infra-alert scenarios

(Plus 3 earlier ENG-1784 commits from prior review iterations: `991dcee`, `a6eb4d2`, `4a21d85`.)