### PR TITLE
docs(sdk): Cloudflare Workers guide + quickstart accountId safety callout

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
                 ]
               },
               "sdk/cookbook-multi-tenant",
+              "sdk/cloudflare-workers",
               "sdk/api-reference",
               "sdk/changelog"
             ]

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -130,12 +130,17 @@ The fastest way to get Walrus Memory running is through the TypeScript SDK.
     import { MemWal } from "@mysten-incubation/memwal";
 
     const memwal = MemWal.create({
-      key: "<your-ed25519-private-key>",
-      accountId: "<your-memwal-account-id>",
+      // Load your own credentials from the environment — don't hardcode an example ID.
+      key: process.env.MEMWAL_KEY ?? "<your-ed25519-private-key>",
+      accountId: process.env.MEMWAL_ACCOUNT_ID ?? "<your-memwal-account-id>",
       serverUrl: "https://relayer.memory.walrus.xyz",
       namespace: "my-app",
     });
     ```
+
+    <Warning>
+    Use the `accountId` **you** generated in the previous step. Recall is scoped per **account + namespace** — reusing an account ID copied from docs or another project puts your memories in a shared space instead of isolating them to you.
+    </Warning>
   </Step>
 
   <Step>

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -130,7 +130,7 @@ The fastest way to get Walrus Memory running is through the TypeScript SDK.
     import { MemWal } from "@mysten-incubation/memwal";
 
     const memwal = MemWal.create({
-      // Load your own credentials from the environment — don't hardcode an example ID.
+      // Load your own credentials from the environment; don't hardcode an example ID.
       key: process.env.MEMWAL_KEY ?? "<your-ed25519-private-key>",
       accountId: process.env.MEMWAL_ACCOUNT_ID ?? "<your-memwal-account-id>",
       serverUrl: "https://relayer.memory.walrus.xyz",
@@ -139,7 +139,7 @@ The fastest way to get Walrus Memory running is through the TypeScript SDK.
     ```
 
     <Warning>
-    Use the `accountId` **you** generated in the previous step. Recall is scoped per **account + namespace** — reusing an account ID copied from docs or another project puts your memories in a shared space instead of isolating them to you.
+    Use the `accountId` **you** generated in the previous step. Recall is scoped per **account + namespace**. Reusing an account ID copied from docs or another project puts your memories in a shared space instead of isolating them to you.
     </Warning>
   </Step>
 

--- a/docs/sdk/cloudflare-workers.md
+++ b/docs/sdk/cloudflare-workers.md
@@ -7,17 +7,17 @@ MemWal runs on the [Cloudflare Workers](https://developers.cloudflare.com/worker
 
 ## Required configuration
 
-The `@mysten-incubation/memwal` dependency tree (`@mysten/seal`, `@mysten/sui`, and others) relies on Node.js built-ins at runtime. Enable the Node.js compatibility flag in your `wrangler.toml`:
+The SDK relies on the Node.js `crypto` built-in (and `@mysten/seal` / `@mysten/sui` pull in more Node APIs). Enable the Node.js compatibility flag in your `wrangler.toml`:
 
 ```toml wrangler.toml
 compatibility_flags = ["nodejs_compat"]
 ```
 
-Without `nodejs_compat`, the dependency tree fails to resolve at runtime even though the Worker bundles successfully.
+Without `nodejs_compat` the build fails outright — `wrangler deploy` stops with `Could not resolve "crypto"` (the SDK calls `await import("crypto")` internally). Adding the flag resolves it.
 
 ## Bundle size
 
-Even the default `MemWal` client requires `@mysten/seal` and `@mysten/sui` as peer dependencies — it builds a SEAL session key on the client to authenticate each request — so it pulls in a sizeable dependency graph. A Worker bundling the default client lands around **~3 MB**. This is within Workers limits but worth knowing:
+Even the default `MemWal` client requires `@mysten/seal` and `@mysten/sui` as peer dependencies — it builds a SEAL session key on the client to authenticate each request — so it pulls in a sizeable dependency graph. A Worker bundling just the default client comes out to roughly **1.2 MB raw / ~225 KB gzipped** (measured with `wrangler deploy --dry-run`, `@mysten/sui` 2.x). That is comfortably within the Workers size limit, but worth knowing:
 
 - A single incompatible peer version can break the build for the **entire** Worker, not just the memory feature. Pin your `@mysten/*` versions and treat the memory dependency as a unit.
 - The default `@mysten-incubation/memwal` entry point is the lightest to bundle: the relayer handles embeddings and Walrus storage server-side, so the client only needs `@mysten/seal` + `@mysten/sui` (both required peers). The `@mysten-incubation/memwal/manual` entry point additionally pulls in `@mysten/walrus` and client-side encryption/upload, adding more to the bundle — prefer the default entry point on Workers unless you specifically need the manual flow.

--- a/docs/sdk/cloudflare-workers.md
+++ b/docs/sdk/cloudflare-workers.md
@@ -1,26 +1,27 @@
 ---
-title: "Cloudflare Workers"
-description: "Run MemWal on the Cloudflare Workers edge runtime — required flags, bundling notes, and a crash-isolation pattern."
+title: Cloudflare Workers
+description: Run MemWal on the Cloudflare Workers edge runtime, with required flags, bundling notes, and a crash-isolation pattern.
+keywords: [Cloudflare Workers, MemWal, SDK, nodejs_compat, bundle size, edge runtime, dynamic import]
 ---
 
 MemWal runs on the [Cloudflare Workers](https://developers.cloudflare.com/workers/) runtime, but the edge environment differs from Node.js in a few ways that affect bundling and reliability. This guide covers the configuration and patterns that make it work cleanly.
 
 ## Required configuration
 
-The SDK relies on the Node.js `crypto` built-in (and `@mysten/seal` / `@mysten/sui` pull in more Node APIs). Enable the Node.js compatibility flag in your `wrangler.toml`:
+The SDK relies on the Node.js `crypto` built-in, and `@mysten/seal` and `@mysten/sui` pull in more Node APIs. Enable the Node.js compatibility flag in your `wrangler.toml`:
 
 ```toml wrangler.toml
 compatibility_flags = ["nodejs_compat"]
 ```
 
-Without `nodejs_compat` the build fails outright — `wrangler deploy` stops with `Could not resolve "crypto"` (the SDK calls `await import("crypto")` internally). Adding the flag resolves it.
+Without `nodejs_compat` the build fails outright: `wrangler deploy` stops with `Could not resolve "crypto"` because the SDK calls `await import("crypto")` internally. Adding the flag resolves it.
 
 ## Bundle size
 
-Even the default `MemWal` client requires `@mysten/seal` and `@mysten/sui` as peer dependencies — it builds a SEAL session key on the client to authenticate each request — so it pulls in a sizeable dependency graph. A Worker bundling just the default client comes out to roughly **1.2 MB raw / ~225 KB gzipped** (measured with `wrangler deploy --dry-run`, `@mysten/sui` 2.x). That is comfortably within the Workers size limit, but worth knowing:
+Even the default `MemWal` client requires `@mysten/seal` and `@mysten/sui` as peer dependencies (it builds a SEAL session key on the client to authenticate each request), so it pulls in a sizeable dependency graph. A Worker bundling just the default client comes out to roughly **1.2 MB raw (around 225 KB gzipped)**, measured with `wrangler deploy --dry-run` against `@mysten/sui` 2.x. That is comfortably within the Workers size limit, but worth knowing:
 
 - A single incompatible peer version can break the build for the **entire** Worker, not just the memory feature. Pin your `@mysten/*` versions and treat the memory dependency as a unit.
-- The default `@mysten-incubation/memwal` entry point is the lightest to bundle: the relayer handles embeddings and Walrus storage server-side, so the client only needs `@mysten/seal` + `@mysten/sui` (both required peers). The `@mysten-incubation/memwal/manual` entry point additionally pulls in `@mysten/walrus` and client-side encryption/upload, adding more to the bundle — prefer the default entry point on Workers unless you specifically need the manual flow.
+- The default `@mysten-incubation/memwal` entry point is the lightest to bundle. The relayer handles embeddings and Walrus storage server-side, so the client only needs `@mysten/seal` and `@mysten/sui` (both required peers). The `@mysten-incubation/memwal/manual` entry point additionally pulls in `@mysten/walrus` and client-side encryption and upload, adding more to the bundle. Prefer the default entry point on Workers unless you specifically need the manual flow.
 
 ## Crash isolation with dynamic import
 
@@ -39,14 +40,16 @@ try {
 }
 ```
 
-Guard your read/write paths on `memwal` being non-null, and the rest of the Worker stays healthy regardless of the memory layer's state.
+Guard your read and write paths on `memwal` being non-null, and the rest of the Worker stays healthy regardless of the memory layer's state.
 
 <Note>
 The dynamic `import()` also keeps the heavy dependency graph out of your Worker's cold-start critical path until memory is actually needed.
 </Note>
 
-## Next Steps
+## Next steps
 
-- [Walrus Memory client](/sdk/usage/memwal) — the default relayer-backed client used above
-- [Public relayer](/relayer/public-relayer) — managed mainnet/testnet relayer endpoints
-- [API Reference](/sdk/api-reference) — full method signatures and config fields
+Continue with the client reference and relayer options used in the examples above:
+
+- [Walrus Memory client](/sdk/usage/memwal): the default relayer-backed client used above
+- [Public relayer](/relayer/public-relayer): managed Mainnet and Testnet relayer endpoints
+- [API Reference](/sdk/api-reference): full method signatures and config fields

--- a/docs/sdk/cloudflare-workers.md
+++ b/docs/sdk/cloudflare-workers.md
@@ -1,0 +1,52 @@
+---
+title: "Cloudflare Workers"
+description: "Run MemWal on the Cloudflare Workers edge runtime — required flags, bundling notes, and a crash-isolation pattern."
+---
+
+MemWal runs on the [Cloudflare Workers](https://developers.cloudflare.com/workers/) runtime, but the edge environment differs from Node.js in a few ways that affect bundling and reliability. This guide covers the configuration and patterns that make it work cleanly.
+
+## Required configuration
+
+The `@mysten-incubation/memwal` dependency tree (`@mysten/seal`, `@mysten/sui`, and others) relies on Node.js built-ins at runtime. Enable the Node.js compatibility flag in your `wrangler.toml`:
+
+```toml wrangler.toml
+compatibility_flags = ["nodejs_compat"]
+```
+
+Without `nodejs_compat`, the dependency tree fails to resolve at runtime even though the Worker bundles successfully.
+
+## Bundle size
+
+`@mysten-incubation/memwal` pulls in a large peer dependency graph. A Worker bundling the default `MemWal` client lands around **~3 MB**. This is within Workers limits but worth knowing:
+
+- A single incompatible peer version can break the build for the **entire** Worker, not just the memory feature. Pin your `@mysten/*` versions and treat the memory dependency as a unit.
+- The default `@mysten-incubation/memwal` entry point bundles most cleanly in edge runtimes because the relayer handles embeddings, SEAL, and storage server-side. The `@mysten-incubation/memwal/manual` entry point pulls in client-side SEAL and Walrus operations, adding significantly more to the bundle — prefer the default entry point on Workers unless you specifically need the manual flow.
+
+## Crash isolation with dynamic import
+
+To keep a MemWal bundling or runtime issue from taking down the rest of your agent, load it behind a defensive dynamic import and feature-flag it off when config is missing or the client fails to come up. This way the app keeps serving requests even if memory is unavailable for a cycle:
+
+```ts
+let memwal: any = null;
+
+try {
+  const mod = await import("@mysten-incubation/memwal");
+  memwal = mod.MemWal.create({ key, accountId, serverUrl, namespace });
+  await memwal.health();
+} catch (e) {
+  console.log("MemWal unavailable, degrading gracefully:", e);
+  memwal = null; // app keeps running without memory this cycle
+}
+```
+
+Guard your read/write paths on `memwal` being non-null, and the rest of the Worker stays healthy regardless of the memory layer's state.
+
+<Note>
+The dynamic `import()` also keeps the heavy dependency graph out of your Worker's cold-start critical path until memory is actually needed.
+</Note>
+
+## Next Steps
+
+- [Walrus Memory client](/sdk/usage/memwal) — the default relayer-backed client used above
+- [Public relayer](/relayer/public-relayer) — managed mainnet/testnet relayer endpoints
+- [API Reference](/sdk/api-reference) — full method signatures and config fields

--- a/docs/sdk/cloudflare-workers.md
+++ b/docs/sdk/cloudflare-workers.md
@@ -17,10 +17,10 @@ Without `nodejs_compat`, the dependency tree fails to resolve at runtime even th
 
 ## Bundle size
 
-`@mysten-incubation/memwal` pulls in a large peer dependency graph. A Worker bundling the default `MemWal` client lands around **~3 MB**. This is within Workers limits but worth knowing:
+Even the default `MemWal` client requires `@mysten/seal` and `@mysten/sui` as peer dependencies — it builds a SEAL session key on the client to authenticate each request — so it pulls in a sizeable dependency graph. A Worker bundling the default client lands around **~3 MB**. This is within Workers limits but worth knowing:
 
 - A single incompatible peer version can break the build for the **entire** Worker, not just the memory feature. Pin your `@mysten/*` versions and treat the memory dependency as a unit.
-- The default `@mysten-incubation/memwal` entry point bundles most cleanly in edge runtimes because the relayer handles embeddings, SEAL, and storage server-side. The `@mysten-incubation/memwal/manual` entry point pulls in client-side SEAL and Walrus operations, adding significantly more to the bundle — prefer the default entry point on Workers unless you specifically need the manual flow.
+- The default `@mysten-incubation/memwal` entry point is the lightest to bundle: the relayer handles embeddings and Walrus storage server-side, so the client only needs `@mysten/seal` + `@mysten/sui` (both required peers). The `@mysten-incubation/memwal/manual` entry point additionally pulls in `@mysten/walrus` and client-side encryption/upload, adding more to the bundle — prefer the default entry point on Workers unless you specifically need the manual flow.
 
 ## Crash isolation with dynamic import
 

--- a/docs/sdk/quick-start.md
+++ b/docs/sdk/quick-start.md
@@ -93,14 +93,14 @@ Before wiring the SDK into your app:
 ## First Memory
 
 <Warning>
-**Use your own account, not an example one.** Generate your own `accountId` and delegate key at [memory.walrus.xyz](https://memory.walrus.xyz) before running. Recall is scoped per **account + namespace**, so writing against an account ID copied from docs or another project means your memories land in — and are readable from — a shared space instead of being isolated to you. The values below are placeholders; replace them with your own.
+**Use your own account, not an example one.** Generate your own `accountId` and delegate key at [memory.walrus.xyz](https://memory.walrus.xyz) before running. Recall is scoped per **account + namespace**, so writing against an account ID copied from docs or another project means your memories land in a shared space that everyone using it can read, instead of being isolated to you. The values below are placeholders; replace them with your own.
 </Warning>
 
 ```ts
 import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
-  // Load your own credentials from the environment — never hardcode a shared example ID.
+  // Load your own credentials from the environment; never hardcode a shared example ID.
   key: process.env.MEMWAL_KEY ?? "<your-ed25519-private-key>",
   accountId: process.env.MEMWAL_ACCOUNT_ID ?? "<your-memwal-account-id>",
   serverUrl: "https://your-relayer-url.com",

--- a/docs/sdk/quick-start.md
+++ b/docs/sdk/quick-start.md
@@ -92,12 +92,17 @@ Before wiring the SDK into your app:
 
 ## First Memory
 
+<Warning>
+**Use your own account, not an example one.** Generate your own `accountId` and delegate key at [memory.walrus.xyz](https://memory.walrus.xyz) before running. Recall is scoped per **account + namespace**, so writing against an account ID copied from docs or another project means your memories land in — and are readable from — a shared space instead of being isolated to you. The values below are placeholders; replace them with your own.
+</Warning>
+
 ```ts
 import { MemWal } from "@mysten-incubation/memwal";
 
 const memwal = MemWal.create({
-  key: "<your-ed25519-private-key>",
-  accountId: "<your-memwal-account-id>",
+  // Load your own credentials from the environment — never hardcode a shared example ID.
+  key: process.env.MEMWAL_KEY ?? "<your-ed25519-private-key>",
+  accountId: process.env.MEMWAL_ACCOUNT_ID ?? "<your-memwal-account-id>",
   serverUrl: "https://your-relayer-url.com",
   namespace: "demo",
 });


### PR DESCRIPTION
Addresses two docs issues reported by @DCSteve96.

## Closes #255 — example accountId easy to copy by mistake
- The concrete shared id (`0x2344…756da`) is already gone from the repo; what was missing was an explicit safety guardrail.
- Added a `<Warning>` to both `docs/sdk/quick-start.md` and `docs/getting-started/quick-start.md`: use **your own** account, and recall is scoped per **account + namespace** so a copied ID lands memories in a shared, mutually-readable space.
- Snippets now use the env-var fallback pattern: `process.env.MEMWAL_ACCOUNT_ID ?? "<your-memwal-account-id>"`.

## Closes #256 — Cloudflare Workers guide
New `docs/sdk/cloudflare-workers.md` (registered in the SDK nav), covering the reporter's working setup:
- Required `compatibility_flags = ["nodejs_compat"]`.
- Expected bundle size (~3 MB) and the single-bad-peer-version caveat.
- Which entry point bundles cleanest on edge (default `@mysten-incubation/memwal` vs `/manual`).
- The defensive dynamic-import / graceful-degradation pattern for crash isolation.

## Notes
- Docs-only change. `docs.json` validated as valid JSON.