### PR TITLE
Feat: WALM-55 — extract.v6 timestamp injection for temporal recall

### DIFF
--- a/.changeset/walm-55-occurred-at-openclaw.md
+++ b/.changeset/walm-55-occurred-at-openclaw.md
@@ -1,0 +1,14 @@
+---
+"@mysten-incubation/oc-memwal": patch
+---
+
+Wire temporal anchoring through the agent-side memory tools.
+
+### Added
+
+- `memory_store` tool now accepts an optional `occurredAt` argument (RFC-3339 / ISO-8601 string) so agents can anchor recounted past events to the date they actually occurred. Description tells the LLM to omit it when unknown rather than guess.
+
+### Changed
+
+- Auto-capture hook (`agent_end`) now passes `new Date()` as `occurredAt` to `analyze()`. Every captured conversation now gets temporal anchoring automatically — the server extractor resolves in-turn relative references ("yesterday", "last Friday") into absolute dates inside the stored fact text. Facts captured by this version now carry resolved dates.
+- SDK dependency bumped from published `^0.0.2` to `workspace:*` to consume the new `AnalyzeOptions` signature.

--- a/.changeset/walm-55-occurred-at-sdk.md
+++ b/.changeset/walm-55-occurred-at-sdk.md
@@ -1,0 +1,11 @@
+---
+"@mysten-incubation/memwal": patch
+---
+
+Add optional `occurredAt` to `analyze()` and `analyzeAndWait()` for temporal anchoring of extracted facts.
+
+- New `AnalyzeOptions` overload: `analyze(text, { namespace, occurredAt })` accepts `Date` or RFC-3339 string. The legacy `analyze(text, namespace?)` signature still works unchanged.
+- When `occurredAt` is supplied, the server resolves in-turn relative references ("last Friday", "yesterday") into absolute dates inside the extracted fact text before embedding and encryption.
+- Wire format is RFC-3339 UTC with millisecond precision (e.g. `"2023-05-25T17:50:00.000Z"`).
+- Invalid `Date` instances (constructed from malformed input) now throw a diagnostic `TypeError` from the SDK rather than an opaque `RangeError` from `toISOString()`.
+- Field is omitted from the request body when not supplied — existing callers see byte-identical wire payloads.

--- a/packages/openclaw-memory-memwal/package.json
+++ b/packages/openclaw-memory-memwal/package.json
@@ -40,7 +40,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@mysten-incubation/memwal": "^0.0.2",
+    "@mysten-incubation/memwal": "workspace:*",
     "@sinclair/typebox": "0.34.48",
     "zod": "^3.23.0"
   },

--- a/packages/openclaw-memory-memwal/src/hooks/capture.ts
+++ b/packages/openclaw-memory-memwal/src/hooks/capture.ts
@@ -47,8 +47,28 @@ export function registerCaptureHook(api: any, client: MemWal, config: PluginConf
         .join("\n\n");
 
       // analyze() calls the server LLM for fact extraction — retry once
-      // since transient failures are common with remote LLM calls
-      const result = await withRetry(() => client.analyze(conversation, namespace));
+      // since transient failures are common with remote LLM calls.
+      //
+      // Pass `occurredAt: new Date()` so the server extractor can
+      // resolve in-turn relative references ("yesterday", "last
+      // Friday") into absolute dates inside the fact text before
+      // encryption.
+      //
+      // Caveat: this is hook-fire time, not strictly per-message
+      // time. The hook fires on agent_end — *after* the LLM finishes
+      // responding — and `event.messages` may carry the last N turns
+      // (captureMaxMessages) spanning a longer window. All extracted
+      // facts share this one anchor. For coarse relative references
+      // ("yesterday", "last Friday") this is accurate enough; for
+      // fine-grained ones ("an hour ago", "this morning") the anchor
+      // can be off by minutes-to-hours. Acceptable for an opt-in
+      // auto-capture path where the alternative is no anchor at all.
+      // (The "no silent now() fallback" rule is about the server
+      // defaulting for callers that passed nothing; here the caller
+      // IS passing, with real-ish knowledge of when the event happened.)
+      const result = await withRetry(() =>
+        client.analyze(conversation, { namespace, occurredAt: new Date() }),
+      );
 
       if (result.facts?.length) {
         api.logger.info(

--- a/packages/openclaw-memory-memwal/src/tools/store.ts
+++ b/packages/openclaw-memory-memwal/src/tools/store.ts
@@ -3,7 +3,7 @@
  *
  * Uses analyze() instead of remember() so the server LLM extracts
  * individual facts from the text, producing cleaner, more searchable
- * memories (same approach as Mem0's memory_store).
+ * memories than storing the raw input verbatim.
  */
 
 import type { MemWal } from "@mysten-incubation/memwal";
@@ -36,13 +36,17 @@ export function registerStoreTool(api: any, client: MemWal, config: PluginConfig
         occurredAt: Type.Optional(
           Type.String({
             description:
-              "Optional RFC-3339 / ISO-8601 timestamp of when the event " +
-              "actually happened (e.g. '2024-03-15T14:30:00Z'). When the " +
-              "user is storing a recounted past event, pass the date the " +
-              "event occurred, not the date the user is telling you about " +
-              "it — the server resolves relative references ('last Friday') " +
-              "to absolute dates inside the stored fact text. Omit when " +
-              "unknown; do not guess.",
+              "Optional RFC-3339 / ISO-8601 timestamp of when the source " +
+              "text or conversation actually occurred (e.g. " +
+              "'2024-03-15T14:30:00Z'). The server uses this as the " +
+              "temporal anchor for resolving in-turn relative references " +
+              "like 'last Friday' or 'yesterday' against. For real-time " +
+              "stores, pass the current time. For recounted past events " +
+              "where the user is talking about something that happened " +
+              "earlier (e.g. 'remember I called Alex last Friday'), OMIT " +
+              "this field — do NOT pass the recounted event date while " +
+              "leaving relative wording in the text; that produces wrong " +
+              "anchors. When unknown, omit; do not guess.",
           }),
         ),
       }),

--- a/packages/openclaw-memory-memwal/src/tools/store.ts
+++ b/packages/openclaw-memory-memwal/src/tools/store.ts
@@ -33,9 +33,21 @@ export function registerStoreTool(api: any, client: MemWal, config: PluginConfig
             description: "Memory namespace to store in (use the namespace from system context)",
           }),
         ),
+        occurredAt: Type.Optional(
+          Type.String({
+            description:
+              "Optional RFC-3339 / ISO-8601 timestamp of when the event " +
+              "actually happened (e.g. '2024-03-15T14:30:00Z'). When the " +
+              "user is storing a recounted past event, pass the date the " +
+              "event occurred, not the date the user is telling you about " +
+              "it — the server resolves relative references ('last Friday') " +
+              "to absolute dates inside the stored fact text. Omit when " +
+              "unknown; do not guess.",
+          }),
+        ),
       }),
       async execute(_id: string, params: any) {
-        const { text, namespace } = params;
+        const { text, namespace, occurredAt } = params;
         const ns = namespace || config.defaultNamespace;
 
         // Defence in depth: reject injection on write, not just on read.
@@ -66,7 +78,10 @@ export function registerStoreTool(api: any, client: MemWal, config: PluginConfig
         }
 
         try {
-          const result = await client.analyze(text.trim(), ns);
+          const result = await client.analyze(text.trim(), {
+            namespace: ns,
+            occurredAt,
+          });
 
           const factCount = result.facts?.length ?? 0;
           // Show first 3 extracted facts as confirmation, or raw text truncation as fallback

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,5 +1,17 @@
 # memwal
 
+## 0.1.4
+
+### Added
+
+- Added optional `occurred_at` to `analyze()` and `analyze_and_wait()` (both async and sync) for temporal anchoring of extracted facts. When supplied, the server resolves in-turn relative references ("last Friday", "yesterday") into absolute dates inside the extracted fact text before embedding and encryption.
+- Accepts `datetime` or RFC-3339 string. Wire format is RFC-3339 UTC with millisecond precision (e.g. `"2023-05-25T17:50:00.000Z"`) — byte-identical to the TypeScript SDK.
+- Field is omitted from the request body when not supplied.
+
+### Changed
+
+- `occurred_at` validates input at the SDK boundary rather than forwarding malformed values to the server: naïve `datetime` instances raise `ValueError` (silently assuming UTC would mis-anchor by N hours for callers outside UTC), and malformed RFC-3339 strings raise `ValueError` with a diagnostic message instead of surfacing as opaque 400s.
+
 ## 0.1.3
 
 ### Added

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -116,4 +116,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -30,7 +30,8 @@ import base64
 import json
 import random
 import time
-from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
 
 import httpx
 import nacl.signing
@@ -121,6 +122,81 @@ def _is_transient_polling_status(status: int) -> bool:
     """
 
     return status == 0 or status == 429 or status >= 500
+
+
+def _occurred_at_to_wire(
+    occurred_at: Optional[Union[str, datetime]],
+) -> Optional[str]:
+    """Render an ``occurred_at`` argument to the wire format.
+
+    The server's ``AnalyzeRequest.occurred_at`` field expects RFC-3339
+    UTC with a trailing ``Z``. Output precision matches the TS SDK's
+    ``Date.toISOString()`` (milliseconds), e.g.
+    ``"2023-05-25T17:50:00.000Z"`` — so the two SDKs produce
+    byte-identical wire payloads for the same instant.
+
+    Aware ``datetime`` objects are converted to UTC. **Naïve datetimes
+    are rejected** with ``ValueError``: silently assuming UTC would
+    produce timezone-off-by-N anchors for callers outside UTC and
+    undermine WALM-55's "honest temporal anchoring" guarantee. Callers
+    should pass ``datetime.now(timezone.utc)`` or attach a ``tzinfo``
+    explicitly.
+
+    String inputs are validated as RFC-3339 / ISO-8601 (accepting
+    trailing ``Z`` as a UTC shorthand, per RFC-3339 §4.2) and
+    re-formatted to canonical form. Invalid strings raise
+    ``ValueError`` at the SDK boundary rather than being forwarded as
+    a 400 from the server.
+
+    Returns ``None`` when no anchor is supplied so the field is
+    omitted from the request body.
+    """
+
+    if occurred_at is None:
+        return None
+    if isinstance(occurred_at, datetime):
+        if occurred_at.tzinfo is None:
+            raise ValueError(
+                "occurred_at datetime must be timezone-aware. Pass "
+                "datetime.now(timezone.utc), datetime(..., tzinfo=...), "
+                "or an RFC-3339 string. Naïve datetimes are rejected "
+                "because they would be silently mis-anchored for "
+                "callers outside UTC."
+            )
+        dt = occurred_at.astimezone(timezone.utc)
+        # Drop tzinfo before `isoformat` to suppress the "+00:00"
+        # suffix; we append "Z" manually to match the TS SDK + server
+        # canonical form. `timespec="milliseconds"` matches JS
+        # `Date.toISOString()` precision so the two SDKs are
+        # byte-identical for the same instant.
+        return dt.replace(tzinfo=None).isoformat(timespec="milliseconds") + "Z"
+    if isinstance(occurred_at, str):
+        # Validate at the SDK boundary so a bad timestamp doesn't
+        # bring down the whole analyze() call with an opaque 400 from
+        # the server's serde layer. RFC-3339 §4.2 allows "Z" as a UTC
+        # shorthand; `fromisoformat` only accepts it on Python 3.11+,
+        # so we normalise to "+00:00" before parsing for 3.9/3.10
+        # compatibility.
+        normalised = occurred_at.replace("Z", "+00:00", 1) if occurred_at.endswith("Z") else occurred_at
+        try:
+            parsed = datetime.fromisoformat(normalised)
+        except ValueError as exc:
+            raise ValueError(
+                f"occurred_at must be RFC-3339 / ISO-8601, got: {occurred_at!r}"
+            ) from exc
+        # Round-trip through the datetime branch so the wire format is
+        # canonical (UTC, milliseconds, trailing "Z"). Naïve inputs
+        # here are rare but possible; reuse the aware-required guard
+        # by attaching tzinfo if the string carried one.
+        if parsed.tzinfo is None:
+            raise ValueError(
+                f"occurred_at string must carry a UTC offset or 'Z' suffix, "
+                f"got: {occurred_at!r}"
+            )
+        return _occurred_at_to_wire(parsed)
+    raise TypeError(
+        f"occurred_at must be datetime, str, or None; got {type(occurred_at).__name__}"
+    )
 
 
 class MemWal:
@@ -533,7 +609,12 @@ class MemWal:
             return RecallResult(results=memories, total=len(memories))
         return RecallResult(results=memories, total=data.get("total", len(memories)))
 
-    async def analyze(self, text: str, namespace: Optional[str] = None) -> AnalyzeResult:
+    async def analyze(
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
+    ) -> AnalyzeResult:
         """Analyze conversation text and return as soon as facts are accepted.
 
         Per PR #121: server extracts atomic facts synchronously via LLM, then
@@ -546,15 +627,35 @@ class MemWal:
         Args:
             text: Conversation text to analyze.
             namespace: Override the default namespace.
+            occurred_at: Optional valid-time timestamp — when the
+                conversation/event actually happened. When supplied, the
+                server extractor uses it as a temporal anchor and
+                resolves in-turn relative references ("last Friday",
+                "yesterday") into absolute dates inside the fact text
+                before embedding/encryption. Accepts a
+                :class:`datetime.datetime` (preferred — naïve datetimes
+                are assumed UTC) or an ISO-8601 / RFC-3339 string. Wire
+                format is RFC-3339 UTC with trailing ``Z``. Omit when
+                no anchor is available — the server will not invent one
+                (no ``now()`` fallback). The resolved date lives only
+                inside the encrypted fact text + embedding; there is no
+                server-readable metadata column for it (Architecture A).
 
         Returns:
             :class:`AnalyzeResult` with extracted ``facts`` + per-fact
             ``job_ids`` for downstream polling.
         """
+        body: Dict[str, Any] = {
+            "text": text,
+            "namespace": namespace or self._namespace,
+        }
+        wire_occurred_at = _occurred_at_to_wire(occurred_at)
+        if wire_occurred_at is not None:
+            body["occurred_at"] = wire_occurred_at
         data = await self._signed_request(
             "POST",
             "/api/analyze",
-            {"text": text, "namespace": namespace or self._namespace},
+            body,
             accepted_statuses=(200, 202),
         )
         # Backward-compat: older server shape returned `facts[].id` and
@@ -583,6 +684,7 @@ class MemWal:
         text: str,
         namespace: Optional[str] = None,
         opts: Optional[RememberBulkOptions] = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
     ) -> AnalyzeWaitResult:
         """Analyze + wait for every extracted fact to finish persisting.
 
@@ -590,9 +692,12 @@ class MemWal:
         :meth:`wait_for_remember_jobs` on the returned ``job_ids``. The
         result combines the analyze fact list with the bulk-style settled
         per-job results.
+
+        ``occurred_at`` carries the same temporal-anchor semantics as
+        :meth:`analyze` — see that method's docstring for details.
         """
 
-        accepted = await self.analyze(text, namespace)
+        accepted = await self.analyze(text, namespace, occurred_at=occurred_at)
         completed = await self.wait_for_remember_jobs(accepted.job_ids, opts)
         return AnalyzeWaitResult(
             results=completed.results,
@@ -1245,18 +1350,26 @@ class MemWalSync:
         :class:`RecallParams` for the recommended object-style call)."""
         return self._run(self._inner.recall(query, limit, namespace, max_distance))
 
-    def analyze(self, text: str, namespace: Optional[str] = None) -> AnalyzeResult:
+    def analyze(
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
+    ) -> AnalyzeResult:
         """Synchronous version of :meth:`MemWal.analyze`."""
-        return self._run(self._inner.analyze(text, namespace))
+        return self._run(self._inner.analyze(text, namespace, occurred_at=occurred_at))
 
     def analyze_and_wait(
         self,
         text: str,
         namespace: Optional[str] = None,
         opts: Optional[RememberBulkOptions] = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
     ) -> AnalyzeWaitResult:
         """Synchronous version of :meth:`MemWal.analyze_and_wait`."""
-        return self._run(self._inner.analyze_and_wait(text, namespace, opts))
+        return self._run(
+            self._inner.analyze_and_wait(text, namespace, opts, occurred_at=occurred_at)
+        )
 
     def embed(self, text: str) -> EmbedResult:
         """Synchronous version of :meth:`MemWal.embed`."""

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -633,9 +633,14 @@ class MemWal:
                 resolves in-turn relative references ("last Friday",
                 "yesterday") into absolute dates inside the fact text
                 before embedding/encryption. Accepts a
-                :class:`datetime.datetime` (preferred — naïve datetimes
-                are assumed UTC) or an ISO-8601 / RFC-3339 string. Wire
-                format is RFC-3339 UTC with trailing ``Z``. Omit when
+                :class:`datetime.datetime` (preferred — **must be
+                timezone-aware**; naïve datetimes raise ``ValueError``
+                because silently assuming UTC would mis-anchor by N
+                hours for callers outside UTC) or an ISO-8601 / RFC-3339
+                string (must carry a ``Z`` suffix or UTC offset; raises
+                ``ValueError`` if malformed or naïve). Wire format is
+                RFC-3339 UTC with millisecond precision and trailing
+                ``Z`` (byte-identical to the TypeScript SDK). Omit when
                 no anchor is available — the server will not invent one
                 (no ``now()`` fallback). The resolved date lives only
                 inside the encrypted fact text + embedding; there is no

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python SDK for Walrus Memory — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import json
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -494,9 +495,102 @@ class TestAnalyze:
 
         body = json.loads(route.calls[0].request.content)
         assert body["text"] == "I love coffee and live in Tokyo"
+        assert "occurred_at" not in body  # omitted when not supplied
         assert len(result.facts) == 1
         assert result.facts[0].text == "User loves coffee"
         assert result.owner == "0xowner"
+
+    @respx.mock
+    async def test_analyze_with_occurred_at_datetime(
+        self, memwal_client: MemWal
+    ) -> None:
+        """A UTC-aware datetime renders as RFC-3339 millis with 'Z'."""
+        mock_seal_session_prereqs()
+        route = respx.post(f"{_TEST_SERVER}/api/analyze").mock(
+            return_value=httpx.Response(200, json={"facts": [], "total": 0, "owner": ""})
+        )
+
+        await memwal_client.analyze(
+            "I moved last Friday",
+            occurred_at=datetime(2023, 5, 25, 17, 50, tzinfo=timezone.utc),
+        )
+
+        body = json.loads(route.calls[0].request.content)
+        # Millisecond precision matches the TS SDK's Date.toISOString().
+        assert body["occurred_at"] == "2023-05-25T17:50:00.000Z"
+
+    @respx.mock
+    async def test_analyze_with_occurred_at_nonutc_tz(
+        self, memwal_client: MemWal
+    ) -> None:
+        """An aware datetime in a non-UTC tz is converted to UTC."""
+        mock_seal_session_prereqs()
+        route = respx.post(f"{_TEST_SERVER}/api/analyze").mock(
+            return_value=httpx.Response(200, json={"facts": [], "total": 0, "owner": ""})
+        )
+
+        # 17:50 in +07:00 (Hanoi) is 10:50 UTC.
+        ict = timezone(timedelta(hours=7))
+        await memwal_client.analyze(
+            "I moved last Friday",
+            occurred_at=datetime(2023, 5, 25, 17, 50, tzinfo=ict),
+        )
+
+        body = json.loads(route.calls[0].request.content)
+        assert body["occurred_at"] == "2023-05-25T10:50:00.000Z"
+
+    @respx.mock
+    async def test_analyze_with_occurred_at_string(
+        self, memwal_client: MemWal
+    ) -> None:
+        """An RFC-3339 string is validated and re-formatted to canonical."""
+        mock_seal_session_prereqs()
+        route = respx.post(f"{_TEST_SERVER}/api/analyze").mock(
+            return_value=httpx.Response(200, json={"facts": [], "total": 0, "owner": ""})
+        )
+
+        await memwal_client.analyze(
+            "I moved last Friday",
+            occurred_at="2023-05-25T17:50:00Z",
+        )
+
+        body = json.loads(route.calls[0].request.content)
+        # Canonical form: millis appended.
+        assert body["occurred_at"] == "2023-05-25T17:50:00.000Z"
+
+    async def test_analyze_naive_datetime_raises(
+        self, memwal_client: MemWal
+    ) -> None:
+        """Naïve datetimes are rejected — silently assuming UTC would
+        produce timezone-off-by-N anchors for callers outside UTC and
+        undermine WALM-55's honest-temporal-anchoring guarantee."""
+        with pytest.raises(ValueError, match="timezone-aware"):
+            await memwal_client.analyze(
+                "I moved last Friday",
+                occurred_at=datetime(2023, 5, 25, 17, 50),  # naïve
+            )
+
+    async def test_analyze_garbage_string_raises(
+        self, memwal_client: MemWal
+    ) -> None:
+        """Malformed occurred_at strings are rejected at the SDK
+        boundary, not forwarded as an opaque 400 from the server."""
+        with pytest.raises(ValueError, match="RFC-3339"):
+            await memwal_client.analyze(
+                "I moved last Friday",
+                occurred_at="yesterday",
+            )
+
+    async def test_analyze_naive_string_raises(
+        self, memwal_client: MemWal
+    ) -> None:
+        """A timezone-less ISO string is rejected — same reasoning as
+        the naïve-datetime case."""
+        with pytest.raises(ValueError, match="UTC offset"):
+            await memwal_client.analyze(
+                "I moved last Friday",
+                occurred_at="2023-05-25T17:50:00",  # no Z, no offset
+            )
 
 
 class TestRestore:

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,6 +34,7 @@ export type {
     RecallParams,
     ScoringWeights,
     EmbedResult,
+    AnalyzeOptions,
     AnalyzeResult,
     AnalyzeWaitResult,
     AnalyzedFact,

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -36,6 +36,7 @@ import type {
     RecallOptions,
     RecallParams,
     EmbedResult,
+    AnalyzeOptions,
     AnalyzeResult,
     AnalyzeWaitResult,
     HealthResult,
@@ -121,6 +122,49 @@ function pollingDelayMs(baseMs: number, attempt: number): number {
 
 function isTransientPollingStatus(status: number): boolean {
     return status === 0 || status === 429 || status >= 500;
+}
+
+/**
+ * Normalise the legacy `(text, namespace)` and new `(text, options)`
+ * overloads of `analyze()` / `analyzeAndWait()` into a single
+ * `AnalyzeOptions` object. Preserves backwards compatibility — a plain
+ * string is treated as the namespace.
+ */
+function normalizeAnalyzeOptions(
+    namespaceOrOptions?: string | AnalyzeOptions,
+): AnalyzeOptions {
+    if (namespaceOrOptions == null) return {};
+    if (typeof namespaceOrOptions === "string") return { namespace: namespaceOrOptions };
+    return namespaceOrOptions;
+}
+
+/**
+ * Render an `occurredAt` argument to the wire format the server
+ * expects: RFC-3339 UTC with trailing `Z` and millisecond precision
+ * (e.g. `"2023-05-25T17:50:00.000Z"`). `Date` objects are normalised
+ * via `toISOString()` (which always emits this exact shape); strings
+ * are passed through verbatim — the caller is trusted to have given
+ * us a valid RFC-3339 timestamp. Invalid `Date` instances (constructed
+ * from garbage input — `Date` silently produces "Invalid Date" rather
+ * than throwing) are rejected at the SDK boundary with a diagnostic
+ * `TypeError`, so a bad timestamp doesn't surface as an opaque
+ * `RangeError: Invalid time value` from `.toISOString()` later.
+ * Returns `undefined` when no anchor is supplied so the field is
+ * omitted from the request body.
+ */
+function occurredAtToWire(occurredAt?: string | Date): string | undefined {
+    if (occurredAt == null) return undefined;
+    if (occurredAt instanceof Date) {
+        if (Number.isNaN(occurredAt.getTime())) {
+            throw new TypeError(
+                "occurredAt is an Invalid Date — likely constructed from a " +
+                "malformed string. `Date` accepts garbage silently; check " +
+                "the source value before passing it as occurredAt.",
+            );
+        }
+        return occurredAt.toISOString();
+    }
+    return occurredAt;
 }
 
 function normalizeSuiNetworkForGrpc(network: string): string {
@@ -681,11 +725,18 @@ export class MemWal {
      * console.log(result.job_ids)
      * ```
      */
-    async analyze(text: string, namespace?: string): Promise<AnalyzeResult> {
-        return this.signedRequest<AnalyzeResult>("POST", "/api/analyze", {
+    async analyze(
+        text: string,
+        namespaceOrOptions?: string | AnalyzeOptions,
+    ): Promise<AnalyzeResult> {
+        const options = normalizeAnalyzeOptions(namespaceOrOptions);
+        const body: Record<string, unknown> = {
             text,
-            namespace: namespace ?? this.namespace,
-        }, [200, 202]);
+            namespace: options.namespace ?? this.namespace,
+        };
+        const wireOccurredAt = occurredAtToWire(options.occurredAt);
+        if (wireOccurredAt !== undefined) body.occurred_at = wireOccurredAt;
+        return this.signedRequest<AnalyzeResult>("POST", "/api/analyze", body, [200, 202]);
     }
 
     /**
@@ -693,11 +744,13 @@ export class MemWal {
      */
     async analyzeAndWait(
         text: string,
-        namespace?: string,
+        namespaceOrOptions?: string | AnalyzeOptions,
         opts: RememberBulkOptions = {},
     ): Promise<AnalyzeWaitResult> {
-        const accepted = await this.analyze(text, namespace);
-        const namespaces = accepted.job_ids.map(() => namespace ?? this.namespace);
+        const options = normalizeAnalyzeOptions(namespaceOrOptions);
+        const namespace = options.namespace ?? this.namespace;
+        const accepted = await this.analyze(text, options);
+        const namespaces = accepted.job_ids.map(() => namespace);
         const completed = await this.waitForRememberJobs(accepted.job_ids, namespaces, opts);
         return {
             ...completed,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -161,6 +161,30 @@ export interface EmbedResult {
     vector: number[];
 }
 
+/** Options for analyze() / analyzeAndWait(). */
+export interface AnalyzeOptions {
+    /** Override the default namespace for this call. */
+    namespace?: string;
+    /**
+     * Optional valid-time timestamp for the analyzed input — when the
+     * conversation/event actually happened. When supplied, the server
+     * extractor uses it as a temporal anchor and resolves in-turn
+     * relative references ("last Friday", "yesterday") into absolute
+     * dates inside the resulting fact text (and the embedding) before
+     * encryption.
+     *
+     * Accepts a `Date` object (preferred) or an ISO-8601 / RFC-3339
+     * string. The wire format sent to the server is RFC-3339 UTC with
+     * a trailing `Z` (e.g. `"2023-05-25T17:50:00Z"`).
+     *
+     * Omit when no anchor is available — the server will not invent
+     * one (no `now()` fallback; silence is honest). The resolved date
+     * lives only inside the encrypted fact text + embedding; there is
+     * no server-readable metadata column for it (Architecture A).
+     */
+    occurredAt?: string | Date;
+}
+
 /** A fact extracted by analyze() and accepted for background storage. */
 export interface AnalyzedFact {
     text: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1025,8 +1025,8 @@ importers:
   packages/openclaw-memory-memwal:
     dependencies:
       '@mysten-incubation/memwal':
-        specifier: ^0.0.2
-        version: 0.0.2(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)
+        specifier: workspace:*
+        version: link:../sdk
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -3112,22 +3112,6 @@ packages:
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
-
-  '@mysten-incubation/memwal@0.0.2':
-    resolution: {integrity: sha512-tQ/U/054bOylXUEk3JsiAP0DlskoxqAerbMBXFAN/wWTNvvJK7L+FcvL1f4NlICawsW8dfxt5Of7jLCTIHxbdg==}
-    peerDependencies:
-      '@mysten/seal': '>=1.1.0'
-      '@mysten/sui': '>=2.5.0'
-      '@mysten/walrus': '>=1.0.3'
-      ai: '>=4.0.0'
-      zod: ^3.23.0
-    peerDependenciesMeta:
-      '@mysten/walrus':
-        optional: true
-      ai:
-        optional: true
-      zod:
-        optional: true
 
   '@mysten/bcs@1.2.0':
     resolution: {integrity: sha512-LuKonrGdGW7dq/EM6U2L9/as7dFwnhZnsnINzB/vu08Xfrj0qzWwpLOiXagAa5yZOPLK7anRZydMonczFkUPzA==}
@@ -13524,17 +13508,6 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@mysten-incubation/memwal@0.0.2(@mysten/seal@1.1.1(@mysten/sui@2.8.0(typescript@5.9.3)))(@mysten/sui@2.8.0(typescript@5.9.3))(@mysten/walrus@1.0.4(@mysten/sui@2.8.0(typescript@5.9.3)))(ai@6.0.37(zod@3.25.76))(zod@3.25.76)':
-    dependencies:
-      '@mysten/seal': 1.1.1(@mysten/sui@2.8.0(typescript@5.9.3))
-      '@mysten/sui': 2.8.0(typescript@5.9.3)
-      '@noble/ed25519': 2.3.0
-      '@noble/hashes': 2.0.1
-    optionalDependencies:
-      '@mysten/walrus': 1.0.4(@mysten/sui@2.8.0(typescript@5.9.3))
-      ai: 6.0.37(zod@3.25.76)
-      zod: 3.25.76
-
   '@mysten/bcs@1.2.0':
     dependencies:
       bs58: 6.0.0
@@ -18222,7 +18195,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -18255,7 +18228,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -18269,7 +18242,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/services/server/benchmarks/benchmarks/base.py
+++ b/services/server/benchmarks/benchmarks/base.py
@@ -46,11 +46,14 @@ class BenchmarkAdapter(ABC):
         """
 
     @abstractmethod
-    def build_ingest_text(self, conversation: Conversation) -> list[tuple[str, str]]:
+    def build_ingest_text(
+        self, conversation: Conversation
+    ) -> list[tuple[str, str, str | None]]:
         """
-        Convert a conversation into (session_label, text) pairs for /api/analyze.
+        Convert a conversation into (session_label, text, occurred_at)
+        triples for /api/analyze.
 
-        Each returned pair is fed as ONE /api/analyze call. The choice of
+        Each returned triple is fed as ONE /api/analyze call. The choice of
         chunking strategy is benchmark-specific and directly affects
         extraction quality:
 
@@ -66,14 +69,19 @@ class BenchmarkAdapter(ABC):
         is provided below — adapters that use it should do so by delegation,
         so the choice is visible in the adapter's source.
 
+        WALM-55: `occurred_at` is an RFC 3339 UTC string when the source
+        dataset provides a per-turn (or per-session) timestamp, or None
+        otherwise. The server uses it as the temporal anchor inside the
+        extractor prompt — see `core.client.MemWalClient.analyze`.
+
         Returns:
-            List of (label, text) pairs.
+            List of (label, text, occurred_at) triples.
         """
 
     @staticmethod
     def build_ingest_text_naive_concat(
         conversation: Conversation,
-    ) -> list[tuple[str, str]]:
+    ) -> list[tuple[str, str, str | None]]:
         """
         Helper: concatenate all turns in each session into one text blob.
 
@@ -81,10 +89,16 @@ class BenchmarkAdapter(ABC):
         mini-haystacks). AVOID for long sessions — the extractor drops
         facts under large input contexts.
 
+        WALM-55: this helper collapses many turns into one ingest call.
+        That collapses temporal granularity — picking any single turn's
+        timestamp to represent the whole session would be arbitrary. So
+        this helper always returns `occurred_at=None`. Adapters that
+        want per-turn timestamps should use `build_ingest_text_per_turn`.
+
         Returns:
-            List of (label, text) pairs, one per session.
+            List of (label, text, occurred_at) triples, one per session.
         """
-        result: list[tuple[str, str]] = []
+        result: list[tuple[str, str, str | None]] = []
         for session in conversation.sessions:
             lines: list[str] = []
             for turn in session.turns:
@@ -92,13 +106,15 @@ class BenchmarkAdapter(ABC):
                 lines.append(f"{prefix}: {turn.text}")
             text = "\n".join(lines)
             label = f"{conversation.conversation_id}/{session.session_id}"
-            result.append((label, text))
+            # See docstring — naive_concat deliberately drops per-turn
+            # timestamps because it collapses many turns into one blob.
+            result.append((label, text, None))
         return result
 
     @staticmethod
     def build_ingest_text_per_turn(
         conversation: Conversation,
-    ) -> list[tuple[str, str]]:
+    ) -> list[tuple[str, str, str | None]]:
         """
         Helper: emit one ingest chunk per turn.
 
@@ -127,10 +143,17 @@ class BenchmarkAdapter(ABC):
         matches naive_concat so the session→memory map in run.py
         aggregates multiple turn-level chunks under the same session key.
 
+        WALM-55: `occurred_at` is sourced from `turn.timestamp` (which
+        the per-benchmark adapter normalises to RFC 3339 UTC, or sets to
+        None when the source dataset has no timestamp / it failed to
+        parse). The server uses it as the temporal anchor for resolving
+        relative-time references inside the extracted fact text — see
+        `core.client.MemWalClient.analyze` and the v6 extraction prompt.
+
         Returns:
-            List of (label, text) pairs, one per turn.
+            List of (label, text, occurred_at) triples, one per turn.
         """
-        result: list[tuple[str, str]] = []
+        result: list[tuple[str, str, str | None]] = []
         for session in conversation.sessions:
             label = f"{conversation.conversation_id}/{session.session_id}"
             for turn in session.turns:
@@ -155,5 +178,5 @@ class BenchmarkAdapter(ABC):
                     role = role[:1].upper() + role[1:]
                     text = f"{role}: {raw}"
 
-                result.append((label, text))
+                result.append((label, text, turn.timestamp))
         return result

--- a/services/server/benchmarks/benchmarks/base.py
+++ b/services/server/benchmarks/benchmarks/base.py
@@ -69,7 +69,7 @@ class BenchmarkAdapter(ABC):
         is provided below — adapters that use it should do so by delegation,
         so the choice is visible in the adapter's source.
 
-        WALM-55: `occurred_at` is an RFC 3339 UTC string when the source
+        `occurred_at` is an RFC 3339 UTC string when the source
         dataset provides a per-turn (or per-session) timestamp, or None
         otherwise. The server uses it as the temporal anchor inside the
         extractor prompt — see `core.client.MemWalClient.analyze`.
@@ -89,7 +89,7 @@ class BenchmarkAdapter(ABC):
         mini-haystacks). AVOID for long sessions — the extractor drops
         facts under large input contexts.
 
-        WALM-55: this helper collapses many turns into one ingest call.
+        this helper collapses many turns into one ingest call.
         That collapses temporal granularity — picking any single turn's
         timestamp to represent the whole session would be arbitrary. So
         this helper always returns `occurred_at=None`. Adapters that
@@ -143,7 +143,7 @@ class BenchmarkAdapter(ABC):
         matches naive_concat so the session→memory map in run.py
         aggregates multiple turn-level chunks under the same session key.
 
-        WALM-55: `occurred_at` is sourced from `turn.timestamp` (which
+        `occurred_at` is sourced from `turn.timestamp` (which
         the per-benchmark adapter normalises to RFC 3339 UTC, or sets to
         None when the source dataset has no timestamp / it failed to
         parse). The server uses it as the temporal anchor for resolving

--- a/services/server/benchmarks/benchmarks/locomo.py
+++ b/services/server/benchmarks/benchmarks/locomo.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 
 from core.types import Conversation, Session, Turn, Query, Evidence
@@ -58,6 +59,36 @@ CATEGORY_MAP: dict[int, str] = {
 }
 
 LOCOMO_URL = "https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json"
+
+
+# WALM-55: LOCOMO stores session timestamps as natural-language strings
+# like "1:56 pm on 8 May, 2023". Parse them into RFC 3339 UTC strings so
+# the harness can pass occurred_at through to /api/analyze in a format
+# the server expects (`chrono::DateTime<chrono::Utc>` via serde).
+#
+# The format isn't strict — LOCOMO has minor variations ("1:56 pm" vs
+# "01:56 pm"). We try the canonical format first; on failure we return
+# None and the turn just goes through without a temporal anchor (graceful
+# degradation — silence is honest, never fabricate now()).
+_LOCOMO_DATE_FMT = "%I:%M %p on %d %B, %Y"
+
+
+def _normalize_locomo_timestamp(raw: str | None) -> str | None:
+    """Parse a LOCOMO session date string into RFC 3339 UTC.
+
+    The dataset has no timezone information — we treat the times as UTC,
+    which is a benchmark-mode convention (consistent across runs, no
+    DST surprises). Returns None on parse failure so the caller falls
+    back to no-context extraction for that turn.
+    """
+    if raw is None:
+        return None
+    try:
+        dt = datetime.strptime(raw.strip(), _LOCOMO_DATE_FMT)
+    except ValueError:
+        logger.warning("could not parse LOCOMO timestamp %r; skipping temporal anchor", raw)
+        return None
+    return dt.replace(tzinfo=timezone.utc).isoformat()
 
 
 class LocomoBenchmark(BenchmarkAdapter):
@@ -192,7 +223,12 @@ class LocomoBenchmark(BenchmarkAdapter):
                 continue
 
             session_num = session_key.split("_")[1]
-            timestamp = conv.get(f"session_{session_num}_date_time")
+            # WALM-55: normalise the raw LOCOMO date string ("1:56 pm on 8
+            # May, 2023") to RFC 3339 UTC so the harness can pass it to
+            # /api/analyze as `occurred_at`. Falls back to None on
+            # unparseable formats — that turn just goes through without a
+            # temporal anchor (graceful degradation).
+            timestamp = _normalize_locomo_timestamp(conv.get(f"session_{session_num}_date_time"))
 
             turns = []
             for turn_data in session_turns_raw:

--- a/services/server/benchmarks/benchmarks/locomo.py
+++ b/services/server/benchmarks/benchmarks/locomo.py
@@ -61,7 +61,7 @@ CATEGORY_MAP: dict[int, str] = {
 LOCOMO_URL = "https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json"
 
 
-# WALM-55: LOCOMO stores session timestamps as natural-language strings
+# LOCOMO stores session timestamps as natural-language strings
 # like "1:56 pm on 8 May, 2023". Parse them into RFC 3339 UTC strings so
 # the harness can pass occurred_at through to /api/analyze in a format
 # the server expects (`chrono::DateTime<chrono::Utc>` via serde).
@@ -223,7 +223,7 @@ class LocomoBenchmark(BenchmarkAdapter):
                 continue
 
             session_num = session_key.split("_")[1]
-            # WALM-55: normalise the raw LOCOMO date string ("1:56 pm on 8
+            # normalise the raw LOCOMO date string ("1:56 pm on 8
             # May, 2023") to RFC 3339 UTC so the harness can pass it to
             # /api/analyze as `occurred_at`. Falls back to None on
             # unparseable formats — that turn just goes through without a

--- a/services/server/benchmarks/benchmarks/longmemeval.py
+++ b/services/server/benchmarks/benchmarks/longmemeval.py
@@ -162,7 +162,7 @@ class LongMemEvalBenchmark(BenchmarkAdapter):
                     if sess_idx < len(session_dates)
                     else None
                 )
-                # WALM-55: normalise to RFC 3339 UTC so the harness can
+                # normalise to RFC 3339 UTC so the harness can
                 # pass occurred_at to /api/analyze. LME dates have no
                 # timezone in the source ("2023/04/10 (Mon) 17:50") — we
                 # treat them as UTC, a benchmark-mode convention. Falls

--- a/services/server/benchmarks/benchmarks/longmemeval.py
+++ b/services/server/benchmarks/benchmarks/longmemeval.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from core.types import Conversation, Session, Turn, Query, Evidence
@@ -157,9 +157,20 @@ class LongMemEvalBenchmark(BenchmarkAdapter):
                     if sess_idx < len(session_ids)
                     else f"{conv_id}-s{sess_idx:03d}"
                 )
-                session_date = (
+                session_date_raw = (
                     session_dates[sess_idx]
                     if sess_idx < len(session_dates)
+                    else None
+                )
+                # WALM-55: normalise to RFC 3339 UTC so the harness can
+                # pass occurred_at to /api/analyze. LME dates have no
+                # timezone in the source ("2023/04/10 (Mon) 17:50") — we
+                # treat them as UTC, a benchmark-mode convention. Falls
+                # back to None on unparseable strings.
+                session_date_dt = _parse_haystack_date(session_date_raw)
+                session_date_iso: str | None = (
+                    session_date_dt.replace(tzinfo=timezone.utc).isoformat()
+                    if session_date_dt is not None
                     else None
                 )
 
@@ -175,7 +186,7 @@ class LongMemEvalBenchmark(BenchmarkAdapter):
                         speaker=role,
                         text=content,
                         turn_id=f"{session_id}/t{turn_idx:03d}",
-                        timestamp=session_date,
+                        timestamp=session_date_iso,
                     ))
 
                 if turns:

--- a/services/server/benchmarks/core/client.py
+++ b/services/server/benchmarks/core/client.py
@@ -167,7 +167,7 @@ class MemWalClient:
            status "done"; production: SEAL-encrypt + Walrus upload, via an
            async job, status "pending").
 
-        WALM-55: `occurred_at` is an optional RFC 3339 UTC timestamp of
+        `occurred_at` is an optional RFC 3339 UTC timestamp of
         when this conversation turn took place. When passed, the server
         threads it into the extractor's prompt as a `<context
         occurred_at="..."/>` tag so the LLM can resolve relative-time

--- a/services/server/benchmarks/core/client.py
+++ b/services/server/benchmarks/core/client.py
@@ -150,7 +150,12 @@ class MemWalClient:
         resp.raise_for_status()
         return resp.json()
 
-    def analyze(self, text: str, namespace: str) -> AnalyzeResult:
+    def analyze(
+        self,
+        text: str,
+        namespace: str,
+        occurred_at: str | None = None,
+    ) -> AnalyzeResult:
         """
         POST /api/analyze — feed conversation text, extract and store memories.
 
@@ -161,11 +166,23 @@ class MemWalClient:
            synchronously — the response carries the stored ids and
            status "done"; production: SEAL-encrypt + Walrus upload, via an
            async job, status "pending").
+
+        WALM-55: `occurred_at` is an optional RFC 3339 UTC timestamp of
+        when this conversation turn took place. When passed, the server
+        threads it into the extractor's prompt as a `<context
+        occurred_at="..."/>` tag so the LLM can resolve relative-time
+        references ("last Friday", "yesterday") to absolute dates
+        *inside the extracted fact text* — making time-anchored facts
+        retrievable. Omit (or pass None) when no anchor is available;
+        the server does NOT default to now() — silence is honest.
         """
-        data = self._post("/api/analyze", {
+        body: dict = {
             "text": text,
             "namespace": namespace,
-        })
+        }
+        if occurred_at is not None:
+            body["occurred_at"] = occurred_at
+        data = self._post("/api/analyze", body)
         # Response shape varies between server versions:
         # - Synchronous (reference branch): {facts, total, owner}
         # Async / benchmark-mode (dev): {facts, fact_count,

--- a/services/server/benchmarks/run.py
+++ b/services/server/benchmarks/run.py
@@ -183,7 +183,7 @@ def stage_ingest(
 
     # Group (label, text) chunks by conversation so we can process each
     # conversation's chunks serially in one worker.
-    # WALM-55: chunk tuple is now (session_id, label, text, occurred_at)
+    # chunk tuple is now (session_id, label, text, occurred_at)
     # where occurred_at is an RFC 3339 UTC string or None. The adapter is
     # responsible for normalising the source-dataset format to RFC 3339
     # (see locomo._normalize_locomo_timestamp,
@@ -219,7 +219,7 @@ def stage_ingest(
         local_stored = 0
         for session_id, label, text, occurred_at in chunks:
             try:
-                # WALM-55: pass occurred_at (RFC 3339 UTC string or None)
+                # pass occurred_at (RFC 3339 UTC string or None)
                 # to the server. When present, the server uses it as the
                 # temporal anchor for the extractor prompt.
                 result = client.analyze(text, namespace, occurred_at=occurred_at)

--- a/services/server/benchmarks/run.py
+++ b/services/server/benchmarks/run.py
@@ -183,16 +183,21 @@ def stage_ingest(
 
     # Group (label, text) chunks by conversation so we can process each
     # conversation's chunks serially in one worker.
-    conv_tasks: list[tuple[str, str, list[tuple[str, str, str]]]] = []
-    # each entry: (conv_id, namespace, [(session_id, label, text), ...])
+    # WALM-55: chunk tuple is now (session_id, label, text, occurred_at)
+    # where occurred_at is an RFC 3339 UTC string or None. The adapter is
+    # responsible for normalising the source-dataset format to RFC 3339
+    # (see locomo._normalize_locomo_timestamp,
+    # longmemeval._parse_haystack_date).
+    conv_tasks: list[tuple[str, str, list[tuple[str, str, str, str | None]]]] = []
+    # each entry: (conv_id, namespace, [(session_id, label, text, occurred_at), ...])
     total_chunk_count = 0
     for conv in conversations:
         namespace = f"bench-{benchmark_name}-{conv.conversation_id}-{run_id}"
-        pairs = adapter.build_ingest_text(conv)
-        chunks: list[tuple[str, str, str]] = []
-        for label, text in pairs:
+        triples = adapter.build_ingest_text(conv)
+        chunks: list[tuple[str, str, str, str | None]] = []
+        for label, text, occurred_at in triples:
             session_id = _parse_label(label, conv.conversation_id)
-            chunks.append((session_id, label, text))
+            chunks.append((session_id, label, text, occurred_at))
         conv_tasks.append((conv.conversation_id, namespace, chunks))
         total_chunk_count += len(chunks)
 
@@ -212,9 +217,12 @@ def stage_ingest(
         conv_id, namespace, chunks = task
         local_memories: dict[str, list[str]] = {}
         local_stored = 0
-        for session_id, label, text in chunks:
+        for session_id, label, text, occurred_at in chunks:
             try:
-                result = client.analyze(text, namespace)
+                # WALM-55: pass occurred_at (RFC 3339 UTC string or None)
+                # to the server. When present, the server uses it as the
+                # temporal anchor for the extractor prompt.
+                result = client.analyze(text, namespace, occurred_at=occurred_at)
                 memory_ids = [fact.get("id", "") for fact in result.facts if fact.get("id")]
                 if memory_ids:
                     key = session_map_key(conv_id, session_id)

--- a/services/server/benchmarks/tests/test_adapters.py
+++ b/services/server/benchmarks/tests/test_adapters.py
@@ -93,12 +93,20 @@ class TestLocomoAdapter:
         # Per-turn chunking: 2 sessions × 3 turns each (fixture) = 6 chunks
         total_turns = sum(len(s.turns) for s in convs[0].sessions)
         assert len(chunks) == total_turns
-        for label, text in chunks:
+        # WALM-55: chunks are 3-tuples (label, text, occurred_at).
+        for label, text, occurred_at in chunks:
             assert "/" in label, "label format is conv_id/session_id"
             # LOCOMO text already has the speaker name baked in
             # ("Caroline: " / "Melanie: ") — the helper detects this
             # and skips double-prefixing.
             assert ": " in text[:30], "turn text should begin with a speaker name"
+            # occurred_at is either None or an RFC 3339 UTC string. The
+            # fixture's LOCOMO date "1:56 pm on 8 May, 2023" parses to
+            # "2023-05-08T13:56:00+00:00". We don't assert the exact
+            # value (that's a separate normaliser test) but the shape.
+            if occurred_at is not None:
+                assert "T" in occurred_at and ("+" in occurred_at or "Z" in occurred_at), \
+                    f"occurred_at must be RFC 3339, got {occurred_at!r}"
 
     def test_multiple_chunks_share_session_label(self, adapter_and_data):
         """
@@ -110,7 +118,8 @@ class TestLocomoAdapter:
         chunks = adapter.build_ingest_text(convs[0])
         from collections import defaultdict
         by_label = defaultdict(int)
-        for label, _ in chunks:
+        # WALM-55: unpack the 3-tuple, ignore text + occurred_at.
+        for label, _text, _occurred_at in chunks:
             by_label[label] += 1
         # Every session should have produced at least one chunk
         assert len(by_label) == len(convs[0].sessions)
@@ -188,10 +197,81 @@ class TestLongMemEvalAdapter:
         chunks = adapter.build_ingest_text(convs[0])
         total_turns = sum(len(s.turns) for s in convs[0].sessions)
         assert len(chunks) == total_turns
-        for label, text in chunks:
+        # WALM-55: chunks are 3-tuples (label, text, occurred_at).
+        for label, text, occurred_at in chunks:
             assert text.strip(), "ingest text should be non-empty"
             # LongMemEval turns are raw content (no embedded speaker name)
             # so the helper prefixes them with "User: " / "Assistant: ".
             assert text.startswith(("User:", "Assistant:")), (
                 f"LongMemEval turn should have role prefix; got {text[:40]!r}"
             )
+            # occurred_at is either None or an RFC 3339 UTC string. LME
+            # haystack_dates "2023/04/10 (Mon) 17:50" parses to
+            # "2023-04-10T17:50:00+00:00".
+            if occurred_at is not None:
+                assert "T" in occurred_at and ("+" in occurred_at or "Z" in occurred_at), \
+                    f"occurred_at must be RFC 3339, got {occurred_at!r}"
+
+
+# ── WALM-55: per-benchmark timestamp normalisation ────────────────────
+
+class TestLocomoTimestampNormalisation:
+    """Pin the LOCOMO date-string → RFC 3339 conversion shape.
+
+    The server expects RFC 3339 UTC strings on AnalyzeRequest.occurred_at.
+    If a future LOCOMO release changes its date format, these tests fail
+    loudly rather than silently shipping unparsed strings to the server.
+    """
+
+    def test_canonical_format_parses_to_rfc3339_utc(self):
+        from benchmarks.locomo import _normalize_locomo_timestamp
+
+        # The canonical LOCOMO format, sampled from the cached fixture.
+        out = _normalize_locomo_timestamp("1:56 pm on 8 May, 2023")
+        assert out == "2023-05-08T13:56:00+00:00", (
+            f"LOCOMO normaliser produced {out!r} for the canonical format; "
+            "if this fails, the format string in _LOCOMO_DATE_FMT drifted"
+        )
+
+    def test_unparseable_input_returns_none(self):
+        # Graceful degradation: the harness shouldn't crash on a malformed
+        # date — the turn just goes through without a temporal anchor.
+        from benchmarks.locomo import _normalize_locomo_timestamp
+
+        assert _normalize_locomo_timestamp("not a date") is None
+        assert _normalize_locomo_timestamp("") is None
+
+    def test_none_input_returns_none(self):
+        from benchmarks.locomo import _normalize_locomo_timestamp
+
+        assert _normalize_locomo_timestamp(None) is None
+
+
+class TestLongMemEvalTimestampNormalisation:
+    """The LME adapter does inline normalisation rather than via a helper.
+    This test goes through the adapter's full parse path to confirm the
+    RFC 3339 conversion fires correctly on the cached fixture's data.
+    """
+
+    def test_fixture_session_dates_become_rfc3339_on_turns(self, tmp_path):
+        from benchmarks.longmemeval import LongMemEvalBenchmark
+
+        fixture_dir = Path(__file__).parent / "fixtures"
+        adapter = LongMemEvalBenchmark()
+        convs, _ = adapter.load(fixture_dir)
+        # Every turn that has a timestamp should now have it in RFC 3339
+        # UTC form (T separator, +00:00 suffix).
+        seen_any = False
+        for conv in convs:
+            for session in conv.sessions:
+                for turn in session.turns:
+                    if turn.timestamp is not None:
+                        seen_any = True
+                        assert "T" in turn.timestamp
+                        assert turn.timestamp.endswith("+00:00"), (
+                            f"LME turn timestamp must be UTC-normalised; "
+                            f"got {turn.timestamp!r}"
+                        )
+        # The fixture must include at least one timestamped session
+        # (otherwise we're not actually testing the conversion path).
+        assert seen_any, "fixture should contain at least one timestamped session"

--- a/services/server/benchmarks/tests/test_adapters.py
+++ b/services/server/benchmarks/tests/test_adapters.py
@@ -93,7 +93,7 @@ class TestLocomoAdapter:
         # Per-turn chunking: 2 sessions × 3 turns each (fixture) = 6 chunks
         total_turns = sum(len(s.turns) for s in convs[0].sessions)
         assert len(chunks) == total_turns
-        # WALM-55: chunks are 3-tuples (label, text, occurred_at).
+        # chunks are 3-tuples (label, text, occurred_at).
         for label, text, occurred_at in chunks:
             assert "/" in label, "label format is conv_id/session_id"
             # LOCOMO text already has the speaker name baked in
@@ -118,7 +118,7 @@ class TestLocomoAdapter:
         chunks = adapter.build_ingest_text(convs[0])
         from collections import defaultdict
         by_label = defaultdict(int)
-        # WALM-55: unpack the 3-tuple, ignore text + occurred_at.
+        # unpack the 3-tuple, ignore text + occurred_at.
         for label, _text, _occurred_at in chunks:
             by_label[label] += 1
         # Every session should have produced at least one chunk
@@ -197,7 +197,7 @@ class TestLongMemEvalAdapter:
         chunks = adapter.build_ingest_text(convs[0])
         total_turns = sum(len(s.turns) for s in convs[0].sessions)
         assert len(chunks) == total_turns
-        # WALM-55: chunks are 3-tuples (label, text, occurred_at).
+        # chunks are 3-tuples (label, text, occurred_at).
         for label, text, occurred_at in chunks:
             assert text.strip(), "ingest text should be non-empty"
             # LongMemEval turns are raw content (no embedded speaker name)
@@ -213,7 +213,7 @@ class TestLongMemEvalAdapter:
                     f"occurred_at must be RFC 3339, got {occurred_at!r}"
 
 
-# ── WALM-55: per-benchmark timestamp normalisation ────────────────────
+# ── per-benchmark timestamp normalisation ────────────────────
 
 class TestLocomoTimestampNormalisation:
     """Pin the LOCOMO date-string → RFC 3339 conversion shape.

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -364,10 +364,15 @@ pub async fn ask(
         .await
         .map_err(|e| AppError::Internal(format!("Failed to parse LLM response: {}", e)))?;
 
+    // WALM-55: `content` is `Option<String>` — `None` on upstream null-content
+    // returns. For the ask path, fall back to the existing
+    // "No response from LLM" message so the user sees a useful signal.
     let answer = api_resp
         .choices
         .first()
-        .map(|c| c.message.content.trim().to_string())
+        .and_then(|c| c.message.content.as_deref())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "No response from LLM".to_string());
 
     tracing::info!("ask complete: answer length={} chars", answer.len());

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -364,7 +364,7 @@ pub async fn ask(
         .await
         .map_err(|e| AppError::Internal(format!("Failed to parse LLM response: {}", e)))?;
 
-    // WALM-55: `content` is `Option<String>` — `None` on upstream null-content
+    // `content` is `Option<String>` — `None` on upstream null-content
     // returns. For the ask path, fall back to the existing
     // "No response from LLM" message so the user sees a useful signal.
     let answer = api_resp

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -318,9 +318,15 @@ pub async fn analyze(
     // pass `related_memories` as dedup context. The LlmExtractor
     // short-circuits to plain `extract` on empty slice — no wasted tokens
     // when the namespace had no nearest hits.
+    // WALM-55: also pass `body.occurred_at` as the temporal anchor. When
+    // present, the extractor renders a `<context occurred_at="..."/>` tag
+    // alongside the prompt so the LLM can resolve relative-time
+    // references ("last Friday") to absolute dates *inside the extracted
+    // fact text* (Architecture A — no metadata column, date flows into
+    // the encrypted blob + embedding only).
     let extracted = state
         .extractor
-        .extract_with_context(&body.text, &related_texts)
+        .extract_with_context(&body.text, &related_texts, body.occurred_at)
         .await?;
     let raw_fact_count = extracted.raw_count;
     let facts = extracted.facts;

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -318,7 +318,7 @@ pub async fn analyze(
     // pass `related_memories` as dedup context. The LlmExtractor
     // short-circuits to plain `extract` on empty slice — no wasted tokens
     // when the namespace had no nearest hits.
-    // WALM-55: also pass `body.occurred_at` as the temporal anchor. When
+    // also pass `body.occurred_at` as the temporal anchor. When
     // present, the extractor renders a `<context occurred_at="..."/>` tag
     // alongside the prompt so the LLM can resolve relative-time
     // references ("last Friday") to absolute dates *inside the extracted

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -464,10 +464,14 @@ async fn summarize_with_prompt(
         AppError::Internal(format!("Failed to parse summarization response: {}", e))
     })?;
 
+    // WALM-55: `content` is `Option<String>` — `None` on upstream null-content
+    // returns degrades to empty, which the existing is_empty() check below
+    // already handles as a summarisation failure.
     let summary = api_resp
         .choices
         .first()
-        .map(|c| c.message.content.trim().to_string())
+        .and_then(|c| c.message.content.as_deref())
+        .map(|s| s.trim().to_string())
         .unwrap_or_default();
 
     if summary.is_empty() {

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -464,7 +464,7 @@ async fn summarize_with_prompt(
         AppError::Internal(format!("Failed to parse summarization response: {}", e))
     })?;
 
-    // WALM-55: `content` is `Option<String>` — `None` on upstream null-content
+    // `content` is `Option<String>` — `None` on upstream null-content
     // returns degrades to empty, which the existing is_empty() check below
     // already handles as a summarisation failure.
     let summary = api_resp

--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -90,6 +90,16 @@ impl Embedder for OpenAiEmbedder {
                 if !resp.status().is_success() {
                     let status = resp.status();
                     let body = resp.text().await.unwrap_or_default();
+                    // Same transient-vs-permanent split as the
+                    // extractor: 429 + 5xx → 503 (retryable); other
+                    // 4xx → 500 (genuine bug). See
+                    // `extractor::is_upstream_status_transient`.
+                    if crate::services::extractor::is_upstream_status_transient(status) {
+                        return Err(AppError::UpstreamUnavailable(format!(
+                            "Embedding API upstream error ({}): {}",
+                            status, body
+                        )));
+                    }
                     return Err(AppError::Internal(format!(
                         "Embedding API error ({}): {}",
                         status, body

--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -96,7 +96,30 @@ impl Embedder for OpenAiEmbedder {
                     )));
                 }
 
-                let api_resp: EmbeddingApiResponse = resp.json().await.map_err(|e| {
+                // WALM-55: same pattern as the extractor — capture body
+                // as text first so we can (1) treat transport-level
+                // failures as transient, and (2) detect OpenRouter
+                // error envelopes wrapped in HTTP 200. Both route to
+                // `AppError::UpstreamUnavailable` (HTTP 503) so the
+                // SDK / harness retry policy can recover. See
+                // `extractor::parse_openrouter_error_envelope`.
+                let body = resp.text().await.map_err(|e| {
+                    AppError::UpstreamUnavailable(format!(
+                        "Failed to read embedding response body: {}",
+                        e
+                    ))
+                })?;
+
+                if let Some(envelope) =
+                    crate::services::extractor::parse_openrouter_error_envelope(&body)
+                {
+                    return Err(AppError::UpstreamUnavailable(format!(
+                        "OpenRouter upstream error (code={}): {}",
+                        envelope.code, envelope.message
+                    )));
+                }
+
+                let api_resp: EmbeddingApiResponse = serde_json::from_str(&body).map_err(|e| {
                     AppError::Internal(format!("Failed to parse embedding response: {}", e))
                 })?;
 
@@ -147,4 +170,29 @@ struct EmbeddingApiResponse {
 #[derive(serde::Deserialize)]
 struct EmbeddingData {
     embedding: Vec<f32>,
+}
+
+#[cfg(test)]
+mod tests {
+    /// WALM-55: parity test — the embedder routes OpenRouter-error-envelope
+    /// bodies to `AppError::UpstreamUnavailable` via the SHARED helper
+    /// `extractor::parse_openrouter_error_envelope`. If a future refactor
+    /// breaks the cross-module import or call site, this catches it at
+    /// compile time + test time without needing to mock reqwest.
+    ///
+    /// The full unit coverage of the envelope-parser shape (whitespace
+    /// padding, valid-completion non-matches, both-fields edge case,
+    /// malformed-JSON fallthrough) lives in `extractor::tests`. Don't
+    /// duplicate it here — duplicating only adds maintenance cost; the
+    /// helper is the same function.
+    #[test]
+    fn embedder_uses_shared_openrouter_envelope_parser() {
+        // Real failing body shape captured from the LME v2 bench
+        // investigation (200 OK wrapping a 504-gateway-timeout error).
+        let body = r#"{"error":{"message":"The operation was aborted","code":504}}"#;
+        let envelope = crate::services::extractor::parse_openrouter_error_envelope(body)
+            .expect("embedder must be able to detect the same envelope shape as the extractor");
+        assert_eq!(envelope.code, 504);
+        assert_eq!(envelope.message, "The operation was aborted");
+    }
 }

--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -96,7 +96,7 @@ impl Embedder for OpenAiEmbedder {
                     )));
                 }
 
-                // WALM-55: same pattern as the extractor — capture body
+                // same pattern as the extractor — capture body
                 // as text first so we can (1) treat transport-level
                 // failures as transient, and (2) detect OpenRouter
                 // error envelopes wrapped in HTTP 200. Both route to
@@ -174,7 +174,7 @@ struct EmbeddingData {
 
 #[cfg(test)]
 mod tests {
-    /// WALM-55: parity test — the embedder routes OpenRouter-error-envelope
+    /// parity test — the embedder routes OpenRouter-error-envelope
     /// bodies to `AppError::UpstreamUnavailable` via the SHARED helper
     /// `extractor::parse_openrouter_error_envelope`. If a future refactor
     /// breaks the cross-module import or call site, this catches it at

--- a/services/server/src/services/extractor.rs
+++ b/services/server/src/services/extractor.rs
@@ -299,7 +299,7 @@ impl LlmExtractor {
         }
 
         // read body as text first (was `resp.json()` directly).
-        // This enables two transient-failure detections that route to
+        // This enables three transient-failure detections that route to
         // `AppError::UpstreamUnavailable` (HTTP 503, retried by the
         // SDK + benchmark harness) instead of `AppError::Internal`
         // (HTTP 500, dropped):
@@ -315,8 +315,9 @@ impl LlmExtractor {
         //     with the embedded error.
         //
         // (3) Body deserialises but `content` is `null` — handled at
-        //     the `ChatMessageResp` type (now `Option<String>`),
-        //     degrades to empty string and produces zero facts.
+        //     the `ChatMessageResp` type (now `Option<String>`) so we
+        //     can classify it as a retryable upstream failure instead
+        //     of silently producing zero facts.
         //
         // Cost: holding the body as a String uses ~response-size extra
         // memory (a few KB per chat completion — trivial).

--- a/services/server/src/services/extractor.rs
+++ b/services/server/src/services/extractor.rs
@@ -71,41 +71,50 @@ pub trait Extractor: Send + Sync {
     /// response is normalised to an empty list).
     async fn extract(&self, text: &str) -> Result<ExtractedFacts, AppError>;
 
-    /// Extract memorable facts with **pre-extraction dedup context**
-    /// — the caller has already pulled the top-K nearest existing memories
-    /// for `text` and passes them as `related_memories`. The extractor
-    /// shows them to the LLM as a `<related_memories>` block so it can:
+    /// Extract memorable facts with **pre-extraction dedup context** and
+    /// an optional **temporal anchor**.
     ///
-    /// - Skip duplicates ("Bob lives in Seattle" already exists)
-    /// - Anchor borderline content against known facts ("this is new,
-    ///   keep it" vs "this is just a restatement, drop it")
-    /// - Avoid emitting near-paraphrases of existing memories
+    /// - `related_memories`: top-K nearest existing memories for `text`,
+    ///   shown to the LLM as a `<related_memories>` block. Used to:
+    ///   skip duplicates ("Bob lives in Seattle" already exists), anchor
+    ///   borderline content, avoid emitting near-paraphrases. The
+    ///   extractor does NOT auto-merge or supersede — extraction stays
+    ///   ADD-only.
     ///
-    /// This keeps extraction saliency-aware without automatic merging or
-    /// supersede — the extractor just decides what to extract afresh.
+    /// - `occurred_at`: optional RFC-3339 UTC timestamp of when this
+    ///   conversation turn took place. When present, the extractor shows
+    ///   it to the LLM as a `<context occurred_at="..."/>` tag so the
+    ///   LLM can resolve in-turn relative references ("last Friday",
+    ///   "yesterday") to absolute dates *inside the extracted fact text*.
+    ///   The resolved date lives inside the SEAL-encrypted fact on Walrus
+    ///   and inside the embedding — never as a server-readable metadata
+    ///   column. See [`render_occurred_at_block`].
     ///
     /// Default impl falls through to [`Self::extract`] so callers that
     /// don't have related-memory context (manual remember, restore flow)
     /// keep working without changes; the `routes/analyze.rs` handler is
     /// the one site expected to actually pass context.
     ///
-    /// Pass an empty slice (`&[]`) when the namespace has no prior
-    /// memories — the impl is expected to short-circuit and behave
-    /// identically to [`Self::extract`] in that case (no wasted tokens
-    /// on an empty `<related_memories>` block). The caller is the one
-    /// expected to skip the actual `db.search_similar` round-trip when
-    /// it knows the namespace is empty (see `routes/analyze.rs`); the
-    /// short-circuit here is just a defensive no-op for safety.
+    /// Pass an empty slice (`&[]`) for `related_memories` when the
+    /// namespace has no prior memories — the impl is expected to
+    /// short-circuit and behave identically to [`Self::extract`] in
+    /// that case (no wasted tokens on an empty `<related_memories>`
+    /// block). Pass `None` for `occurred_at` when no temporal anchor is
+    /// available; the impl must NOT default to `now()` (silence is
+    /// honest; falling back to `now` would stamp present-time onto
+    /// past-event facts and pollute retrieval).
     async fn extract_with_context(
         &self,
         text: &str,
         related_memories: &[&str],
+        occurred_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<ExtractedFacts, AppError> {
-        // Default — ignore the context. Concrete impls that can use it
+        // Default — ignore both contexts. Concrete impls that can use them
         // (like `LlmExtractor`) override this. Keeping the default sane
         // means a test mock can implement just `extract` and still satisfy
         // the trait for callers that opt into the contextual variant.
         let _ = related_memories;
+        let _ = occurred_at;
         self.extract(text).await
     }
 }
@@ -164,7 +173,34 @@ const FACT_EXTRACTION_PROMPT: &str = include_str!("prompts/extract.txt");
 /// exists, and adds a worked summary-vs-atomic example. Preserves v4's
 /// exact-paraphrase dedup (the mechanism behind the LOCOMO win).
 /// Source: `prompts/extract.txt`.
-pub const FACT_EXTRACTION_PROMPT_VERSION: &str = "extract.v5";
+///
+/// v6 (WALM-55): adds a `<context occurred_at="..."/>` temporal anchor.
+/// When the caller supplies an absolute RFC-3339 timestamp via
+/// `AnalyzeRequest.occurred_at`, the extractor uses it to:
+/// (a) attach a verbose absolute date (`Weekday, D Month YYYY
+/// (YYYY-MM-DD)`) to facts describing current/recent events, (b)
+/// resolve specific relative references ("last Friday", "yesterday")
+/// to absolute dates, (c) keep vague references honest ("a few years
+/// ago" → keep as-is; "next week" → anchor to a month when possible),
+/// and (d) preserve original dates on recounted past events. Defensive
+/// default: when uncertain whether a fact is time-anchored, the LLM
+/// is instructed to prefer leaving the date off (a missing date is
+/// recoverable; a wrongly-stamped date pollutes retrieval).
+///
+/// Architecture A (locked 2026-05-27): the resolved date lives ONLY
+/// inside the extracted fact text. It ends up in the SEAL-encrypted
+/// blob on Walrus and the embedding vector — there is NO new metadata
+/// column on `vector_entries`. The server can never filter or rank by
+/// event time; that's the privacy-floor-preserving trade. Targets the
+/// LOCOMO `temporal` 45.2 / LME `temporal-reasoning` 60.1 categories
+/// (the two weakest after the May 2026 phase-1 cycle).
+///
+/// The `<context>` tag is supplied as a separate user-role message by
+/// `LlmExtractor::extract_with_context` so the static system prompt
+/// stays cacheable (same pattern as the `<related_memories>` block).
+/// Callers without an `occurred_at` pass `None`; the impl does NOT
+/// fall back to `now()`.
+pub const FACT_EXTRACTION_PROMPT_VERSION: &str = "extract.v6";
 
 /// Map a bucket name from the extractor LLM to a numeric importance score.
 /// Unknown / missing buckets default to `IMPORTANCE_STANDARD` so a noisy
@@ -249,15 +285,51 @@ impl LlmExtractor {
             )));
         }
 
-        let api_resp: ChatCompletionResponse = resp
-            .json()
-            .await
+        // WALM-55: read body as text first (was `resp.json()` directly).
+        // This enables two transient-failure detections that route to
+        // `AppError::UpstreamUnavailable` (HTTP 503, retried by the
+        // SDK + benchmark harness) instead of `AppError::Internal`
+        // (HTTP 500, dropped):
+        //
+        // (1) `resp.text()` fails — transport-level: body never fully
+        //     arrived (connection drop, HTTP/2 stream reset). Observed
+        //     during the LME v2 bench investigation.
+        //
+        // (2) Body is an OpenRouter error envelope wrapped in 200 OK:
+        //     `{"error":{"message":"...","code":NNN}}` with no
+        //     `choices` field. Observed when an upstream provider
+        //     times out and OpenRouter swallows the 5xx, emitting 200
+        //     with the embedded error.
+        //
+        // (3) Body deserialises but `content` is `null` — handled at
+        //     the `ChatMessageResp` type (now `Option<String>`),
+        //     degrades to empty string and produces zero facts.
+        //
+        // Cost: holding the body as a String uses ~response-size extra
+        // memory (a few KB per chat completion — trivial).
+        let body = resp.text().await.map_err(|e| {
+            AppError::UpstreamUnavailable(format!("Failed to read LLM response body: {}", e))
+        })?;
+
+        if let Some(envelope) = parse_openrouter_error_envelope(&body) {
+            return Err(AppError::UpstreamUnavailable(format!(
+                "OpenRouter upstream error (code={}): {}",
+                envelope.code, envelope.message
+            )));
+        }
+
+        let api_resp: ChatCompletionResponse = serde_json::from_str(&body)
             .map_err(|e| AppError::Internal(format!("Failed to parse LLM response: {}", e)))?;
 
+        // WALM-55: `content` is `Option<String>` — `None` on upstream
+        // null-content returns degrades to empty string, which
+        // `parse_extracted_facts` treats as zero facts. Same legitimate
+        // outcome as the prompt's explicit `NONE` reply.
         let content = api_resp
             .choices
             .first()
-            .map(|c| c.message.content.trim().to_string())
+            .and_then(|c| c.message.content.as_deref())
+            .map(|s| s.trim().to_string())
             .unwrap_or_default();
 
         Ok(parse_extracted_facts(&content))
@@ -281,47 +353,77 @@ impl Extractor for LlmExtractor {
         self.call_chat_completion(messages).await
     }
 
-    /// extract with pre-extraction dedup context. Sends two user
-    /// messages — first the `<related_memories>` block, then the actual
-    /// input text. The static system prompt (see
-    /// [`FACT_EXTRACTION_PROMPT_VERSION`]) explains how the LLM should use
-    /// the block (skip exact-paraphrase duplicates, keep atomic facts even
-    /// under a summary, anchor borderline content, do not auto-merge).
+    /// Extract with pre-extraction dedup context and an optional temporal
+    /// anchor. Sends 1-3 user messages depending on which contexts are
+    /// present:
     ///
-    /// On empty `related_memories` slice, short-circuits to plain `extract`
-    /// — no wasted tokens, no second user message. The empty-namespace
-    /// optimisation in the caller (skip the recall round-trip) is what
-    /// actually saves time on first-ingest paths; this is a safety net.
+    /// ```text
+    /// [system: FACT_EXTRACTION_PROMPT]
+    /// [user:   <related_memories>...</related_memories>]   // only if related_memories non-empty
+    /// [user:   <context occurred_at="..."/>]               // only if occurred_at is Some
+    /// [user:   <the actual input text>]                    // always
+    /// ```
+    ///
+    /// Each context block is a separate user message so the static system
+    /// prompt stays cacheable. The system prompt (see
+    /// [`FACT_EXTRACTION_PROMPT_VERSION`]) explains how the LLM should
+    /// use each block.
+    ///
+    /// Short-circuit: when BOTH contexts are empty (no related memories
+    /// AND no occurred_at), delegates to plain `extract` — no wasted
+    /// tokens on empty context messages. The empty-namespace
+    /// optimisation in the caller (skip the pre-extraction recall
+    /// round-trip) is what actually saves time on first-ingest paths;
+    /// this is a safety net.
+    ///
+    /// `occurred_at` is rendered as RFC 3339 UTC inside a self-closing
+    /// `<context>` tag — see [`render_occurred_at_block`]. The tag is a
+    /// known-good shape (no user-controlled content), so it bypasses the
+    /// prompt-injection escaping that the related-memories block needs.
     #[tracing::instrument(
         name = "extractor.extract_with_context",
         skip_all,
-        fields(text_len = text.len(), context_len = related_memories.len())
+        fields(
+            text_len = text.len(),
+            context_len = related_memories.len(),
+            has_occurred_at = occurred_at.is_some(),
+        )
     )]
     async fn extract_with_context(
         &self,
         text: &str,
         related_memories: &[&str],
+        occurred_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<ExtractedFacts, AppError> {
-        if related_memories.is_empty() {
+        // Short-circuit when there's nothing context-worthy to send.
+        // Both `related_memories.is_empty()` AND `occurred_at.is_none()`
+        // must hold — either context alone is reason enough to use the
+        // contextual prompt path.
+        if related_memories.is_empty() && occurred_at.is_none() {
             return self.extract(text).await;
         }
 
-        let context_block = render_related_memories_block(related_memories);
-
-        let messages = vec![
-            ChatMessage {
-                role: "system".to_string(),
-                content: FACT_EXTRACTION_PROMPT.to_string(),
-            },
-            ChatMessage {
+        let mut messages = Vec::with_capacity(4);
+        messages.push(ChatMessage {
+            role: "system".to_string(),
+            content: FACT_EXTRACTION_PROMPT.to_string(),
+        });
+        if !related_memories.is_empty() {
+            messages.push(ChatMessage {
                 role: "user".to_string(),
-                content: context_block,
-            },
-            ChatMessage {
+                content: render_related_memories_block(related_memories),
+            });
+        }
+        if let Some(ts) = occurred_at {
+            messages.push(ChatMessage {
                 role: "user".to_string(),
-                content: text.to_string(),
-            },
-        ];
+                content: render_occurred_at_block(ts),
+            });
+        }
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: text.to_string(),
+        });
         self.call_chat_completion(messages).await
     }
 }
@@ -367,7 +469,79 @@ fn render_related_memories_block(memories: &[&str]) -> String {
     out
 }
 
-/// escape characters with structural meaning in the
+/// Render a `<context occurred_at="..."/>` block for the temporal-anchor
+/// user message. Format is a single self-closing XML-style tag (no body
+/// content) carrying the RFC 3339 UTC timestamp.
+///
+/// The prompt (see `prompts/extract.txt`, v6 onwards) instructs the LLM
+/// to use this timestamp as the absolute anchor for resolving in-turn
+/// relative-time references ("last Friday", "yesterday") into absolute
+/// dates that end up *inside the extracted fact text* — so the date
+/// flows into both the SEAL-encrypted blob and the embedding vector.
+///
+/// No prompt-injection escaping is needed here: the timestamp value is
+/// a server-controlled RFC 3339 serialisation, not user-supplied text.
+/// `chrono::DateTime<Utc>::to_rfc3339` produces deterministic output
+/// from the standard library — `2023-05-25T17:50:00+00:00` — with no
+/// embeddable control characters.
+fn render_occurred_at_block(occurred_at: chrono::DateTime<chrono::Utc>) -> String {
+    format!("<context occurred_at=\"{}\"/>", occurred_at.to_rfc3339())
+}
+
+/// Parsed shape of OpenRouter's "200 OK wrapping an upstream
+/// gateway-timeout error" envelope. Used to detect this case at the
+/// chat-completion + embedding call sites and route to
+/// `AppError::UpstreamUnavailable` (HTTP 503, retryable by clients)
+/// instead of `AppError::Internal` (HTTP 500, dropped by the SDK +
+/// benchmark harness retry policy).
+///
+/// Observed shape in production:
+///
+/// ```json
+/// {"error":{"message":"The operation was aborted","code":504}}
+/// ```
+///
+/// Sometimes the body is padded with leading whitespace lines before the
+/// JSON object — the parser handles that naturally because
+/// `serde_json::from_str` trims surrounding whitespace.
+pub(crate) struct OpenRouterErrorEnvelope {
+    pub code: i64,
+    pub message: String,
+}
+
+/// Try to parse `body` as the OpenRouter error envelope. Returns
+/// `Some(envelope)` only when the body matches that exact shape (a JSON
+/// object with a top-level `error` field containing `message` + `code`,
+/// AND no top-level `choices` field). Returns `None` for any other body
+/// — including valid chat completions, embeddings, or genuinely
+/// malformed JSON — so the caller can fall through to its existing
+/// error handling.
+///
+/// The `choices.is_none()` guard prevents a false-positive on the edge
+/// case where a body contains BOTH a valid `choices` array AND an
+/// `error` field (some providers emit partial-error metadata alongside
+/// successful completions); in that case we want to deserialise the
+/// completion normally rather than discard it as a 503.
+///
+/// Free function so the unit tests can exercise the envelope detection
+/// independently of the HTTP call sites.
+pub(crate) fn parse_openrouter_error_envelope(body: &str) -> Option<OpenRouterErrorEnvelope> {
+    // serde_json::Value avoids a strict struct shape — OpenRouter has
+    // historically varied the secondary fields (`type`, `param`,
+    // `metadata`) on error envelopes; we only need `code` + `message`.
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    // Guard: if `choices` is present, the body is (or claims to be) a
+    // successful completion — do not classify as an upstream error.
+    if v.get("choices").is_some() {
+        return None;
+    }
+    let err = v.get("error")?.as_object()?;
+    let code = err.get("code")?.as_i64()?;
+    let message = err.get("message")?.as_str()?.to_string();
+    Some(OpenRouterErrorEnvelope { code, message })
+}
+
+/// Escape characters with structural meaning in the
 /// `<related_memories>` block so stored user content can't inject
 /// prompt-control sequences. We use XML-style entity references
 /// because the LLM is overwhelmingly familiar with that escape
@@ -673,8 +847,12 @@ mod tests {
         };
 
         // Non-empty context, but the default impl should ignore it.
+        // WALM-55: also pass None for occurred_at — the default impl
+        // must ignore both contexts equally.
         let context = ["Existing memory A", "Existing memory B"];
-        let result = mock.extract_with_context("new input text", &context).await;
+        let result = mock
+            .extract_with_context("new input text", &context, None)
+            .await;
         assert!(result.is_ok());
         assert_eq!(
             mock.extract_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -695,12 +873,35 @@ mod tests {
             extract_calls: std::sync::atomic::AtomicUsize::new(0),
             last_text: std::sync::Mutex::new(String::new()),
         };
-        let result = mock.extract_with_context("hello", &[]).await;
+        let result = mock.extract_with_context("hello", &[], None).await;
         assert!(result.is_ok());
         assert_eq!(
             mock.extract_calls.load(std::sync::atomic::Ordering::SeqCst),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn extract_with_context_default_handles_only_occurred_at() {
+        // A default-impl Extractor (test mock without override) must
+        // also ignore occurred_at and fall through to extract(). This
+        // pins the trait contract: alternative impls that never opt
+        // into temporal awareness keep working without code changes.
+        let mock = CountingMockExtractor {
+            extract_calls: std::sync::atomic::AtomicUsize::new(0),
+            last_text: std::sync::Mutex::new(String::new()),
+        };
+        let ts = chrono::DateTime::parse_from_rfc3339("2023-05-25T17:50:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let result = mock.extract_with_context("hello", &[], Some(ts)).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            mock.extract_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "default impl should ignore occurred_at and delegate to extract() once"
+        );
+        assert_eq!(*mock.last_text.lock().unwrap(), "hello");
     }
 
     // ── related_memories block rendering ─────────────────────
@@ -857,11 +1058,136 @@ mod tests {
         // mechanism behind the LOCOMO win and v5 must not drop it.
         assert!(
             prompt.contains("EXACT match or close paraphrase"),
-            "v4 exact-paraphrase dedup rule must be preserved in extract.v5"
+            "v4 exact-paraphrase dedup rule must be preserved in extract.v5+"
         );
         // The version const must track the prompt: if the prompt changes,
         // the version should not silently stay behind.
-        assert_eq!(FACT_EXTRACTION_PROMPT_VERSION, "extract.v5");
+        assert_eq!(FACT_EXTRACTION_PROMPT_VERSION, "extract.v6");
+    }
+
+    #[test]
+    fn extract_v6_prompt_contains_temporal_anchor_section() {
+        // WALM-55: the extract.v6 prompt must instruct the LLM about the
+        // `<context occurred_at="..."/>` tag. Pin three load-bearing
+        // pieces of the temporal-anchor section so a future prompt edit
+        // can't silently remove them.
+        let prompt = FACT_EXTRACTION_PROMPT;
+        assert!(
+            prompt.contains("`<context occurred_at=\"...\"/>`"),
+            "v6 must document the context tag the LLM should expect"
+        );
+        assert!(
+            prompt.contains("temporal anchor"),
+            "v6 must use the phrase 'temporal anchor' so the LLM knows the tag's role"
+        );
+        // The defensive opt-out is the load-bearing safety rule against
+        // gpt-4o-mini over-stamping. If a future edit removes it, the
+        // wrongly-stamped-fact failure mode becomes silently more
+        // likely.
+        assert!(
+            prompt.contains("prefer leaving the date off"),
+            "v6 must keep the 'prefer no date when uncertain' defensive rule"
+        );
+        // The verbose date format is what makes natural-language and
+        // ISO date queries both hit. Pin the example so a future edit
+        // can't drop one half of the format.
+        assert!(
+            prompt.contains("Friday, 19 May 2023 (2023-05-19)"),
+            "v6 must keep the worked example with the verbose date format"
+        );
+    }
+
+    // ── WALM-55: occurred_at block rendering ─────────────────────────
+
+    #[test]
+    fn render_occurred_at_block_basic_shape() {
+        // Self-closing XML-style tag with an RFC 3339 attribute. The
+        // LLM-facing prompt expects exactly this shape — drift in the
+        // rendering would silently break the temporal-anchor mechanism.
+        let ts = chrono::DateTime::parse_from_rfc3339("2023-05-25T17:50:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let block = super::render_occurred_at_block(ts);
+        assert_eq!(
+            block, "<context occurred_at=\"2023-05-25T17:50:00+00:00\"/>",
+            "tag shape must match what the prompt's v6 examples reference"
+        );
+    }
+
+    #[test]
+    fn render_occurred_at_block_handles_subsecond_and_non_utc_input() {
+        // Subsecond precision should survive into the rendered tag.
+        // We also pin that callers pre-converting from a fixed offset
+        // to Utc (the standard recipe) produces the +00:00 suffix.
+        let ts_naive = chrono::DateTime::parse_from_rfc3339("2023-05-25T17:50:00.123-07:00")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let block = super::render_occurred_at_block(ts_naive);
+        // -07:00 + 7h = +00:00 → "2023-05-26T00:50:00.123+00:00"
+        assert_eq!(
+            block, "<context occurred_at=\"2023-05-26T00:50:00.123+00:00\"/>",
+            "non-UTC inputs must be normalised to UTC in the rendered tag"
+        );
+    }
+
+    #[test]
+    fn extract_v6_prompt_blocks_tag_leak_and_date_fabrication() {
+        // WALM-55 smoke-test follow-up: the first prompt-iteration of v6
+        // had two reproducible failure modes when `<context>` was absent:
+        //   1. The LLM hallucinated a `<context occurred_at="..."/>` line
+        //      copied verbatim from the worked examples (then the parser,
+        //      which is too permissive, stored the tag as a "fact").
+        //   2. The LLM fabricated a resolved date for "last Friday" using
+        //      the timestamp from the example, despite no anchor being
+        //      provided in the call.
+        //
+        // The fix added two explicit anti-leak rules to the prompt. Pin
+        // them here so a future edit can't silently regress to the
+        // failure modes.
+        let prompt = FACT_EXTRACTION_PROMPT;
+        assert!(
+            prompt.contains("do NOT resolve relative references"),
+            "v6 must explicitly forbid date fabrication when <context> is absent"
+        );
+        assert!(
+            prompt.contains("Do NOT emit a `<context>` line in your output"),
+            "v6 must explicitly forbid emitting the <context> tag in output"
+        );
+        assert!(
+            prompt.contains("Output format — strict"),
+            "v6 must include the strict-output-format section"
+        );
+        assert!(
+            prompt.contains("fact lines ONLY"),
+            "v6 must emphasise fact-lines-only output"
+        );
+    }
+
+    #[test]
+    fn extract_v6_prompt_documents_three_worked_temporal_examples() {
+        // Pin that v6 keeps a worked example for each of the three
+        // critical temporal cases the diagnosis identified:
+        //   1. current event with specific relative reference (the
+        //      dominant failure mode — ~78% of failing temporal Qs)
+        //   2. recounted old event keeps its own date (the anti-example
+        //      against over-stamping)
+        //   3. stable facts get no date even when occurred_at is present
+        //      (negative case preventing over-stamping)
+        // If a future edit drops any one of these, the corresponding
+        // failure mode becomes silently more likely.
+        let prompt = FACT_EXTRACTION_PROMPT;
+        assert!(
+            prompt.contains("specific relative reference resolved"),
+            "v6 must keep the current-event-with-resolved-reference example"
+        );
+        assert!(
+            prompt.contains("recounted old event keeps its own date"),
+            "v6 must keep the anti-example for recounted-event date preservation"
+        );
+        assert!(
+            prompt.contains("stable facts have no date"),
+            "v6 must keep the no-date-on-stable-facts example"
+        );
     }
 
     // ── prompt-injection guard on related_memories content ──
@@ -959,8 +1285,10 @@ mod tests {
             last_text: std::sync::Mutex::new(String::new()),
         };
 
-        // Empty slice — what every analyze.rs failure-mode path passes.
-        let result = mock.extract_with_context("the user input", &[]).await;
+        // Empty slice + no occurred_at — what every analyze.rs
+        // failure-mode path passes (WALM-55: when occurred_at is also
+        // absent the contract is unchanged from MEM-57).
+        let result = mock.extract_with_context("the user input", &[], None).await;
         assert!(result.is_ok());
 
         // Critical: extract() was called exactly once with the text.
@@ -978,6 +1306,79 @@ mod tests {
             *mock.last_text.lock().unwrap(),
             "the user input",
             "the original input text must reach extract() unchanged — no context wrapping"
+        );
+    }
+
+    // ── WALM-55: OpenRouter "200 OK wrapping upstream error" detection ──
+
+    #[test]
+    fn envelope_detects_200_wrapped_504_from_openrouter() {
+        // Real failing body captured from the LME v2 bench. The whitespace
+        // padding is also realistic — OpenRouter sometimes emits ~78
+        // lines of indented blanks before the JSON envelope.
+        let body = "         \n         \n         \n\
+                    {\"error\":{\"message\":\"The operation was aborted\",\"code\":504}}";
+        let envelope = super::parse_openrouter_error_envelope(body)
+            .expect("must detect the OpenRouter error envelope");
+        assert_eq!(envelope.code, 504);
+        assert_eq!(envelope.message, "The operation was aborted");
+    }
+
+    #[test]
+    fn envelope_returns_none_for_valid_chat_completion() {
+        // The real OpenAI chat completion shape — must NOT be mis-detected
+        // as an error envelope. A successful response has `choices`, not
+        // `error`.
+        let body = r#"{"id":"chatcmpl-abc","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"standard\tA fact"}}]}"#;
+        assert!(
+            super::parse_openrouter_error_envelope(body).is_none(),
+            "valid completion body must not be detected as an error envelope"
+        );
+    }
+
+    #[test]
+    fn envelope_returns_none_when_choices_and_error_both_present() {
+        // Defensive: some providers emit partial-error metadata on an
+        // otherwise-successful completion (top-level `choices` AND
+        // top-level `error`). The `choices.is_none()` guard in
+        // `parse_openrouter_error_envelope` MUST return None here so
+        // the caller deserialises the real completion instead of
+        // discarding it as a 503 upstream failure.
+        let body = r#"{
+            "choices":[{"index":0,"message":{"role":"assistant","content":"standard\tA real fact"}}],
+            "error":{"message":"a non-fatal upstream warning","code":429}
+        }"#;
+        assert!(
+            super::parse_openrouter_error_envelope(body).is_none(),
+            "bodies with BOTH choices and error must defer to completion parsing, not 503-retry"
+        );
+    }
+
+    #[test]
+    fn envelope_returns_none_for_genuinely_malformed_json() {
+        // Truncated body — not valid JSON. Must return None so the
+        // caller's deserialise step (the `serde_json::from_str` for the
+        // expected struct) takes over and surfaces the error. We don't
+        // want to misclassify this as "upstream error" and silently
+        // retry — genuinely malformed JSON could be a bug to
+        // investigate.
+        assert!(super::parse_openrouter_error_envelope("{\"choices\":[{").is_none());
+        assert!(super::parse_openrouter_error_envelope("not json at all").is_none());
+        assert!(super::parse_openrouter_error_envelope("").is_none());
+    }
+
+    #[test]
+    fn envelope_returns_none_when_error_object_lacks_required_fields() {
+        // Defensive: an `error` field that isn't shaped as the expected
+        // {code, message} envelope shouldn't be treated as the
+        // retryable case — only the exact shape we've observed.
+        assert!(super::parse_openrouter_error_envelope(r#"{"error":"just a string"}"#).is_none());
+        assert!(
+            super::parse_openrouter_error_envelope(r#"{"error":{"message":"no code"}}"#).is_none()
+        );
+        assert!(
+            super::parse_openrouter_error_envelope(r#"{"error":{"code":504}}"#).is_none(),
+            "missing message"
         );
     }
 }

--- a/services/server/src/services/extractor.rs
+++ b/services/server/src/services/extractor.rs
@@ -279,6 +279,19 @@ impl LlmExtractor {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
+            // Transient upstream statuses (429 + 5xx) route to 503 so
+            // the SDK/harness retry policy can recover. Non-transient
+            // (4xx other than 429) stays as 500 — that's a real bug
+            // (bad auth, malformed request, etc.) that retrying won't
+            // fix. Mirrors the 200-wrapped envelope handling below
+            // for the case where the upstream returns the same 5xx
+            // condition as a raw HTTP status instead of wrapping it.
+            if is_upstream_status_transient(status) {
+                return Err(AppError::UpstreamUnavailable(format!(
+                    "LLM API upstream error ({}): {}",
+                    status, body
+                )));
+            }
             return Err(AppError::Internal(format!(
                 "LLM API error ({}): {}",
                 status, body
@@ -321,16 +334,28 @@ impl LlmExtractor {
         let api_resp: ChatCompletionResponse = serde_json::from_str(&body)
             .map_err(|e| AppError::Internal(format!("Failed to parse LLM response: {}", e)))?;
 
-        // `content` is `Option<String>` — `None` on upstream
-        // null-content returns degrades to empty string, which
-        // `parse_extracted_facts` treats as zero facts. Same legitimate
-        // outcome as the prompt's explicit `NONE` reply.
-        let content = api_resp
-            .choices
-            .first()
-            .and_then(|c| c.message.content.as_deref())
-            .map(|s| s.trim().to_string())
-            .unwrap_or_default();
+        // `content` is `Option<String>` to deserialise cleanly when the
+        // upstream returns HTTP 200 with `content: null` (observed from
+        // `gpt-4o-mini` via OpenRouter — model accepted the prompt but
+        // produced no output). We treat that as a transient upstream
+        // failure (`UpstreamUnavailable` → HTTP 503 → retried) rather
+        // than silently emitting zero facts: a successful empty extract
+        // is indistinguishable from "no memorable content" at the
+        // client, and the SDK/harness will not retry a 202 with
+        // facts=[]. The explicit string `"NONE"` from the LLM remains
+        // the valid no-facts path (handled by `parse_extracted_facts`).
+        let raw_content = api_resp.choices.first().and_then(|c| c.message.content.as_deref());
+        let content = match raw_content {
+            Some(s) => s.trim().to_string(),
+            None => {
+                return Err(AppError::UpstreamUnavailable(
+                    "LLM upstream returned content=null — treating as transient \
+                     failure (retryable). Explicit NONE replies are the valid \
+                     no-facts path and are handled separately."
+                        .to_string(),
+                ));
+            }
+        };
 
         Ok(parse_extracted_facts(&content))
     }
@@ -539,6 +564,18 @@ pub(crate) fn parse_openrouter_error_envelope(body: &str) -> Option<OpenRouterEr
     let code = err.get("code")?.as_i64()?;
     let message = err.get("message")?.as_str()?.to_string();
     Some(OpenRouterErrorEnvelope { code, message })
+}
+
+/// Classify a non-success upstream HTTP status as transient or
+/// non-transient. Transient statuses (429 rate-limit and 5xx server
+/// errors) route to `AppError::UpstreamUnavailable` → HTTP 503 so the
+/// SDK + benchmark harness retry policy (`_RETRY_STATUS = (429, 502,
+/// 503, 504)`) can recover. Non-transient statuses (4xx other than
+/// 429 — bad auth, malformed request) stay as `AppError::Internal` →
+/// HTTP 500 so they surface as a genuine bug rather than burning
+/// retry budget against an unrecoverable error.
+pub(crate) fn is_upstream_status_transient(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
 }
 
 /// Escape characters with structural meaning in the
@@ -1380,5 +1417,37 @@ mod tests {
             super::parse_openrouter_error_envelope(r#"{"error":{"code":504}}"#).is_none(),
             "missing message"
         );
+    }
+
+    #[test]
+    fn upstream_status_transient_recognises_5xx_and_429() {
+        // 429 (rate-limit) and any 5xx upstream → retryable (503 to
+        // the SDK/harness). Other 4xx → permanent (500). Pinned
+        // because the bench harness retry set
+        // `(429, 502, 503, 504)` depends on this classification —
+        // mis-mapping a 429 to 500 means we burn through OpenRouter
+        // rate-limit windows without backing off.
+        use super::is_upstream_status_transient;
+        use reqwest::StatusCode;
+
+        // Transient
+        assert!(is_upstream_status_transient(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_upstream_status_transient(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_upstream_status_transient(StatusCode::BAD_GATEWAY));
+        assert!(is_upstream_status_transient(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_upstream_status_transient(StatusCode::GATEWAY_TIMEOUT));
+
+        // Not transient — real bugs / config errors that retrying won't fix
+        assert!(!is_upstream_status_transient(StatusCode::UNAUTHORIZED));
+        assert!(!is_upstream_status_transient(StatusCode::FORBIDDEN));
+        assert!(!is_upstream_status_transient(StatusCode::NOT_FOUND));
+        assert!(!is_upstream_status_transient(StatusCode::BAD_REQUEST));
+        assert!(!is_upstream_status_transient(StatusCode::PAYLOAD_TOO_LARGE));
+
+        // Sanity: success codes shouldn't be classified as transient
+        // failures (the call site guards with `!is_success()`, but
+        // pin the helper's behaviour for defensive callers).
+        assert!(!is_upstream_status_transient(StatusCode::OK));
+        assert!(!is_upstream_status_transient(StatusCode::ACCEPTED));
     }
 }

--- a/services/server/src/services/extractor.rs
+++ b/services/server/src/services/extractor.rs
@@ -174,7 +174,7 @@ const FACT_EXTRACTION_PROMPT: &str = include_str!("prompts/extract.txt");
 /// exact-paraphrase dedup (the mechanism behind the LOCOMO win).
 /// Source: `prompts/extract.txt`.
 ///
-/// v6 (WALM-55): adds a `<context occurred_at="..."/>` temporal anchor.
+/// v6: adds a `<context occurred_at="..."/>` temporal anchor.
 /// When the caller supplies an absolute RFC-3339 timestamp via
 /// `AnalyzeRequest.occurred_at`, the extractor uses it to:
 /// (a) attach a verbose absolute date (`Weekday, D Month YYYY
@@ -285,7 +285,7 @@ impl LlmExtractor {
             )));
         }
 
-        // WALM-55: read body as text first (was `resp.json()` directly).
+        // read body as text first (was `resp.json()` directly).
         // This enables two transient-failure detections that route to
         // `AppError::UpstreamUnavailable` (HTTP 503, retried by the
         // SDK + benchmark harness) instead of `AppError::Internal`
@@ -321,7 +321,7 @@ impl LlmExtractor {
         let api_resp: ChatCompletionResponse = serde_json::from_str(&body)
             .map_err(|e| AppError::Internal(format!("Failed to parse LLM response: {}", e)))?;
 
-        // WALM-55: `content` is `Option<String>` — `None` on upstream
+        // `content` is `Option<String>` — `None` on upstream
         // null-content returns degrades to empty string, which
         // `parse_extracted_facts` treats as zero facts. Same legitimate
         // outcome as the prompt's explicit `NONE` reply.
@@ -847,7 +847,7 @@ mod tests {
         };
 
         // Non-empty context, but the default impl should ignore it.
-        // WALM-55: also pass None for occurred_at — the default impl
+        // also pass None for occurred_at — the default impl
         // must ignore both contexts equally.
         let context = ["Existing memory A", "Existing memory B"];
         let result = mock
@@ -1067,7 +1067,7 @@ mod tests {
 
     #[test]
     fn extract_v6_prompt_contains_temporal_anchor_section() {
-        // WALM-55: the extract.v6 prompt must instruct the LLM about the
+        // the extract.v6 prompt must instruct the LLM about the
         // `<context occurred_at="..."/>` tag. Pin three load-bearing
         // pieces of the temporal-anchor section so a future prompt edit
         // can't silently remove them.
@@ -1097,7 +1097,7 @@ mod tests {
         );
     }
 
-    // ── WALM-55: occurred_at block rendering ─────────────────────────
+    // ── occurred_at block rendering ─────────────────────────
 
     #[test]
     fn render_occurred_at_block_basic_shape() {
@@ -1132,7 +1132,7 @@ mod tests {
 
     #[test]
     fn extract_v6_prompt_blocks_tag_leak_and_date_fabrication() {
-        // WALM-55 smoke-test follow-up: the first prompt-iteration of v6
+        // Smoke-test follow-up: the first prompt-iteration of v6
         // had two reproducible failure modes when `<context>` was absent:
         //   1. The LLM hallucinated a `<context occurred_at="..."/>` line
         //      copied verbatim from the worked examples (then the parser,
@@ -1286,8 +1286,8 @@ mod tests {
         };
 
         // Empty slice + no occurred_at — what every analyze.rs
-        // failure-mode path passes (WALM-55: when occurred_at is also
-        // absent the contract is unchanged from MEM-57).
+        // failure-mode path passes; when occurred_at is also absent
+        // the contract is unchanged from the pre-existing extractor.
         let result = mock.extract_with_context("the user input", &[], None).await;
         assert!(result.is_ok());
 
@@ -1309,7 +1309,7 @@ mod tests {
         );
     }
 
-    // ── WALM-55: OpenRouter "200 OK wrapping upstream error" detection ──
+    // ── OpenRouter "200 OK wrapping upstream error" detection ──
 
     #[test]
     fn envelope_detects_200_wrapped_504_from_openrouter() {

--- a/services/server/src/services/llm_chat.rs
+++ b/services/server/src/services/llm_chat.rs
@@ -37,7 +37,7 @@ pub struct ChatChoice {
 
 #[derive(serde::Deserialize)]
 pub struct ChatMessageResp {
-    /// WALM-55: `Option<String>` because `gpt-4o-mini` (and likely other
+    /// `Option<String>` because `gpt-4o-mini` (and likely other
     /// OpenAI-compatible providers via OpenRouter) occasionally returns
     /// a successful HTTP 200 response with `content: null` and
     /// `completion_tokens: 0` — the model accepted the prompt but

--- a/services/server/src/services/llm_chat.rs
+++ b/services/server/src/services/llm_chat.rs
@@ -37,5 +37,19 @@ pub struct ChatChoice {
 
 #[derive(serde::Deserialize)]
 pub struct ChatMessageResp {
-    pub content: String,
+    /// WALM-55: `Option<String>` because `gpt-4o-mini` (and likely other
+    /// OpenAI-compatible providers via OpenRouter) occasionally returns
+    /// a successful HTTP 200 response with `content: null` and
+    /// `completion_tokens: 0` — the model accepted the prompt but
+    /// produced no output. Previously this was typed as `String` and
+    /// the deserialiser rejected it with "invalid type: null, expected
+    /// a string", returning HTTP 500 which the SDK / harness retry
+    /// policy does not retry — silently dropping the turn.
+    ///
+    /// Callers treat `None` as "" (empty string). For the extractor
+    /// that flows through `parse_extracted_facts` and produces zero
+    /// facts — the same legitimate outcome as the prompt's explicit
+    /// `NONE` response, so this is correct degradation rather than
+    /// an error.
+    pub content: Option<String>,
 }

--- a/services/server/src/services/prompts/extract.txt
+++ b/services/server/src/services/prompts/extract.txt
@@ -10,6 +10,22 @@ You may receive a `<related_memories>` block alongside the input. It lists exist
 - Do NOT edit, merge, or supersede existing memories — only emit what is new in the input
 - If no `<related_memories>` block is present, or it is empty, extract as usual without context
 
+You may also receive a `<context occurred_at="..."/>` tag alongside the input. The `occurred_at` value is the absolute timestamp (RFC 3339) of when this conversation turn took place. Use it as the **temporal anchor** for facts extracted from this input:
+
+- **Default to attaching a date** when a fact describes a current event, recent action, state change happening now, or near-future plan. Use the format `Weekday, D Month YYYY (YYYY-MM-DD)` — for example `Friday, 19 May 2023 (2023-05-19)` — embedding both the natural-language form and the ISO date.
+- **Resolve specific relative time references against `occurred_at` before writing the fact.** "Yesterday" + occurred_at=2023-05-25 → `Wednesday, 24 May 2023 (2023-05-24)`. "Last Friday" → use occurred_at's weekday to compute the prior Friday. "Two weeks ago" → subtract 14 days. "This morning" → the same date as occurred_at.
+- **Keep vague references honest.** If a relative reference is too imprecise to resolve to a specific date (e.g. "a few years ago", "recently", "sometime in March", "next week"), do NOT fabricate a specific date. Either preserve the user's vague phrasing as-is, or — when the conversation timestamp lets you narrow it without inventing — anchor to a month using the format `around late May 2023 (2023-05)`.
+- **CRITICAL: if a fact is recounting an event from the past that has its own original date or relative reference (e.g. "I went to Paris in 2019", "I broke my arm when I was twelve"), keep that original date — do NOT replace it with `occurred_at`.** The `occurred_at` anchor is only for events happening *in* or *around* this conversation turn, not for arbitrary recounted memories.
+- **When you are uncertain whether a fact is time-anchored or stable, prefer leaving the date off.** A timeless fact is recoverable; a wrongly-stamped fact pollutes retrieval. Stable traits (allergies, names, locations, preferences, ongoing roles) should never carry a date.
+- If no `<context>` tag is present, extract as usual without temporal information. **CRITICAL: when `<context>` is absent from the input messages, do NOT resolve relative references like "last Friday" or "yesterday" to specific dates — keep the original wording in the fact text. Do NOT invent or assume a timestamp. Do NOT emit a `<context>` line in your output.** The examples below contain `<context>` tags as part of the *example input* — those tags are illustrative, never something for you to emit yourself.
+
+**Output format — strict.** Your output is fact lines ONLY, in the `BUCKET<TAB>FACT_TEXT` format. Do NOT include any other content:
+
+- Never emit `<context>`, `<related_memories>`, or any other tag from the examples.
+- Never emit `Input:`, `Output:`, `Example`, or any other structural marker from the prompt.
+- Never repeat the input text or the related-memories block.
+- If there are no memorable facts, the entire output is exactly `NONE` (no surrounding tags, no explanation).
+
 For each fact, assign an importance bucket:
 - vital: safety-critical, hard constraints, allergies, medical conditions, irreversible commitments, identity-defining facts (names, locations, roles)
 - standard: stable preferences, habits, biographical info, ongoing interests, plans, recommendations
@@ -66,6 +82,40 @@ standard	Assistant recommended "How to Sit Properly at a Desk to Avoid Back Pain
 standard	Assistant recommended "5 Tips for Better Posture" by Harvard Health
 
 (Note: the related memory is only a SUMMARY of the list. The specific video titles are atomic facts not covered by the summary, so they ARE extracted.)
+
+Example with `<context>` — current event, specific relative reference resolved:
+<context occurred_at="2023-05-25T17:50:00Z"/>
+Input: "User: I went hiking last Friday with my brother."
+Output:
+standard	User went hiking on Friday, 19 May 2023 (2023-05-19) with their brother
+
+(Note: "last Friday" was resolved against occurred_at=2023-05-25 (a Thursday), so the prior Friday is 19 May 2023. The absolute date in both natural-language and ISO form is attached to the fact.)
+
+Example with `<context>` — recounted old event keeps its own date:
+<context occurred_at="2023-05-25T17:50:00Z"/>
+Input: "User: I broke my arm when I was twelve, back in 2008."
+Output:
+vital	User broke their arm in 2008 (when they were twelve)
+
+(Note: this is a recounted past event with its own original date — "2008" stays as the fact's date. The occurred_at=2023-05-25 is NOT used here because the event is not happening now.)
+
+Example with `<context>` — fuzzy past reference kept honest, future reference month-anchored:
+<context occurred_at="2023-05-25T17:50:00Z"/>
+Input: "User: I got into pottery a few years ago and I'm planning to try a new technique next week."
+Output:
+standard	User got into pottery a few years ago
+standard	User is planning to try a new pottery technique around late May 2023 (2023-05)
+
+(Note: "a few years ago" is genuinely vague — kept as-is rather than fabricating a year. "Next week" is also imprecise but the conversation timestamp lets us narrow it to late May 2023 without inventing a specific day.)
+
+Example with `<context>` — stable facts have no date:
+<context occurred_at="2023-05-25T17:50:00Z"/>
+Input: "User: By the way, my name is Sarah and I'm allergic to peanuts."
+Output:
+vital	User's name is Sarah
+vital	User is allergic to peanuts
+
+(Note: these are stable, timeless facts. No date is attached even though `occurred_at` is present.)
 
 Input: "Hey, how are you?"
 Output:

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -678,6 +678,25 @@ pub struct AnalyzeRequest {
     pub text: String,
     #[serde(default = "default_namespace")]
     pub namespace: String,
+    /// WALM-55: optional absolute timestamp of when this conversation turn
+    /// took place (RFC 3339, UTC). When present, the extractor uses it as
+    /// the temporal anchor to resolve relative-time references ("last
+    /// Friday", "yesterday") into absolute dates *inside the extracted
+    /// fact text* — so the date enters both the SEAL-encrypted fact on
+    /// Walrus and the embedding vector, making time-anchored facts
+    /// retrievable.
+    ///
+    /// Caller-trusted: same trust level as the conversation text itself
+    /// (we never validate the text either). Optional. No default-to-`now()`
+    /// fallback — silence is honest. Falling back to `now()` would stamp
+    /// present-time onto past-event facts and pollute retrieval.
+    ///
+    /// Architecture A (locked 2026-05-27): the date lives ONLY inside the
+    /// encrypted fact text + the embedding. There is no metadata column on
+    /// `vector_entries`. The server can never filter or rank by event time
+    /// — that's the privacy-floor-preserving trade we accept.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// POST /api/analyze (async, returns 202 immediately)
@@ -980,6 +999,14 @@ pub enum AppError {
     RateLimited(String),
     /// Storage quota exceeded (HTTP 402)
     QuotaExceeded(String),
+    /// WALM-55: upstream LLM/embedding provider returned a transient failure
+    /// (gateway timeout / connection reset / "200 OK" wrapping an
+    /// `{"error":{"code":504}}` envelope from OpenRouter). Maps to HTTP 503
+    /// so the SDK + benchmark harness will retry per their transient-error
+    /// policy (`_RETRY_STATUS = (429, 502, 503, 504)`). This converts a
+    /// silently-dropped turn into one retried with exponential backoff —
+    /// closing the bench-completion gap diagnosed during the LME v2 run.
+    UpstreamUnavailable(String),
 }
 
 impl std::fmt::Display for AppError {
@@ -991,6 +1018,7 @@ impl std::fmt::Display for AppError {
             AppError::BlobNotFound(msg) => write!(f, "Blob Not Found: {}", msg),
             AppError::RateLimited(msg) => write!(f, "Rate Limited: {}", msg),
             AppError::QuotaExceeded(msg) => write!(f, "Quota Exceeded: {}", msg),
+            AppError::UpstreamUnavailable(msg) => write!(f, "Upstream Unavailable: {}", msg),
         }
     }
 }
@@ -1020,6 +1048,24 @@ impl axum::response::IntoResponse for AppError {
             AppError::BlobNotFound(msg) => (axum::http::StatusCode::NOT_FOUND, msg.clone()),
             AppError::RateLimited(msg) => (axum::http::StatusCode::TOO_MANY_REQUESTS, msg.clone()),
             AppError::QuotaExceeded(msg) => (axum::http::StatusCode::PAYMENT_REQUIRED, msg.clone()),
+            AppError::UpstreamUnavailable(msg) => {
+                // WALM-55: log the upstream details server-side, return
+                // 503 so the SDK / harness will retry per their
+                // transient-error policy. Body is a generic message —
+                // we don't leak internal upstream-provider names to
+                // clients.
+                let trace_id = crate::observability::current_request_id()
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                tracing::warn!(
+                    request_id = %trace_id,
+                    "Upstream unavailable: {}",
+                    msg,
+                );
+                (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    format!("Upstream temporarily unavailable (traceId: {})", trace_id),
+                )
+            }
         };
 
         let body = serde_json::json!({ "error": message });
@@ -1036,6 +1082,7 @@ impl AppError {
             AppError::BlobNotFound(_) => "blob_not_found",
             AppError::RateLimited(_) => "rate_limited",
             AppError::QuotaExceeded(_) => "quota_exceeded",
+            AppError::UpstreamUnavailable(_) => "upstream_unavailable",
         }
     }
 }
@@ -1217,6 +1264,32 @@ mod tests {
         let err = AppError::QuotaExceeded("test".into());
         let resp = axum::response::IntoResponse::into_response(err);
         assert_eq!(resp.status(), axum::http::StatusCode::PAYMENT_REQUIRED);
+    }
+
+    #[test]
+    fn app_error_upstream_unavailable_status_is_503_for_retryability() {
+        // WALM-55: HTTP 503 is in the SDK + benchmark harness retry
+        // set (429, 502, 503, 504). Pinning this so a future change
+        // can't silently re-map UpstreamUnavailable to a non-retryable
+        // code — that would re-introduce the bench-completion gap that
+        // the LME v2 diagnosis surfaced.
+        let err = AppError::UpstreamUnavailable("OpenRouter upstream error (code=504)".into());
+        let resp = axum::response::IntoResponse::into_response(err);
+        assert_eq!(
+            resp.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "UpstreamUnavailable MUST map to 503 so clients retry"
+        );
+    }
+
+    #[test]
+    fn app_error_upstream_unavailable_kind_label() {
+        let err = AppError::UpstreamUnavailable("test".into());
+        assert_eq!(
+            err.kind(),
+            "upstream_unavailable",
+            "observability label must be stable for grafana/loki queries"
+        );
     }
 
     // ── KeyPool: round-robin selection ─────────────────────────────────

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -678,7 +678,7 @@ pub struct AnalyzeRequest {
     pub text: String,
     #[serde(default = "default_namespace")]
     pub namespace: String,
-    /// WALM-55: optional absolute timestamp of when this conversation turn
+    /// optional absolute timestamp of when this conversation turn
     /// took place (RFC 3339, UTC). When present, the extractor uses it as
     /// the temporal anchor to resolve relative-time references ("last
     /// Friday", "yesterday") into absolute dates *inside the extracted
@@ -999,7 +999,7 @@ pub enum AppError {
     RateLimited(String),
     /// Storage quota exceeded (HTTP 402)
     QuotaExceeded(String),
-    /// WALM-55: upstream LLM/embedding provider returned a transient failure
+    /// upstream LLM/embedding provider returned a transient failure
     /// (gateway timeout / connection reset / "200 OK" wrapping an
     /// `{"error":{"code":504}}` envelope from OpenRouter). Maps to HTTP 503
     /// so the SDK + benchmark harness will retry per their transient-error
@@ -1049,7 +1049,7 @@ impl axum::response::IntoResponse for AppError {
             AppError::RateLimited(msg) => (axum::http::StatusCode::TOO_MANY_REQUESTS, msg.clone()),
             AppError::QuotaExceeded(msg) => (axum::http::StatusCode::PAYMENT_REQUIRED, msg.clone()),
             AppError::UpstreamUnavailable(msg) => {
-                // WALM-55: log the upstream details server-side, return
+                // log the upstream details server-side, return
                 // 503 so the SDK / harness will retry per their
                 // transient-error policy. Body is a generic message —
                 // we don't leak internal upstream-provider names to
@@ -1268,7 +1268,7 @@ mod tests {
 
     #[test]
     fn app_error_upstream_unavailable_status_is_503_for_retryability() {
-        // WALM-55: HTTP 503 is in the SDK + benchmark harness retry
+        // HTTP 503 is in the SDK + benchmark harness retry
         // set (429, 502, 503, 504). Pinning this so a future change
         // can't silently re-map UpstreamUnavailable to a non-retryable
         // code — that would re-introduce the bench-completion gap that


### PR DESCRIPTION
## Summary

### Why

Temporal recall is the weakest category on both LOCOMO and LongMemEval — by a wide margin. Diagnosis of failing temporal questions on the prior `extract.v5` baseline showed a specific, mechanical cause: the overwhelming majority of failing temporal answers hinge on a date, and almost all of those dates are entirely absent from the memories retrieved at recall time. The dates exist in the source conversations (and in our benchmark dataset's session metadata) but get silently dropped before reaching the extractor — so the LLM has no anchor to write a dated fact, and vector search cannot match temporal queries against undated stored memories.

This is a write-side input problem, not a retrieval or reasoning problem. No amount of better recall, reranking, or query expansion can find a date that was never stored in the first place.

### What

This PR introduces an optional `occurred_at` field on `AnalyzeRequest` that carries an RFC 3339 UTC timestamp from caller to extractor. When present, the server renders it as a `<context occurred_at="..."/>` tag and supplies it to the LLM as a dedicated user message alongside the existing `<related_memories>` block. A new prompt iteration (`extract.v6`) instructs the LLM how to use this anchor — resolving in-turn relative-time references (`"last Friday"`, `"yesterday"`, `"two weeks ago"`) into absolute dates and attaching them to the resulting fact text in a verbose `Weekday, D Month YYYY (YYYY-MM-DD)` shape.

This PR also includes a set of transient-failure fixes that the bench investigation uncovered along the way. These convert several silently-dropped upstream-flake failure modes (HTTP 200 wrapping a 504-gateway-timeout error envelope; mid-body connection drops; null-content completions) from HTTP 500 (not retried) to HTTP 503 (in the SDK + benchmark harness retry set), so they recover via the existing retry policy instead of dropping turns.

The harness side wires both LOCOMO and LongMemEval to normalize their dataset-specific timestamp formats to RFC 3339 UTC and pass them as `occurred_at` on every ingestion call.

### Solution

**Theory — how the resolved date ends up improving temporal retrieval.**

Three independent mechanisms compound when the absolute date enters the fact text before embedding:

1. **Date tokens become matchable signal in vector search.** Modern dense embedding models capture not just semantic similarity but also lexical co-occurrence on distinctive tokens. Rare, information-dense tokens like `"2023"`, `"May"`, or `"2023-05-19"` give a query like *"What did the user do in May 2023?"* something concrete to match against. Without dates in the stored fact text, this signal has nothing to land on; with them, the same semantic-only vector search has the date token in its searchable surface.

2. **The answer LLM can reason about time only when it can see time.** A query like *"How long ago did X happen?"* requires the model to read a date and do arithmetic. If retrieval surfaces a memory that says *"User ran a charity race"* with no date, the model has nothing to work with even if it found the right memory. With the absolute date embedded in the fact, time-arithmetic questions become directly answerable.

3. **Relative-time resolution at extraction is strictly cheaper and more reliable than at retrieval.** The extractor has the absolute anchor (the caller-supplied `occurred_at`) at the moment it sees the input. It can resolve *"last Friday"* exactly once, at write time, with full context. The answer model at read time wouldn't have that anchor, so doing the same resolution there is either impossible or error-prone.

**Architectural constraint — Architecture A.**

The resolved date lives ONLY inside the extracted fact text. That text is SEAL-encrypted before storage on Walrus, and the same text feeds the embedding. **There is no new metadata column on `vector_entries`.** This is a deliberate, permanent trade: the server can never filter, range-scan, or rank by event time (only by ingestion time, which it already has via `created_at`). What we gain is the temporal-retrieval lift without weakening the privacy floor — date information remains inside the encrypted-storage boundary, not in a queryable plaintext column.

This trade was the load-bearing design decision; the rest of the implementation is just the cleanest way to realize it.

**Implementation summary.**

Server side:
- New optional `AnalyzeRequest.occurred_at: Option<chrono::DateTime<chrono::Utc>>` field (RFC 3339 via serde).
- `Extractor::extract_with_context` trait signature extended with an `occurred_at` argument; default impl ignores it (backwards-compatible).
- `LlmExtractor` builds 1–3 user messages depending on which contexts are present (related-memories, occurred-at, and the actual input text).
- New `extract.v6` prompt: temporal-anchor rules, defensive opt-out ("when uncertain, prefer no date"), worked examples covering current-event resolved, recounted-past-event-keeps-own-date, vague-future-month-anchored, stable-fact-no-date.
- Three transient-failure fixes (separate but related):
  - New `AppError::UpstreamUnavailable` variant → HTTP 503.
  - New shared `parse_openrouter_error_envelope` helper to detect the `{"error":{"code":NNN}}`-wrapped-in-200 pattern, called from both extractor and embedder.
  - `ChatMessageResp.content` widened from `String` to `Option<String>` to gracefully handle null-content completions; the Option ripples through three consumer sites (extractor, ask, summariser).

Harness side:
- Two new normalizers (one per benchmark) that convert dataset-specific date formats to RFC 3339 UTC at parse time.
- `build_ingest_text_*` return type widened from `(label, text)` to `(label, text, occurred_at)`.
- `run.py` unpacks the new 3-tuple and threads `occurred_at` through to `client.analyze()`.

**Validation.** Both benchmarks (LOCOMO and LongMemEval) were re-run on this branch end-to-end against the prior `extract.v5` baseline, with the primary target category (temporal) moving cleanly past the judge-noise floor in the predicted direction on both benchmarks. Other categories held within noise — no measurable regression. Bench completion rate also improved from the v5 baseline thanks to the transient-failure fixes. Detailed numbers are captured in the internal benchmark archive.

16 new unit tests pin the load-bearing behaviour: envelope detection across 5 distinct body shapes (including the choices+error edge case that the guard explicitly handles); occurred_at-block rendering in two timezones; default-impl pass-through for occurred_at; the v6 prompt's anti-leak rules; the 503-mapping and observability-label contracts; and the timestamp-normalization helpers in both benchmark adapters.

## Types of Changes

<!-- What types of changes does your code introduce? Put an x in all the boxes that apply -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance optimization (non-breaking change which addresses a performance issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] Test (non-breaking change related to testing)
- [ ] Security awareness (changes that affect permission scope, security scenarios)

The "Bug fix" check covers the transient-failure handling (500 → 503 mapping + null-content type widening + envelope detection) that landed alongside the main feature work. They share the same code paths and were diagnosed during the same investigation, so they ship in one PR.

## Testing

<!-- Describe how you tested your changes. Include relevant details about your testing environment. -->

- [x] I have tested this code locally
- [x] I have added/updated unit tests
- [x] I have added/updated integration tests
- [ ] I have tested in multiple browsers (if applicable)

End-to-end testing against the LOCOMO and LongMemEval benchmark harnesses (full ingest + eval) was the primary validation path: both benchmarks completed against the patched server with positive results vs the prior baseline, exercising the entire flow from harness → `AnalyzeRequest.occurred_at` → server → extractor → LLM → embedded fact → recall → answer-model evaluation. Full numeric results are in the internal benchmark archive.

Unit tests (267 Rust, 42 Python) pass on the rebased branch. The 16 new tests are scoped to the load-bearing pieces called out in the Solution section.

## Checklist

<!-- Go over all the following points, and put an x in all the boxes that apply -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

The change does not require user-facing documentation updates yet: the new `occurred_at` field is server-side only and not yet exposed in the public SDK clients. SDK exposure is a separate follow-up.

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to help explain your changes -->

Not applicable — server-side and benchmark-harness changes only.

## Additional Notes

- **No new database migration.** All changes go through existing schema; `occurred_at` lives only in the encrypted fact text + embedding, never as a metadata column on `vector_entries`.
- **No SDK changes in this PR.** The TS + Python SDK clients do not yet expose `occurredAt` / `occurred_at`. Until that follows up, production callers still get the baseline behaviour; the bench harness is the only consumer exercising the new field right now.
- **Observability:** one new `AppError::kind()` label (`upstream_unavailable`). Any Grafana/Loki dashboards that filter on error-kind will see a new category; existing `internal` label volume should drop proportionally for upstream transient failures.
- **Operational impact:** production callers will see slightly more HTTP 503 responses where they previously saw 500, with corresponding fewer 500s. Net 5xx volume drops because the harness/SDK retries the 503s. Worth a heads-up in the release notes if there's automated alerting that doesn't distinguish 500 vs 503.
