### PR TITLE
fix(mcp): ship plugin .mcp.json with the marketplace bundle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.5"
+      "version": "0.0.6"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.5"
+      "version": "0.0.6"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,8 @@ railway-*.md
 
 # Per-developer MCP client config (user paths)
 .mcp.json
+# ...but the marketplace plugin must ship its own MCP config
+!packages/mcp/plugin/.mcp.json
 
 # Personal/internal planning notes — never include in repo
 plans/

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -4,6 +4,12 @@ description: Release history for the Walrus Memory MCP package.
 keywords: [MCP, Walrus Memory, MemWal, changelog, releases]
 ---
 
+## 0.0.6
+
+### Fixed
+
+- Ship the plugin's `.mcp.json` in the marketplace bundle. A root gitignore rule excluded it, so plugin installs loaded the lifecycle hooks but never registered the MCP server.
+
 ## 0.0.5
 
 ### Added

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mysten-incubation/memwal-mcp
 
+## 0.0.6
+
+### Fixed
+
+- Ship the plugin's `.mcp.json` in the marketplace bundle. A root gitignore rule excluded it, so plugin installs loaded the lifecycle hooks but never registered the MCP server.
+
 ## 0.0.5
 
 ### Added

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/.mcp.json
+++ b/packages/mcp/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "memwal": {
+      "command": "npx",
+      "args": ["-y", "@mysten-incubation/memwal-mcp"]
+    }
+  }
+}

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",


### PR DESCRIPTION
## Problem
The root `.gitignore` rule `.mcp.json` (meant for per-developer MCP configs)
silently excluded `packages/mcp/plugin/.mcp.json` from the WALM-94 merge.
Installing `memwal@memwal-plugins` therefore loads the lifecycle hooks but never
registers the MCP server — no `memwal_*` tools appear in the session.

## Fix
- Add a gitignore exception for `packages/mcp/plugin/.mcp.json`
- Commit the file (prod default: `npx -y @mysten-incubation/memwal-mcp`)
- Bump to 0.0.6 (plugin manifests + package + changelog) so installed copies refresh on `/plugin update` — the plugin cache is keyed by version

## Verified
- `git check-ignore` no longer matches the file
- Same bundle layout as the working local install (hooks + MCP both load)

## After merge
Existing installs: `/plugin marketplace update memwal-plugins`, then update or reinstall `memwal@memwal-plugins`.
