### PR TITLE
Fix: Publish workspace packages with pnpm (backport to staging)

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -79,7 +79,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           npm view @mysten-incubation/memwal-mcp@$VERSION version 2>/dev/null \
             && echo "Version $VERSION already published, skipping" && echo "published=false" >> $GITHUB_OUTPUT && exit 0
-          cd packages/mcp && npm publish --provenance --access public
+          cd packages/mcp && pnpm publish --provenance --access public --no-git-checks
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -126,7 +126,7 @@ jobs:
           echo "Publishing @mysten-incubation/memwal-mcp@${NEW_VERSION}"
           cd packages/mcp
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag rc --provenance --access public
+          pnpm publish --tag rc --provenance --access public --no-git-checks
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
@@ -148,4 +148,4 @@ jobs:
           echo "Publishing @mysten-incubation/memwal-mcp@${NEW_VERSION}"
           cd packages/mcp
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag dev --provenance --access public
+          pnpm publish --tag dev --provenance --access public --no-git-checks

--- a/.github/workflows/release-oc-memwal.yml
+++ b/.github/workflows/release-oc-memwal.yml
@@ -77,7 +77,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           npm view @mysten-incubation/oc-memwal@$VERSION version 2>/dev/null \
             && echo "Version $VERSION already published, skipping" && echo "published=false" >> $GITHUB_OUTPUT && exit 0
-          cd packages/openclaw-memory-memwal && npm publish --provenance --access public
+          cd packages/openclaw-memory-memwal && pnpm publish --provenance --access public --no-git-checks
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -123,7 +123,7 @@ jobs:
           echo "Publishing @mysten-incubation/oc-memwal@${NEW_VERSION}"
           cd packages/openclaw-memory-memwal
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag rc --provenance --access public
+          pnpm publish --tag rc --provenance --access public --no-git-checks
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
@@ -144,4 +144,4 @@ jobs:
           echo "Publishing @mysten-incubation/oc-memwal@${NEW_VERSION}"
           cd packages/openclaw-memory-memwal
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag dev --provenance --access public
+          pnpm publish --tag dev --provenance --access public --no-git-checks

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -76,7 +76,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           npm view @mysten-incubation/memwal@$VERSION version 2>/dev/null \
             && echo "Version $VERSION already published, skipping" && echo "published=false" >> $GITHUB_OUTPUT && exit 0
-          cd packages/sdk && npm publish --provenance --access public
+          cd packages/sdk && pnpm publish --provenance --access public --no-git-checks
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -123,7 +123,7 @@ jobs:
           echo "Publishing @mysten-incubation/memwal@${NEW_VERSION}"
           cd packages/sdk
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag rc --provenance --access public
+          pnpm publish --tag rc --provenance --access public --no-git-checks
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
@@ -144,4 +144,4 @@ jobs:
           echo "Publishing @mysten-incubation/memwal@${NEW_VERSION}"
           cd packages/sdk
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag dev --provenance --access public
+          pnpm publish --tag dev --provenance --access public --no-git-checks

--- a/packages/openclaw-memory-memwal/CHANGELOG.md
+++ b/packages/openclaw-memory-memwal/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @mysten-incubation/oc-memwal
 
+## 0.0.5
+
+### Patch Changes
+
+- Fix unresolvable `workspace:*` dependency in the published package. The release
+  workflow used `npm publish`, which ships `package.json` verbatim and cannot
+  rewrite the `workspace:` protocol, so the published artifact carried
+  `"@mysten-incubation/memwal": "workspace:*"` and failed to install outside the
+  monorepo (`Unsupported URL Type 'workspace:'`). Switched the release workflows
+  to `pnpm publish`, which rewrites `workspace:*` to the concrete dependency
+  version at pack time.
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/openclaw-memory-memwal/package.json
+++ b/packages/openclaw-memory-memwal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysten-incubation/oc-memwal",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "description": "NemoClaw/OpenClaw memory plugin — encrypted, decentralized long-term memory via Walrus Memory",
   "license": "Apache-2.0",


### PR DESCRIPTION
Backport of #280 to `staging`.

Switches the release workflows from `npm publish` to `pnpm publish`, which resolves the `workspace:*` protocol at pack time (fixes #279). Also brings the oc-memwal base version to `0.0.5` so staging prereleases track `0.0.5-rc.N`.

Already merged to `main` and published as `0.0.5` (`latest`). Cherry-pick of 2365ed8b.

On merge, staging will publish a corrected `0.0.5-rc.0` prerelease.