### PR TITLE
WALM-77 dev-validation follow-up: object-lock alert tests + detection/coverage fixes

### DIFF
--- a/services/server/scripts/__tests__/walrus-object-lock.test.ts
+++ b/services/server/scripts/__tests__/walrus-object-lock.test.ts
@@ -18,6 +18,8 @@ test("detects the exact production object-lock error", () => {
 test("detects each lock-specific anchor on its own", () => {
     const cases = [
         "object 0xabc already locked by a different transaction",
+        // Same conflict without the "already" prefix — must still match.
+        "object 0xabc locked by a different transaction",
         "the input object is equivocated",
         "equivocation detected on gas coin",
         "object reserved for another transaction",

--- a/services/server/scripts/walrus-error-detection.ts
+++ b/services/server/scripts/walrus-error-detection.ts
@@ -48,8 +48,10 @@ export function isWalrusPackageVersionMismatch(message: string): boolean {
  */
 export function isWalrusObjectLockEquivocation(message: string): boolean {
     if (!message) return false;
+    // "locked by a different transaction" (not anchored on "already") so we
+    // catch Sui lock-conflict phrasings that omit the "already" prefix.
     const hasLockAnchor =
-        /already locked by a different transaction/i.test(message)
+        /locked by a different transaction/i.test(message)
         || /reserved for another transaction/i.test(message)
         || /equivocated|equivocation/i.test(message);
     const corroboratedLock =

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -679,4 +679,106 @@ mod tests {
         assert!(json.contains("unparsed"));
         assert!(json.contains("mainnet"));
     }
+
+    // ── Dispatch-level integration: drive the real AlertManager against a
+    //    local capture server so we assert the actual HTTP send, not just the
+    //    payload struct. Proves the object-lock alert reaches Slack with the
+    //    parsed metadata and that dedup suppresses a burst. ──
+
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    fn enabled_manager(webhook_url: String) -> AlertManager {
+        AlertManager {
+            slack: Some(SlackNotifier {
+                http_client: reqwest::Client::new(),
+                webhook_url,
+            }),
+            walrus_upgrade_dedup: AlertDedup::new(Duration::from_secs(600)),
+            walrus_object_lock_dedup: AlertDedup::new(Duration::from_secs(600)),
+        }
+    }
+
+    /// Bind a webhook capture server on an ephemeral port; returns its URL and
+    /// the shared buffer of received request bodies.
+    async fn spawn_capture_server() -> (String, Arc<StdMutex<Vec<String>>>) {
+        use axum::{extract::State, routing::post, Router};
+
+        async fn capture(
+            State(buf): State<Arc<StdMutex<Vec<String>>>>,
+            body: String,
+        ) -> &'static str {
+            buf.lock().expect("capture mutex").push(body);
+            "ok"
+        }
+
+        let buf = Arc::new(StdMutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/hook", post(capture))
+            .with_state(buf.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind capture server");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{}/hook", addr), buf)
+    }
+
+    fn prod_object_lock_alert() -> WalrusObjectLockedAlert {
+        WalrusObjectLockedAlert {
+            remember_job_id: Some("3d607892".into()),
+            owner: Some(
+                "0xab27e2141234567890abcdef1234567890abcdef1234567890abcdef0064e132".into(),
+            ),
+            namespace: Some("autonomous-participation".into()),
+            sui_network: "testnet".into(),
+            locked_object_id: Some(
+                "0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e".into(),
+            ),
+            locked_object_version: Some("884613305".into()),
+            locking_transaction_digest: Some("8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82BtHrp3F".into()),
+            error: "Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable)".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn object_lock_alert_is_dispatched_with_lock_metadata() {
+        // #given a webhook capture server and a Slack-enabled manager
+        let (url, buf) = spawn_capture_server().await;
+        let mgr = enabled_manager(url);
+
+        // #when the dedicated object-lock alert is sent
+        mgr.notify_walrus_object_locked(prod_object_lock_alert())
+            .await
+            .expect("alert send");
+
+        // #then exactly one POST lands, carrying the parsed lock metadata and
+        //       the object-lock copy — NOT the generic exhausted-retries copy.
+        let posts = buf.lock().unwrap().clone();
+        assert_eq!(posts.len(), 1, "expected exactly one webhook POST");
+        let body = &posts[0];
+        assert!(body.contains("0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e"));
+        assert!(body.contains("884613305"));
+        assert!(body.contains("8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82BtHrp3F"));
+        assert!(body.to_lowercase().contains("object lock"));
+        assert!(!body.to_lowercase().contains("exhausted retries"));
+    }
+
+    #[tokio::test]
+    async fn object_lock_alert_burst_is_deduped_to_one_post() {
+        // #given a Slack-enabled manager
+        let (url, buf) = spawn_capture_server().await;
+        let mgr = enabled_manager(url);
+
+        // #when the same (network, object) raises the alert repeatedly
+        for _ in 0..5 {
+            mgr.notify_walrus_object_locked(prod_object_lock_alert())
+                .await
+                .expect("alert send");
+        }
+
+        // #then only the first POST reaches Slack; the burst is suppressed
+        assert_eq!(buf.lock().unwrap().len(), 1);
+    }
 }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -536,6 +536,15 @@ pub(crate) async fn execute_wallet_job(
                 },
                 Err(err) => {
                     let msg = err.to_string();
+                    maybe_alert_walrus_object_locked(
+                        state,
+                        &err,
+                        remember_job_id.as_deref(),
+                        Some(&owner),
+                        Some(&namespace),
+                        &msg,
+                    )
+                    .await;
                     update_remember_job_after_wallet_error(
                         state,
                         remember_job_id.as_deref(),
@@ -1218,7 +1227,9 @@ impl WalletJobError {
         // message. Checked before the MoveAbort→Permanent catch so a genuine
         // lock isn't Dead-marked, while a bare non-retriable MoveAbort falls
         // through to Permanent.
-        let has_lock_anchor = lower.contains("already locked by a different transaction")
+        // "locked by a different transaction" (not anchored on "already") so
+        // we catch Sui lock-conflict phrasings that omit the "already" prefix.
+        let has_lock_anchor = lower.contains("locked by a different transaction")
             || lower.contains("reserved for another transaction")
             || lower.contains("equivocated")
             || lower.contains("equivocation");
@@ -1752,6 +1763,8 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
         // Lock-specific anchors classify on their own.
         for msg in [
             "object 0xabc already locked by a different transaction: TransactionDigest(d)",
+            // Same conflict without the "already" prefix — must still match.
+            "object 0xabc locked by a different transaction: TransactionDigest(d)",
             "the input object is equivocated",
             "equivocation detected on gas coin",
             "object reserved for another transaction",


### PR DESCRIPTION
Linear: WALM-77 (dev validation follow-up to #212)

Two small fixes surfaced while validating the merged object-lock classifier on dev, plus dispatch-level integration tests.

## Fixes

- **Broaden the lock anchor.** The detector required the literal `already locked by a different transaction`. Sui renders some lock-conflict errors without the `already` prefix, which would slip past the anchor (the corroborated `non-retriable` + `object (` + `locked` branch only catches those when the preamble is present). Now matches `locked by a different transaction` — still lock-specific, resilient to the prefix. Mirrored in the TS detector.
- **Alert on the set-metadata path too.** The dedicated object-lock Slack alert previously fired only from the upload path. An equivocation during the set-metadata / transfer Sui tx classified correctly (abort, no retry burn) but raised no alert. `maybe_alert_walrus_object_locked` is now wired into the set-metadata error branch, so the alert fires from every Sui-tx path that can lock an owned object.

## Tests

- **`object_lock_alert_is_dispatched_with_lock_metadata`** — drives the real `AlertManager` against a local capture webhook; asserts one POST with parsed object id / version / locking digest, object-lock copy, and not the generic "exhausted retries" copy.
- **`object_lock_alert_burst_is_deduped_to_one_post`** — a 5× burst on the same `(network, object_id)` collapses to a single POST.
- Anchor tests extended with the no-`already` lock variant (Rust + TS).

## Validation summary (against merged dev `f1a70d9`)

| Review check | Evidence |
|---|---|
| classifies as `ObjectLockedUntilEpoch` | `classify_prod_equivocation_as_object_locked_until_epoch` |
| does not consume wallet retry budget | `object_locked_until_epoch_aborts_apalis` + `object_locked_until_epoch_does_not_exhaust_wallet_budget` |
| no generic "exhausted retries" alert | exhausted gate test + dispatch body assertion |
| dedicated object-lock alert with object id/version/digest | `object_lock_alert_is_dispatched_with_lock_metadata` |

Full suite on dev: 280 Rust + 48 sidecar TS, green. Clippy clean on the changed code.

## Note

A real Sui equivocation can't be induced on dev on demand (needs two concurrent txns racing the same owned object within an epoch), so validation is pinned to the exact production error string rather than a live-induced lock. P1 prevention work (single-flight per wallet, coin/object reservation, finality checks) stays separate, prioritized off the new `walletObjectLockEquivocationTotal` signal.

## Deliberately NOT changed

- DB status for `ObjectLockedUntilEpoch` stays `failed` (abort → client re-submits), not an auto-requeue-next-epoch defer. That's a candidate enhancement, flagged for P1 rather than silently changed here.