### PR TITLE
fix(server): WALM-77 detect Sui object-lock / equivocation, stop burning wallet retries

### DIFF
--- a/services/server/scripts/__tests__/walrus-object-lock.test.ts
+++ b/services/server/scripts/__tests__/walrus-object-lock.test.ts
@@ -15,11 +15,9 @@ test("detects the exact production object-lock error", () => {
     assert.equal(isWalrusObjectLockEquivocation(PROD_OBJECT_LOCK_ERROR), true);
 });
 
-test("detects each equivocation phrase variant", () => {
+test("detects each lock-specific anchor on its own", () => {
     const cases = [
         "object 0xabc already locked by a different transaction",
-        "rejected as invalid by more than 1/3 of validators by stake",
-        "this error is non-retriable",
         "the input object is equivocated",
         "equivocation detected on gas coin",
         "object reserved for another transaction",
@@ -27,6 +25,28 @@ test("detects each equivocation phrase variant", () => {
     for (const msg of cases) {
         assert.equal(isWalrusObjectLockEquivocation(msg), true, msg);
     }
+});
+
+test("detects a corroborated non-retriable lock (preamble + object + locked)", () => {
+    const msg =
+        "rejected as invalid by more than 1/3 of validators by stake (non-retriable). " +
+        "Object (0xabc, SequenceNumber(1)) already locked";
+    assert.equal(isWalrusObjectLockEquivocation(msg), true);
+});
+
+test("bare non-retriable / >1/3 preamble is NOT an object lock", () => {
+    // Not lock-specific without object-lock evidence — must not misclassify
+    // generic invalid / non-retriable failures.
+    assert.equal(
+        isWalrusObjectLockEquivocation(
+            "Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable)",
+        ),
+        false,
+    );
+    assert.equal(
+        isWalrusObjectLockEquivocation("MoveAbort in 1st command, abort code: 3 — non-retriable"),
+        false,
+    );
 });
 
 test("matching is case-insensitive", () => {

--- a/services/server/scripts/__tests__/walrus-object-lock.test.ts
+++ b/services/server/scripts/__tests__/walrus-object-lock.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isWalrusObjectLockEquivocation } from "../walrus-error-detection.js";
+
+// Exact production error from the object-lock incident (testnet job 3d607892…).
+const PROD_OBJECT_LOCK_ERROR =
+    "walrus upload failed: Internal Error: walrus upload failed: " +
+    "Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable). " +
+    "Non-retriable errors: [Object (0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e, " +
+    "SequenceNumber(884613305), o#B61aVqEgDskxru255FTdzua2RxbbnhDMFxmQ8SCxvj3n) already locked by a " +
+    "different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82BtHrp3F) with 6842 stake].";
+
+test("detects the exact production object-lock error", () => {
+    assert.equal(isWalrusObjectLockEquivocation(PROD_OBJECT_LOCK_ERROR), true);
+});
+
+test("detects each equivocation phrase variant", () => {
+    const cases = [
+        "object 0xabc already locked by a different transaction",
+        "rejected as invalid by more than 1/3 of validators by stake",
+        "this error is non-retriable",
+        "the input object is equivocated",
+        "equivocation detected on gas coin",
+        "object reserved for another transaction",
+    ];
+    for (const msg of cases) {
+        assert.equal(isWalrusObjectLockEquivocation(msg), true, msg);
+    }
+});
+
+test("matching is case-insensitive", () => {
+    assert.equal(
+        isWalrusObjectLockEquivocation("ALREADY LOCKED BY A DIFFERENT TRANSACTION"),
+        true,
+    );
+});
+
+test("recoverable lock-at-version is NOT an equivocation", () => {
+    // This class is retryable (rebuild against a fresh version) and must not be
+    // swept into the abort path.
+    assert.equal(
+        isWalrusObjectLockEquivocation("object is locked at version 17"),
+        false,
+    );
+});
+
+test("unrelated errors and empty input do not match", () => {
+    assert.equal(isWalrusObjectLockEquivocation("connection refused"), false);
+    assert.equal(isWalrusObjectLockEquivocation("MoveAbort(0x2::balance, split, 2)"), false);
+    assert.equal(isWalrusObjectLockEquivocation(""), false);
+});

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -21,7 +21,10 @@ import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
 import { WalrusClient } from "@mysten/walrus";
 import { mountMcpRoutes, shutdownMcpSessions } from "./mcp/index.js";
 import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-config.js";
-import { isWalrusPackageVersionMismatch } from "./walrus-error-detection.js";
+import {
+    isWalrusObjectLockEquivocation,
+    isWalrusPackageVersionMismatch,
+} from "./walrus-error-detection.js";
 
 // ============================================================
 // Shared clients (initialized once at boot — the whole point!)
@@ -190,16 +193,19 @@ type EnokiSponsorResponse = { bytes: string; digest: string };
 type EnokiExecuteResponse = { digest: string };
 
 // in-memory counters surfaced via /metrics/wallet.
-// Per Will Bradley (Mysten, 2026-05-12 Slack): Sui no longer permanently
-// locks coin objects on equivocation, so the original multi-wallet routing
-// is unnecessary. We use a single wallet concurrently and rely on Apalis
-// retries for transient Sui/RPC/coin-selection races.
 //
-// `walletLockErrorsTotal` should stay at 0 under load and is the canary
-// for re-evaluating the simplification if the Sui guarantee changes.
+// `walletLockErrorsTotal` counts the recoverable "locked at version" class,
+// where a retry can rebuild against a fresh version. `walletObjectLockEquivocationTotal`
+// counts the NON-recoverable class — an owned object equivocated and is locked
+// to a competing transaction until the lock clears (typically the next epoch
+// boundary). The latter has been observed in production despite earlier
+// guidance that Sui no longer permanently locks coin objects on equivocation,
+// so it is tracked separately as the canary for whether concurrent uploads are
+// still equivocating owned objects.
 const sidecarMetrics = {
     walletSubmittedTotal: 0,
     walletLockErrorsTotal: 0,
+    walletObjectLockEquivocationTotal: 0,
     walletPermanentFailuresTotal: 0,
 };
 
@@ -362,6 +368,7 @@ function sidecarStateSnapshot(): Record<string, unknown> {
         activeWalrusUploads,
         walletSubmittedTotal: sidecarMetrics.walletSubmittedTotal,
         walletLockErrorsTotal: sidecarMetrics.walletLockErrorsTotal,
+        walletObjectLockEquivocationTotal: sidecarMetrics.walletObjectLockEquivocationTotal,
         walletPermanentFailuresTotal: sidecarMetrics.walletPermanentFailuresTotal,
         uploadRelayTipCache:
             uploadRelayTipAddressCache === undefined
@@ -562,7 +569,14 @@ async function submitWalletTransaction(
         return digest;
     } catch (err: any) {
         const msg = err?.message || String(err);
-        if (/objectlocked|locked at version|object is locked/i.test(msg)) {
+        if (isWalrusObjectLockEquivocation(msg)) {
+            // Non-recoverable owned-object lock — held until the lock clears
+            // (typically the next epoch boundary). The Rust worker classifies
+            // this as ObjectLockedUntilEpoch and aborts rather than burning
+            // wallet retries; here we only categorize the metric.
+            sidecarMetrics.walletObjectLockEquivocationTotal += 1;
+            console.error(`[wallet] object lock / equivocation: ${msg}`);
+        } else if (/objectlocked|locked at version|object is locked/i.test(msg)) {
             sidecarMetrics.walletLockErrorsTotal += 1;
             console.error(`[wallet] coin-object lock error: ${msg}`);
         } else if (/moveabort|move abort/i.test(msg)) {
@@ -667,10 +681,10 @@ mountMcpRoutes(app, {
 // Wallet-execution metrics (observability). Placed before auth so
 // operators / scrapers don't need a token.
 //
-// `walletLockErrorsTotal` is the canary for the simplification: it should
-// stay at 0 because Sui no longer permanently locks coin objects on
-// equivocation. If it ever climbs, the original multi-wallet rationale
-// would need re-evaluating.
+// `walletObjectLockEquivocationTotal` is the canary for concurrent uploads
+// equivocating owned objects: a non-zero value means jobs are hitting Sui
+// object locks that hold until the epoch boundary, which is the signal for
+// the follow-up single-flight / coin-reservation work.
 //
 // Values are integer counters that monotonically increase; clients compute
 // deltas.

--- a/services/server/scripts/walrus-error-detection.ts
+++ b/services/server/scripts/walrus-error-detection.ts
@@ -27,3 +27,24 @@ export function isWalrusPackageVersionMismatch(message: string): boolean {
     if (!/moveabort/i.test(message)) return false;
     return /::system::inner_mut/i.test(message) || /ewrongversion/i.test(message);
 }
+
+/**
+ * Detect a Sui owned-object lock / equivocation error: a specific
+ * object+version is locked to a competing transaction, so the transaction is
+ * rejected by >1/3 of validator stake and is non-retriable within the epoch.
+ * Retrying re-fails against the same locked object until the lock clears
+ * (typically the next epoch boundary).
+ *
+ * Mirrors the Rust classifier in `services/server/src/jobs.rs`
+ * (`classify_sidecar_error` → `ObjectLockedUntilEpoch`); keep both in sync.
+ * Distinct from the recoverable `locked at version` case, where a retry can
+ * rebuild against a fresh version.
+ */
+export function isWalrusObjectLockEquivocation(message: string): boolean {
+    if (!message) return false;
+    return /already locked by a different transaction/i.test(message)
+        || /rejected as invalid by more than 1\/3 of validators by stake/i.test(message)
+        || /non-retriable/i.test(message)
+        || /equivocated|equivocation/i.test(message)
+        || /reserved for another transaction/i.test(message);
+}

--- a/services/server/scripts/walrus-error-detection.ts
+++ b/services/server/scripts/walrus-error-detection.ts
@@ -39,12 +39,23 @@ export function isWalrusPackageVersionMismatch(message: string): boolean {
  * (`classify_sidecar_error` → `ObjectLockedUntilEpoch`); keep both in sync.
  * Distinct from the recoverable `locked at version` case, where a retry can
  * rebuild against a fresh version.
+ *
+ * Requires a lock/equivocation-specific anchor. The `non-retriable` /
+ * ">1/3 of validators by stake" preamble is NOT lock-specific on its own (a
+ * generic invalid MoveAbort is also non-retriable), so it only qualifies when
+ * corroborated by object-lock evidence (`Object (` + `locked`) in the same
+ * message.
  */
 export function isWalrusObjectLockEquivocation(message: string): boolean {
     if (!message) return false;
-    return /already locked by a different transaction/i.test(message)
-        || /rejected as invalid by more than 1\/3 of validators by stake/i.test(message)
-        || /non-retriable/i.test(message)
-        || /equivocated|equivocation/i.test(message)
-        || /reserved for another transaction/i.test(message);
+    const hasLockAnchor =
+        /already locked by a different transaction/i.test(message)
+        || /reserved for another transaction/i.test(message)
+        || /equivocated|equivocation/i.test(message);
+    const corroboratedLock =
+        (/non-retriable/i.test(message)
+            || /rejected as invalid by more than 1\/3 of validators by stake/i.test(message))
+        && /object \(/i.test(message)
+        && /locked/i.test(message);
+    return hasLockAnchor || corroboratedLock;
 }

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -8,6 +8,8 @@ const ALERT_TO_SLACK_ENV: &str = "ALERT_TO_SLACK";
 const MAX_SLACK_ERROR_LEN: usize = 1_500;
 const WALRUS_UPGRADE_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_PACKAGE_UPGRADE_ALERT_DEDUP_SECS";
 const WALRUS_UPGRADE_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
+const WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS";
+const WALRUS_OBJECT_LOCK_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
 
 /// Mirrors the `@mysten/walrus` dep version in
 /// `services/server/scripts/package.json`. Bump this constant in lockstep
@@ -15,18 +17,62 @@ const WALRUS_UPGRADE_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
 /// runtime version, not a stale label.
 pub const SIDECAR_WALRUS_DEP_VERSION: &str = "1.1.7";
 
+/// Time-window dedup keyed by a `(String, String)` identity. Suppresses
+/// duplicate alerts for the same logical event during a burst.
+#[derive(Debug)]
+struct AlertDedup {
+    seen: Mutex<HashMap<(String, String), Instant>>,
+    window: Duration,
+}
+
+impl AlertDedup {
+    fn new(window: Duration) -> Self {
+        Self {
+            seen: Mutex::new(HashMap::new()),
+            window,
+        }
+    }
+
+    /// Returns `true` if an alert with this key fired within the window —
+    /// caller should drop it. On the firing path (returns `false`) the entry
+    /// is stamped to `now`, so the window slides from the most-recent fire.
+    fn should_suppress(&self, key: (String, String)) -> bool {
+        let now = Instant::now();
+        let mut guard = self.seen.lock().expect("dedup mutex poisoned");
+        // Opportunistic cleanup so the map can't grow without bound on a
+        // long-running relayer: drop entries older than 2× the window.
+        let cleanup_horizon = self.window.saturating_mul(2);
+        guard.retain(|_, fired_at| {
+            now.checked_duration_since(*fired_at)
+                .map(|elapsed| elapsed < cleanup_horizon)
+                .unwrap_or(true)
+        });
+        if let Some(fired_at) = guard.get(&key) {
+            if let Some(elapsed) = now.checked_duration_since(*fired_at) {
+                if elapsed < self.window {
+                    return true;
+                }
+            }
+        }
+        guard.insert(key, now);
+        false
+    }
+}
+
 #[derive(Debug)]
 pub struct AlertManager {
     slack: Option<SlackNotifier>,
     /// Suppresses Walrus package-upgrade alert spam during an upgrade burst.
-    /// Keyed by `(sui_network, sidecar_walrus_dep_version)` because that's
-    /// what makes two alerts "the same event" — concurrent queued jobs all
-    /// hit EWrongVersion against the same on-chain package change, so a
-    /// single notification per (network, dep) is enough until either the
-    /// dep bumps or enough time passes that this is plausibly a separate
-    /// upgrade event.
-    walrus_upgrade_dedup: Mutex<HashMap<(String, String), Instant>>,
-    walrus_upgrade_dedup_window: Duration,
+    /// Keyed by `(sui_network, sidecar_walrus_dep_version)` — concurrent queued
+    /// jobs all hit EWrongVersion against the same on-chain package change, so
+    /// one notification per (network, dep) is enough until the dep bumps or the
+    /// window elapses.
+    walrus_upgrade_dedup: AlertDedup,
+    /// Suppresses Walrus object-lock alert spam. Keyed by
+    /// `(sui_network, locked_object_id)` — when one owned object equivocates,
+    /// every concurrent job touching it raises the same error, so one
+    /// notification per (network, object) is enough until the window elapses.
+    walrus_object_lock_dedup: AlertDedup,
 }
 
 impl AlertManager {
@@ -34,17 +80,17 @@ impl AlertManager {
         let slack = std::env::var(ALERT_TO_SLACK_ENV)
             .ok()
             .and_then(|raw| SlackNotifier::from_env_value(http_client, &raw));
-        let window = std::env::var(WALRUS_UPGRADE_ALERT_DEDUP_SECS_ENV)
-            .ok()
-            .and_then(|raw| raw.parse::<u64>().ok())
-            .filter(|secs| *secs > 0)
-            .map(Duration::from_secs)
-            .unwrap_or(WALRUS_UPGRADE_ALERT_DEDUP_DEFAULT);
 
         Self {
             slack,
-            walrus_upgrade_dedup: Mutex::new(HashMap::new()),
-            walrus_upgrade_dedup_window: window,
+            walrus_upgrade_dedup: AlertDedup::new(dedup_window_from_env(
+                WALRUS_UPGRADE_ALERT_DEDUP_SECS_ENV,
+                WALRUS_UPGRADE_ALERT_DEDUP_DEFAULT,
+            )),
+            walrus_object_lock_dedup: AlertDedup::new(dedup_window_from_env(
+                WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS_ENV,
+                WALRUS_OBJECT_LOCK_ALERT_DEDUP_DEFAULT,
+            )),
         }
     }
 
@@ -70,40 +116,51 @@ impl AlertManager {
         let Some(slack) = &self.slack else {
             return Ok(());
         };
-        if self.suppress_walrus_upgrade_alert(&alert.sui_network, &alert.sidecar_walrus_dep_version)
-        {
+        let key = (
+            alert.sui_network.clone(),
+            alert.sidecar_walrus_dep_version.clone(),
+        );
+        if self.walrus_upgrade_dedup.should_suppress(key) {
             return Ok(());
         }
         let payload = SlackPayload::for_walrus_package_upgrade_detected(&alert);
         slack.send_payload(&payload).await
     }
 
-    /// Returns `true` if a Walrus-upgrade alert with the same
-    /// (network, dep version) fired within the dedup window — caller should
-    /// drop the alert. Updates the entry to `now` on the *firing* path (i.e.
-    /// returns `false`), so the window slides from the most-recent fire.
-    fn suppress_walrus_upgrade_alert(&self, sui_network: &str, dep_version: &str) -> bool {
-        let key = (sui_network.to_string(), dep_version.to_string());
-        let now = Instant::now();
-        let mut guard = self.walrus_upgrade_dedup.lock().expect("dedup mutex poisoned");
-        // Opportunistic cleanup so the map can't grow without bound on a
-        // long-running relayer: drop entries older than 2× the window.
-        let cleanup_horizon = self.walrus_upgrade_dedup_window.saturating_mul(2);
-        guard.retain(|_, fired_at| {
-            now.checked_duration_since(*fired_at)
-                .map(|elapsed| elapsed < cleanup_horizon)
-                .unwrap_or(true)
-        });
-        if let Some(fired_at) = guard.get(&key) {
-            if let Some(elapsed) = now.checked_duration_since(*fired_at) {
-                if elapsed < self.walrus_upgrade_dedup_window {
-                    return true;
-                }
-            }
+    pub async fn notify_walrus_object_locked(
+        &self,
+        alert: WalrusObjectLockedAlert,
+    ) -> Result<(), AlertError> {
+        let Some(slack) = &self.slack else {
+            return Ok(());
+        };
+        // Dedup per (network, object). When object id is unparseable, fall back
+        // to a constant so a burst of unparseable locks still collapses to one
+        // alert per network rather than spamming.
+        let key = (
+            alert.sui_network.clone(),
+            alert
+                .locked_object_id
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
+        );
+        if self.walrus_object_lock_dedup.should_suppress(key) {
+            return Ok(());
         }
-        guard.insert(key, now);
-        false
+        let payload = SlackPayload::for_walrus_object_locked(&alert);
+        slack.send_payload(&payload).await
     }
+}
+
+/// Read a dedup window (seconds) from `env_var`, falling back to `default`
+/// when unset, unparseable, or zero.
+fn dedup_window_from_env(env_var: &str, default: Duration) -> Duration {
+    std::env::var(env_var)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(default)
 }
 
 #[derive(Clone, Debug)]
@@ -180,6 +237,24 @@ pub struct WalrusPackageUpgradeDetectedAlert {
     pub on_chain_version_before: Option<String>,
     pub on_chain_version_after: Option<String>,
     pub action_taken: String,
+    pub error: String,
+}
+
+/// Fired when a wallet job fails because a Sui owned object/version is locked
+/// to a competing transaction (equivocation / ">1/3 of validators …
+/// non-retriable"). Distinct from the "exhausted retries" alert: this case
+/// aborts immediately rather than burning the wallet budget, and the on-call
+/// message must name the real cause and surface the locked object + locking
+/// transaction so they can check lock status / wait for the epoch boundary.
+#[derive(Debug)]
+pub struct WalrusObjectLockedAlert {
+    pub remember_job_id: Option<String>,
+    pub owner: Option<String>,
+    pub namespace: Option<String>,
+    pub sui_network: String,
+    pub locked_object_id: Option<String>,
+    pub locked_object_version: Option<String>,
+    pub locking_transaction_digest: Option<String>,
     pub error: String,
 }
 
@@ -292,6 +367,55 @@ impl SlackPayload {
             alert.sui_network,
             alert.wallet_index,
             alert.configured_wallets,
+            truncate(&alert.error, MAX_SLACK_ERROR_LEN),
+        );
+
+        Self {
+            text: summary.clone(),
+            blocks: vec![
+                SlackBlock::Header {
+                    text: plain_text(title),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(summary),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(details),
+                },
+            ],
+        }
+    }
+
+    fn for_walrus_object_locked(alert: &WalrusObjectLockedAlert) -> Self {
+        let title = "MemWal Walrus upload blocked — Sui object lock".to_string();
+        let summary = format!(
+            "Walrus upload hit a Sui owned-object lock / equivocation on {}. \
+             Not retried (would re-fail against the same locked object); the lock \
+             typically clears at the next epoch boundary.",
+            alert.sui_network,
+        );
+        let object = alert.locked_object_id.as_deref().unwrap_or("unparsed");
+        let version = alert.locked_object_version.as_deref().unwrap_or("unparsed");
+        let locking = alert
+            .locking_transaction_digest
+            .as_deref()
+            .unwrap_or("unparsed");
+        let job = alert.remember_job_id.as_deref().unwrap_or("-");
+        let owner = alert
+            .owner
+            .as_deref()
+            .map(short_address)
+            .unwrap_or_else(|| "-".to_string());
+        let namespace = alert.namespace.as_deref().unwrap_or("-");
+        let details = format!(
+            "*Network:* `{}`\n*Locked object:* `{}`\n*Object version:* `{}`\n*Locked by tx:* `{}`\n*Job:* `{}`\n*Owner:* `{}`\n*Namespace:* `{}`\n*Error:* ```{}```",
+            alert.sui_network,
+            object,
+            version,
+            locking,
+            job,
+            owner,
+            namespace,
             truncate(&alert.error, MAX_SLACK_ERROR_LEN),
         );
 
@@ -468,52 +592,91 @@ mod tests {
         assert!(json.len() < MAX_SLACK_ERROR_LEN * 3);
     }
 
-    fn test_alert_manager_with_window(window: Duration) -> AlertManager {
-        AlertManager {
-            // No Slack notifier so we test the dedup gate in isolation —
-            // suppress_walrus_upgrade_alert is the unit we care about; the
-            // outer notify_* short-circuits on `slack=None` anyway.
-            slack: None,
-            walrus_upgrade_dedup: Mutex::new(HashMap::new()),
-            walrus_upgrade_dedup_window: window,
-        }
+    fn key(a: &str, b: &str) -> (String, String) {
+        (a.to_string(), b.to_string())
     }
 
     #[test]
-    fn walrus_upgrade_dedup_lets_first_alert_through() {
-        let mgr = test_alert_manager_with_window(Duration::from_secs(600));
-        assert!(!mgr.suppress_walrus_upgrade_alert("mainnet", "1.1.7"));
+    fn alert_dedup_lets_first_through() {
+        let dedup = AlertDedup::new(Duration::from_secs(600));
+        assert!(!dedup.should_suppress(key("mainnet", "1.1.7")));
     }
 
     #[test]
-    fn walrus_upgrade_dedup_suppresses_burst_within_window() {
-        // Concurrent queued jobs all hit EWrongVersion on the same upgrade —
-        // only the first one fires; the rest are suppressed.
-        let mgr = test_alert_manager_with_window(Duration::from_secs(600));
-        assert!(!mgr.suppress_walrus_upgrade_alert("mainnet", "1.1.7"));
+    fn alert_dedup_suppresses_burst_within_window() {
+        // Concurrent jobs all raise the same logical event — only the first
+        // fires; the rest are suppressed until the window elapses.
+        let dedup = AlertDedup::new(Duration::from_secs(600));
+        assert!(!dedup.should_suppress(key("mainnet", "obj-A")));
         for _ in 0..50 {
-            assert!(mgr.suppress_walrus_upgrade_alert("mainnet", "1.1.7"));
+            assert!(dedup.should_suppress(key("mainnet", "obj-A")));
         }
     }
 
     #[test]
-    fn walrus_upgrade_dedup_separates_networks_and_dep_versions() {
-        // Mainnet vs testnet are independent events. A dep bump between
-        // upgrades also resets — we want to know about the next event.
-        let mgr = test_alert_manager_with_window(Duration::from_secs(600));
-        assert!(!mgr.suppress_walrus_upgrade_alert("mainnet", "1.1.7"));
-        assert!(!mgr.suppress_walrus_upgrade_alert("testnet", "1.1.7"));
-        assert!(!mgr.suppress_walrus_upgrade_alert("mainnet", "1.2.0"));
+    fn alert_dedup_separates_distinct_keys() {
+        // Different network or different second component are independent events.
+        let dedup = AlertDedup::new(Duration::from_secs(600));
+        assert!(!dedup.should_suppress(key("mainnet", "obj-A")));
+        assert!(!dedup.should_suppress(key("testnet", "obj-A")));
+        assert!(!dedup.should_suppress(key("mainnet", "obj-B")));
         // …but a repeat on the same key is still suppressed.
-        assert!(mgr.suppress_walrus_upgrade_alert("mainnet", "1.1.7"));
+        assert!(dedup.should_suppress(key("mainnet", "obj-A")));
     }
 
     #[test]
-    fn walrus_upgrade_dedup_re_fires_after_window_expires() {
+    fn alert_dedup_re_fires_after_window_expires() {
         // Very short window → immediately past it on the second call.
-        let mgr = test_alert_manager_with_window(Duration::from_millis(1));
-        assert!(!mgr.suppress_walrus_upgrade_alert("mainnet", "1.1.7"));
+        let dedup = AlertDedup::new(Duration::from_millis(1));
+        assert!(!dedup.should_suppress(key("mainnet", "1.1.7")));
         std::thread::sleep(Duration::from_millis(5));
-        assert!(!mgr.suppress_walrus_upgrade_alert("mainnet", "1.1.7"));
+        assert!(!dedup.should_suppress(key("mainnet", "1.1.7")));
+    }
+
+    #[test]
+    fn walrus_object_locked_payload_surfaces_lock_metadata_not_exhausted_copy() {
+        let payload = SlackPayload::for_walrus_object_locked(&WalrusObjectLockedAlert {
+            remember_job_id: Some("3d607892".into()),
+            owner: Some(
+                "0xab27e2141234567890abcdef1234567890abcdef1234567890abcdef0064e132".into(),
+            ),
+            namespace: Some("autonomous-participation".into()),
+            sui_network: "testnet".into(),
+            locked_object_id: Some("0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e".into()),
+            locked_object_version: Some("884613305".into()),
+            locking_transaction_digest: Some("8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82BtHrp3F".into()),
+            error: "Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable)".into(),
+        });
+
+        let json = serde_json::to_string(&payload).unwrap();
+        // Names the real cause, NOT the misleading "exhausted retries" copy.
+        assert!(json.contains("object lock") || json.contains("Sui object lock"));
+        assert!(!json.to_lowercase().contains("exhausted retries"));
+        // Surfaces lock metadata for triage.
+        assert!(json.contains("0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e"));
+        assert!(json.contains("884613305"));
+        assert!(json.contains("8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82BtHrp3F"));
+        assert!(json.contains("testnet"));
+        assert!(json.contains("autonomous-participation"));
+    }
+
+    #[test]
+    fn walrus_object_locked_payload_handles_unparsed_metadata() {
+        // When the error didn't yield object/version/digest, the payload still
+        // ships with explicit `unparsed` placeholders rather than crashing.
+        let payload = SlackPayload::for_walrus_object_locked(&WalrusObjectLockedAlert {
+            remember_job_id: None,
+            owner: None,
+            namespace: None,
+            sui_network: "mainnet".into(),
+            locked_object_id: None,
+            locked_object_version: None,
+            locking_transaction_digest: None,
+            error: "equivocation detected".into(),
+        });
+
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("unparsed"));
+        assert!(json.contains("mainnet"));
     }
 }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -20,7 +20,8 @@ use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
 
 use crate::alerts::{
-    SIDECAR_WALRUS_DEP_VERSION, WalrusPackageUpgradeDetectedAlert, WalrusUploadExhaustedAlert,
+    SIDECAR_WALRUS_DEP_VERSION, WalrusObjectLockedAlert, WalrusPackageUpgradeDetectedAlert,
+    WalrusUploadExhaustedAlert,
 };
 use crate::storage::walrus::{SetMetadataBatchEntry, UploadBlobError};
 use crate::types::{configured_walrus_storage_epochs, AppState, BLOB_CACHE_KEY_PREFIX};
@@ -168,7 +169,12 @@ async fn update_remember_job_after_wallet_error(
         return;
     };
 
-    let status = if error.is_permanent() {
+    // Aborting errors (Permanent or ObjectLockedUntilEpoch) get no further
+    // retries, so the row is terminal — mark it failed rather than leaving it
+    // stuck on `running` forever. Retryable errors stay `running` for the next
+    // attempt. The error_msg carries the lock detail; the object-lock case
+    // also fires its own distinct Slack alert.
+    let status = if error.aborts_retries() {
         "failed"
     } else {
         "running"
@@ -364,7 +370,10 @@ pub(crate) struct WalletJobAttemptInfo {
 
 impl WalletJobAttemptInfo {
     fn exhausted_by(&self, error: &WalletJobError) -> bool {
-        !error.is_permanent() && self.current >= self.max
+        // Only retryable (non-aborting) errors can "exhaust" the budget. An
+        // aborting error — Permanent or ObjectLockedUntilEpoch — stops retries
+        // immediately, so it never produces a misleading "exhausted" alert.
+        !error.aborts_retries() && self.current >= self.max
     }
 }
 
@@ -874,6 +883,15 @@ async fn execute_upload_and_transfer(
                 &msg,
             )
             .await;
+            maybe_alert_walrus_object_locked(
+                state,
+                &classified,
+                remember_job_id.as_deref(),
+                Some(&owner),
+                Some(&namespace),
+                &msg,
+            )
+            .await;
             maybe_alert_walrus_upload_exhausted(
                 state,
                 &classified,
@@ -985,6 +1003,88 @@ async fn maybe_alert_walrus_package_upgrade_detected(
     }
 }
 
+/// Identifiers parsed from a Sui owned-object lock / equivocation error, used
+/// to enrich the object-lock alert and the persisted job row. Every field is
+/// best-effort: Sui error formatting varies, so a field stays `None` when its
+/// token isn't present rather than failing the whole parse.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct LockedObjectInfo {
+    object_id: Option<String>,
+    version: Option<String>,
+    locking_digest: Option<String>,
+}
+
+/// Extract the text between the first `open` delimiter and the next `close`
+/// after it. Returns `None` if either delimiter is missing or the span is
+/// empty.
+fn extract_delimited(haystack: &str, open: &str, close: &str) -> Option<String> {
+    let start = haystack.find(open)? + open.len();
+    let rest = &haystack[start..];
+    let end = rest.find(close)?;
+    let value = rest[..end].trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// Extract the first `0x`-prefixed hex object id in the message (the locked
+/// object always appears first inside `Object (0x…, …)`).
+fn extract_first_object_id(haystack: &str) -> Option<String> {
+    let idx = haystack.find("0x")?;
+    let hex: String = haystack[idx + 2..]
+        .chars()
+        .take_while(char::is_ascii_hexdigit)
+        .collect();
+    (!hex.is_empty()).then(|| format!("0x{hex}"))
+}
+
+/// Parse the locked object id, version, and locking transaction digest out of
+/// a Sui object-lock error string, e.g.:
+/// `…[Object (0xabc…, SequenceNumber(884613305), o#…) already locked by a
+///  different transaction: TransactionDigest(8bjFg…) … with 6842 stake]`.
+fn parse_locked_object_info(msg: &str) -> LockedObjectInfo {
+    LockedObjectInfo {
+        object_id: extract_first_object_id(msg),
+        version: extract_delimited(msg, "SequenceNumber(", ")"),
+        locking_digest: extract_delimited(msg, "TransactionDigest(", ")"),
+    }
+}
+
+/// Fire the distinct object-lock / equivocation alert when a wallet job fails
+/// with `ObjectLockedUntilEpoch`. Kept separate from the "exhausted retries"
+/// alert: this case never reaches retry exhaustion (it aborts immediately), so
+/// the on-call message must name the real cause — an owned-object lock — and
+/// surface the object id / version / locking digest for triage.
+async fn maybe_alert_walrus_object_locked(
+    state: &AppState,
+    error: &WalletJobError,
+    remember_job_id: Option<&str>,
+    owner: Option<&str>,
+    namespace: Option<&str>,
+    msg: &str,
+) {
+    if !matches!(error, WalletJobError::ObjectLockedUntilEpoch(_)) {
+        return;
+    }
+
+    let info = parse_locked_object_info(msg);
+    let alert = WalrusObjectLockedAlert {
+        remember_job_id: remember_job_id.map(str::to_owned),
+        owner: owner.map(str::to_owned),
+        namespace: namespace.map(str::to_owned),
+        sui_network: state.config.sui_network.clone(),
+        locked_object_id: info.object_id,
+        locked_object_version: info.version,
+        locking_transaction_digest: info.locking_digest,
+        error: msg.to_string(),
+    };
+
+    if let Err(err) = state.alerts.notify_walrus_object_locked(alert).await {
+        tracing::warn!(
+            "[wallet-job:upload] failed to send Slack alert for Walrus object lock: {}",
+            err
+        );
+    }
+}
+
 async fn maybe_alert_walrus_upload_exhausted(
     state: &AppState,
     error: &WalletJobError,
@@ -1034,6 +1134,9 @@ async fn maybe_alert_walrus_upload_exhausted(
 ///   `balance::split` stale-state failures that can recover after sidecar refresh
 /// - `ObjectLockedAtVersion(_)` → `Transient` (retry can rebuild with a fresh
 ///   wallet assignment)
+/// - owned-object lock / equivocation ("already locked by a different
+///   transaction", ">1/3 of validators … non-retriable", "equivocated") →
+///   `ObjectLockedUntilEpoch` (abort: retrying within the epoch re-fails)
 /// - `InsufficientGas` / `ObjectNotFound` /
 ///   `ObjectVersionUnavailableForConsumption` → `Transient` (refill wallet,
 ///   refresh local state, retry)
@@ -1044,6 +1147,14 @@ pub enum WalletJobError {
     Transient(String),
     /// Permanent failure — Apalis should mark Dead immediately (no retry).
     Permanent(String),
+    /// A Sui owned object/version is locked to a competing transaction. The
+    /// lock does not clear with immediate retries — it holds until the lock
+    /// resolves, typically at the next epoch boundary — so retrying within the
+    /// epoch re-fails against the same object and only burns the wallet attempt
+    /// budget. NOT `Permanent`: the same input can succeed in a later epoch.
+    /// Apalis aborts so we surface a distinct object-lock alert rather than a
+    /// misleading "wallet retries exhausted" one.
+    ObjectLockedUntilEpoch(String),
 }
 
 impl WalletJobError {
@@ -1051,12 +1162,25 @@ impl WalletJobError {
         match self {
             WalletJobError::Transient(_) => "transient",
             WalletJobError::Permanent(_) => "permanent",
+            WalletJobError::ObjectLockedUntilEpoch(_) => "object_locked_until_epoch",
         }
     }
 
     /// True if the error is `Permanent` — caller should NOT retry.
     pub fn is_permanent(&self) -> bool {
         matches!(self, WalletJobError::Permanent(_))
+    }
+
+    /// True if Apalis should stop retrying this job (abort rather than
+    /// re-queue). Covers both `Permanent` (never valid) and
+    /// `ObjectLockedUntilEpoch` (not valid again until the lock clears).
+    /// Used to gate both the Apalis disposition and the "exhausted retries"
+    /// alert so a single locked object doesn't burn the whole wallet budget.
+    pub fn aborts_retries(&self) -> bool {
+        matches!(
+            self,
+            WalletJobError::Permanent(_) | WalletJobError::ObjectLockedUntilEpoch(_)
+        )
     }
 
     /// Heuristic classification from the sidecar's error string. The sidecar
@@ -1080,6 +1204,23 @@ impl WalletJobError {
         {
             return WalletJobError::Transient(msg.to_string());
         }
+        // Sui owned-object lock / equivocation. The referenced object+version
+        // is locked to a competing transaction and stays locked until the lock
+        // clears (typically the next epoch boundary), so retrying within this
+        // epoch deterministically re-fails against the same object. Distinct
+        // from the recoverable `locked at version` case below — there is no
+        // fresh version to rebuild against until the lock resolves. Checked
+        // before the MoveAbort→Permanent catch so a "non-retriable" MoveAbort
+        // is classified as a lock (recoverable next epoch) rather than Dead.
+        if lower.contains("already locked by a different transaction")
+            || lower.contains("rejected as invalid by more than 1/3 of validators by stake")
+            || lower.contains("non-retriable")
+            || lower.contains("equivocated")
+            || lower.contains("equivocation")
+            || lower.contains("reserved for another transaction")
+        {
+            return WalletJobError::ObjectLockedUntilEpoch(msg.to_string());
+        }
         if lower.contains("moveabort") || lower.contains("move abort") {
             return WalletJobError::Permanent(msg.to_string());
         }
@@ -1100,7 +1241,9 @@ impl WalletJobError {
         let error = io::Error::other(self.to_string());
         match self {
             WalletJobError::Transient(_) => Error::Failed(Arc::new(Box::new(error))),
-            WalletJobError::Permanent(_) => Error::Abort(Arc::new(Box::new(error))),
+            WalletJobError::Permanent(_) | WalletJobError::ObjectLockedUntilEpoch(_) => {
+                Error::Abort(Arc::new(Box::new(error)))
+            }
         }
     }
 }
@@ -1110,6 +1253,9 @@ impl std::fmt::Display for WalletJobError {
         match self {
             WalletJobError::Transient(msg) => write!(f, "wallet job error (transient): {}", msg),
             WalletJobError::Permanent(msg) => write!(f, "wallet job error (permanent): {}", msg),
+            WalletJobError::ObjectLockedUntilEpoch(msg) => {
+                write!(f, "wallet job error (object locked until epoch): {}", msg)
+            }
         }
     }
 }
@@ -1500,9 +1646,18 @@ mod tests {
 
     use super::{
         classify_wallet_remember_handoff_failure, is_walrus_package_version_mismatch,
-        mark_remember_job_failed, wallet_job_request, WalletJob, WalletJobAttemptInfo,
-        WalletJobError, WalletOperation, MAX_ATTEMPTS,
+        mark_remember_job_failed, parse_locked_object_info, wallet_job_request, WalletJob,
+        WalletJobAttemptInfo, WalletJobError, WalletOperation, MAX_ATTEMPTS,
     };
+
+    /// The exact production error string from the object-lock incident
+    /// (testnet job 3d607892…). Used to pin the classifier against real output.
+    const PROD_OBJECT_LOCK_ERROR: &str = "walrus upload failed: Internal Error: walrus upload failed: \
+Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable). \
+Non-retriable errors: [Object (0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e, \
+SequenceNumber(884613305), o#B61aVqEgDskxru255FTdzua2RxbbnhDMFxmQ8SCxvj3n) already locked by a \
+different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82BtHrp3F) \
+{ k#80127c70.., k#81626d03.. } with 6842 stake].";
 
     static DB_SETUP_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 
@@ -1544,7 +1699,102 @@ mod tests {
                 "expected transient for: {}",
                 msg
             );
+            assert!(
+                !WalletJobError::classify_sidecar_error(msg).aborts_retries(),
+                "recoverable lock-at-version should stay retryable: {}",
+                msg
+            );
         }
+    }
+
+    #[test]
+    fn classify_prod_equivocation_as_object_locked_until_epoch() {
+        let classified = WalletJobError::classify_sidecar_error(PROD_OBJECT_LOCK_ERROR);
+        assert!(
+            matches!(classified, WalletJobError::ObjectLockedUntilEpoch(_)),
+            "prod equivocation error must classify as ObjectLockedUntilEpoch, got {}",
+            classified.kind()
+        );
+        // It aborts retries (doesn't burn the wallet budget) but is NOT
+        // "permanent" — the same input can succeed in a later epoch.
+        assert!(classified.aborts_retries());
+        assert!(!classified.is_permanent());
+    }
+
+    #[test]
+    fn object_locked_until_epoch_aborts_apalis() {
+        let err = WalletJobError::ObjectLockedUntilEpoch("locked".to_string());
+        assert!(matches!(
+            err.into_apalis_error(),
+            apalis::prelude::Error::Abort(_)
+        ));
+    }
+
+    #[test]
+    fn object_locked_until_epoch_does_not_exhaust_wallet_budget() {
+        // At the final attempt, an object-lock error must NOT trigger the
+        // "exhausted retries" alert — that gate is what produced the
+        // misleading prod alert.
+        let err = WalletJobError::ObjectLockedUntilEpoch("locked".to_string());
+        assert!(!WalletJobAttemptInfo { current: 5, max: 5 }.exhausted_by(&err));
+    }
+
+    #[test]
+    fn classify_equivocation_phrase_variants() {
+        for msg in [
+            "object 0xabc already locked by a different transaction: TransactionDigest(d)",
+            "Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable)",
+            "the input object is equivocated",
+            "equivocation detected on gas coin",
+            "object reserved for another transaction",
+        ] {
+            assert!(
+                matches!(
+                    WalletJobError::classify_sidecar_error(msg),
+                    WalletJobError::ObjectLockedUntilEpoch(_)
+                ),
+                "expected ObjectLockedUntilEpoch for: {}",
+                msg
+            );
+        }
+    }
+
+    #[test]
+    fn equivocation_does_not_regress_recoverable_classes() {
+        // balance::split and EWrongVersion must still be Transient (recoverable),
+        // not swept into the new abort path.
+        let balance = "Enoki dry run failed: MoveAbort(0x2::balance, split, 2)";
+        let ewrong = "MoveAbort in 1st command, abort code: 1, in '0xabc::system::inner_mut'";
+        assert!(matches!(
+            WalletJobError::classify_sidecar_error(balance),
+            WalletJobError::Transient(_)
+        ));
+        assert!(matches!(
+            WalletJobError::classify_sidecar_error(ewrong),
+            WalletJobError::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn parse_locked_object_info_from_prod_error() {
+        let info = parse_locked_object_info(PROD_OBJECT_LOCK_ERROR);
+        assert_eq!(
+            info.object_id.as_deref(),
+            Some("0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e")
+        );
+        assert_eq!(info.version.as_deref(), Some("884613305"));
+        assert_eq!(
+            info.locking_digest.as_deref(),
+            Some("8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82BtHrp3F")
+        );
+    }
+
+    #[test]
+    fn parse_locked_object_info_tolerates_missing_tokens() {
+        let info = parse_locked_object_info("some unrelated error with no object tokens");
+        assert!(info.object_id.is_none());
+        assert!(info.version.is_none());
+        assert!(info.locking_digest.is_none());
     }
 
     #[test]

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -548,7 +548,7 @@ pub(crate) async fn execute_wallet_job(
                         remember_job_id.as_deref().unwrap_or("-"),
                         msg,
                         err.kind(),
-                        !err.is_permanent()
+                        !err.aborts_retries()
                     );
                     Err(err)
                 }
@@ -668,7 +668,7 @@ async fn insert_vector_and_mark_remember_done(
             remember_job_id.unwrap_or("-"),
             msg,
             classified.kind(),
-            !classified.is_permanent()
+            !classified.aborts_retries()
         );
         return Err(classified);
     }
@@ -915,7 +915,7 @@ async fn execute_upload_and_transfer(
                 remember_job_id.as_deref().unwrap_or("-"),
                 msg,
                 classified.kind(),
-                !classified.is_permanent()
+                !classified.aborts_retries()
             );
             return Err(classified);
         }
@@ -1209,16 +1209,24 @@ impl WalletJobError {
         // clears (typically the next epoch boundary), so retrying within this
         // epoch deterministically re-fails against the same object. Distinct
         // from the recoverable `locked at version` case below — there is no
-        // fresh version to rebuild against until the lock resolves. Checked
-        // before the MoveAbort→Permanent catch so a "non-retriable" MoveAbort
-        // is classified as a lock (recoverable next epoch) rather than Dead.
-        if lower.contains("already locked by a different transaction")
-            || lower.contains("rejected as invalid by more than 1/3 of validators by stake")
-            || lower.contains("non-retriable")
-            || lower.contains("equivocated")
-            || lower.contains("equivocation")
+        // fresh version to rebuild against until the lock resolves.
+        //
+        // Requires a lock/equivocation-specific anchor. The "non-retriable" /
+        // ">1/3 of validators by stake" preamble is NOT lock-specific on its
+        // own (a generic invalid MoveAbort is also non-retriable), so it only
+        // qualifies when corroborated by object-lock evidence in the same
+        // message. Checked before the MoveAbort→Permanent catch so a genuine
+        // lock isn't Dead-marked, while a bare non-retriable MoveAbort falls
+        // through to Permanent.
+        let has_lock_anchor = lower.contains("already locked by a different transaction")
             || lower.contains("reserved for another transaction")
-        {
+            || lower.contains("equivocated")
+            || lower.contains("equivocation");
+        let corroborated_lock = (lower.contains("non-retriable")
+            || lower.contains("rejected as invalid by more than 1/3 of validators by stake"))
+            && lower.contains("object (")
+            && lower.contains("locked");
+        if has_lock_anchor || corroborated_lock {
             return WalletJobError::ObjectLockedUntilEpoch(msg.to_string());
         }
         if lower.contains("moveabort") || lower.contains("move abort") {
@@ -1741,12 +1749,15 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
 
     #[test]
     fn classify_equivocation_phrase_variants() {
+        // Lock-specific anchors classify on their own.
         for msg in [
             "object 0xabc already locked by a different transaction: TransactionDigest(d)",
-            "Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable)",
             "the input object is equivocated",
             "equivocation detected on gas coin",
             "object reserved for another transaction",
+            // Corroborated: non-retriable preamble + object-lock evidence.
+            "rejected as invalid by more than 1/3 of validators by stake (non-retriable). \
+             Object (0xabc, SequenceNumber(1)) already locked",
         ] {
             assert!(
                 matches!(
@@ -1757,6 +1768,25 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
                 msg
             );
         }
+    }
+
+    #[test]
+    fn bare_non_retriable_is_not_an_object_lock() {
+        // The "non-retriable" / ">1/3 of validators" preamble alone is not
+        // lock-specific. Without object-lock evidence it must NOT be classified
+        // as ObjectLockedUntilEpoch.
+        // - generic invalid tx (no MoveAbort) → default Transient
+        let invalid = "Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable)";
+        assert!(matches!(
+            WalletJobError::classify_sidecar_error(invalid),
+            WalletJobError::Transient(_)
+        ));
+        // - generic non-retriable MoveAbort → Permanent (not a lock)
+        let move_abort = "MoveAbort in 1st command, abort code: 3 — non-retriable";
+        assert!(matches!(
+            WalletJobError::classify_sidecar_error(move_abort),
+            WalletJobError::Permanent(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Linear: WALM-77 — Walrus upload: detect Sui object-lock / equivocation and stop burning wallet retries

## Issue

Prod testnet alert: a Walrus upload "exhausted" all 5 wallet attempts. The real cause was a Sui owned-object equivocation — a specific object/version was already locked by a competing transaction, so the tx was rejected by >1/3 of validator stake and is non-retriable until the lock clears (typically the next epoch boundary). Every immediate retry re-failed against the same locked object, burned the wallet budget, and produced a misleading "wallet retries exhausted" alert.

Root cause: `classify_sidecar_error` had no branch for this error string, so it fell through to the generic `Transient` arm.

## Scope

This is the **P0** slice per review. The P1 prevention work (single-flight per wallet, coin reservation, `ParallelTransactionExecutor`, finality checks) is intentionally **not** included — it changes scheduling/concurrency behavior and is tracked separately.

## What was done

**Rust (`jobs.rs`, `alerts.rs`)**
- New `WalletJobError::ObjectLockedUntilEpoch` — neither `Transient` (don't retry into the same lock) nor `Permanent` (the input can succeed in a later epoch). `aborts_retries()` gates both the Apalis `Abort` and the exhausted-retries alert, so one locked object no longer consumes the whole wallet budget.
- Classifier branch matches `already locked by a different transaction`, `rejected as invalid by more than 1/3 of validators by stake`, `non-retriable`, `equivocated`/`equivocation`, `reserved for another transaction` — ahead of the `MoveAbort -> Permanent` catch and distinct from the recoverable `locked at version` case.
- Parse locked object id / version / locking digest from the error string.
- New `WalrusObjectLockedAlert`: copy names the real cause (object lock / equivocation), surfaces object id + version + locking digest, deduped per `(network, object_id)` via a reusable `AlertDedup` (window env-overridable: `WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS`).
- Aborting errors persist `status='failed'` instead of leaving the row stuck on `running` forever.

**TS sidecar (`sidecar-server.ts`, `walrus-error-detection.ts`)**
- Mirror detection (`isWalrusObjectLockEquivocation`, kept in sync with the Rust classifier) + dedicated `walletObjectLockEquivocationTotal` counter on `/metrics/wallet`.
- Corrected the adjacent metric comments: the earlier "Sui no longer permanently locks coin objects on equivocation" claim is contradicted by this incident; the new counter is the canary for whether concurrent uploads still equivocate owned objects.

## Tests

- Rust: 262 pass (8 new) — exact prod string → `ObjectLockedUntilEpoch`, abort disposition, no-exhaust gate, metadata parser, phrase variants, and no regression of `balance::split` / `EWrongVersion`.
- Sidecar TS: 46 pass (5 new) — exact prod string, phrase variants, case-insensitivity, recoverable-lock negative case.

## Follow-up (P1, separate)

Single-flight per wallet, dedicated coin reservation / `ParallelTransactionExecutor`, and finality checks before reusing a wallet — these prevent the equivocation rather than just classifying it. The new `walletObjectLockEquivocationTotal` counter is the signal for prioritizing that work.