### PR TITLE
[codex] fix Enoki transient retries

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -57,6 +57,9 @@ These are not all enforced at boot, but most real deployments need them.
 | `ENOKI_API_KEY` | none | Optional Enoki key for sponsored sidecar transactions |
 | `ENOKI_NETWORK` | `mainnet` | Network used for Enoki-sponsored flows |
 | `ENOKI_FALLBACK_TO_DIRECT_SIGN` | `false` | If true, sidecar pays gas directly with the server wallet when Enoki sponsorship fails or is not configured |
+| `ENOKI_TRANSIENT_MAX_ATTEMPTS` | `2` | Attempts for sidecar-level retries of transient Enoki failures (`429`, `5xx`, network errors) before failing the wallet job |
+| `ENOKI_TRANSIENT_BASE_DELAY_MS` | `5000` | Base delay for transient Enoki retries when the response does not include `Retry-After` or a retry hint |
+| `ENOKI_TRANSIENT_MAX_DELAY_MS` | `30000` | Maximum delay for one transient Enoki retry, including parsed retry hints such as “try again in 30 seconds” |
 | `MEMWAL_RELAYER_URL` | `http://127.0.0.1:$PORT` | Relayer URL passed from the Rust server to the sidecar for MCP tool calls |
 | `MCP_MAX_TOTAL_SESSIONS` | `1000` | Maximum active MCP sessions across SSE and Streamable HTTP transports |
 | `MCP_MAX_SESSIONS_PER_IP` | `16` | Maximum active MCP sessions from one source IP |

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -100,6 +100,11 @@ ENOKI_NETWORK=mainnet
 # Keep false in production so missing/expired/rejected sponsorship retries
 # through Apalis instead of making the server wallet pay gas directly.
 ENOKI_FALLBACK_TO_DIRECT_SIGN=false
+# Retry transient Enoki HTTP failures (429/5xx/network) inside the sidecar
+# before consuming a durable wallet-job retry.
+ENOKI_TRANSIENT_MAX_ATTEMPTS=2
+ENOKI_TRANSIENT_BASE_DELAY_MS=5000
+ENOKI_TRANSIENT_MAX_DELAY_MS=30000
 
 # Sponsor endpoint rate limiting (per IP + per sender, sliding window)
 SPONSOR_RATE_LIMIT_PER_MINUTE=10

--- a/services/server/scripts/__tests__/enoki-retry.test.ts
+++ b/services/server/scripts/__tests__/enoki-retry.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+    getEnokiRetryDelayMs,
+    isTransientEnokiStatus,
+    parseRetryAfterMs,
+    parseTryAgainBodyDelayMs,
+} from "../enoki-retry.js";
+
+const policy = {
+    maxAttempts: 2,
+    baseDelayMs: 5_000,
+    maxDelayMs: 30_000,
+};
+
+test("classifies only Enoki rate-limit and server statuses as transient", () => {
+    assert.equal(isTransientEnokiStatus(429), true);
+    assert.equal(isTransientEnokiStatus(500), true);
+    assert.equal(isTransientEnokiStatus(502), true);
+    assert.equal(isTransientEnokiStatus(599), true);
+    assert.equal(isTransientEnokiStatus(400), false);
+    assert.equal(isTransientEnokiStatus(403), false);
+});
+
+test("uses Retry-After seconds before fallback backoff", () => {
+    assert.equal(parseRetryAfterMs("7", 0), 7_000);
+    assert.equal(getEnokiRetryDelayMs({
+        ...policy,
+        attempt: 1,
+        status: 429,
+        retryAfter: "7",
+    }), 7_000);
+});
+
+test("uses Enoki HTML body retry hint for 502 responses", () => {
+    const body = "<h2>The server encountered a temporary error. Please try again in 30 seconds.</h2>";
+    assert.equal(parseTryAgainBodyDelayMs(body), 30_000);
+    assert.equal(getEnokiRetryDelayMs({
+        ...policy,
+        attempt: 1,
+        status: 502,
+        body,
+    }), 30_000);
+});
+
+test("caps long retry hints", () => {
+    assert.equal(getEnokiRetryDelayMs({
+        ...policy,
+        attempt: 1,
+        status: 503,
+        body: "please try again in 2 minutes",
+    }), 30_000);
+});
+
+test("does not retry final attempt or deterministic 400 errors", () => {
+    assert.equal(getEnokiRetryDelayMs({
+        ...policy,
+        attempt: 2,
+        status: 502,
+        body: "please try again in 30 seconds",
+    }), null);
+    assert.equal(getEnokiRetryDelayMs({
+        ...policy,
+        attempt: 1,
+        status: 400,
+        body: "{\"errors\":[{\"code\":\"dry_run_failed\"}]}",
+    }), null);
+});
+
+test("retries transport errors with exponential fallback", () => {
+    assert.equal(getEnokiRetryDelayMs({
+        ...policy,
+        attempt: 1,
+        transportError: true,
+    }), 5_000);
+});

--- a/services/server/scripts/enoki-retry.ts
+++ b/services/server/scripts/enoki-retry.ts
@@ -1,0 +1,63 @@
+export type EnokiRetryPolicy = {
+    maxAttempts: number;
+    baseDelayMs: number;
+    maxDelayMs: number;
+};
+
+export type EnokiRetryInput = EnokiRetryPolicy & {
+    attempt: number;
+    status?: number;
+    body?: string;
+    retryAfter?: string | null;
+    transportError?: boolean;
+};
+
+export function isTransientEnokiStatus(status: number): boolean {
+    return status === 429 || (status >= 500 && status <= 599);
+}
+
+export function parseRetryAfterMs(value: string | null | undefined, nowMs = Date.now()): number | null {
+    if (!value) return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    const seconds = Number(trimmed);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+        return Math.round(seconds * 1000);
+    }
+
+    const dateMs = Date.parse(trimmed);
+    if (Number.isFinite(dateMs)) {
+        return Math.max(0, dateMs - nowMs);
+    }
+
+    return null;
+}
+
+export function parseTryAgainBodyDelayMs(body: string | undefined): number | null {
+    if (!body) return null;
+    const match = body.match(/try again in\s+(\d+(?:\.\d+)?)\s*(seconds?|s|minutes?|m)\b/i);
+    if (!match) return null;
+
+    const amount = Number(match[1]);
+    if (!Number.isFinite(amount) || amount < 0) return null;
+
+    const unit = match[2].toLowerCase();
+    const multiplier = unit.startsWith("m") ? 60_000 : 1000;
+    return Math.round(amount * multiplier);
+}
+
+export function getEnokiRetryDelayMs(input: EnokiRetryInput): number | null {
+    if (input.attempt >= input.maxAttempts) return null;
+
+    const retryable = input.transportError
+        || (typeof input.status === "number" && isTransientEnokiStatus(input.status));
+    if (!retryable) return null;
+
+    const hintedDelayMs = parseRetryAfterMs(input.retryAfter)
+        ?? parseTryAgainBodyDelayMs(input.body);
+    const fallbackDelayMs = input.baseDelayMs * 2 ** Math.max(0, input.attempt - 1);
+    const rawDelayMs = hintedDelayMs ?? fallbackDelayMs;
+
+    return Math.max(0, Math.min(input.maxDelayMs, rawDelayMs));
+}

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -21,6 +21,7 @@ import { SealClient, SessionKey, EncryptedObject } from "@mysten/seal";
 import { WalrusClient } from "@mysten/walrus";
 import { mountMcpRoutes, shutdownMcpSessions } from "./mcp/index.js";
 import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-config.js";
+import { getEnokiRetryDelayMs } from "./enoki-retry.js";
 import {
     isWalrusBlobObjectMissingFromEffects,
     isWalrusObjectLockEquivocation,
@@ -177,6 +178,24 @@ const ENOKI_FALLBACK_TO_DIRECT_SIGN = (() => {
     const raw = (process.env.ENOKI_FALLBACK_TO_DIRECT_SIGN || "false").trim().toLowerCase();
     return raw !== "0" && raw !== "false" && raw !== "no";
 })();
+const ENOKI_TRANSIENT_MAX_ATTEMPTS = parsePositiveIntEnv(
+    "ENOKI_TRANSIENT_MAX_ATTEMPTS",
+    2,
+    1,
+    5,
+);
+const ENOKI_TRANSIENT_BASE_DELAY_MS = parsePositiveIntEnv(
+    "ENOKI_TRANSIENT_BASE_DELAY_MS",
+    5_000,
+    100,
+    60_000,
+);
+const ENOKI_TRANSIENT_MAX_DELAY_MS = parsePositiveIntEnv(
+    "ENOKI_TRANSIENT_MAX_DELAY_MS",
+    30_000,
+    1_000,
+    120_000,
+);
 const WALRUS_CLIENT_MAX_AGE_MS = (() => {
     const parsed = Number.parseInt(process.env.WALRUS_CLIENT_MAX_AGE_MS || "", 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 30 * 60 * 1000;
@@ -561,6 +580,7 @@ function sidecarStateSnapshot(): Record<string, unknown> {
         enokiNetwork,
         enokiEnabled: !!enokiApiKey,
         fallbackToDirectSign: ENOKI_FALLBACK_TO_DIRECT_SIGN,
+        enokiTransientMaxAttempts: ENOKI_TRANSIENT_MAX_ATTEMPTS,
     };
 }
 
@@ -605,28 +625,68 @@ async function callEnoki<T>(path: string, payload: unknown): Promise<T> {
         throw new Error("ENOKI_API_KEY is not configured");
     }
 
-    const resp = await fetch(`${ENOKI_API_BASE_URL}${path}`, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${enokiApiKey}`,
-        },
-        body: JSON.stringify(payload),
-    });
+    for (let attempt = 1; ; attempt += 1) {
+        let resp: Response;
+        try {
+            resp = await fetch(`${ENOKI_API_BASE_URL}${path}`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${enokiApiKey}`,
+                },
+                body: JSON.stringify(payload),
+            });
+        } catch (err) {
+            const retryDelayMs = getEnokiRetryDelayMs({
+                attempt,
+                maxAttempts: ENOKI_TRANSIENT_MAX_ATTEMPTS,
+                baseDelayMs: ENOKI_TRANSIENT_BASE_DELAY_MS,
+                maxDelayMs: ENOKI_TRANSIENT_MAX_DELAY_MS,
+                transportError: true,
+            });
+            if (retryDelayMs === null) throw err;
+            console.warn(`[enoki] transport_retry ${JSON.stringify({
+                path: redactEnokiPath(path),
+                network: enokiNetwork,
+                attempt,
+                maxAttempts: ENOKI_TRANSIENT_MAX_ATTEMPTS,
+                retryDelayMs,
+                error: errorMessage(err),
+            })}`);
+            await sleep(retryDelayMs);
+            continue;
+        }
 
-    const text = await resp.text();
-    if (!resp.ok) {
-        console.error(`[enoki] api_error ${JSON.stringify({
-            path: redactEnokiPath(path),
-            status: resp.status,
-            network: enokiNetwork,
-            ...summarizeEnokiError(text),
-        })}`);
-        throw new Error(`Enoki API error (${resp.status}): ${text}`);
+        const text = await resp.text();
+        if (!resp.ok) {
+            const retryDelayMs = getEnokiRetryDelayMs({
+                attempt,
+                maxAttempts: ENOKI_TRANSIENT_MAX_ATTEMPTS,
+                baseDelayMs: ENOKI_TRANSIENT_BASE_DELAY_MS,
+                maxDelayMs: ENOKI_TRANSIENT_MAX_DELAY_MS,
+                status: resp.status,
+                retryAfter: resp.headers.get("retry-after"),
+                body: text,
+            });
+            console.error(`[enoki] api_error ${JSON.stringify({
+                path: redactEnokiPath(path),
+                status: resp.status,
+                network: enokiNetwork,
+                attempt,
+                maxAttempts: ENOKI_TRANSIENT_MAX_ATTEMPTS,
+                retryDelayMs,
+                ...summarizeEnokiError(text),
+            })}`);
+            if (retryDelayMs !== null) {
+                await sleep(retryDelayMs);
+                continue;
+            }
+            throw new Error(`Enoki API error (${resp.status}): ${text}`);
+        }
+
+        const parsed = JSON.parse(text) as EnokiDataWrapper<T>;
+        return parsed.data;
     }
-
-    const parsed = JSON.parse(text) as EnokiDataWrapper<T>;
-    return parsed.data;
 }
 
 function isSponsoredTransactionExpired(err: unknown): boolean {


### PR DESCRIPTION
## Summary
- add sidecar-level retries for transient Enoki failures (429, 5xx, network errors)
- honor Retry-After and Enoki HTML retry hints such as "try again in 30 seconds"
- document retry tuning env vars and add focused retry policy tests

## Root cause
Walrus upload jobs were consuming durable wallet-job attempts when Enoki returned temporary 502 responses. In the observed incident, most attempts failed in Enoki sponsor/execute calls before the upstream recovered.

## Impact
Short Enoki outages are retried inside the sidecar before failing the wallet job, reducing false exhausted-wallet alerts while keeping ENOKI_FALLBACK_TO_DIRECT_SIGN=false behavior unchanged.

## Validation
- npm test (services/server/scripts): 60/60 pass
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext enoki-retry.ts