### PR TITLE
docs: use canonical MystenLabs/MemWal GitHub URL

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "CommandOSSLabs/MemWal" }
+    { "repo": "MystenLabs/MemWal" }
   ],
   "commit": true,
   "fixed": [],

--- a/SKILL.md
+++ b/SKILL.md
@@ -581,6 +581,6 @@ If you're writing user-facing copy, prefer "Walrus Memory". If you're writing an
 
 - **Docs**: https://memory.walrus.xyz
 - **SDK on npm**: https://www.npmjs.com/package/@mysten-incubation/memwal
-- **GitHub**: https://github.com/CommandOSSLabs/MemWal
+- **GitHub**: https://github.com/MystenLabs/MemWal
 - **Dashboard**: https://memory.walrus.xyz
 - **llms.txt**: https://docs.wal.app/walrus-memory/llms.txt

--- a/docs/contributing/run-repo-locally.md
+++ b/docs/contributing/run-repo-locally.md
@@ -18,7 +18,7 @@ If you only work on TypeScript apps or docs, you don't need Rust.
 ## Step 1 — Clone and Install
 
 ```bash
-git clone https://github.com/CommandOSSLabs/MemWal.git
+git clone https://github.com/MystenLabs/MemWal.git
 cd MemWal
 pnpm install
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -462,5 +462,5 @@ MEMWAL_REGISTRY_ID=0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75
 
 - **Docs**: https://docs.wal.app/walrus-memory/getting-started/what-is-memwal
 - **SDK on npm**: https://www.npmjs.com/package/@mysten-incubation/memwal
-- **GitHub**: https://github.com/CommandOSSLabs/MemWal
+- **GitHub**: https://github.com/MystenLabs/MemWal
 - **Dashboard**: https://memory.walrus.xyz


### PR DESCRIPTION
## What

Replace stale `CommandOSSLabs/MemWal` GitHub links with the canonical `MystenLabs/MemWal` across the skill and docs.

## Why

The repo was transferred `CommandOSSLabs/MemWal` → `MystenLabs/MemWal`. The old URL still **redirects**, so nothing is broken, but `origin` and `packages/sdk/package.json` already use the MystenLabs name — these were just missed in the WALM-84 domain migration.

## Changes

| File | Change |
|---|---|
| `SKILL.md` | GitHub link in Links section |
| `docs/llms-full.txt` | GitHub link in Links section |
| `docs/contributing/run-repo-locally.md` | `git clone` URL |
| `.changeset/config.json` | `changelog-github` `repo` (so generated changelog PR/commit links resolve to the canonical repo) |

Docs/links only — no code or behavior change.

## Out of scope (noted, not fixed here)

While reviewing the `MystenLabs/walrus-skills` `walrus-memory` skill against this source, its `mcp.md` lists "six built-in tools" but the live set is **8** (the stdio bridge proxies the relayer `tools/list` + splices `login`/`logout`) — missing `memwal_remember_bulk` and `memwal_health`. That fix belongs in the walrus-skills repo.