### PR TITLE
WALM-113: setup skill polish + grounded MCP tool results

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.6"
+      "version": "0.0.5"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.6"
+      "version": "0.0.5"
     }
   ]
 }

--- a/apps/app/public/skills/setup
+++ b/apps/app/public/skills/setup
@@ -22,17 +22,24 @@ user explicitly asks for developer integration.
 
 ## Setup Rules
 
-1. First decide whether you have local shell and filesystem access.
-2. If you can edit local user config files, do the setup yourself after showing
+1. Identify the AI client first. ChatGPT (or another client that cannot run a
+   local MCP command but supports custom connector headers) uses the Remote
+   MCP section below. Every other client (Claude Desktop, Claude Code, Cursor,
+   Codex, other local apps) uses the Local MCP Server section.
+2. Decide whether you have local shell and filesystem access.
+3. If you can edit local user config files, do the setup yourself after showing
    the config you will add.
-3. If you cannot edit local files, give the user exact commands/config to paste
-   and wait for their result.
-4. Preserve existing MCP servers. Merge the `memwal` server; do not replace the
+4. If you cannot edit local files yourself, prefer giving the user ONE terminal
+   command to paste (for example a `claude mcp add ...` or login command) over
+   raw JSON/TOML to hand-edit. Fall back to a config block only when no command
+   exists for that client; then state the exact file path and merge the
+   `memwal` entry, never replace the whole file.
+5. Preserve existing MCP servers. Merge the `memwal` server; do not replace the
    whole config.
-5. Never print or expose values from `~/.memwal/credentials.json`.
-6. Tell the user to fully quit and reopen the AI client after config changes.
-7. Stop at the first real blocker and report the exact failure.
-8. Keep the final status short. Do not repeat full config blocks or terminal
+6. Never print or expose values from `~/.memwal/credentials.json`.
+7. Tell the user to fully quit and reopen the AI client after config changes.
+8. Stop at the first real blocker and report the exact failure.
+9. Keep the final status short. Do not repeat full config blocks or terminal
    commands after setup succeeds unless the user must copy/paste them manually.
 
 ## Requirements
@@ -45,6 +52,8 @@ node -v
 
 Walrus Memory MCP requires Node.js 20 or newer. If Node is missing or older
 than 20, ask the user to install Node.js 20+ from https://nodejs.org/ and stop.
+The Remote MCP path needs Node.js only once, for the login step on the user's
+computer.
 
 The user signs in through the browser with Google/zkLogin or a Sui-compatible
 wallet. The sign-in flow writes persistent credentials to:
@@ -116,6 +125,9 @@ Edit `~/.cursor/mcp.json` and merge:
 ```
 
 ### Claude Desktop
+
+Use the config file below. Claude Desktop's Settings > Connectors UI only
+supports OAuth remote servers and does not work for Walrus Memory.
 
 Edit:
 
@@ -195,7 +207,11 @@ seconds while `npx` fetches the package.
 
 ## Verify Tools
 
-Ask the AI client:
+Fastest check: ask the client to call `memwal_health`. A healthy reply proves
+the server is reachable. If health succeeds but memory tools return 401,
+credentials are missing; run the login.
+
+Then ask the AI client:
 
 ```text
 What MCP tools do you have available?
@@ -236,11 +252,23 @@ Use memwal_recall to search for: "setup verification succeeded"
 If the tools support a `namespace` argument, use a setup-only namespace such as
 `setup-verification`.
 
-## ChatGPT and Remote MCP
+## Remote MCP (ChatGPT and other header-capable clients)
 
-ChatGPT custom MCP apps use remote MCP servers, not a local `npx` stdio config.
+Some clients connect to a remote MCP server URL instead of running a local
+command. Use this path only when the client supports custom request headers.
+ChatGPT (developer mode) supports this today.
 
-Use remote MCP only when the client supports custom headers:
+Prerequisite: credentials must already exist. Have the user run the login once
+on their computer (see Recommended Login). The Remote MCP path needs Node.js
+only for that one step.
+
+For ChatGPT:
+
+1. Settings > Connectors > enable Developer mode.
+2. Add a connector with URL `https://relayer.memory.walrus.xyz/api/mcp`.
+3. Add the two headers shown in the template below.
+
+For config-file clients that support remote servers with headers, merge:
 
 ```json
 {
@@ -256,11 +284,21 @@ Use remote MCP only when the client supports custom headers:
 }
 ```
 
-The values come from `~/.memwal/credentials.json` after login. Treat the bearer
-token like an API key. Do not save it in a repo file or print it in chat.
+To fill the placeholders, have the USER open the credentials file themselves:
 
-If the client cannot attach required headers, explain the blocker and suggest a
-local MCP client such as Cursor, Claude Desktop, Claude Code, or Codex.
+```bash
+cat ~/.memwal/credentials.json
+```
+
+`delegatePrivateKey` is the Bearer token; `accountId` is the
+`x-memwal-account-id` value. The user pastes them directly into the connector
+settings, never into the chat. You (the agent) must not read or print this
+file. Treat the bearer token like an API key and never save it in a repo file.
+
+If the client cannot attach custom headers, remote MCP is not available for it
+today. Tell the user which clients are supported (ChatGPT developer mode,
+Claude Desktop, Claude Code, Cursor, Codex) and offer to set one of those up
+instead. Do not re-run this skill for the same client.
 
 ## Troubleshooting
 
@@ -290,12 +328,19 @@ window is not enough.
 Login: succeeded.
 Config: <path changed>.
 After reopening, ask: "What MCP tools do you have available?"
+
+Memory is automatic from here: the assistant saves durable facts and recalls
+them as you chat. There is no sync schedule to configure. Try:
+- "What do you remember about me?"
+- "Remember that I prefer short answers."
 ```
 
 Rules for the final response:
 
 - Put the restart instruction before verification details.
-- Keep it under 8 lines if there is no blocker.
+- Keep it under 14 lines if there is no blocker.
+- Offer at most 3 starter prompts.
+- Never state storage sizes or explorer links that the tools did not return.
 - Do not include the full TOML/JSON config again after it has already been
   applied.
 - Do not include long verification prompts before the restart. After restart,

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -4,12 +4,6 @@ description: Release history for the Walrus Memory MCP package.
 keywords: [MCP, Walrus Memory, MemWal, changelog, releases]
 ---
 
-## 0.0.6
-
-### Fixed
-
-- Ship the plugin's `.mcp.json` in the marketplace bundle. A root gitignore rule excluded it, so plugin installs loaded the lifecycle hooks but never registered the MCP server.
-
 ## 0.0.5
 
 ### Added
@@ -17,6 +11,10 @@ keywords: [MCP, Walrus Memory, MemWal, changelog, releases]
 - **Automatic memory plugin** for Claude Code, Codex, Cursor, and Antigravity: an installable plugin that bundles the MCP server with lifecycle hooks (SessionStart, UserPromptSubmit, PostToolUse) which remind the agent to recall context and save durable facts on its own. See [Claude Code](/mcp/claude-code).
 - New **`memwal_remember_bulk`** tool to save several facts in one call.
 - New **`memwal_health`** tool for a fast connectivity check (use it instead of `memwal_recall` to confirm the server is reachable).
+
+### Fixed
+
+- Ship the plugin's `.mcp.json` in the marketplace bundle. A root gitignore rule excluded it, so plugin installs loaded the lifecycle hooks but never registered the MCP server.
 
 ### Changed
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,16 +1,14 @@
 # @mysten-incubation/memwal-mcp
 
-## 0.0.6
-
-### Fixed
-
-- Ship the plugin's `.mcp.json` in the marketplace bundle. A root gitignore rule excluded it, so plugin installs loaded the lifecycle hooks but never registered the MCP server.
-
 ## 0.0.5
 
 ### Added
 
 - **Automatic memory plugin** for Claude Code, Codex, Cursor, and Antigravity (`plugin/`): an installable plugin that bundles the MemWal MCP server with lifecycle hooks (SessionStart, UserPromptSubmit, PostToolUse) which remind the agent to recall relevant context and save durable facts on its own — no manual prompting. Install in Claude Code via `/plugin marketplace add` + `/plugin install memwal`; install in Codex via `node plugin/scripts/install_codex_hooks.mjs`.
+
+### Fixed
+
+- Ship the plugin's `.mcp.json` in the marketplace bundle. A root gitignore rule excluded it, so plugin installs loaded the lifecycle hooks but never registered the MCP server.
 
 ### Changed
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.6",
+    "version": "0.0.5",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/services/server/scripts/mcp/tools/analyze.ts
+++ b/services/server/scripts/mcp/tools/analyze.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
-import { wrapTool } from "./util.js";
+import { wrapTool, explorerFooter } from "./util.js";
 
 const ANALYZE_INPUT = {
     text: z
@@ -37,19 +37,20 @@ export function registerAnalyzeTool(
             });
             const lines = result.results.map(
                 (r, i) =>
-                    `${i + 1}. [${r.status}] ${
+                    `${i + 1}. [${r.status}]${r.blob_id ? ` blob_id=${r.blob_id}` : ""} ${
                         result.facts[i]?.text ?? "(unknown fact)"
                     }`
             );
             const summary = `Extracted ${result.facts.length} fact(s) — succeeded=${result.succeeded} failed=${result.failed}`;
+            const footer = result.succeeded > 0 ? `\n\n${explorerFooter()}` : "";
             return {
                 content: [
                     {
                         type: "text",
                         text:
                             lines.length > 0
-                                ? `${summary}\n\n${lines.join("\n")}`
-                                : summary,
+                                ? `${summary}\n\n${lines.join("\n")}${footer}`
+                                : `${summary}${footer}`,
                     },
                 ],
             };

--- a/services/server/scripts/mcp/tools/remember-bulk.ts
+++ b/services/server/scripts/mcp/tools/remember-bulk.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
-import { wrapTool } from "./util.js";
+import { wrapTool, explorerFooter } from "./util.js";
 
 const REMEMBER_BULK_INPUT = {
     facts: z
@@ -48,15 +48,16 @@ export function registerRememberBulkTool(
                 const err = r.error ? ` error=${r.error}` : "";
                 return `${i + 1}. [${r.status}]${blob}${err}${text ? ` — ${text}` : ""}`;
             });
-            const summary = `Saved ${result.succeeded}/${result.total} fact(s) to MemWal (failed=${result.failed}).`;
+            const summary = `Saved ${result.succeeded}/${result.total} fact(s) to Walrus Memory (failed=${result.failed}).`;
+            const footer = result.succeeded > 0 ? `\n\n${explorerFooter()}` : "";
             return {
                 content: [
                     {
                         type: "text",
                         text:
                             lines.length > 0
-                                ? `${summary}\n\n${lines.join("\n")}`
-                                : summary,
+                                ? `${summary}\n\n${lines.join("\n")}${footer}`
+                                : `${summary}${footer}`,
                     },
                 ],
             };

--- a/services/server/scripts/mcp/tools/remember.ts
+++ b/services/server/scripts/mcp/tools/remember.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
-import { wrapTool } from "./util.js";
+import { wrapTool, walruscanBlobUrl } from "./util.js";
 
 const REMEMBER_INPUT = {
     text: z
@@ -45,7 +45,7 @@ export function registerRememberTool(
                 content: [
                     {
                         type: "text",
-                        text: `Saved to MemWal. blob_id=${result.blob_id} namespace=${result.namespace}`,
+                        text: `Saved to Walrus Memory. blob_id=${result.blob_id} namespace=${result.namespace}\nExplorer: ${walruscanBlobUrl(result.blob_id)}`,
                     },
                 ],
             };

--- a/services/server/scripts/mcp/tools/util.ts
+++ b/services/server/scripts/mcp/tools/util.ts
@@ -4,7 +4,7 @@
 
 interface ToolResultLike {
     [x: string]: unknown;
-    content: Array<{ type: "text"; text: string; [x: string]: unknown }>;
+    content: Array<{ type: "text"; text: string;[x: string]: unknown }>;
     isError?: boolean;
 }
 
@@ -24,6 +24,24 @@ interface ToolResultLike {
  * failed")`) is logged to sidecar stderr for operators and appended to the
  * client-facing message so the agent has enough context to act.
  */
+/**
+ * Canonical Walruscan explorer URL for a blob. Built server-side so agents
+ * cite the real domain (walruscan.com) instead of guessing one.
+ */
+export function walruscanBlobUrl(blobId: string): string {
+    const network =
+        process.env.SUI_NETWORK === "testnet" ? "testnet" : "mainnet";
+    return `https://walruscan.com/${network}/blob/${blobId}`;
+}
+
+/**
+ * One-line footer for write-tool results. A function (not a module const) so
+ * SUI_NETWORK is read at call time, after the sidecar's env loading.
+ */
+export function explorerFooter(): string {
+    return `Explorer: ${walruscanBlobUrl("<blob_id>")} for any blob_id above.`;
+}
+
 export function wrapTool<Args>(
     handler: (args: Args) => Promise<ToolResultLike>
 ): (args: Args) => Promise<ToolResultLike> {
@@ -41,9 +59,9 @@ export function wrapTool<Args>(
             // Operator-side diagnostic — full chain to sidecar stderr.
             console.error(
                 `[mcp.tool.error] name=${name} msg=${msg}` +
-                    (cause
-                        ? ` cause_name=${cause?.constructor?.name} cause_msg=${cause?.message} cause_code=${cause?.code}`
-                        : "")
+                (cause
+                    ? ` cause_name=${cause?.constructor?.name} cause_msg=${cause?.message} cause_code=${cause?.code}`
+                    : "")
             );
 
             let prefix = "Tool error";


### PR DESCRIPTION
## Summary
WALM-113: polish the agent-facing setup skill and ground MCP tool results, driven by
community feedback (10+ minute setup, config-editing dead ends, agent-invented
backup sizes, hallucinated walruscan.io URL, abrupt post-setup ending). No auth
changes, no dashboard changes; the Node requirement stays for the stdio path.

### Setup skill (`apps/app/public/skills/setup`)
- Rule 1 now routes by client: ChatGPT (developer mode, supports custom headers)
  goes to the Remote MCP section; every other client uses the local stdio path
- Terminal-command-first rule: agents offer one paste-able command before raw
  JSON/TOML hand-editing
- Claude Desktop note: the Settings > Connectors UI is OAuth-only and does not
  work for Walrus Memory (prevents a dead end)
- Remote MCP section generalized: ChatGPT steps, self-serve credentials (the USER
  reads `~/.memwal/credentials.json` themselves; the agent never prints it), and
  the circular "suggest a local client" redirect is replaced with a terminal state
- Verify Tools starts with a `memwal_health` fast check
- Final Report: states that memory syncs automatically (no schedule to configure),
  offers starter prompts, and forbids inventing sizes or explorer links

### Sidecar tool results (`services/server/scripts/mcp/tools/`)
- `remember`/`remember_bulk`/`analyze` results now include the canonical
  `https://walruscan.com/<network>/blob/<id>` link (network from `SUI_NETWORK`),
  so agents cite a real URL instead of guessing walruscan.io
- `analyze` per-fact lines now include `blob_id`; "Saved to MemWal" renamed to
  "Saved to Walrus Memory"

### Version
- Revert 0.0.6 -> 0.0.5 across package + plugin manifests; the 0.0.6 changelog
  entry (ship plugin `.mcp.json`) is folded into 0.0.5. No stable 0.0.5/0.0.6 was
  ever published, so the future stable release ships everything as 0.0.5

## Notes for reviewers
- On merge, `release-mcp.yml` fires (path `packages/mcp/**`) and the npm `dev`
  dist-tag moves backwards from `0.0.6-dev.0` to `0.0.5-dev.1` (team-internal only)
- Claude Code plugin cache is version-keyed: anyone on cached plugin 0.0.6 should
  uninstall + reinstall once after merge
- Sidecar result-string changes ship with the next relayer deploy, not with npm

## Testing
- Sidecar test suite: 78/78 pass; tools module load-checked via tsx
- `walruscanBlobUrl`/`explorerFooter` verified for testnet/mainnet
- No `0.0.6` references remain in MCP manifests or changelogs
