### PR TITLE
fix(server): retry invalidated Enoki wallet txs

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -60,6 +60,9 @@ These are not all enforced at boot, but most real deployments need them.
 | `ENOKI_TRANSIENT_MAX_ATTEMPTS` | `2` | Attempts for sidecar-level retries of transient Enoki failures (`429`, `5xx`, network errors) before failing the wallet job |
 | `ENOKI_TRANSIENT_BASE_DELAY_MS` | `5000` | Base delay for transient Enoki retries when the response does not include `Retry-After` or a retry hint |
 | `ENOKI_TRANSIENT_MAX_DELAY_MS` | `30000` | Maximum delay for one transient Enoki retry, including parsed retry hints such as “try again in 30 seconds” |
+| `ENOKI_INVALIDATED_MAX_ATTEMPTS` | `4` | Attempts for rebuildable sponsored transactions invalidated by Enoki `expired` responses or short Sui object visibility lag before failing the wallet job |
+| `ENOKI_INVALIDATED_BASE_DELAY_MS` | `1000` | Base delay for retrying rebuildable sponsored transactions after Enoki invalidation |
+| `ENOKI_INVALIDATED_MAX_DELAY_MS` | `8000` | Maximum delay for one rebuildable sponsored transaction invalidation retry |
 | `MEMWAL_RELAYER_URL` | `http://127.0.0.1:$PORT` | Relayer URL passed from the Rust server to the sidecar for MCP tool calls |
 | `MCP_MAX_TOTAL_SESSIONS` | `1000` | Maximum active MCP sessions across SSE and Streamable HTTP transports |
 | `MCP_MAX_SESSIONS_PER_IP` | `16` | Maximum active MCP sessions from one source IP |

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -105,6 +105,11 @@ ENOKI_FALLBACK_TO_DIRECT_SIGN=false
 ENOKI_TRANSIENT_MAX_ATTEMPTS=2
 ENOKI_TRANSIENT_BASE_DELAY_MS=5000
 ENOKI_TRANSIENT_MAX_DELAY_MS=30000
+# Retry Enoki-sponsored tx invalidation (`expired`) and short Sui object
+# visibility lag before consuming a durable wallet-job retry.
+ENOKI_INVALIDATED_MAX_ATTEMPTS=4
+ENOKI_INVALIDATED_BASE_DELAY_MS=1000
+ENOKI_INVALIDATED_MAX_DELAY_MS=8000
 
 # Sponsor endpoint rate limiting (per IP + per sender, sliding window)
 SPONSOR_RATE_LIMIT_PER_MINUTE=10

--- a/services/server/scripts/__tests__/walrus-referenced-object-stale.test.ts
+++ b/services/server/scripts/__tests__/walrus-referenced-object-stale.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isWalrusReferencedObjectStale } from "../walrus-error-detection.js";
+import {
+    classifyEnokiSponsoredTransactionInvalidation,
+    isEnokiSponsoredTransactionExpired,
+    isWalrusReferencedObjectStale,
+} from "../walrus-error-detection.js";
 
 test("detects Enoki dry-run referenced object stale at explicit version", () => {
     const message =
@@ -28,4 +32,32 @@ test("does not match unrelated dry-run or object errors", () => {
     assert.equal(isWalrusReferencedObjectStale("Could not find the referenced object 0xabc"), false);
     assert.equal(isWalrusReferencedObjectStale("connection refused"), false);
     assert.equal(isWalrusReferencedObjectStale(""), false);
+});
+
+test("detects Enoki sponsored transaction expiration", () => {
+    const message =
+        "Enoki API error (400): {\"errors\":[{\"code\":\"expired\"," +
+        "\"message\":\"Sponsored transaction has expired\"}]}";
+
+    assert.equal(isEnokiSponsoredTransactionExpired(message), true);
+    assert.equal(classifyEnokiSponsoredTransactionInvalidation(message), "expired");
+});
+
+test("classifies Enoki object visibility lag as rebuildable invalidation", () => {
+    const message =
+        "Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\"," +
+        "\"message\":\"Error checking transaction input objects: Could not find the " +
+        "referenced object 0x78043f83bf219f750d65e454d6b72a4142e6abf2b7e88a641175fb523bc5c1ca " +
+        "at version None\"}]}";
+
+    assert.equal(classifyEnokiSponsoredTransactionInvalidation(message), "referenced_object_stale");
+});
+
+test("does not classify unrelated Enoki 400 errors as rebuildable", () => {
+    const message =
+        "Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\"," +
+        "\"message\":\"MoveAbort in balance::split\"}]}";
+
+    assert.equal(isEnokiSponsoredTransactionExpired(message), false);
+    assert.equal(classifyEnokiSponsoredTransactionInvalidation(message), null);
 });

--- a/services/server/scripts/sidecar-server.ts
+++ b/services/server/scripts/sidecar-server.ts
@@ -11,7 +11,7 @@
  *   GET  /health         → { status: "ok" }
  */
 
-import express, { Request, Response, NextFunction } from "express";
+import express, { Request, Response as ExpressResponse, NextFunction } from "express";
 import { timingSafeEqual, randomUUID } from "crypto";
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
@@ -23,6 +23,7 @@ import { mountMcpRoutes, shutdownMcpSessions } from "./mcp/index.js";
 import { getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "./seal-config.js";
 import { getEnokiRetryDelayMs, isSponsoredTransactionInvalidatedMessage } from "./enoki-retry.js";
 import {
+    classifyEnokiSponsoredTransactionInvalidation,
     isWalrusBlobObjectMissingFromEffects,
     isWalrusObjectLockEquivocation,
     isWalrusPackageVersionMismatch,
@@ -214,6 +215,24 @@ const ENOKI_TRANSIENT_MAX_DELAY_MS = parsePositiveIntEnv(
     "ENOKI_TRANSIENT_MAX_DELAY_MS",
     30_000,
     1_000,
+    120_000,
+);
+const ENOKI_INVALIDATED_MAX_ATTEMPTS = parsePositiveIntEnv(
+    "ENOKI_INVALIDATED_MAX_ATTEMPTS",
+    4,
+    1,
+    10,
+);
+const ENOKI_INVALIDATED_BASE_DELAY_MS = parsePositiveIntEnv(
+    "ENOKI_INVALIDATED_BASE_DELAY_MS",
+    1_000,
+    100,
+    60_000,
+);
+const ENOKI_INVALIDATED_MAX_DELAY_MS = parsePositiveIntEnv(
+    "ENOKI_INVALIDATED_MAX_DELAY_MS",
+    8_000,
+    100,
     120_000,
 );
 const WALRUS_CLIENT_MAX_AGE_MS = (() => {
@@ -468,7 +487,7 @@ function formattedError(err: unknown): string {
 }
 
 function sendSealFailure(
-    res: Response,
+    res: ExpressResponse,
     operation: string,
     phase: string,
     err: unknown,
@@ -601,6 +620,7 @@ function sidecarStateSnapshot(): Record<string, unknown> {
         enokiEnabled: !!enokiApiKey,
         fallbackToDirectSign: ENOKI_FALLBACK_TO_DIRECT_SIGN,
         enokiTransientMaxAttempts: ENOKI_TRANSIENT_MAX_ATTEMPTS,
+        enokiInvalidatedMaxAttempts: ENOKI_INVALIDATED_MAX_ATTEMPTS,
     };
 }
 
@@ -790,6 +810,48 @@ async function executeWithEnokiSponsor(tx: Transaction, signer: Ed25519Keypair, 
     }
 }
 
+function getEnokiInvalidatedRetryDelayMs(attempt: number): number | null {
+    if (attempt >= ENOKI_INVALIDATED_MAX_ATTEMPTS) {
+        return null;
+    }
+
+    const delay = ENOKI_INVALIDATED_BASE_DELAY_MS * 2 ** (attempt - 1);
+    return Math.min(delay, ENOKI_INVALIDATED_MAX_DELAY_MS);
+}
+
+async function submitRebuildableWalletTransaction(
+    phaseName: string,
+    buildTransaction: () => Transaction,
+    signer: Ed25519Keypair,
+    allowedAddresses?: string[],
+    logContext: Record<string, unknown> = {},
+): Promise<string> {
+    for (let attempt = 1; ; attempt += 1) {
+        try {
+            return await submitWalletTransaction(buildTransaction(), signer, allowedAddresses);
+        } catch (err: unknown) {
+            const message = errorMessage(err);
+            const reason = classifyEnokiSponsoredTransactionInvalidation(message);
+            const retryDelayMs = getEnokiInvalidatedRetryDelayMs(attempt);
+            if (!reason || retryDelayMs === null) {
+                throw err;
+            }
+
+            console.warn(`[enoki-sponsor] rebuildable_retry ${JSON.stringify({
+                phase: phaseName,
+                ...logContext,
+                attempt,
+                nextAttempt: attempt + 1,
+                maxAttempts: ENOKI_INVALIDATED_MAX_ATTEMPTS,
+                retryDelayMs,
+                reason,
+                message: truncateForLog(message),
+            })}`);
+            await sleep(retryDelayMs);
+        }
+    }
+}
+
 async function getSuiBalanceMist(owner: string): Promise<string | null> {
     try {
         const balance = await (suiClient as any).getBalance({ owner, coinType: SUI_TYPE });
@@ -885,7 +947,7 @@ function sidecarLog(
     }
 }
 
-app.use((req: RequestWithId, res: Response, next: NextFunction) => {
+app.use((req: RequestWithId, res: ExpressResponse, next: NextFunction) => {
     const requestId = sanitizeRequestId(req.headers["x-request-id"])
         ?? sanitizeRequestId(req.headers["x-correlation-id"])
         ?? randomUUID();
@@ -896,7 +958,7 @@ app.use((req: RequestWithId, res: Response, next: NextFunction) => {
 
 // CORS — sidecar is called only by the co-located Rust server, never by browsers.
 // Remove all CORS headers so no cross-origin access is granted.
-app.use((_req: Request, res: Response, next: NextFunction) => {
+app.use((_req: Request, res: ExpressResponse, next: NextFunction) => {
     res.removeHeader("Access-Control-Allow-Origin");
     res.removeHeader("Access-Control-Allow-Methods");
     res.removeHeader("Access-Control-Allow-Headers");
@@ -907,7 +969,7 @@ app.use((_req: Request, res: Response, next: NextFunction) => {
 });
 
 // Health check — placed before auth middleware so it is always reachable.
-app.get("/health", (_req: Request, res: Response) => {
+app.get("/health", (_req: Request, res: ExpressResponse) => {
     res.json({
         status: "ok",
         uptimeMs: Date.now() - sidecarStartedAtMs,
@@ -941,7 +1003,7 @@ mountMcpRoutes(app, {
 //
 // Values are integer counters that monotonically increase; clients compute
 // deltas.
-app.get("/metrics/wallet", (_req: Request, res: Response) => {
+app.get("/metrics/wallet", (_req: Request, res: ExpressResponse) => {
     res.json({
         ...sidecarMetrics,
         enokiEnabled: !!enokiApiKey,
@@ -958,7 +1020,7 @@ if (!SIDECAR_AUTH_TOKEN) {
     process.exit(1);
 }
 
-app.use((req: Request, res: Response, next: NextFunction) => {
+app.use((req: Request, res: ExpressResponse, next: NextFunction) => {
     const token = req.headers.authorization?.replace("Bearer ", "");
     const secretBuf = Buffer.from(SIDECAR_AUTH_TOKEN!);
     const providedBuf = Buffer.from(typeof token === "string" ? token : "");
@@ -1307,69 +1369,80 @@ async function setMetadataAndTransferBlobs(
     owner: string,
     packageId?: string,
     agentId?: string,
+    retryLogContext: Record<string, unknown> = {},
 ): Promise<string> {
     if (blobs.length === 0) {
         throw new Error("No blobs to transfer");
     }
 
     const signerAddress = signer.toSuiAddress();
-    const metaTx = new Transaction();
-    const blobArgs = [];
+    const buildMetadataTransferTx = () => {
+        const metaTx = new Transaction();
+        const blobArgs = [];
 
-    for (const blob of blobs) {
-        const blobArg = metaTx.object(blob.blobObjectId);
-        blobArgs.push(blobArg);
+        for (const blob of blobs) {
+            const blobArg = metaTx.object(blob.blobObjectId);
+            blobArgs.push(blobArg);
 
-        metaTx.moveCall({
-            target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
-            arguments: [
-                blobArg,
-                metaTx.pure.string("memwal_namespace"),
-                metaTx.pure.string(blob.namespace || "default"),
-            ],
-            typeArguments: [],
-        });
-
-        metaTx.moveCall({
-            target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
-            arguments: [
-                blobArg,
-                metaTx.pure.string("memwal_owner"),
-                metaTx.pure.string(owner),
-            ],
-            typeArguments: [],
-        });
-
-        if (packageId) {
             metaTx.moveCall({
                 target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
                 arguments: [
                     blobArg,
-                    metaTx.pure.string("memwal_package_id"),
-                    metaTx.pure.string(packageId),
+                    metaTx.pure.string("memwal_namespace"),
+                    metaTx.pure.string(blob.namespace || "default"),
                 ],
                 typeArguments: [],
             });
-        }
 
-        if (agentId) {
             metaTx.moveCall({
                 target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
                 arguments: [
                     blobArg,
-                    metaTx.pure.string("memwal_agent_id"),
-                    metaTx.pure.string(agentId),
+                    metaTx.pure.string("memwal_owner"),
+                    metaTx.pure.string(owner),
                 ],
                 typeArguments: [],
             });
-        }
-    }
 
-    metaTx.transferObjects(blobArgs, owner);
-    const digest = await submitWalletTransaction(
-        metaTx,
+            if (packageId) {
+                metaTx.moveCall({
+                    target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+                    arguments: [
+                        blobArg,
+                        metaTx.pure.string("memwal_package_id"),
+                        metaTx.pure.string(packageId),
+                    ],
+                    typeArguments: [],
+                });
+            }
+
+            if (agentId) {
+                metaTx.moveCall({
+                    target: `${WALRUS_PACKAGE_ID}::blob::insert_or_update_metadata_pair`,
+                    arguments: [
+                        blobArg,
+                        metaTx.pure.string("memwal_agent_id"),
+                        metaTx.pure.string(agentId),
+                    ],
+                    typeArguments: [],
+                });
+            }
+        }
+
+        metaTx.transferObjects(blobArgs, owner);
+        return metaTx;
+    };
+
+    const digest = await submitRebuildableWalletTransaction(
+        "metadata_transfer",
+        buildMetadataTransferTx,
         signer,
         dedupeAddresses([signerAddress, owner]),
+        {
+            ...retryLogContext,
+            blobCount: blobs.length,
+            owner: shortAddress(owner),
+        },
     );
     await suiClient.waitForTransaction({ digest });
     return digest;
@@ -1554,10 +1627,15 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
         );
 
         phase = "certify_build";
-        const certifyTx = flow.certify();
         const certifyDigest = await timedPhase(
             "certify_sponsor",
-            () => submitWalletTransaction(certifyTx, signer),
+            () => submitRebuildableWalletTransaction(
+                "certify_sponsor",
+                () => flow.certify(),
+                signer,
+                undefined,
+                { traceId, jobId: jobIdForLog, keyIndex: keySlot },
+            ),
             (digest) => ({ digest }),
         );
         await timedPhase(
@@ -1581,6 +1659,7 @@ app.post("/walrus/upload", express.json({ limit: JSON_LIMIT_WALRUS_UPLOAD }), as
                         owner,
                         packageId,
                         agentId,
+                        { traceId, jobId: jobIdForLog, keyIndex: keySlot },
                     ),
                     (digest) => ({ digest, blobObjectId }),
                 );

--- a/services/server/scripts/walrus-error-detection.ts
+++ b/services/server/scripts/walrus-error-detection.ts
@@ -41,6 +41,26 @@ export function isWalrusReferencedObjectStale(message: string): boolean {
         && /at version/i.test(message);
 }
 
+export type EnokiSponsoredTransactionInvalidation = "expired" | "referenced_object_stale";
+
+export function isEnokiSponsoredTransactionExpired(message: string): boolean {
+    if (!message) return false;
+    return /sponsored transaction has expired/i.test(message)
+        || /"code"\s*:\s*"expired"/i.test(message);
+}
+
+export function classifyEnokiSponsoredTransactionInvalidation(
+    message: string,
+): EnokiSponsoredTransactionInvalidation | null {
+    if (isEnokiSponsoredTransactionExpired(message)) {
+        return "expired";
+    }
+    if (isWalrusReferencedObjectStale(message)) {
+        return "referenced_object_stale";
+    }
+    return null;
+}
+
 /**
  * Detect Walrus SDK upload failures where register succeeded, but the SDK/RPC
  * path cannot observe the newly-created blob object in transaction effects yet.


### PR DESCRIPTION
## Summary
- Rebuild and retry wallet transactions when Enoki sponsored transaction state is invalidated.
- Add configurable retry limits/delays for invalidated Enoki transactions.
- Add tests for sponsored transaction expiration and referenced-object stale detection.

This is a fresh `dev`-based replacement branch for the older conflicting PR #249.

## Validation
- `npm test` in `services/server/scripts`
- `npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck sidecar-server.ts`
- `git diff --check`