### PR TITLE
fix(app): relayer URL from env in SDK snippets (WALM-87)

### DIFF
--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -122,7 +122,6 @@ interface OnChainDelegateKey {
 
 const MAX_DELEGATE_KEYS = 20
 const MAX_DELEGATE_KEYS_MESSAGE = 'This wallet already has 20 delegate keys. Remove an old key before creating a new delegate key.'
-const SDK_DEFAULT_SERVER_URL = 'https://relayer.memwal.ai'
 const PRIVATE_KEY_ENV = 'MEMWAL_PRIVATE_KEY'
 const ACCOUNT_ID_ENV = 'MEMWAL_ACCOUNT_ID'
 const SERVER_URL_ENV = 'MEMWAL_SERVER_URL'
@@ -372,9 +371,9 @@ export default function Dashboard({
     const activeEnvironmentLabel = config.suiNetwork === 'mainnet'
         ? 'production / mainnet'
         : 'staging / testnet'
-    const expectedRelayerUrl = config.suiNetwork === 'mainnet'
-        ? 'https://relayer.memwal.ai'
-        : 'https://relayer.memwal.ai'
+    const expectedRelayerLabel = config.suiNetwork === 'mainnet'
+        ? 'a production / mainnet relayer'
+        : 'a staging or dev / testnet relayer'
     const normalizedRelayerUrl = config.memwalServerUrl.toLowerCase()
     const relayerEnvironmentLabel = normalizedRelayerUrl.startsWith('/')
         ? 'local dev proxy / testnet'
@@ -690,13 +689,23 @@ export default function Dashboard({
     // in DOM / copyable snippets. Use a static placeholder instead.
     const PRIVATE_KEY_PLACEHOLDER = '<YOUR_PRIVATE_KEY>'
     const ACCOUNT_ID_PLACEHOLDER = '<YOUR_ACCOUNT_ID>'
+    const SERVER_URL_PLACEHOLDER = '<YOUR_MEMWAL_SERVER_URL>'
+    // Target the relayer this dashboard is configured for so copy-pasted
+    // snippets hit the same environment the user is on. A local dev proxy
+    // (relative path) or localhost is not a usable endpoint in someone else's
+    // project, so fall back to a placeholder rather than emitting it.
+    const snippetServerUrl =
+        /^https?:\/\//i.test(config.memwalServerUrl) &&
+        !/localhost|127\.0\.0\.1/i.test(config.memwalServerUrl)
+            ? config.memwalServerUrl
+            : SERVER_URL_PLACEHOLDER
 
     const sdkTypeScriptSnippet = `import { MemWal } from "@mysten-incubation/memwal"
 
 const memwal = MemWal.create({
   key: process.env.${PRIVATE_KEY_ENV} ?? "${PRIVATE_KEY_PLACEHOLDER}",
   accountId: process.env.${ACCOUNT_ID_ENV} ?? "${effectiveAccountObjectId ?? ACCOUNT_ID_PLACEHOLDER}",
-  serverUrl: process.env.${SERVER_URL_ENV} ?? "${SDK_DEFAULT_SERVER_URL}",
+  serverUrl: process.env.${SERVER_URL_ENV} ?? "${snippetServerUrl}",
 })
 
 // Remember something
@@ -715,7 +724,7 @@ async def main():
     memwal = MemWal.create(
         key=os.environ["${PRIVATE_KEY_ENV}"],
         account_id=os.environ["${ACCOUNT_ID_ENV}"],
-        server_url=os.environ.get("${SERVER_URL_ENV}", "${SDK_DEFAULT_SERVER_URL}"),
+        server_url=os.environ.get("${SERVER_URL_ENV}", "${snippetServerUrl}"),
     )
 
     await memwal.remember_and_wait("I'm allergic to peanuts")
@@ -738,7 +747,7 @@ import { openai } from "@ai-sdk/openai"
 const model = withMemWal(openai("gpt-4o"), {
   key: process.env.${PRIVATE_KEY_ENV} ?? "${PRIVATE_KEY_PLACEHOLDER}",
   accountId: process.env.${ACCOUNT_ID_ENV} ?? "${effectiveAccountObjectId ?? ACCOUNT_ID_PLACEHOLDER}",
-  serverUrl: process.env.${SERVER_URL_ENV} ?? "${SDK_DEFAULT_SERVER_URL}",
+  serverUrl: process.env.${SERVER_URL_ENV} ?? "${snippetServerUrl}",
 })
 
 const result = await generateText({
@@ -924,7 +933,7 @@ const result = await generateText({
                             <p>
                                 <strong>{activeEnvironmentLabel}</strong>
                                 <span>Configured relayer: <code>{config.memwalServerUrl}</code> ({relayerEnvironmentLabel}).</span>
-                                <span>Expected relayer: <code>{expectedRelayerUrl}</code>.</span>
+                                <span>Expected: {expectedRelayerLabel}.</span>
                             </p>
                             {relayerLooksMismatched && (
                                 <p>


### PR DESCRIPTION
## WALM-87 — [FE] wrong URL: hardcoded relayer in dashboard SDK snippets

The Quickstart SDK and AI SDK Integration snippets on the dashboard hardcoded
`https://relayer.memwal.ai` as the `serverUrl` fallback, so they always showed
the production endpoint regardless of which environment the dashboard ran in.

### Changes (`apps/app/src/pages/Dashboard.tsx`)
**A — snippets no longer hardcode prod**
- Removed `SDK_DEFAULT_SERVER_URL = 'https://relayer.memwal.ai'`.
- Added `snippetServerUrl`: uses the relayer the dashboard is configured for
  (`config.memwalServerUrl` ← `VITE_MEMWAL_SERVER_URL`) when it's a usable
  absolute `https?://` URL; falls back to `<YOUR_MEMWAL_SERVER_URL>` for local
  dev proxy / localhost.
- TS, Python and AI SDK snippets now emit
  `serverUrl: process.env.MEMWAL_SERVER_URL ?? "<connected-relayer-or-placeholder>"`.

**B — related "wrong url" bug**
- `expectedRelayerUrl` returned `relayer.memwal.ai` for **both** mainnet and
  testnet, so the credentials warning told testnet users the production relayer
  was "expected". Replaced with a network-descriptive `expectedRelayerLabel`
  (no hardcoded env URL); the mismatch heuristic is unchanged.

### Behavior by environment
| Dashboard env | snippet `serverUrl` fallback |
|---|---|
| prod | the configured prod relayer |
| dev / staging | the configured dev/staging relayer |
| local (localhost / proxy) | `<YOUR_MEMWAL_SERVER_URL>` |

### Acceptance criteria
- [x] No hardcoded `https://relayer.memwal.ai` in Quickstart SDK example
- [x] No hardcoded `https://relayer.memwal.ai` in AI SDK Integration example
- [x] Endpoint configured via `MEMWAL_SERVER_URL`
- [x] Works for prod / staging / self-hosted (driven by dashboard env)

### Out of scope (per agreed scope A+B)
- "Add Environment Variables section" doc block and a repo-wide docs sweep
  (`README`/`SKILL`/`docs/*`) are not included; docs already migrated to the
  new `relayer.memory.walrus.xyz` domain under WALM-84.

### Verification
- `tsc -b`: no new type errors (the remaining module-resolution / implicit-any
  errors are pre-existing on `dev`, confirmed by comparing against the unmodified
  file).
- `eslint src/pages/Dashboard.tsx`: clean.