### PR TITLE
fix(relayer): classify Enoki balance::split ENotEnough as gas-pool failure (WALM-88)

### DIFF
--- a/docs/relayer/runbook-gas-pool.md
+++ b/docs/relayer/runbook-gas-pool.md
@@ -1,5 +1,7 @@
 ---
-title: "Gas Pool Maintenance Runbook"
+title: Gas Pool Maintenance Runbook
+description: How to diagnose and fix Enoki gas-pool failures on relayer pool wallets by consolidating or topping up SUI gas coins.
+keywords: [relayer, gas pool, Enoki, SUI, sponsored transaction, runbook]
 ---
 
 When to use this: a **gas-pool alert** fires (the SUI gas pool maintenance

--- a/docs/relayer/runbook-gas-pool.md
+++ b/docs/relayer/runbook-gas-pool.md
@@ -2,7 +2,7 @@
 title: "Gas Pool Maintenance Runbook"
 ---
 
-When to use this: a **gas-pool alert** fires (the "SUI gas pool maintenance"
+When to use this: a **gas-pool alert** fires (the SUI gas pool maintenance
 alert), or relayer logs show wallet jobs aborting with
 `classification=gas_pool_exhausted` or Enoki `dry_run_failed` plus
 `0x2::balance::split` (ENotEnough, abort code 2).
@@ -18,7 +18,7 @@ with `ENotEnough`.
 The relayer now classifies this as `GasPoolExhausted` and **aborts the job
 immediately** instead of retrying across the whole pool (which would just
 re-fail on the next equally-starved wallet and burn the attempt budget). The
-fix is operational: consolidate and/or top up SUI on the pool wallets.
+fix is operational: consolidate or top up SUI on the pool wallets, or both.
 
 > WAL balance is unrelated. This is specifically about **SUI** gas coins.
 
@@ -53,6 +53,8 @@ Red flags:
 
 ## Fix
 
+There are two operational fixes, depending on the diagnosis.
+
 ### Consolidate (merge fragmented coins)
 
 Merge all SUI coins on a wallet into one (gas budgeting picks the largest coin):
@@ -63,7 +65,7 @@ sui client switch --address <POOL_ADDRESS>
 sui client merge-coin --primary-coin <BIGGEST_COIN_ID> --coin-to-merge <COIN_ID> [--coin-to-merge <COIN_ID> ...]
 ```
 
-For many coins, a PTB or `sui client pay-all-sui` to self consolidates in one tx:
+For many coins, a PTB or `sui client pay-all-sui` to self consolidates in one transaction:
 
 ```bash
 sui client pay-all-sui --input-coins <COIN_ID_1> <COIN_ID_2> ... --recipient <POOL_ADDRESS> --gas-budget 5000000
@@ -71,7 +73,7 @@ sui client pay-all-sui --input-coins <COIN_ID_1> <COIN_ID_2> ... --recipient <PO
 
 ### Top up
 
-Send SUI to the starved pool wallet(s) so the largest coin comfortably exceeds
+Send SUI to the starved pool wallets so the largest coin comfortably exceeds
 the sponsored budget with headroom.
 
 ## Verify
@@ -83,6 +85,6 @@ through `WALRUS_GAS_POOL_ALERT_DEDUP_SECS`).
 
 ## Prevention (follow-up)
 
-A preflight pool-health check (min total SUI, min largest-coin size, max coin
-count) before Walrus upload is tracked as a follow-up in WALM-88. It would catch
+A preflight pool-health check (minimum total SUI, minimum largest-coin size,
+maximum coin count) before Walrus upload is tracked as a follow-up in WALM-88. It would catch
 fragmentation before a job fails rather than after.

--- a/docs/relayer/runbook-gas-pool.md
+++ b/docs/relayer/runbook-gas-pool.md
@@ -1,0 +1,86 @@
+# Runbook — relayer SUI gas pool maintenance
+
+When to use this: a **gas-pool alert** fires ("MemWal Walrus upload blocked — SUI
+gas pool maintenance"), or relayer logs show wallet jobs aborting with
+`classification=gas_pool_exhausted` / Enoki `dry_run_failed` + `0x2::balance::split`
+(ENotEnough, abort code 2).
+
+## What it means
+
+The relayer sponsors Walrus register transactions through Enoki. Enoki's dry-run
+splits a SUI gas coin on the selected pool wallet to cover the sponsored budget.
+If that wallet has **no single SUI coin large enough** — i.e. its gas is
+fragmented into many small coins, or it is low on SUI — Sui aborts in
+`0x2::balance::split` with `ENotEnough`.
+
+The relayer now classifies this as `GasPoolExhausted` and **aborts the job
+immediately** instead of retrying across the whole pool (which would just
+re-fail on the next equally-starved wallet and burn the attempt budget). The
+fix is operational: consolidate and/or top up SUI on the pool wallets.
+
+> WAL balance is unrelated — this is specifically about **SUI** gas coins.
+
+## Pool wallets
+
+Pool signing keys come from `SERVER_SUI_PRIVATE_KEYS` (comma-separated
+`suiprivkey1...`), or the single `SERVER_SUI_PRIVATE_KEY`. Each key maps to one
+Sui address. Derive the addresses (per key):
+
+```bash
+sui keytool import "$KEY" ed25519        # then `sui keytool list`, or:
+sui keytool list                          # shows addresses for imported keys
+```
+
+## Diagnose (per pool wallet)
+
+Check total SUI, the **largest single coin**, and fragmentation (coin count):
+
+```bash
+# All SUI coins for an address, largest first:
+sui client gas <POOL_ADDRESS>
+
+# Or via RPC (balance + coin count):
+curl -s https://fullnode.mainnet.sui.io:443 -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"suix_getBalance","params":["<POOL_ADDRESS>","0x2::sui::SUI"]}'
+```
+
+Red flags:
+- **Largest coin** smaller than the sponsored budget (fragmentation) → consolidate.
+- **Total SUI** low → top up.
+- Many tiny coins → consolidate.
+
+## Fix
+
+### Consolidate (merge fragmented coins)
+
+Merge all SUI coins on a wallet into one (gas budgeting picks the largest coin):
+
+```bash
+sui client switch --address <POOL_ADDRESS>
+# Merge every other SUI coin into the primary one:
+sui client merge-coin --primary-coin <BIGGEST_COIN_ID> --coin-to-merge <COIN_ID> [--coin-to-merge <COIN_ID> ...]
+```
+
+For many coins, a PTB / `sui client pay-all-sui` to self consolidates in one tx:
+
+```bash
+sui client pay-all-sui --input-coins <COIN_ID_1> <COIN_ID_2> ... --recipient <POOL_ADDRESS> --gas-budget 5000000
+```
+
+### Top up
+
+Send SUI to the starved pool wallet(s) so the largest coin comfortably exceeds
+the sponsored budget with headroom.
+
+## Verify
+
+Re-run the diagnose step — each pool wallet should have one (or few) large SUI
+coins. Re-trigger a failed upload (or wait for the next job); the gas-pool alert
+should not re-fire (alert dedup is per network, default 600s window — tunable via
+`WALRUS_GAS_POOL_ALERT_DEDUP_SECS`).
+
+## Prevention (follow-up)
+
+A preflight pool-health check (min total SUI, min largest-coin size, max coin
+count) before Walrus upload is tracked as follow-up in WALM-88 — it would catch
+fragmentation before a job fails rather than after.

--- a/docs/relayer/runbook-gas-pool.md
+++ b/docs/relayer/runbook-gas-pool.md
@@ -1,24 +1,26 @@
-# Runbook — relayer SUI gas pool maintenance
+---
+title: "Gas Pool Maintenance Runbook"
+---
 
-When to use this: a **gas-pool alert** fires ("MemWal Walrus upload blocked — SUI
-gas pool maintenance"), or relayer logs show wallet jobs aborting with
-`classification=gas_pool_exhausted` / Enoki `dry_run_failed` + `0x2::balance::split`
-(ENotEnough, abort code 2).
+When to use this: a **gas-pool alert** fires (the "SUI gas pool maintenance"
+alert), or relayer logs show wallet jobs aborting with
+`classification=gas_pool_exhausted` or Enoki `dry_run_failed` plus
+`0x2::balance::split` (ENotEnough, abort code 2).
 
 ## What it means
 
 The relayer sponsors Walrus register transactions through Enoki. Enoki's dry-run
 splits a SUI gas coin on the selected pool wallet to cover the sponsored budget.
-If that wallet has **no single SUI coin large enough** — i.e. its gas is
-fragmented into many small coins, or it is low on SUI — Sui aborts in
-`0x2::balance::split` with `ENotEnough`.
+When that wallet has **no single SUI coin large enough** (its gas is fragmented
+into many small coins, or it is low on SUI), Sui aborts in `0x2::balance::split`
+with `ENotEnough`.
 
 The relayer now classifies this as `GasPoolExhausted` and **aborts the job
 immediately** instead of retrying across the whole pool (which would just
 re-fail on the next equally-starved wallet and burn the attempt budget). The
 fix is operational: consolidate and/or top up SUI on the pool wallets.
 
-> WAL balance is unrelated — this is specifically about **SUI** gas coins.
+> WAL balance is unrelated. This is specifically about **SUI** gas coins.
 
 ## Pool wallets
 
@@ -39,15 +41,15 @@ Check total SUI, the **largest single coin**, and fragmentation (coin count):
 # All SUI coins for an address, largest first:
 sui client gas <POOL_ADDRESS>
 
-# Or via RPC (balance + coin count):
+# Or through RPC (balance + coin count):
 curl -s https://fullnode.mainnet.sui.io:443 -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"suix_getBalance","params":["<POOL_ADDRESS>","0x2::sui::SUI"]}'
 ```
 
 Red flags:
-- **Largest coin** smaller than the sponsored budget (fragmentation) → consolidate.
-- **Total SUI** low → top up.
-- Many tiny coins → consolidate.
+- **Largest coin** smaller than the sponsored budget (fragmentation): consolidate.
+- **Total SUI** low: top up.
+- Many tiny coins: consolidate.
 
 ## Fix
 
@@ -61,7 +63,7 @@ sui client switch --address <POOL_ADDRESS>
 sui client merge-coin --primary-coin <BIGGEST_COIN_ID> --coin-to-merge <COIN_ID> [--coin-to-merge <COIN_ID> ...]
 ```
 
-For many coins, a PTB / `sui client pay-all-sui` to self consolidates in one tx:
+For many coins, a PTB or `sui client pay-all-sui` to self consolidates in one tx:
 
 ```bash
 sui client pay-all-sui --input-coins <COIN_ID_1> <COIN_ID_2> ... --recipient <POOL_ADDRESS> --gas-budget 5000000
@@ -74,13 +76,13 @@ the sponsored budget with headroom.
 
 ## Verify
 
-Re-run the diagnose step — each pool wallet should have one (or few) large SUI
+Re-run the diagnose step. Each pool wallet should have one (or few) large SUI
 coins. Re-trigger a failed upload (or wait for the next job); the gas-pool alert
-should not re-fire (alert dedup is per network, default 600s window — tunable via
-`WALRUS_GAS_POOL_ALERT_DEDUP_SECS`).
+should not re-fire (alert dedup is per network, default 600s window, tunable
+through `WALRUS_GAS_POOL_ALERT_DEDUP_SECS`).
 
 ## Prevention (follow-up)
 
 A preflight pool-health check (min total SUI, min largest-coin size, max coin
-count) before Walrus upload is tracked as follow-up in WALM-88 — it would catch
+count) before Walrus upload is tracked as a follow-up in WALM-88. It would catch
 fragmentation before a job fails rather than after.

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -10,6 +10,8 @@ const WALRUS_UPGRADE_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_PACKAGE_UPGRADE_ALERT_
 const WALRUS_UPGRADE_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
 const WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS";
 const WALRUS_OBJECT_LOCK_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
+const WALRUS_GAS_POOL_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_GAS_POOL_ALERT_DEDUP_SECS";
+const WALRUS_GAS_POOL_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
 
 /// Mirrors the `@mysten/walrus` dep version in
 /// `services/server/scripts/package.json`. Bump this constant in lockstep
@@ -73,6 +75,11 @@ pub struct AlertManager {
     /// every concurrent job touching it raises the same error, so one
     /// notification per (network, object) is enough until the window elapses.
     walrus_object_lock_dedup: AlertDedup,
+    /// Suppresses Walrus gas-pool alert spam. A gas-pool starvation is
+    /// pool-wide, so every concurrent upload job raises the same
+    /// `balance::split` ENotEnough — one notification per network is enough
+    /// until ops tops up gas or the window elapses.
+    walrus_gas_pool_dedup: AlertDedup,
 }
 
 impl AlertManager {
@@ -90,6 +97,10 @@ impl AlertManager {
             walrus_object_lock_dedup: AlertDedup::new(dedup_window_from_env(
                 WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS_ENV,
                 WALRUS_OBJECT_LOCK_ALERT_DEDUP_DEFAULT,
+            )),
+            walrus_gas_pool_dedup: AlertDedup::new(dedup_window_from_env(
+                WALRUS_GAS_POOL_ALERT_DEDUP_SECS_ENV,
+                WALRUS_GAS_POOL_ALERT_DEDUP_DEFAULT,
             )),
         }
     }
@@ -148,6 +159,23 @@ impl AlertManager {
             return Ok(());
         }
         let payload = SlackPayload::for_walrus_object_locked(&alert);
+        slack.send_payload(&payload).await
+    }
+
+    pub async fn notify_walrus_gas_pool_exhausted(
+        &self,
+        alert: WalrusGasPoolExhaustedAlert,
+    ) -> Result<(), AlertError> {
+        let Some(slack) = &self.slack else {
+            return Ok(());
+        };
+        // Gas-pool starvation is pool-wide: dedup per network so a burst of
+        // concurrent jobs collapses to one ops notification per window.
+        let key = (alert.sui_network.clone(), "gas_pool".to_string());
+        if self.walrus_gas_pool_dedup.should_suppress(key) {
+            return Ok(());
+        }
+        let payload = SlackPayload::for_walrus_gas_pool_exhausted(&alert);
         slack.send_payload(&payload).await
     }
 }
@@ -255,6 +283,23 @@ pub struct WalrusObjectLockedAlert {
     pub locked_object_id: Option<String>,
     pub locked_object_version: Option<String>,
     pub locking_transaction_digest: Option<String>,
+    pub error: String,
+}
+
+/// Fired when a wallet job aborts because an Enoki sponsored dry-run failed in
+/// `0x2::balance::split` with ENotEnough — the relayer pool wallets' SUI gas
+/// coins are fragmented or too small to cover the sponsored budget. Distinct
+/// from the "exhausted retries" alert: this aborts immediately rather than
+/// burning the whole pool, and the on-call message must point ops at SUI gas
+/// coin consolidation/top-up rather than implying an app bug.
+#[derive(Debug)]
+pub struct WalrusGasPoolExhaustedAlert {
+    pub remember_job_id: Option<String>,
+    pub owner: Option<String>,
+    pub namespace: Option<String>,
+    pub sui_network: String,
+    pub wallet_index: usize,
+    pub configured_wallets: usize,
     pub error: String,
 }
 
@@ -427,6 +472,55 @@ impl SlackPayload {
                 },
                 SlackBlock::Section {
                     text: mrkdwn(summary),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(details),
+                },
+            ],
+        }
+    }
+
+    fn for_walrus_gas_pool_exhausted(alert: &WalrusGasPoolExhaustedAlert) -> Self {
+        let title = "MemWal Walrus upload blocked — SUI gas pool maintenance".to_string();
+        let summary = format!(
+            "Walrus upload aborted on {}: Enoki sponsored dry-run failed in \
+             `0x2::balance::split` (ENotEnough). The relayer pool wallets' SUI \
+             gas coins are fragmented or too small to cover the sponsored budget. \
+             Not retried — retrying just rotates to the next starved pool wallet.",
+            alert.sui_network,
+        );
+        let action = "*Action (ops):* consolidate/merge SUI gas coins on the \
+             relayer pool wallets and top up SUI if low. See the gas-pool runbook."
+            .to_string();
+        let job = alert.remember_job_id.as_deref().unwrap_or("-");
+        let owner = alert
+            .owner
+            .as_deref()
+            .map(short_address)
+            .unwrap_or_else(|| "-".to_string());
+        let namespace = alert.namespace.as_deref().unwrap_or("-");
+        let details = format!(
+            "*Network:* `{}`\n*Pool wallet:* `{}` of `{}`\n*Job:* `{}`\n*Owner:* `{}`\n*Namespace:* `{}`\n*Error:* ```{}```",
+            alert.sui_network,
+            alert.wallet_index,
+            alert.configured_wallets,
+            job,
+            owner,
+            namespace,
+            truncate(&alert.error, MAX_SLACK_ERROR_LEN),
+        );
+
+        Self {
+            text: summary.clone(),
+            blocks: vec![
+                SlackBlock::Header {
+                    text: plain_text(title),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(summary),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(action),
                 },
                 SlackBlock::Section {
                     text: mrkdwn(details),
@@ -678,5 +772,29 @@ mod tests {
         let json = serde_json::to_string(&payload).unwrap();
         assert!(json.contains("unparsed"));
         assert!(json.contains("mainnet"));
+    }
+
+    #[test]
+    fn walrus_gas_pool_payload_points_ops_to_gas_consolidation_not_exhausted_copy() {
+        let payload = SlackPayload::for_walrus_gas_pool_exhausted(&WalrusGasPoolExhaustedAlert {
+            remember_job_id: Some("591c13bc".into()),
+            owner: Some(
+                "0x51667727aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa04bca2".into(),
+            ),
+            namespace: Some("people".into()),
+            sui_network: "mainnet".into(),
+            wallet_index: 4,
+            configured_wallets: 5,
+            error: "Dry run failed: MoveAbort(0x2::balance::split, 2)".into(),
+        });
+
+        let json = serde_json::to_string(&payload).unwrap();
+        // Points ops at gas-coin maintenance, not the misleading exhausted copy.
+        assert!(json.to_lowercase().contains("gas"));
+        assert!(json.contains("consolidate") || json.contains("top up"));
+        assert!(!json.to_lowercase().contains("exhausted retries"));
+        assert!(json.contains("balance::split") || json.contains("balance"));
+        assert!(json.contains("mainnet"));
+        assert!(json.contains("people"));
     }
 }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -535,7 +535,28 @@ pub(crate) async fn execute_wallet_job(
                     )),
                 },
                 Err(err) => {
+                    // Same gas-pool escalation as the upload path: a
+                    // balance::split failure stays retriable until the pool is
+                    // exhausted, then aborts. Dispatch the dedicated ops alert
+                    // here too so a gas-pool failure on the metadata-transfer
+                    // recovery path isn't silently marked failed.
+                    let err = escalate_if_gas_pool_exhausted(
+                        err,
+                        attempt_info.current,
+                        attempt_info.max,
+                        state.key_pool.len(),
+                    );
                     let msg = err.to_string();
+                    maybe_alert_walrus_gas_pool_exhausted(
+                        state,
+                        &err,
+                        remember_job_id.as_deref(),
+                        Some(&owner),
+                        Some(&namespace),
+                        enqueued_wallet_index,
+                        &msg,
+                    )
+                    .await;
                     update_remember_job_after_wallet_error(
                         state,
                         remember_job_id.as_deref(),
@@ -875,7 +896,15 @@ async fn execute_upload_and_transfer(
         }
         Err(UploadBlobError::App(e)) => {
             let msg = format!("walrus upload failed: {}", e);
-            let classified = WalletJobError::classify_sidecar_error(&msg);
+            // A balance::split gas-budget failure stays retriable (rotates onto
+            // another pool wallet) until every candidate wallet has failed it,
+            // then escalates to an aborting GasPoolExhausted (+ ops alert below).
+            let classified = escalate_if_gas_pool_exhausted(
+                WalletJobError::classify_sidecar_error(&msg),
+                attempt_info.current,
+                attempt_info.max,
+                state.key_pool.len(),
+            );
             maybe_alert_walrus_package_upgrade_detected(
                 state,
                 remember_job_id.as_deref(),
@@ -1096,6 +1125,37 @@ async fn maybe_alert_walrus_object_locked(
     }
 }
 
+/// Attempts after which repeated gas-budget (`balance::split` ENotEnough)
+/// failures are treated as pool-level exhaustion rather than a single starved
+/// wallet. Upload retries rotate round-robin across the pool, so once the
+/// attempt count reaches the pool size (capped by the max attempt budget) every
+/// candidate wallet has been tried. At least 1, so a single-wallet pool
+/// escalates immediately (nothing else to rotate onto).
+fn gas_pool_exhaustion_threshold(pool_size: usize, max_attempts: usize) -> usize {
+    pool_size.min(max_attempts).max(1)
+}
+
+/// Escalate a retriable gas-budget failure to an aborting `GasPoolExhausted`
+/// once every candidate pool wallet has failed the same way. Below the
+/// threshold the error stays `Transient` so Apalis rotates onto another wallet —
+/// a single starved wallet must not fail an upload a healthy wallet could serve.
+/// Non-gas-budget errors pass through unchanged.
+fn escalate_if_gas_pool_exhausted(
+    classified: WalletJobError,
+    attempt: usize,
+    max_attempts: usize,
+    pool_size: usize,
+) -> WalletJobError {
+    if let WalletJobError::Transient(ref msg) = classified {
+        if WalletJobError::is_gas_pool_budget_error(msg)
+            && attempt >= gas_pool_exhaustion_threshold(pool_size, max_attempts)
+        {
+            return WalletJobError::GasPoolExhausted(msg.clone());
+        }
+    }
+    classified
+}
+
 /// Fire the distinct gas-pool maintenance alert when a wallet job fails with
 /// `GasPoolExhausted` (Enoki dry-run `balance::split` ENotEnough). Kept separate
 /// from the "exhausted retries" alert: this case aborts immediately, so the
@@ -1244,25 +1304,33 @@ impl WalletJobError {
         )
     }
 
+    /// True if `msg` is an Enoki sponsored dry-run gas-budget failure: an abort
+    /// in `0x2::balance::split` (ENotEnough). A single occurrence only proves the
+    /// *selected* pool wallet is gas-starved, not the whole pool — escalation to
+    /// `GasPoolExhausted` is gated on pool-level confirmation by the caller.
+    pub fn is_gas_pool_budget_error(msg: &str) -> bool {
+        let lower = msg.to_ascii_lowercase();
+        (lower.contains("moveabort") || lower.contains("move abort"))
+            && lower.contains("balance")
+            && lower.contains("split")
+    }
+
     /// Heuristic classification from the sidecar's error string. The sidecar
     /// surfaces Sui execution errors verbatim (Move abort codes, lock errors).
     /// Until the sidecar emits structured error codes, we match on substrings.
     pub fn classify_sidecar_error(msg: &str) -> Self {
         let lower = msg.to_ascii_lowercase();
         // Enoki sponsored dry-run aborts in 0x2::balance::split with ENotEnough
-        // (abort code 2) when the pool wallet's selected SUI gas coin cannot be
-        // split to cover the sponsored budget — i.e. the relayer's SUI gas coins
-        // are fragmented or too small. This is a gas-pool maintenance issue, not
-        // a transient: retrying just rotates to the next equally-starved pool
-        // wallet and burns the whole attempt budget. Abort and surface a
-        // dedicated gas-pool alert pointing ops to consolidate/top-up SUI gas.
-        // (balance::split's only abort is ENotEnough, so the balance+split anchor
-        // is sufficient to identify it.)
-        if (lower.contains("moveabort") || lower.contains("move abort"))
-            && lower.contains("balance")
-            && lower.contains("split")
-        {
-            return WalletJobError::GasPoolExhausted(msg.to_string());
+        // (abort code 2) when the selected pool wallet's SUI gas coin cannot be
+        // split to cover the sponsored budget (its SUI is fragmented or too low).
+        // A single failure only proves THAT wallet is gas-starved, not the whole
+        // pool, so classify Transient: Apalis rotates onto another pool wallet on
+        // retry rather than failing an upload a healthy wallet could serve. The
+        // wallet-job error arm escalates to an aborting GasPoolExhausted (+ ops
+        // alert) only once every candidate wallet has failed the same way — see
+        // escalate_if_gas_pool_exhausted.
+        if Self::is_gas_pool_budget_error(msg) {
+            return WalletJobError::Transient(msg.to_string());
         }
         // Walrus on-chain package upgrade — the cached @mysten/walrus client
         // carries stale package metadata until refreshed. The sidecar already
@@ -1727,7 +1795,8 @@ mod tests {
     use sqlx::postgres::PgPoolOptions;
 
     use super::{
-        classify_wallet_remember_handoff_failure, is_walrus_package_version_mismatch,
+        classify_wallet_remember_handoff_failure, escalate_if_gas_pool_exhausted,
+        gas_pool_exhaustion_threshold, is_walrus_package_version_mismatch,
         mark_remember_job_failed, parse_locked_object_info, wallet_job_request, WalletJob,
         WalletJobAttemptInfo, WalletJobError, WalletOperation, MAX_ATTEMPTS,
     };
@@ -1865,14 +1934,15 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
 
     #[test]
     fn equivocation_does_not_regress_recoverable_classes() {
-        // EWrongVersion must still be Transient (recoverable). balance::split
-        // ENotEnough is a gas-pool maintenance abort, not an object lock — it
-        // must classify as GasPoolExhausted, not swept into the object-lock path.
+        // EWrongVersion and a lone balance::split ENotEnough must both stay
+        // Transient (recoverable) — neither is swept into the object-lock abort
+        // path. balance::split only escalates to GasPoolExhausted at the pool
+        // level (see gas_pool_* tests below), not on a single occurrence.
         let balance = "Enoki dry run failed: MoveAbort(0x2::balance, split, 2)";
         let ewrong = "MoveAbort in 1st command, abort code: 1, in '0xabc::system::inner_mut'";
         assert!(matches!(
             WalletJobError::classify_sidecar_error(balance),
-            WalletJobError::GasPoolExhausted(_)
+            WalletJobError::Transient(_)
         ));
         assert!(matches!(
             WalletJobError::classify_sidecar_error(ewrong),
@@ -1916,24 +1986,68 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
         }
     }
 
+    const BALANCE_SPLIT_ERR: &str = "walrus upload failed: Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\",\"message\":\"Dry run failed: MoveAbort(MoveLocation { module: 0x2::balance, function_name: Some(\\\"split\\\") }, 2)\"}]}";
+
     #[test]
-    fn classify_balance_split_move_abort_as_gas_pool_exhausted() {
-        // Enoki dry-run balance::split ENotEnough → gas-pool maintenance abort:
-        // classified GasPoolExhausted, aborts retries (so it does not burn the
-        // whole wallet pool), and is not Permanent (succeeds after gas top-up).
-        for msg in [
-            "walrus upload failed: Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\",\"message\":\"Dry run failed: MoveAbort(MoveLocation { module: 0x2::balance, function_name: Some(\\\"split\\\") }, 2)\"}]}",
-            "move abort during balance split",
-        ] {
+    fn classify_balance_split_is_retriable_transient_by_default() {
+        // A single balance::split ENotEnough is Transient (retriable) so Apalis
+        // rotates onto another pool wallet — it must NOT abort on its own.
+        for msg in [BALANCE_SPLIT_ERR, "move abort during balance split"] {
             let classified = WalletJobError::classify_sidecar_error(msg);
             assert!(
-                matches!(classified, WalletJobError::GasPoolExhausted(_)),
-                "expected gas_pool_exhausted for: {}",
+                matches!(classified, WalletJobError::Transient(_)),
+                "expected transient for: {}",
                 msg
             );
-            assert!(classified.aborts_retries(), "must abort retries: {}", msg);
-            assert!(!classified.is_permanent(), "must not be permanent: {}", msg);
+            assert!(!classified.aborts_retries(), "must retry: {}", msg);
+            assert!(WalletJobError::is_gas_pool_budget_error(msg));
         }
+    }
+
+    #[test]
+    fn gas_pool_threshold_tracks_pool_then_caps_at_max_attempts() {
+        assert_eq!(gas_pool_exhaustion_threshold(1, 5), 1); // single wallet → escalate immediately
+        assert_eq!(gas_pool_exhaustion_threshold(2, 5), 2); // try both wallets first
+        assert_eq!(gas_pool_exhaustion_threshold(10, 5), 5); // capped by max attempts
+        assert_eq!(gas_pool_exhaustion_threshold(0, 5), 1); // never 0
+    }
+
+    #[test]
+    fn gas_pool_one_bad_wallet_keeps_retrying_onto_healthy_wallet() {
+        // pool of 2: the first wallet's balance::split must stay retriable so the
+        // job rotates onto the second (healthy) wallet instead of failing.
+        let classified = WalletJobError::classify_sidecar_error(BALANCE_SPLIT_ERR);
+        let after = escalate_if_gas_pool_exhausted(classified, /*attempt*/ 1, /*max*/ 5, /*pool*/ 2);
+        assert!(
+            matches!(after, WalletJobError::Transient(_)) && !after.aborts_retries(),
+            "single bad wallet must keep retrying, got {:?}",
+            after
+        );
+    }
+
+    #[test]
+    fn gas_pool_all_wallets_failed_escalates_and_aborts() {
+        // pool of 2, both wallets hit balance::split → at attempt 2 we have tried
+        // every candidate wallet → escalate to an aborting GasPoolExhausted.
+        let classified = WalletJobError::classify_sidecar_error(BALANCE_SPLIT_ERR);
+        let after = escalate_if_gas_pool_exhausted(classified, /*attempt*/ 2, /*max*/ 5, /*pool*/ 2);
+        assert!(
+            matches!(after, WalletJobError::GasPoolExhausted(_)),
+            "exhausted pool must escalate, got {:?}",
+            after
+        );
+        assert!(after.aborts_retries());
+        assert!(!after.is_permanent());
+        assert_eq!(after.kind(), "gas_pool_exhausted");
+    }
+
+    #[test]
+    fn escalation_ignores_non_gas_budget_transient() {
+        // A generic transient (e.g. timeout) must never be escalated to the
+        // gas-pool abort path, even past the threshold.
+        let other = WalletJobError::Transient("network timeout".into());
+        let after = escalate_if_gas_pool_exhausted(other, 5, 5, 2);
+        assert!(matches!(after, WalletJobError::Transient(_)));
     }
 
     #[test]

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -20,8 +20,8 @@ use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
 
 use crate::alerts::{
-    SIDECAR_WALRUS_DEP_VERSION, WalrusGasPoolExhaustedAlert, WalrusObjectLockedAlert,
-    WalrusPackageUpgradeDetectedAlert, WalrusUploadExhaustedAlert,
+    WalrusGasPoolExhaustedAlert, WalrusObjectLockedAlert, WalrusPackageUpgradeDetectedAlert,
+    WalrusUploadExhaustedAlert, SIDECAR_WALRUS_DEP_VERSION,
 };
 use crate::storage::walrus::{SetMetadataBatchEntry, UploadBlobError};
 use crate::types::{configured_walrus_storage_epochs, AppState, BLOB_CACHE_KEY_PREFIX};
@@ -128,6 +128,10 @@ fn default_epochs() -> u32 {
 /// neutral "standard" bucket on dequeue.
 fn default_importance() -> f32 {
     crate::services::extractor::IMPORTANCE_STANDARD
+}
+
+fn remember_job_failed_apalis_error(msg: String) -> Error {
+    Error::Failed(Arc::new(Box::new(io::Error::other(msg))))
 }
 
 pub(crate) async fn warm_blob_cache_after_upload(
@@ -244,22 +248,20 @@ async fn handle_legacy_remember_handoff_failure(
     pool: &sqlx::PgPool,
     remember_job_id: &str,
     msg: String,
-) -> Result<(), RememberJobError> {
-    match mark_remember_job_failed(pool, Some(remember_job_id), &msg).await {
-        Ok(()) => Ok(()),
-        Err(persist_err) => Err(RememberJobError::Internal(
-            remember_job_persist_failure_message(&msg, &persist_err),
-        )),
-    }
+) -> Result<(), Error> {
+    let classified =
+        classify_wallet_remember_handoff_failure(pool, Some(remember_job_id), msg).await;
+    Err(classified.into_apalis_error())
 }
 
 /// A wallet job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletJob {
     /// Index into `config.sui_private_keys` used by the sidecar for signing.
-    /// For `UploadAndTransfer`, this is the enqueue-time assignment used for
-    /// logging only; the worker selects a fresh round-robin wallet at execution
-    /// time so retries can move to another wallet.
+    /// For `UploadAndTransfer`, this is the enqueue-time starting assignment;
+    /// retries derive the next wallet from this index plus the Apalis attempt
+    /// number so a job can walk distinct pool wallets without relying on the
+    /// global round-robin cursor.
     pub wallet_index: usize,
     pub operation: WalletOperation,
 }
@@ -381,16 +383,60 @@ impl FromRequest<Request<WalletJob, apalis_sql::context::SqlContext>> for Wallet
     fn from_request(
         req: &Request<WalletJob, apalis_sql::context::SqlContext>,
     ) -> Result<Self, Error> {
-        let mut max =
-            usize::try_from(req.parts.context.max_attempts()).unwrap_or(MAX_ATTEMPTS as usize);
-        if max == 0 {
-            max = MAX_ATTEMPTS as usize;
-        }
-        Ok(Self {
-            current: req.parts.attempt.current(),
-            max,
-        })
+        wallet_attempt_info_from_request(req)
     }
+}
+
+impl FromRequest<Request<RememberJob, apalis_sql::context::SqlContext>> for WalletJobAttemptInfo {
+    fn from_request(
+        req: &Request<RememberJob, apalis_sql::context::SqlContext>,
+    ) -> Result<Self, Error> {
+        wallet_attempt_info_from_request(req)
+    }
+}
+
+fn wallet_attempt_info_from_request<T>(
+    req: &Request<T, apalis_sql::context::SqlContext>,
+) -> Result<WalletJobAttemptInfo, Error> {
+    let mut max =
+        usize::try_from(req.parts.context.max_attempts()).unwrap_or(MAX_ATTEMPTS as usize);
+    if max == 0 {
+        max = MAX_ATTEMPTS as usize;
+    }
+    Ok(WalletJobAttemptInfo {
+        current: req.parts.attempt.current(),
+        max,
+    })
+}
+
+/// Returns the wallet this job should use for a specific Apalis attempt. The
+/// starting wallet is chosen when the job is enqueued; retries advance from that
+/// start index deterministically so concurrent jobs cannot consume this job's
+/// next pool candidate through the global round-robin cursor.
+fn wallet_index_for_upload_attempt(
+    starting_wallet_index: usize,
+    attempt: usize,
+    pool_size: usize,
+) -> Option<usize> {
+    if pool_size == 0 {
+        return None;
+    }
+    let start = starting_wallet_index % pool_size;
+    let offset = attempt.saturating_sub(1) % pool_size;
+    Some(start.wrapping_add(offset) % pool_size)
+}
+
+fn stable_wallet_start_index(seed: &str, pool_size: usize) -> Option<usize> {
+    if pool_size == 0 {
+        return None;
+    }
+
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in seed.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    Some((hash as usize) % pool_size)
 }
 
 // ============================================================
@@ -400,9 +446,10 @@ impl FromRequest<Request<WalletJob, apalis_sql::context::SqlContext>> for Wallet
 /// Apalis worker handler for WalletJob.
 ///
 /// Multiple concurrent invocations of this handler share the `wallet_jobs`
-/// queue. Upload jobs select a fresh wallet index at execution time; legacy
-/// metadata-transfer jobs keep their pinned wallet because the blob object is
-/// owned by the wallet that registered/certified it.
+/// queue. Upload jobs derive the execution wallet from the enqueued starting
+/// wallet and current attempt; legacy metadata-transfer jobs keep their pinned
+/// wallet because the blob object is owned by the wallet that
+/// registered/certified it.
 pub(crate) async fn execute_wallet_job(
     job: WalletJob,
     ctx: Data<Arc<AppState>>,
@@ -423,7 +470,11 @@ pub(crate) async fn execute_wallet_job(
             remember_job_id,
             epochs,
         } => {
-            let wallet_index = match state.key_pool.next_index() {
+            let wallet_index = match wallet_index_for_upload_attempt(
+                enqueued_wallet_index,
+                attempt_info.current,
+                state.key_pool.len(),
+            ) {
                 Some(index) => index,
                 None => {
                     return Err(WalletJobError::Permanent(
@@ -433,11 +484,13 @@ pub(crate) async fn execute_wallet_job(
                     .into_apalis_error());
                 }
             };
-            if wallet_index != enqueued_wallet_index {
+            if wallet_index != enqueued_wallet_index || attempt_info.current > 1 {
                 tracing::info!(
-                    "[wallet-job:upload] reassigned wallet at execution: enqueued={} executing={}",
+                    "[wallet-job:upload] selected wallet for attempt: enqueued={} executing={} attempt={}/{}",
                     enqueued_wallet_index,
                     wallet_index,
+                    attempt_info.current,
+                    attempt_info.max,
                 );
             }
             execute_upload_and_transfer(
@@ -523,9 +576,9 @@ pub(crate) async fn execute_wallet_job(
                                 return Err(classified.into_apalis_error());
                             }
                             tracing::warn!(
-                                    "[wallet-job:set-metadata] finalization failed after transfer; enqueued index-only retry: {}",
-                                    err
-                                );
+                                "[wallet-job:set-metadata] finalization failed after transfer; enqueued index-only retry: {}",
+                                err
+                            );
                         }
                         Ok(())
                     }
@@ -535,16 +588,14 @@ pub(crate) async fn execute_wallet_job(
                     )),
                 },
                 Err(err) => {
-                    // Same gas-pool escalation as the upload path: a
-                    // balance::split failure stays retriable until the pool is
-                    // exhausted, then aborts. Dispatch the dedicated ops alert
-                    // here too so a gas-pool failure on the metadata-transfer
-                    // recovery path isn't silently marked failed.
+                    // This operation is pinned to the wallet that owns the blob,
+                    // so retrying cannot rotate onto another pool candidate.
+                    // Escalate a balance::split gas-budget failure immediately.
                     let err = escalate_if_gas_pool_exhausted(
                         err,
                         attempt_info.current,
                         attempt_info.max,
-                        state.key_pool.len(),
+                        1,
                     );
                     let msg = err.to_string();
                     maybe_alert_walrus_gas_pool_exhausted(
@@ -1126,13 +1177,12 @@ async fn maybe_alert_walrus_object_locked(
 }
 
 /// Attempts after which repeated gas-budget (`balance::split` ENotEnough)
-/// failures are treated as pool-level exhaustion rather than a single starved
-/// wallet. Upload retries rotate round-robin across the pool, so once the
-/// attempt count reaches the pool size (capped by the max attempt budget) every
-/// candidate wallet has been tried. At least 1, so a single-wallet pool
-/// escalates immediately (nothing else to rotate onto).
-fn gas_pool_exhaustion_threshold(pool_size: usize, max_attempts: usize) -> usize {
-    pool_size.min(max_attempts).max(1)
+/// failures are treated as candidate-level exhaustion rather than a single
+/// starved wallet. Upload jobs pass the configured pool size because retries
+/// walk that pool deterministically. Pinned operations pass 1 because they
+/// cannot rotate onto another wallet.
+fn gas_pool_exhaustion_threshold(candidate_wallets: usize, max_attempts: usize) -> usize {
+    candidate_wallets.min(max_attempts).max(1)
 }
 
 /// Escalate a retriable gas-budget failure to an aborting `GasPoolExhausted`
@@ -1144,11 +1194,11 @@ fn escalate_if_gas_pool_exhausted(
     classified: WalletJobError,
     attempt: usize,
     max_attempts: usize,
-    pool_size: usize,
+    candidate_wallets: usize,
 ) -> WalletJobError {
     if let WalletJobError::Transient(ref msg) = classified {
         if WalletJobError::is_gas_pool_budget_error(msg)
-            && attempt >= gas_pool_exhaustion_threshold(pool_size, max_attempts)
+            && attempt >= gas_pool_exhaustion_threshold(candidate_wallets, max_attempts)
         {
             return WalletJobError::GasPoolExhausted(msg.clone());
         }
@@ -1441,22 +1491,6 @@ pub struct RememberJob {
 /// Type alias for the RememberJob Apalis storage.
 pub type RememberJobStorage = PostgresStorage<RememberJob>;
 
-/// Error type for the RememberJob handler.
-#[derive(Debug)]
-pub enum RememberJobError {
-    Internal(String),
-}
-
-impl std::fmt::Display for RememberJobError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RememberJobError::Internal(msg) => write!(f, "remember job error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for RememberJobError {}
-
 /// Apalis handler for the full remember pipeline.
 ///
 /// Steps:
@@ -1471,7 +1505,8 @@ impl std::error::Error for RememberJobError {}
 pub async fn execute_remember(
     job: RememberJob,
     ctx: Data<Arc<AppState>>,
-) -> Result<(), RememberJobError> {
+    attempt_info: WalletJobAttemptInfo,
+) -> Result<(), Error> {
     let state: &AppState = &ctx;
 
     // ── Step 1: mark running ──────────────────────────────────────
@@ -1494,7 +1529,7 @@ pub async fn execute_remember(
             .bind(&job.job_id)
             .execute(state.db.pool())
             .await;
-            return Err(RememberJobError::Internal(msg));
+            return Err(remember_job_failed_apalis_error(msg));
         }};
     }
 
@@ -1505,10 +1540,14 @@ pub async fn execute_remember(
     };
     // vector is also pre-computed in route handler — no network call needed here.
 
-    let key_index = match state.key_pool.next_index() {
+    let key_pool_len = state.key_pool.len();
+    let starting_key_index = match stable_wallet_start_index(&job.job_id, key_pool_len) {
         Some(idx) => idx,
         None => fail!("No Sui keys configured in pool"),
     };
+    let key_index =
+        wallet_index_for_upload_attempt(starting_key_index, attempt_info.current, key_pool_len)
+            .expect("non-empty key pool must yield wallet index");
 
     // ── Step 3: walrus upload (the slow part ~2-3s) ───────────────
     let upload_result = crate::storage::walrus::upload_blob(
@@ -1607,9 +1646,57 @@ pub async fn execute_remember(
                     job.job_id,
                     msg
                 );
-                return Err(RememberJobError::Internal(msg));
+                let classified = WalletJobError::classify_sidecar_error(&msg);
+                update_remember_job_after_wallet_error(state, Some(&job.job_id), &classified, &msg)
+                    .await;
+                return Err(classified.into_apalis_error());
             }
-            fail!(msg);
+            let classified = escalate_if_gas_pool_exhausted(
+                WalletJobError::classify_sidecar_error(&msg),
+                attempt_info.current,
+                attempt_info.max,
+                key_pool_len,
+            );
+            maybe_alert_walrus_object_locked(
+                state,
+                &classified,
+                Some(&job.job_id),
+                Some(&job.owner),
+                Some(&job.namespace),
+                &msg,
+            )
+            .await;
+            maybe_alert_walrus_gas_pool_exhausted(
+                state,
+                &classified,
+                Some(&job.job_id),
+                Some(&job.owner),
+                Some(&job.namespace),
+                key_index,
+                &msg,
+            )
+            .await;
+            maybe_alert_walrus_upload_exhausted(
+                state,
+                &classified,
+                attempt_info,
+                Some(&job.job_id),
+                &job.owner,
+                &job.namespace,
+                key_index,
+                &msg,
+            )
+            .await;
+            update_remember_job_after_wallet_error(state, Some(&job.job_id), &classified, &msg)
+                .await;
+            tracing::error!(
+                "[remember-job] job_id={} {} classification={} retryable={}",
+                job.job_id,
+                msg,
+                classified.kind(),
+                !classified.aborts_retries()
+            );
+            return Err(classified.into_apalis_error());
         }
     };
     let blob_id = upload.blob_id.clone();
@@ -1797,13 +1884,15 @@ mod tests {
     use super::{
         classify_wallet_remember_handoff_failure, escalate_if_gas_pool_exhausted,
         gas_pool_exhaustion_threshold, is_walrus_package_version_mismatch,
-        mark_remember_job_failed, parse_locked_object_info, wallet_job_request, WalletJob,
-        WalletJobAttemptInfo, WalletJobError, WalletOperation, MAX_ATTEMPTS,
+        mark_remember_job_failed, parse_locked_object_info, wallet_index_for_upload_attempt,
+        wallet_job_request, WalletJob, WalletJobAttemptInfo, WalletJobError, WalletOperation,
+        MAX_ATTEMPTS,
     };
 
     /// The exact production error string from the object-lock incident
     /// (testnet job 3d607892…). Used to pin the classifier against real output.
-    const PROD_OBJECT_LOCK_ERROR: &str = "walrus upload failed: Internal Error: walrus upload failed: \
+    const PROD_OBJECT_LOCK_ERROR: &str =
+        "walrus upload failed: Internal Error: walrus upload failed: \
 Transaction is rejected as invalid by more than 1/3 of validators by stake (non-retriable). \
 Non-retriable errors: [Object (0x36f866a4d400ec3dd5d8b0bac30cc36ab6d56172634a6b4dea9e2a554a43b08e, \
 SequenceNumber(884613305), o#B61aVqEgDskxru255FTdzua2RxbbnhDMFxmQ8SCxvj3n) already locked by a \
@@ -2013,11 +2102,23 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
     }
 
     #[test]
+    fn wallet_retry_selection_walks_pool_from_enqueued_wallet() {
+        // This selection is per-job and does not depend on the global KeyPool
+        // cursor, so concurrent jobs cannot consume this job's next wallet.
+        let picked: Vec<_> = (1..=5)
+            .map(|attempt| wallet_index_for_upload_attempt(3, attempt, 4).unwrap())
+            .collect();
+        assert_eq!(picked, vec![3, 0, 1, 2, 3]);
+    }
+
+    #[test]
     fn gas_pool_one_bad_wallet_keeps_retrying_onto_healthy_wallet() {
         // pool of 2: the first wallet's balance::split must stay retriable so the
         // job rotates onto the second (healthy) wallet instead of failing.
         let classified = WalletJobError::classify_sidecar_error(BALANCE_SPLIT_ERR);
-        let after = escalate_if_gas_pool_exhausted(classified, /*attempt*/ 1, /*max*/ 5, /*pool*/ 2);
+        let after = escalate_if_gas_pool_exhausted(
+            classified, /*attempt*/ 1, /*max*/ 5, /*pool*/ 2,
+        );
         assert!(
             matches!(after, WalletJobError::Transient(_)) && !after.aborts_retries(),
             "single bad wallet must keep retrying, got {:?}",
@@ -2030,7 +2131,9 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
         // pool of 2, both wallets hit balance::split → at attempt 2 we have tried
         // every candidate wallet → escalate to an aborting GasPoolExhausted.
         let classified = WalletJobError::classify_sidecar_error(BALANCE_SPLIT_ERR);
-        let after = escalate_if_gas_pool_exhausted(classified, /*attempt*/ 2, /*max*/ 5, /*pool*/ 2);
+        let after = escalate_if_gas_pool_exhausted(
+            classified, /*attempt*/ 2, /*max*/ 5, /*pool*/ 2,
+        );
         assert!(
             matches!(after, WalletJobError::GasPoolExhausted(_)),
             "exhausted pool must escalate, got {:?}",
@@ -2039,6 +2142,16 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
         assert!(after.aborts_retries());
         assert!(!after.is_permanent());
         assert_eq!(after.kind(), "gas_pool_exhausted");
+    }
+
+    #[test]
+    fn gas_pool_pinned_wallet_escalates_immediately() {
+        // Metadata-transfer recovery is pinned to the blob owner wallet, so
+        // there are no alternate pool candidates to try.
+        let classified = WalletJobError::classify_sidecar_error(BALANCE_SPLIT_ERR);
+        let after =
+            escalate_if_gas_pool_exhausted(classified, /*attempt*/ 1, /*max*/ 5, 1);
+        assert!(matches!(after, WalletJobError::GasPoolExhausted(_)));
     }
 
     #[test]

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -20,8 +20,8 @@ use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
 
 use crate::alerts::{
-    SIDECAR_WALRUS_DEP_VERSION, WalrusObjectLockedAlert, WalrusPackageUpgradeDetectedAlert,
-    WalrusUploadExhaustedAlert,
+    SIDECAR_WALRUS_DEP_VERSION, WalrusGasPoolExhaustedAlert, WalrusObjectLockedAlert,
+    WalrusPackageUpgradeDetectedAlert, WalrusUploadExhaustedAlert,
 };
 use crate::storage::walrus::{SetMetadataBatchEntry, UploadBlobError};
 use crate::types::{configured_walrus_storage_epochs, AppState, BLOB_CACHE_KEY_PREFIX};
@@ -893,6 +893,16 @@ async fn execute_upload_and_transfer(
                 &msg,
             )
             .await;
+            maybe_alert_walrus_gas_pool_exhausted(
+                state,
+                &classified,
+                remember_job_id.as_deref(),
+                Some(&owner),
+                Some(&namespace),
+                wallet_index,
+                &msg,
+            )
+            .await;
             maybe_alert_walrus_upload_exhausted(
                 state,
                 &classified,
@@ -1086,6 +1096,42 @@ async fn maybe_alert_walrus_object_locked(
     }
 }
 
+/// Fire the distinct gas-pool maintenance alert when a wallet job fails with
+/// `GasPoolExhausted` (Enoki dry-run `balance::split` ENotEnough). Kept separate
+/// from the "exhausted retries" alert: this case aborts immediately, so the
+/// on-call message must name the real cause — fragmented/insufficient SUI gas on
+/// the pool wallets — and point ops at gas-coin consolidation/top-up.
+async fn maybe_alert_walrus_gas_pool_exhausted(
+    state: &AppState,
+    error: &WalletJobError,
+    remember_job_id: Option<&str>,
+    owner: Option<&str>,
+    namespace: Option<&str>,
+    wallet_index: usize,
+    msg: &str,
+) {
+    if !matches!(error, WalletJobError::GasPoolExhausted(_)) {
+        return;
+    }
+
+    let alert = WalrusGasPoolExhaustedAlert {
+        remember_job_id: remember_job_id.map(str::to_owned),
+        owner: owner.map(str::to_owned),
+        namespace: namespace.map(str::to_owned),
+        sui_network: state.config.sui_network.clone(),
+        wallet_index,
+        configured_wallets: state.key_pool.len(),
+        error: msg.to_string(),
+    };
+
+    if let Err(err) = state.alerts.notify_walrus_gas_pool_exhausted(alert).await {
+        tracing::warn!(
+            "[wallet-job:upload] failed to send Slack alert for Walrus gas-pool exhaustion: {}",
+            err
+        );
+    }
+}
+
 async fn maybe_alert_walrus_upload_exhausted(
     state: &AppState,
     error: &WalletJobError,
@@ -1131,8 +1177,10 @@ async fn maybe_alert_walrus_upload_exhausted(
 /// don't burn retry budget on inputs that can never succeed.
 ///
 /// Mapping rules (enforced at the point of error origination):
-/// - `MoveAbort(_)` → `Permanent` (deterministic Move-level failure), except
-///   `balance::split` stale-state failures that can recover after sidecar refresh
+/// - `MoveAbort(_)` → `Permanent` (deterministic Move-level failure)
+/// - Enoki dry-run `0x2::balance::split` ENotEnough → `GasPoolExhausted`
+///   (abort: pool SUI gas coins are fragmented/insufficient; retrying rotates
+///   to the next starved wallet — needs ops gas consolidation/top-up)
 /// - `ObjectLockedAtVersion(_)` → `Transient` (retry can rebuild with a fresh
 ///   wallet assignment)
 /// - owned-object lock / equivocation ("already locked by a different
@@ -1156,6 +1204,15 @@ pub enum WalletJobError {
     /// Apalis aborts so we surface a distinct object-lock alert rather than a
     /// misleading "wallet retries exhausted" one.
     ObjectLockedUntilEpoch(String),
+    /// An Enoki sponsored dry-run aborted in `0x2::balance::split` with
+    /// ENotEnough (abort code 2): the pool wallet's SUI gas coins are
+    /// fragmented or too small to cover the sponsored budget. Retrying rotates
+    /// to the next pool wallet and re-fails the same way, burning the attempt
+    /// budget without progress. NOT `Permanent`: it succeeds again once ops
+    /// consolidates / tops up SUI gas on the pool wallets. Apalis aborts so we
+    /// surface a distinct gas-pool maintenance alert rather than a misleading
+    /// "wallet retries exhausted" one.
+    GasPoolExhausted(String),
 }
 
 impl WalletJobError {
@@ -1164,6 +1221,7 @@ impl WalletJobError {
             WalletJobError::Transient(_) => "transient",
             WalletJobError::Permanent(_) => "permanent",
             WalletJobError::ObjectLockedUntilEpoch(_) => "object_locked_until_epoch",
+            WalletJobError::GasPoolExhausted(_) => "gas_pool_exhausted",
         }
     }
 
@@ -1180,7 +1238,9 @@ impl WalletJobError {
     pub fn aborts_retries(&self) -> bool {
         matches!(
             self,
-            WalletJobError::Permanent(_) | WalletJobError::ObjectLockedUntilEpoch(_)
+            WalletJobError::Permanent(_)
+                | WalletJobError::ObjectLockedUntilEpoch(_)
+                | WalletJobError::GasPoolExhausted(_)
         )
     }
 
@@ -1189,11 +1249,20 @@ impl WalletJobError {
     /// Until the sidecar emits structured error codes, we match on substrings.
     pub fn classify_sidecar_error(msg: &str) -> Self {
         let lower = msg.to_ascii_lowercase();
+        // Enoki sponsored dry-run aborts in 0x2::balance::split with ENotEnough
+        // (abort code 2) when the pool wallet's selected SUI gas coin cannot be
+        // split to cover the sponsored budget — i.e. the relayer's SUI gas coins
+        // are fragmented or too small. This is a gas-pool maintenance issue, not
+        // a transient: retrying just rotates to the next equally-starved pool
+        // wallet and burns the whole attempt budget. Abort and surface a
+        // dedicated gas-pool alert pointing ops to consolidate/top-up SUI gas.
+        // (balance::split's only abort is ENotEnough, so the balance+split anchor
+        // is sufficient to identify it.)
         if (lower.contains("moveabort") || lower.contains("move abort"))
             && lower.contains("balance")
             && lower.contains("split")
         {
-            return WalletJobError::Transient(msg.to_string());
+            return WalletJobError::GasPoolExhausted(msg.to_string());
         }
         // Walrus on-chain package upgrade — the cached @mysten/walrus client
         // carries stale package metadata until refreshed. The sidecar already
@@ -1250,9 +1319,9 @@ impl WalletJobError {
         let error = io::Error::other(self.to_string());
         match self {
             WalletJobError::Transient(_) => Error::Failed(Arc::new(Box::new(error))),
-            WalletJobError::Permanent(_) | WalletJobError::ObjectLockedUntilEpoch(_) => {
-                Error::Abort(Arc::new(Box::new(error)))
-            }
+            WalletJobError::Permanent(_)
+            | WalletJobError::ObjectLockedUntilEpoch(_)
+            | WalletJobError::GasPoolExhausted(_) => Error::Abort(Arc::new(Box::new(error))),
         }
     }
 }
@@ -1264,6 +1333,9 @@ impl std::fmt::Display for WalletJobError {
             WalletJobError::Permanent(msg) => write!(f, "wallet job error (permanent): {}", msg),
             WalletJobError::ObjectLockedUntilEpoch(msg) => {
                 write!(f, "wallet job error (object locked until epoch): {}", msg)
+            }
+            WalletJobError::GasPoolExhausted(msg) => {
+                write!(f, "wallet job error (gas pool exhausted): {}", msg)
             }
         }
     }
@@ -1793,13 +1865,14 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
 
     #[test]
     fn equivocation_does_not_regress_recoverable_classes() {
-        // balance::split and EWrongVersion must still be Transient (recoverable),
-        // not swept into the new abort path.
+        // EWrongVersion must still be Transient (recoverable). balance::split
+        // ENotEnough is a gas-pool maintenance abort, not an object lock — it
+        // must classify as GasPoolExhausted, not swept into the object-lock path.
         let balance = "Enoki dry run failed: MoveAbort(0x2::balance, split, 2)";
         let ewrong = "MoveAbort in 1st command, abort code: 1, in '0xabc::system::inner_mut'";
         assert!(matches!(
             WalletJobError::classify_sidecar_error(balance),
-            WalletJobError::Transient(_)
+            WalletJobError::GasPoolExhausted(_)
         ));
         assert!(matches!(
             WalletJobError::classify_sidecar_error(ewrong),
@@ -1844,16 +1917,22 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
     }
 
     #[test]
-    fn classify_balance_split_move_abort_as_transient() {
+    fn classify_balance_split_move_abort_as_gas_pool_exhausted() {
+        // Enoki dry-run balance::split ENotEnough → gas-pool maintenance abort:
+        // classified GasPoolExhausted, aborts retries (so it does not burn the
+        // whole wallet pool), and is not Permanent (succeeds after gas top-up).
         for msg in [
             "walrus upload failed: Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\",\"message\":\"Dry run failed: MoveAbort(MoveLocation { module: 0x2::balance, function_name: Some(\\\"split\\\") }, 2)\"}]}",
             "move abort during balance split",
         ] {
+            let classified = WalletJobError::classify_sidecar_error(msg);
             assert!(
-                !WalletJobError::classify_sidecar_error(msg).is_permanent(),
-                "expected transient for: {}",
+                matches!(classified, WalletJobError::GasPoolExhausted(_)),
+                "expected gas_pool_exhausted for: {}",
                 msg
             );
+            assert!(classified.aborts_retries(), "must abort retries: {}", msg);
+            assert!(!classified.is_permanent(), "must not be permanent: {}", msg);
         }
     }
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -121,8 +121,9 @@ pub struct AppState {
 // ============================================================
 
 /// Wallet key holder for distributing Walrus uploads across configured server
-/// keys. Apalis retries call `next_index()` again at execution time, so a
-/// transient sponsor/RPC failure can move to the next wallet in the pool.
+/// keys. Routes and other non-retry callers use `next_index()` for round-robin
+/// starting assignments; wallet-job retries derive their next index from the
+/// job's starting index and attempt number.
 pub struct KeyPool {
     keys: Vec<String>,
     cursor: AtomicUsize,


### PR DESCRIPTION
## Summary

Implements WALM-88 Enoki gas-pool failure classification for Walrus upload jobs. Changes Enoki `dry_run_failed` + `balance::split` + `ENotEnough` from a generic transient wallet error into a dedicated `GasPoolExhausted` abort path.

## Changes

- **Added `WalletJobError::GasPoolExhausted`**
  - `aborts_retries() = true`, maps to Apalis `Abort`, `is_permanent() = false` (maintenance issue, not a data/user error)
  - emits `kind = "gas_pool_exhausted"`
- **Updated sidecar error classification**
  - `MoveAbort` + `balance::split` + `ENotEnough` now maps to `GasPoolExhausted`
  - avoids rotating through the full wallet pool for a gas/budget maintenance issue
- **Added dedicated ops alert**
  - `WalrusGasPoolExhaustedAlert`, deduped per network
  - alert copy points ops to consolidate or top up SUI gas coins
- **Updated the Walrus upload path** to dispatch the new gas-pool alert
- **Added runbook** `docs/relayer/runbook-gas-pool.md` — diagnosis, SUI gas coin merge/top-up steps, verification guidance

## Validation

- `cargo build` passed
- `cargo test` passed: 279/279
- Covered tests: `classify_balance_split_move_abort_as_gas_pool_exhausted`, `equivocation_does_not_regress_recoverable_classes`, `walrus_gas_pool_payload_points_ops_to_gas_consolidation_not_exhausted_copy`

## Notes

Preflight wallet-pool health checks (min SUI total, largest coin size, fragmentation) are **left as a follow-up** and are **not in scope** for this PR — the acceptance criteria allow "a health check **or** runbook". This PR satisfies the current acceptance criteria through dedicated classification, fail-fast retry behavior, ops alerting, and a runbook.