### PR TITLE
feat: label delegate public key as Agent ID and document it

### DIFF
--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -174,7 +174,7 @@ function DelegateKeySkeletonList() {
                     <tr>
                         <th scope="col" className="dashboard-key-table-select">Select</th>
                         <th scope="col">Key name</th>
-                        <th scope="col">Public key</th>
+                        <th scope="col">Public key (Agent ID)</th>
                         <th scope="col">Created</th>
                         <th scope="col" className="dashboard-key-table-actions">Actions</th>
                     </tr>
@@ -977,7 +977,7 @@ const result = await generateText({
 
                         <div className="dashboard-credential-row">
                             <div className="dashboard-credential-main">
-                                <div className="dashboard-credential-label">Delegate public key</div>
+                                <div className="dashboard-credential-label">Delegate public key (Agent ID)</div>
                                 <code className="dashboard-credential-value">{delegatePublicKey}</code>
                             </div>
                             <div className="dashboard-credential-actions">
@@ -1208,7 +1208,7 @@ const result = await generateText({
                                     <tr>
                                         <th scope="col" className="dashboard-key-table-select">Select</th>
                                         <th scope="col">Key name</th>
-                                        <th scope="col">Public key</th>
+                                        <th scope="col">Public key (Agent ID)</th>
                                         <th scope="col">Created</th>
                                         <th scope="col" className="dashboard-key-table-actions">Actions</th>
                                     </tr>
@@ -1241,7 +1241,7 @@ const result = await generateText({
                                                         {isCurrentKey && <span className="dashboard-key-current-badge">current</span>}
                                                     </div>
                                                 </td>
-                                                <td data-label="Public key">
+                                                <td data-label="Public key (Agent ID)">
                                                     <code className="dashboard-key-public" title={k.publicKey}>
                                                         {compactPublicKey(k.publicKey)}
                                                     </code>
@@ -1254,8 +1254,8 @@ const result = await generateText({
                                                         <button
                                                             className={`btn btn-secondary btn-sm dashboard-key-icon-action${copied === copyPublicKeyLabel ? ' dashboard-key-icon-action--copied' : ''}`}
                                                             onClick={() => copyToClipboard(k.publicKey, copyPublicKeyLabel)}
-                                                            aria-label={copied === copyPublicKeyLabel ? 'Public key copied' : 'Copy public key'}
-                                                            title={copied === copyPublicKeyLabel ? 'Copied' : 'Copy public key'}
+                                                            aria-label={copied === copyPublicKeyLabel ? 'Agent ID copied' : 'Copy Agent ID (public key)'}
+                                                            title={copied === copyPublicKeyLabel ? 'Copied' : 'Copy Agent ID (public key)'}
                                                         >
                                                             <Copy size={14} />
                                                         </button>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,7 @@
             "pages": [
               "getting-started/what-is-memwal",
               "getting-started/quick-start",
+              "getting-started/find-your-agent-id",
               "getting-started/choose-your-path",
               "examples/example-apps"
             ]

--- a/docs/getting-started/find-your-agent-id.md
+++ b/docs/getting-started/find-your-agent-id.md
@@ -1,0 +1,66 @@
+---
+title: "Find Your Agent ID"
+description: "Your Agent ID is your delegate public key. Find and copy it from the dashboard, the MCP credential file, or the SDK."
+keywords:
+  - agent id
+  - MEMWAL_AGENT_ID
+  - delegate public key
+  - memwal_agent_id
+  - follow activity
+  - beta testing
+---
+
+Your **Agent ID** is your **delegate public key**: a hex-encoded Ed25519 public key (64 hex characters). Every memory you create is stamped on-chain with this value under the `memwal_agent_id` key, so an Agent ID is the stable identifier for the agent that wrote a memory.
+
+<Note>
+Each delegate key has its own Agent ID. An account can hold more than one delegate key, so it can have more than one Agent ID. Share the Agent ID for the key your app is configured with.
+</Note>
+
+## Find your Agent ID on the dashboard
+
+The dashboard is the fastest way to collect your Agent ID.
+
+<Steps>
+  <Step>
+    Open the [Walrus Memory dashboard](https://memory.walrus.xyz/dashboard) and connect the wallet that owns your account.
+  </Step>
+  <Step>
+    Go to the **Delegate keys** section. Each row is one delegate key.
+  </Step>
+  <Step>
+    The **Public key (Agent ID)** column holds your Agent ID. Use the copy button on the row to copy the full value. The displayed value is shortened for readability, but the copy button always copies the complete key.
+  </Step>
+</Steps>
+
+## Other ways to find your Agent ID
+
+### MCP and CLI clients
+
+The stdio MCP package stores your credentials at `~/.memwal/credentials.json`. The **delegate public key** field in that file is your Agent ID. See the [MCP reference](/mcp/reference) for the full list of stored fields.
+
+### SDK
+
+Both SDKs return the Agent ID for the current delegate key.
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```ts
+    const agentId = memwal.getPublicKeyHex();
+    console.log(agentId);
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```py
+    agent_id = memwal.get_public_key_hex()
+    print(agent_id)
+    ```
+  </Tab>
+</Tabs>
+
+## Why the Agent ID matters
+
+Because every memory blob is tagged on-chain with `memwal_agent_id`, the Agent ID lets you and the Walrus Memory team attribute and follow the activity tied to a given delegate key. During beta testing, share your Agent ID with the team so they can follow your activity.
+
+<Note>
+The Agent ID is your delegate **public** key, so it is safe to share. Never share your delegate **private** key (`MEMWAL_PRIVATE_KEY`). Anyone who holds the private key can act as your agent until you revoke it.
+</Note>

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -104,6 +104,10 @@ The fastest way to get Walrus Memory running is through the TypeScript SDK.
     | **Walrus Memory Playground** | [memory.walrus.xyz](https://memory.walrus.xyz) |
 
     For the contract-based setup flow, see [Delegate Key Management](/contract/delegate-key-management) and [Walrus Memory smart contract](/contract/overview).
+
+    <Note>
+    Your delegate public key is also your **Agent ID** (`MEMWAL_AGENT_ID`). To collect it later, see [Find Your Agent ID](/getting-started/find-your-agent-id).
+    </Note>
   </Step>
 
   <Step>


### PR DESCRIPTION
## Summary
Make the delegate public key easy to find and collect as the Agent ID (MEMWAL_AGENT_ID).

## Changes
- Dashboard: label the delegate public key as Agent ID (Delegate keys table column and SDK credentials row), with a "What is this?" link to docs. Existing copy buttons copy the full key.
- Docs: add a "Find Your Agent ID" guide covering the dashboard, the MCP credentials file, and the SDK; wire it into nav and link it from Quick Start.

## Notes
- Agent ID is the delegate public key, stamped on-chain as `memwal_agent_id` on every memory blob.