### PR TITLE
docs(sdk): document silent truncation at recall() default limit

### DIFF
--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -83,6 +83,8 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 
 - Preferred form: `recall({ query, limit?, topK?, namespace?, maxDistance? })`
 - `limit` defaults to `10`; `topK` is an alias and wins when both are set
+
+> ⚠️ **Truncation is silent.** The response carries no "more results" indicator. If `results.length === limit`, assume more matches exist and retry with a higher `limit`. Reads that need completeness — leaderboards, accuracy/score computations, deduplication — should not rely on the default of 10.
 - Legacy positional forms still work: `recall(query)`, `recall(query, limit)`, `recall(query, limit, namespace)`, and `recall(query, options)`
 - `maxDistance` filters weak matches client-side by dropping results where `distance >= maxDistance`
 

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -84,7 +84,7 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 - Preferred form: `recall({ query, limit?, topK?, namespace?, maxDistance? })`
 - `limit` defaults to `10`; `topK` is an alias and wins when both are set
 
-> ⚠️ **Truncation is silent.** The response carries no "more results" indicator. If `results.length === limit`, assume more matches exist and retry with a higher `limit`. Reads that need completeness — leaderboards, accuracy/score computations, deduplication — should not rely on the default of 10.
+> ⚠️ **Truncation is silent.** The response carries no *more results* indicator. If `results.length === limit`, assume more matches exist and retry with a higher `limit`. Reads that need completeness (leaderboards, accuracy computations, deduplication) should not rely on the default of 10.
 - Legacy positional forms still work: `recall(query)`, `recall(query, limit)`, `recall(query, limit, namespace)`, and `recall(query, options)`
 - `maxDistance` filters weak matches client-side by dropping results where `distance >= maxDistance`
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -66,7 +66,14 @@ export interface RecallResult {
 
 /** Options for recall(). */
 export interface RecallOptions {
-    /** Max number of nearest memories to request from the relayer (default: 10). */
+    /**
+     * Max number of nearest memories to request from the relayer (default: 10).
+     *
+     * NOTE: results are silently capped at this value — the response carries no
+     * "truncated" flag. If `results.length === limit`, more matches likely exist:
+     * raise the limit for completeness-critical reads (leaderboards, accuracy
+     * computations, deduplication passes).
+     */
     limit?: number;
     /** Alias for limit, useful when describing top-K search behaviour. */
     topK?: number;


### PR DESCRIPTION
Addresses #271 (docs side).

`recall()` defaults to `limit: 10` and truncates silently — the response carries no flag, and `total` can't serve as one (after the client-side `maxDistance` filter it mirrors `results.length`). Until the API can signal truncation, this labels the foot-gun where developers meet it: JSDoc on `RecallOptions.limit` and a warning callout in the SDK API reference.

Real-world impact: our Session 4 agent (Kairos · World Cup) computed wrong accuracy stats because a prediction-history recall was capped at 10 with no indication.

Happy to mirror the note in the Python SDK docs if useful.