### PR TITLE
docs(sdk): add @mysten/* peer dependency version matrix (#254)

### DIFF
--- a/docs/sdk/quick-start.md
+++ b/docs/sdk/quick-start.md
@@ -47,6 +47,10 @@ yarn add @mysten/sui @mysten/seal @mysten/walrus
 
 </CodeGroup>
 
+<Note>
+**Version compatibility:** `@mysten/seal` and `@mysten/walrus` must both accept the same `@mysten/sui` major. Known-good versions: `@mysten/sui@^2.16.2`, `@mysten/seal@^1.1.3`, `@mysten/walrus@^1.1.7`. Avoid `@mysten/walrus@0.x` — it bundles `@mysten/sui@1.x` and conflicts with `@mysten/seal@1.x`. If installation fails with `ERESOLVE` on `@mysten/sui`, upgrade `@mysten/walrus` and run `npm why @mysten/sui` to find which dependency still pins sui v1.
+</Note>
+
 For `withMemWal`, you also need:
 
 <CodeGroup>

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -20,6 +20,18 @@ Peer dependencies (install as needed):
 pnpm add @mysten/sui @mysten/seal @mysten/walrus ai zod
 ```
 
+### Version compatibility
+
+`@mysten/seal` and `@mysten/walrus` must both resolve to versions that accept the same `@mysten/sui` major. Known-good matrix:
+
+| Package | Version |
+| --- | --- |
+| `@mysten/sui` | `^2.16.2` |
+| `@mysten/seal` | `^1.1.3` |
+| `@mysten/walrus` | `^1.1.7` |
+
+`@mysten/walrus@0.x` bundles `@mysten/sui@1.x` and cannot coexist with `@mysten/seal@1.x`, which requires `@mysten/sui@^2.x`. If `npm install` fails with `ERESOLVE` mentioning `@mysten/sui@^1.x`, upgrade `@mysten/walrus` to `^1.1.7`, refresh your lockfile, and run `npm why @mysten/sui` to find any remaining dependency that pins sui v1.
+
 ## Quick Start
 
 ```ts


### PR DESCRIPTION
## Summary

Addresses #254 — documents a known-good version matrix for `@mysten/sui` / `@mysten/seal` / `@mysten/walrus` in the SDK README and the docs quick-start, plus a troubleshooting note for the `ERESOLVE` conflict.

## Context

The conflict reported in #254 comes from `@mysten/walrus@0.x`, which bundles `@mysten/sui@1.x` as a direct dependency. Since `@mysten/walrus@1.0.0` it is a peer dependency on `@mysten/sui@^2.x`, and as of `1.1.7` the range is `^2.16.2` — identical to what `@mysten/seal@1.1.3` requires, so the latest versions resolve together cleanly.

Verified with a clean install:

```bash
npm i @mysten-incubation/memwal @mysten/walrus @mysten/sui
# resolves: memwal@0.0.7, walrus@1.1.7, sui@2.17.0, seal@1.1.3 — no ERESOLVE
```

No code changes — `packages/sdk` peer ranges already exclude `walrus@0.x` (`>=1.0.3`).