### PR TITLE
Lower WAL low-balance alert threshold to 2 WAL

### DIFF
--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -12,6 +12,8 @@ const WALRUS_OBJECT_LOCK_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_OBJECT_LOCK_ALERT_
 const WALRUS_OBJECT_LOCK_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
 const WALRUS_GAS_POOL_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_GAS_POOL_ALERT_DEDUP_SECS";
 const WALRUS_GAS_POOL_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
+const WALRUS_LOW_BALANCE_ALERT_DEDUP_SECS_ENV: &str = "WALRUS_LOW_BALANCE_ALERT_DEDUP_SECS";
+const WALRUS_LOW_BALANCE_ALERT_DEDUP_DEFAULT: Duration = Duration::from_secs(600);
 
 /// Mirrors the `@mysten/walrus` dep version in
 /// `services/server/scripts/package.json`. Bump this constant in lockstep
@@ -80,6 +82,9 @@ pub struct AlertManager {
     /// `balance::split` ENotEnough — one notification per network is enough
     /// until ops tops up gas or the window elapses.
     walrus_gas_pool_dedup: AlertDedup,
+    /// Suppresses low-WAL balance spam. WAL shortfalls are wallet-specific;
+    /// one alert per (network, wallet_index) per window is enough.
+    walrus_low_balance_dedup: AlertDedup,
 }
 
 impl AlertManager {
@@ -101,6 +106,10 @@ impl AlertManager {
             walrus_gas_pool_dedup: AlertDedup::new(dedup_window_from_env(
                 WALRUS_GAS_POOL_ALERT_DEDUP_SECS_ENV,
                 WALRUS_GAS_POOL_ALERT_DEDUP_DEFAULT,
+            )),
+            walrus_low_balance_dedup: AlertDedup::new(dedup_window_from_env(
+                WALRUS_LOW_BALANCE_ALERT_DEDUP_SECS_ENV,
+                WALRUS_LOW_BALANCE_ALERT_DEDUP_DEFAULT,
             )),
         }
     }
@@ -176,6 +185,26 @@ impl AlertManager {
             return Ok(());
         }
         let payload = SlackPayload::for_walrus_gas_pool_exhausted(&alert);
+        slack.send_payload(&payload).await
+    }
+
+    pub async fn notify_walrus_low_wal_balance(
+        &self,
+        alert: WalrusWalletBalanceLowAlert,
+    ) -> Result<(), AlertError> {
+        let Some(slack) = &self.slack else {
+            return Ok(());
+        };
+        // Duplicate key is per network + wallet so repeated low-balance hits
+        // from the same wallet collapse while still surfacing across wallets.
+        let key = (
+            alert.sui_network.clone(),
+            format!("wallet-{}", alert.wallet_index),
+        );
+        if self.walrus_low_balance_dedup.should_suppress(key) {
+            return Ok(());
+        }
+        let payload = SlackPayload::for_walrus_low_wal_balance(&alert);
         slack.send_payload(&payload).await
     }
 }
@@ -298,6 +327,20 @@ pub struct WalrusGasPoolExhaustedAlert {
     pub owner: Option<String>,
     pub namespace: Option<String>,
     pub sui_network: String,
+    pub wallet_index: usize,
+    pub configured_wallets: usize,
+    pub error: String,
+}
+
+#[derive(Debug)]
+pub struct WalrusWalletBalanceLowAlert {
+    pub remember_job_id: Option<String>,
+    pub owner: Option<String>,
+    pub namespace: Option<String>,
+    pub sui_network: String,
+    pub available: u64,
+    pub required: Option<u64>,
+    pub threshold: u64,
     pub wallet_index: usize,
     pub configured_wallets: usize,
     pub error: String,
@@ -528,6 +571,65 @@ impl SlackPayload {
             ],
         }
     }
+
+    fn for_walrus_low_wal_balance(alert: &WalrusWalletBalanceLowAlert) -> Self {
+        let title = "MemWal Walrus upload blocked — insufficient WAL".to_string();
+        let available_wal = format_wal_amount(alert.available);
+        let threshold_wal = format_wal_amount(alert.threshold);
+        let required_line = alert
+            .required
+            .map(|required| {
+                format!("*Required:* {} WAL\n", format_wal_amount(required))
+            })
+            .unwrap_or_default();
+        let action = "*Action (ops):* top up WAL for this relayer wallet before retrying.
+If the wallet is being topped up, rotate or temporarily remove that key from pool to keep uploads flowing."
+            .to_string();
+        let summary = format!(
+            "Walrus operation blocked on {}: wallet ({}) has only {} WAL available, below the alert threshold of {} WAL.\n",
+            alert.sui_network,
+            alert.wallet_index,
+            available_wal,
+            threshold_wal,
+        );
+        let job = alert.remember_job_id.as_deref().unwrap_or("-");
+        let owner = alert
+            .owner
+            .as_deref()
+            .map(short_address)
+            .unwrap_or_else(|| "-".to_string());
+        let namespace = alert.namespace.as_deref().unwrap_or("-");
+        let details = format!(
+            "*Network:* `{}`\n*Wallet:* `{}` of `{}`\n*Job:* `{}`\n*Owner:* `{}`\n*Namespace:* `{}`\n{}*Available:* `{}` WAL\n*Error:* ```{}```",
+            alert.sui_network,
+            alert.wallet_index,
+            alert.configured_wallets,
+            job,
+            owner,
+            namespace,
+            required_line,
+            available_wal,
+            truncate(&alert.error, MAX_SLACK_ERROR_LEN),
+        );
+
+        Self {
+            text: summary.clone(),
+            blocks: vec![
+                SlackBlock::Header {
+                    text: plain_text(title),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(summary),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(action),
+                },
+                SlackBlock::Section {
+                    text: mrkdwn(details),
+                },
+            ],
+        }
+    }
 }
 
 fn plain_text(text: String) -> SlackText {
@@ -564,6 +666,21 @@ fn truncate(value: &str, max_len: usize) -> String {
     }
 
     format!("{}...", value.chars().take(max_len).collect::<String>())
+}
+
+fn format_wal_amount(mist: u64) -> String {
+    let integer = mist / 1_000_000_000;
+    let mut fractional = format!("{:09}", mist % 1_000_000_000);
+
+    while fractional.ends_with('0') {
+        fractional.pop();
+    }
+
+    if fractional.is_empty() {
+        format!("{}.0", integer)
+    } else {
+        format!("{}.{}", integer, fractional)
+    }
 }
 
 #[cfg(test)]
@@ -796,5 +913,30 @@ mod tests {
         assert!(json.contains("balance::split") || json.contains("balance"));
         assert!(json.contains("mainnet"));
         assert!(json.contains("people"));
+    }
+
+    #[test]
+    fn walrus_low_balance_payload_promotes_available_below_threshold() {
+        let payload = SlackPayload::for_walrus_low_wal_balance(&WalrusWalletBalanceLowAlert {
+            remember_job_id: Some("low-wal-1".into()),
+            owner: Some(
+                "0xabc1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".into(),
+            ),
+            namespace: Some("default".into()),
+            sui_network: "mainnet".into(),
+            available: 1_234_567_890,
+            required: Some(64_367_730),
+            threshold: 2_000_000_000,
+            wallet_index: 3,
+            configured_wallets: 5,
+            error: "walrus upload failed: Insufficient balance ... available: 1234567890".into(),
+        });
+
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.to_lowercase().contains("insufficient wal"));
+        assert!(json.contains("1.23456789"));
+        assert!(json.contains("default"));
+        assert!(json.contains("low-wal-1"));
+        assert!(json.contains("wallet"));
     }
 }

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::alerts::{
     WalrusGasPoolExhaustedAlert, WalrusObjectLockedAlert, WalrusPackageUpgradeDetectedAlert,
-    WalrusUploadExhaustedAlert, SIDECAR_WALRUS_DEP_VERSION,
+    WalrusUploadExhaustedAlert, WalrusWalletBalanceLowAlert, SIDECAR_WALRUS_DEP_VERSION,
 };
 use crate::storage::walrus::{SetMetadataBatchEntry, UploadBlobError};
 use crate::types::{configured_walrus_storage_epochs, AppState, BLOB_CACHE_KEY_PREFIX};
@@ -349,6 +349,7 @@ pub async fn execute_meta_transfer(
 /// Maximum number of attempts (1 initial + N-1 retries).
 #[allow(dead_code)]
 pub const MAX_ATTEMPTS: u32 = 5;
+const WAL_BALANCE_LOW_THRESHOLD_MIST: u64 = 2_000_000_000;
 
 /// Exponential back-off: attempt 1→2s, 2→4s, 3→8s, 4→16s, 5→32s.
 #[allow(dead_code)]
@@ -372,6 +373,9 @@ pub(crate) struct WalletJobAttemptInfo {
 
 impl WalletJobAttemptInfo {
     fn exhausted_by(&self, error: &WalletJobError) -> bool {
+        if matches!(error, WalletJobError::WalrusBalanceLow(_)) {
+            return false;
+        }
         // Only retryable (non-aborting) errors can "exhaust" the budget. An
         // aborting error — Permanent or ObjectLockedUntilEpoch — stops retries
         // immediately, so it never produces a misleading "exhausted" alert.
@@ -676,7 +680,7 @@ async fn execute_set_metadata_and_transfer(
     package_id: Option<String>,
     agent_id: Option<String>,
 ) -> Result<(), WalletJobError> {
-    crate::storage::walrus::set_metadata_batch(
+    let set_metadata_result = crate::storage::walrus::set_metadata_batch(
         &state.http_client,
         &state.config.sidecar_url,
         state.config.sidecar_secret.as_deref(),
@@ -689,19 +693,32 @@ async fn execute_set_metadata_and_transfer(
             namespace,
         }],
     )
-    .await
-    .map(|_| ())
-    .map_err(|e| {
-        let msg = e.to_string();
-        let classified = WalletJobError::classify_sidecar_error(&msg);
-        if classified.is_permanent() {
-            tracing::error!(
-                "[wallet-job:set-metadata] permanent failure (will mark Dead): {}",
-                msg
-            );
+    .await;
+
+    match set_metadata_result {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let msg = e.to_string();
+            let classified = WalletJobError::classify_sidecar_error(&msg);
+            maybe_alert_walrus_low_wal_balance(
+                state,
+                &classified,
+                wallet_index,
+                None,
+                Some(&owner),
+                Some(&namespace),
+                &msg,
+            )
+            .await;
+            if classified.is_permanent() {
+                tracing::error!(
+                    "[wallet-job:set-metadata] permanent failure (will mark Dead): {}",
+                    msg
+                );
+            }
+            Err(classified)
         }
-        classified
-    })
+    }
 }
 
 async fn insert_vector_and_mark_remember_done(
@@ -967,6 +984,16 @@ async fn execute_upload_and_transfer(
             maybe_alert_walrus_object_locked(
                 state,
                 &classified,
+                remember_job_id.as_deref(),
+                Some(&owner),
+                Some(&namespace),
+                &msg,
+            )
+            .await;
+            maybe_alert_walrus_low_wal_balance(
+                state,
+                &classified,
+                wallet_index,
                 remember_job_id.as_deref(),
                 Some(&owner),
                 Some(&namespace),
@@ -1242,6 +1269,92 @@ async fn maybe_alert_walrus_gas_pool_exhausted(
     }
 }
 
+#[derive(Debug)]
+struct WalrusWALBalanceAlert {
+    required: Option<u64>,
+    available: u64,
+}
+
+fn extract_u64_after_token(message: &str, token: &str) -> Option<u64> {
+    let lower = message.to_ascii_lowercase();
+    let start = lower.find(token)?;
+    let mut saw_digit = false;
+    let mut digits = String::new();
+    for ch in lower[start + token.len()..].chars() {
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            digits.push(ch);
+        } else if saw_digit {
+            break;
+        }
+    }
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+fn parse_wal_balance_alert_info(message: &str) -> Option<WalrusWALBalanceAlert> {
+    let lower = message.to_ascii_lowercase();
+    if !lower.contains("insufficient balance") || !lower.contains("::wal::wal") {
+        return None;
+    }
+
+    let available = extract_u64_after_token(message, "available:")?;
+    if available >= WAL_BALANCE_LOW_THRESHOLD_MIST {
+        return None;
+    }
+
+    Some(WalrusWALBalanceAlert {
+        required: extract_u64_after_token(message, "required:"),
+        available,
+    })
+}
+
+async fn maybe_alert_walrus_low_wal_balance(
+    state: &AppState,
+    error: &WalletJobError,
+    wallet_index: usize,
+    remember_job_id: Option<&str>,
+    owner: Option<&str>,
+    namespace: Option<&str>,
+    msg: &str,
+) {
+    if !matches!(error, WalletJobError::WalrusBalanceLow(_)) {
+        return;
+    }
+
+    let info = match parse_wal_balance_alert_info(msg) {
+        Some(info) => info,
+        None => return,
+    };
+
+    let alert = WalrusWalletBalanceLowAlert {
+        remember_job_id: remember_job_id.map(str::to_owned),
+        owner: owner.map(str::to_owned),
+        namespace: namespace.map(str::to_owned),
+        sui_network: state.config.sui_network.clone(),
+        available: info.available,
+        required: info.required,
+        threshold: WAL_BALANCE_LOW_THRESHOLD_MIST,
+        wallet_index,
+        configured_wallets: state.key_pool.len(),
+        error: msg.to_string(),
+    };
+
+    if let Err(err) = state
+        .alerts
+        .notify_walrus_low_wal_balance(alert)
+        .await
+    {
+        tracing::warn!(
+            "[wallet-job:upload] failed to send Slack alert for low WAL balance: {}",
+            err
+        );
+    }
+}
+
 async fn maybe_alert_walrus_upload_exhausted(
     state: &AppState,
     error: &WalletJobError,
@@ -1252,6 +1365,10 @@ async fn maybe_alert_walrus_upload_exhausted(
     wallet_index: usize,
     msg: &str,
 ) {
+    if matches!(error, WalletJobError::WalrusBalanceLow(_)) {
+        return;
+    }
+
     if !attempt_info.exhausted_by(error) {
         return;
     }
@@ -1306,6 +1423,10 @@ pub enum WalletJobError {
     Transient(String),
     /// Permanent failure — Apalis should mark Dead immediately (no retry).
     Permanent(String),
+    /// A wallet's WAL balance is below the alert threshold (default 2 WAL). This
+    /// keeps retries enabled so other pool wallets can carry the request, while
+    /// still surfacing a dedicated ops alert.
+    WalrusBalanceLow(String),
     /// A Sui owned object/version is locked to a competing transaction. The
     /// lock does not clear with immediate retries — it holds until the lock
     /// resolves, typically at the next epoch boundary — so retrying within the
@@ -1330,6 +1451,7 @@ impl WalletJobError {
         match self {
             WalletJobError::Transient(_) => "transient",
             WalletJobError::Permanent(_) => "permanent",
+            WalletJobError::WalrusBalanceLow(_) => "walrus_balance_low",
             WalletJobError::ObjectLockedUntilEpoch(_) => "object_locked_until_epoch",
             WalletJobError::GasPoolExhausted(_) => "gas_pool_exhausted",
         }
@@ -1370,6 +1492,9 @@ impl WalletJobError {
     /// Until the sidecar emits structured error codes, we match on substrings.
     pub fn classify_sidecar_error(msg: &str) -> Self {
         let lower = msg.to_ascii_lowercase();
+        if parse_wal_balance_alert_info(msg).is_some() {
+            return WalletJobError::WalrusBalanceLow(msg.to_string());
+        }
         // Enoki sponsored dry-run aborts in 0x2::balance::split with ENotEnough
         // (abort code 2) when the selected pool wallet's SUI gas coin cannot be
         // split to cover the sponsored budget (its SUI is fragmented or too low).
@@ -1437,6 +1562,7 @@ impl WalletJobError {
         let error = io::Error::other(self.to_string());
         match self {
             WalletJobError::Transient(_) => Error::Failed(Arc::new(Box::new(error))),
+            WalletJobError::WalrusBalanceLow(_) => Error::Failed(Arc::new(Box::new(error))),
             WalletJobError::Permanent(_)
             | WalletJobError::ObjectLockedUntilEpoch(_)
             | WalletJobError::GasPoolExhausted(_) => Error::Abort(Arc::new(Box::new(error))),
@@ -1451,6 +1577,9 @@ impl std::fmt::Display for WalletJobError {
             WalletJobError::Permanent(msg) => write!(f, "wallet job error (permanent): {}", msg),
             WalletJobError::ObjectLockedUntilEpoch(msg) => {
                 write!(f, "wallet job error (object locked until epoch): {}", msg)
+            }
+            WalletJobError::WalrusBalanceLow(msg) => {
+                write!(f, "wallet job error (insufficient WAL): {}", msg)
             }
             WalletJobError::GasPoolExhausted(msg) => {
                 write!(f, "wallet job error (gas pool exhausted): {}", msg)
@@ -1885,8 +2014,8 @@ mod tests {
         classify_wallet_remember_handoff_failure, escalate_if_gas_pool_exhausted,
         gas_pool_exhaustion_threshold, is_walrus_package_version_mismatch,
         mark_remember_job_failed, parse_locked_object_info, wallet_index_for_upload_attempt,
-        wallet_job_request, WalletJob, WalletJobAttemptInfo, WalletJobError, WalletOperation,
-        MAX_ATTEMPTS,
+        wallet_job_request, parse_wal_balance_alert_info,
+        WalletJob, WalletJobAttemptInfo, WalletJobError, WalletOperation, MAX_ATTEMPTS,
     };
 
     /// The exact production error string from the object-lock incident
@@ -2076,6 +2205,33 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
     }
 
     const BALANCE_SPLIT_ERR: &str = "walrus upload failed: Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\",\"message\":\"Dry run failed: MoveAbort(MoveLocation { module: 0x2::balance, function_name: Some(\\\"split\\\") }, 2)\"}]}";
+    const LOW_WAL_BALANCE_ERR: &str =
+        "walrus upload failed: Insufficient balance of 0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL for owner 0xabc...def. Required: 64367730, Available: 10708877";
+
+    #[test]
+    fn parse_wal_balance_alert_info_extracts_required_and_available() {
+        let parsed = parse_wal_balance_alert_info(LOW_WAL_BALANCE_ERR).expect("expected low WAL signal");
+        assert_eq!(parsed.required, Some(64367730));
+        assert_eq!(parsed.available, 10708877);
+    }
+
+    #[test]
+    fn classify_low_wal_balance_is_dedicated_transient() {
+        let classified = WalletJobError::classify_sidecar_error(LOW_WAL_BALANCE_ERR);
+        assert!(matches!(
+            classified,
+            WalletJobError::WalrusBalanceLow(_)
+        ));
+        assert!(!classified.aborts_retries());
+        assert!(!classified.is_permanent());
+        assert_eq!(classified.kind(), "walrus_balance_low");
+    }
+
+    #[test]
+    fn low_wal_balance_does_not_trigger_exhausted_retries_alert_gate() {
+        let classified = WalletJobError::classify_sidecar_error(LOW_WAL_BALANCE_ERR);
+        assert!(!WalletJobAttemptInfo { current: 5, max: 5 }.exhausted_by(&classified));
+    }
 
     #[test]
     fn classify_balance_split_is_retriable_transient_by_default() {


### PR DESCRIPTION
## Summary
- Lower WAL balance alert threshold from 5 WAL to 2 WAL for relayer wallet exhaustion warnings.

## Changes
- Update WAL threshold constant in  from 5,000,000,000 (5 WAL) to 2,000,000,000 (2 WAL).
- Update related alert payload test fixture in .
- No other functional paths changed; this affects only alerting/notification threshold and keeps retry behavior unchanged.

## Verification
- Changes applied locally and committed.,