### PR TITLE
fix(app): update sign-in title/OpenGraph meta + underline legal links

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -12,18 +12,18 @@
   <link rel="preload" href="/fonts/Ratch-Variable.ttf" as="font" type="font/ttf" crossorigin>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description"
-    content="Walrus Memory is portable memory for reliable AI agents across apps and sessions." />
+    content="Generate delegate keys, manage your account, and view your dashboard. Walrus Memory gives AI agents portable, verifiable memory across apps and sessions." />
   <meta name="theme-color" content="#000000" />
-  <meta itemprop="name" content="Walrus Memory" />
-  <meta itemprop="description" content="Portable memory for reliable AI agents across apps and sessions." />
+  <meta itemprop="name" content="Portable AI Agent Memory | Walrus Memory Dashboard" />
+  <meta itemprop="description" content="Generate delegate keys, manage your account, and view your dashboard. Walrus Memory gives AI agents portable, verifiable memory across apps and sessions." />
   <meta itemprop="image" content="https://dev.memwal.ai/walrus-memory-social-preview.jpg" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://dev.memwal.ai/" />
   <meta property="og:site_name" content="Walrus Memory" />
-  <meta property="og:title" content="Walrus Memory" />
-  <meta property="og:description" content="Portable memory for reliable AI agents across apps and sessions." />
+  <meta property="og:title" content="Portable AI Agent Memory | Walrus Memory Dashboard" />
+  <meta property="og:description" content="Generate delegate keys, manage your account, and view your dashboard. Walrus Memory gives AI agents portable, verifiable memory across apps and sessions." />
   <meta property="og:image" content="https://dev.memwal.ai/walrus-memory-social-preview.jpg" />
   <meta property="og:image:secure_url" content="https://dev.memwal.ai/walrus-memory-social-preview.jpg" />
   <meta property="og:image:type" content="image/jpeg" />
@@ -33,12 +33,12 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Walrus Memory" />
-  <meta name="twitter:description" content="Portable memory for reliable AI agents across apps and sessions." />
+  <meta name="twitter:title" content="Portable AI Agent Memory | Walrus Memory Dashboard" />
+  <meta name="twitter:description" content="Generate delegate keys, manage your account, and view your dashboard. Walrus Memory gives AI agents portable, verifiable memory across apps and sessions." />
   <meta name="twitter:image" content="https://dev.memwal.ai/walrus-memory-social-preview.jpg" />
   <meta name="twitter:image:alt" content="Walrus Memory mascot on an aurora background" />
 
-  <title>Walrus Memory</title>
+  <title>Portable AI Agent Memory | Walrus Memory Dashboard</title>
 </head>
 
 <body>

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -9867,7 +9867,7 @@ h1, h2, h3 {
 
 .wm-signin-tos a {
   color: #faf8f5;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .wm-signin-trusted {


### PR DESCRIPTION
Two pieces of feedback for the sign-in page (memory.walrus.xyz).

## Changes
1. **Title & meta / OpenGraph (Daniel)** — update `<title>`, `description`, `og:*`, `twitter:*`, and `itemprop` so the link-preview card reads:
   - **Title:** Portable AI Agent Memory | Walrus Memory Dashboard
   - **Description:** Generate delegate keys, manage your account, and view your dashboard. Walrus Memory gives AI agents portable, verifiable memory across apps and sessions.
2. **Legal** — underline "Terms of Service" and "Privacy Policy" links (`text-decoration: underline`).

## Notes
- OpenGraph preview only updates after deploy; Slack/Twitter cache OG data and may need a re-scrape.
- Verified served HTML on local matches the requested copy exactly.