### PR TITLE
docs: how an agent funds Walrus storage (WAL or sponsored) [BEDU-602]

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,6 +64,7 @@
             "pages": [
               "fundamentals/architecture/core-components",
               "fundamentals/architecture/how-storage-works",
+              "fundamentals/architecture/funding-storage",
               "fundamentals/architecture/data-flow-security-model"
             ]
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -206,6 +206,17 @@
         ]
       },
       {
+        "tab": "Troubleshooting",
+        "groups": [
+          {
+            "group": "Troubleshooting",
+            "pages": [
+              "troubleshooting/overview"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Contributing",
         "groups": [
           {

--- a/docs/fundamentals/architecture/funding-storage.md
+++ b/docs/fundamentals/architecture/funding-storage.md
@@ -1,0 +1,129 @@
+---
+title: "How an Agent Funds Walrus Storage"
+description: "How an autonomous agent pays for Walrus storage, either by holding WAL directly or through sponsored storage such as the relayer."
+---
+
+Walrus Memory writes your encrypted memories to Walrus as blobs, as described in [How Storage Works](/fundamentals/architecture/how-storage-works). Someone has to pay for that storage. This page explains who, and the trade-offs between an agent holding WAL itself and having a third party sponsor the cost.
+
+<Note>
+In a typical Walrus Memory setup, the relayer operates the Walrus write path for you, so most agents never touch WAL directly. Whether the storage is sponsored or self-funded then depends on how the relayer is deployed: a [public relayer](/relayer/public-relayer) abstracts funding away from the agent, while [self-hosting](/relayer/self-hosting) means you fund the writes. The models below explain what sits underneath either choice.
+</Note>
+
+## What a write costs: 2 tokens, not 1
+
+A Walrus write consumes 2 different tokens, and any funding design accounts for both:
+
+- **WAL:** Pays for storage. You pay per encoded storage unit per epoch, plus a one-time write fee for each blob. Walrus prices storage at a fixed fiat rate (about 0.023 USD per GB per month) and adjusts the WAL amount automatically as the WAL price changes. The smallest unit of WAL is FROST, where 1 WAL equals 1 billion FROST.
+- **SUI:** Pays gas for the Sui transactions that coordinate the write, such as `reserve_space`, `register_blob`, and `certify_blob`, plus any later `extend`, `delete`, or `burn`. The smallest unit of SUI is MIST, where 1 SUI equals 1 billion MIST.
+
+WAL cost scales with blob size and the number of epochs. SUI gas stays roughly fixed for each transaction. A typical store runs as 2 transactions: one for `reserve_space` and `register_blob`, which changes both your SUI and WAL balances, and one for `certify_blob`, which changes only your SUI balance.
+
+<Note>
+The funding question is really 2 questions: who supplies the WAL, and who supplies the SUI gas. Different sponsored mechanisms cover different halves, so be explicit about which part a given mechanism handles.
+</Note>
+
+A successful write also produces a `Blob` object on Sui. Whoever owns that object controls the blob lifecycle, such as extending its lifetime, deleting it, adding attributes, or burning it to reclaim Sui storage. Ownership matters as much as payment, so track it deliberately, especially in sponsored flows.
+
+## Model A: the agent holds WAL directly
+
+The agent has its own Sui address (key pair) that holds both SUI and WAL, and it signs and pays for its own writes. This is the default model for a long-lived, autonomous agent that owns and manages its own data.
+
+Store through the CLI:
+
+```bash
+$ walrus store memory.json --epochs 10
+```
+
+Store through the TypeScript SDK, where the agent's key pair is the `signer` that pays both gas and storage fees:
+
+```ts
+await client.walrus.writeFiles({
+  files: [file],
+  epochs: 10,
+  deletable: true,
+  signer: keypair, // must hold enough SUI for gas and enough WAL for storage and the write fee
+});
+```
+
+The agent's address needs WAL before it can write. The most basic path swaps SUI for WAL onchain:
+
+```bash
+$ walrus get-wal --amount AMOUNT_IN_FROST
+```
+
+You can also receive WAL through a transfer from another wallet, a bridge, or an exchange. On Testnet, WAL has no value and you obtain it 1:1 from Testnet SUI, which makes this model easy to develop against before any real funding exists.
+
+This model gives the agent full autonomy, because no external service sits in the write path, and the agent owns the resulting `Blob` object outright, so it can extend, delete, or burn it at any time. In exchange, the agent takes on 2 responsibilities:
+
+- Keep both balances funded. Running out of either SUI or WAL stalls writes.
+- Manage the blob lifecycle. Blobs expire after the paid number of epochs (an epoch is about 2 weeks on Mainnet and about 1 day on Testnet, and you can buy up to about 2 years in advance), so the agent extends them before expiry or the network drops the data.
+
+## Model B: sponsored storage
+
+Sponsored storage is not a single feature. Several distinct patterns exist, and they sponsor different parts of the cost. Choose based on how much you want the agent to hold and own.
+
+### Publisher: sponsor pays WAL and SUI
+
+A publisher is an HTTP service that accepts raw bytes and runs the entire write flow for the caller. Its sub-wallets hold SUI and WAL and pay for everything, so the agent needs no tokens at all and only sends the data. A Walrus Memory relayer plays this role for your memories.
+
+- This is the most complete form of sponsorship, because the sponsoring application carries 100% of the WAL and SUI cost.
+- By default, the publisher's sub-wallet owns the resulting `Blob` object. To let the agent keep ownership, set the publisher's `send-object-to` parameter to the agent's Sui address so the publisher transfers the blob after upload.
+
+<Warning>
+Mainnet has no public, unauthenticated publisher, because each upload spends the operator's real WAL and SUI. In production, this is a private, authenticated publisher that the sponsoring application runs and gates for its own agents.
+</Warning>
+
+Use a publisher when the agent runs in a constrained or untrusted environment, or when you do not want the agent to custody tokens.
+
+### Sui sponsored transactions: sponsor pays SUI gas only
+
+Sui natively supports sponsored transactions, where a sponsor account provides the gas coin for a transaction the agent signs. This covers only the SUI side. The WAL storage fee still comes from somewhere else, either the agent's own WAL or a publisher.
+
+Use sponsored transactions when the agent can hold WAL but you do not want it to manage SUI gas, for example when a separate service handles all gas.
+
+### Pre-funding: transfer WAL or storage resources
+
+Because WAL is a coin and storage resources are transferable Sui objects, a sponsor can fund an agent ahead of time without sitting in the write path:
+
+- Send WAL to the agent's address, and the agent then writes through Model A.
+- Buy storage resources in bulk and transfer them to the agent. You can split, merge, transfer, and even trade storage resources on marketplaces. The agent then pays only SUI gas to call `register_blob` and `certify_blob` against pre-bought capacity. Buying larger resources once and splitting them amortizes gas, which suits predictable, high-volume agents.
+
+Use pre-funding for fleets of agents or batch workloads where a treasury provisions capacity centrally.
+
+### What an upload relay does not do
+
+An upload relay is easy to mistake for a sponsor, but it is not one. A relay only distributes the encoded slivers to storage nodes for the client, which helps in browser, mobile, or edge environments where opening thousands of connections is impractical. The agent still registers and certifies the blob onchain and still pays the WAL and SUI. A relay can also charge a tip, configured as `const` (a flat amount for each blob) or `linear` (an amount that scales with blob size), paid in MIST or WAL.
+
+In short, an upload relay reduces the agent's network load, not its funding load. Do not confuse a Walrus upload relay with the Walrus Memory relayer: the Walrus Memory relayer runs the full write flow and can fund it, while a bare Walrus upload relay only forwards slivers.
+
+### Protocol subsidies are network-level, not per-agent
+
+Walrus reserves a portion of WAL supply as subsidies that supplement storage-node rewards while the network grows. This lowers effective costs across the whole network, but it is not a way for one party to fund a specific agent's blob. Do not model subsidies as sponsored storage in your architecture.
+
+## Choose a model
+
+| **If the agent** | **Use** | **Pays WAL** | **Pays SUI gas** | **Owns the blob** |
+| --- | --- | --- | --- | --- |
+| Is long-lived, owns its data, and manages its own lifecycle | Hold WAL directly | Agent | Agent | Agent |
+| Holds no tokens, such as in a browser or untrusted environment | Publisher or relayer | Sponsor | Sponsor | Sponsor, unless you set `send-object-to` the agent |
+| Holds WAL but should not manage gas | Sui sponsored transactions | Agent | Sponsor | Agent |
+| Is one of many, funded from a central treasury | Pre-funded WAL or storage resources | Sponsor (upfront) | Agent | Agent |
+| Needs help distributing slivers and still self-funds | Upload relay | Agent | Agent | Agent |
+
+## Operate an agent that funds its own storage
+
+- Watch both balances. Monitor SUI and WAL together, because running dry on either blocks writes. The publisher reference design keeps each sub-wallet between 0.5 and 1.0 SUI and WAL in steady state with an automatic refill loop, which is a good pattern to copy for any self-funded agent.
+- Plan for expiry. Blobs live only for the epochs you pay for. An agent that needs durable memory runs an extend-before-expiry loop, or hands that responsibility to its sponsor.
+- Track ownership. Whoever owns the `Blob` object controls extend and delete. In sponsored uploads, confirm the object lands at the agent's address through `send-object-to` if the agent is meant to manage it.
+- Estimate before you spend. The `walrus info` command shows current storage and write prices, and `walrus store --dry-run` reports the encoded size used for the WAL cost. Neither command submits a transaction.
+- Develop on Testnet first. Free Testnet WAL that you swap 1:1 from Testnet SUI lets you exercise the full funding and lifecycle flow before you connect real treasury funds. Testnet might wipe data and uses 1-day epochs.
+
+## Related links
+
+- [How Storage Works](/fundamentals/architecture/how-storage-works)
+- [Public relayer](/relayer/public-relayer)
+- [Self-hosting the relayer](/relayer/self-hosting)
+- [Walrus storage costs](https://docs.wal.app/docs/system-overview/storage-costs)
+- [Walrus network reference](https://docs.wal.app/docs/network-reference)
+- [Walrus upload relay](https://docs.wal.app/operator-guide/upload-relay.html)
+- [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus)

--- a/docs/fundamentals/architecture/funding-storage.md
+++ b/docs/fundamentals/architecture/funding-storage.md
@@ -1,6 +1,7 @@
 ---
 title: "How an Agent Funds Walrus Storage"
 description: "How an autonomous agent pays for Walrus storage, either by holding WAL directly or through sponsored storage such as the relayer."
+keywords: [funding, WAL, SUI, gas, sponsored storage, publisher, storage resources, upload relay, blob lifecycle, autonomous agent, MemWal, Walrus]
 ---
 
 Walrus Memory writes your encrypted memories to Walrus as blobs, as described in [How Storage Works](/fundamentals/architecture/how-storage-works). Someone has to pay for that storage. This page explains who, and the trade-offs between an agent holding WAL itself and having a third party sponsor the cost.
@@ -125,5 +126,5 @@ Walrus reserves a portion of WAL supply as subsidies that supplement storage-nod
 - [Self-hosting the relayer](/relayer/self-hosting)
 - [Walrus storage costs](https://docs.wal.app/docs/system-overview/storage-costs)
 - [Walrus network reference](https://docs.wal.app/docs/network-reference)
-- [Walrus upload relay](https://docs.wal.app/operator-guide/upload-relay.html)
+- [Walrus upload relay](https://docs.wal.app/docs/operator-guide/upload-relay)
 - [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus)

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -1,0 +1,151 @@
+---
+title: Troubleshooting and FAQ
+description: Resolve common Walrus Memory problems, including delegate-key authentication errors, MCP connection issues, and save timeouts.
+keywords: [Walrus Memory, MemWal, troubleshooting, AUTH_REJECTED, delegate key, MCP, timeout, memwal_analyze]
+---
+
+<!--
+Source: BEDU-612, seeded from a Walrus Memory Discord support thread.
+The 401 reporter self-resolved without recording the exact fix, so the AUTH_REJECTED
+entry documents all known causes from the authentication model rather than a single
+confirmed one. Confirm the specific fix with the reporter before treating that entry
+as final. Grounded in: contract/delegate-key-management, relayer/api-reference,
+sdk/api-reference, mcp/reference, getting-started/quick-start.
+-->
+
+This page collects the support questions that come up most often and the fastest way to resolve each one. Every entry lists the symptom you observe, the cause behind it, and the fix to apply.
+
+If your issue is not here, set `MEMWAL_MCP_DEBUG=1` for the Model Context Protocol (MCP) server, or enable `debug` in the SDK configuration, to get verbose logs, then open an issue on the repository with that output.
+
+## How authentication works
+
+Read this section first, because most authentication problems make sense once the model is clear. Walrus Memory does not use your owner wallet for day-to-day calls. Instead:
+
+1. You generate a delegate key pair, an Ed25519 key, for example from the [Walrus Memory dashboard](https://memory.walrus.xyz).
+2. The account owner registers the delegate public key onchain in your `MemWalAccount`. See [Delegate Key Management](/contract/delegate-key-management).
+3. The SDK or MCP client signs each request with the delegate private key.
+4. On every request, the relayer verifies the signature, then looks up that public key in your account's onchain `delegate_keys` list to resolve the owner.
+
+The key word is **registered**. A delegate key that exists locally but is not added to your account onchain, or is added to a different account, or is added on a different network, fails authentication. That single fact explains most `AUTH_REJECTED` reports.
+
+Every signed request also carries a timestamp with a 5-minute validity window and a one-time nonce for replay protection, which is the second most common source of unexpected rejections.
+
+## Authentication and delegate keys
+
+This section covers credential and authorization errors.
+
+### 401 `AUTH_REJECTED` errors
+
+**Symptom:** You generated a delegate key, often from the dashboard, confirmed your account ID, and every authenticated call returns `AUTH_REJECTED` with HTTP status 401. A health check still succeeds, because the health endpoint needs no authentication, so the relayer is reachable but your signed requests are not accepted.
+
+**Cause:** The relayer cannot match your signed request to an active, registered delegate key on the account you named. It verifies the Ed25519 signature, then resolves the owner by finding your public key in that account's onchain `delegate_keys`. Anything that breaks that lookup returns the same 401. The following causes are ordered by how often they apply to a freshly generated key, and each row pairs the check with its fix:
+
+| **Cause** | **How to check** | **How to fix** |
+| --- | --- | --- |
+| The delegate key is not registered onchain yet, or its registration transaction is not indexed | Confirm the key appears under your account in the dashboard, and that any `addDelegateKey` call succeeded. | Register the public key onchain through the dashboard or `addDelegateKey`, then wait a few seconds for indexing and retry. |
+| The account ID does not match the account that owns the key | Compare the `accountId` in your configuration against the account that lists this delegate key in the dashboard. A stale value in `localStorage` is a common source. | Use the account ID that you generated and that owns this delegate key, and do not reuse an account ID copied from another project. |
+| The client points at a different network than the one where the account lives | Confirm your `serverUrl` or environment preset matches where you created the account. Production is `https://relayer.memory.walrus.xyz` and staging is `https://relayer-staging.memory.walrus.xyz`. | Point the client at the relayer for the correct network, or recreate the account and key in the environment you intend to use. |
+| The system clock is outside the 5-minute signing window | Confirm the machine clock is accurate and synchronized using the Network Time Protocol (NTP). | Synchronize the clock and retry. |
+| The delegate key is revoked, or the account is deactivated | Confirm the key is present and the account is active in the dashboard. | Re-add the delegate key, or reactivate the account, which only the owner can do. |
+
+<Tip>
+To triage quickly, confirm 3 things in order: the key is listed under the correct account in the dashboard, your account ID matches that account exactly, and your relayer environment matches where you created the account.
+</Tip>
+
+<Info>
+A version mismatch is rarely the cause here. The relayer reports its minimum supported SDK version, which is TypeScript 0.0.4 at the time of writing, so 0.0.7 is supported. A true version mismatch surfaces as `MemWalCompatibilityError` rather than `AUTH_REJECTED`.
+</Info>
+
+## MCP connection issues
+
+This section covers problems that appear before the memory tools work.
+
+### Only `memwal_login` appears
+
+**Symptom:** After you connect the MCP server, the agent sees only `memwal_login`, or the memory tools return an authentication-required error.
+
+**Cause:** No credentials file exists at `~/.memwal/credentials.json`. When an MCP host launches the package without credentials, it starts in an authentication-required mode that exposes `memwal_login` first.
+
+**Fix:** Ask the agent to call `memwal_login`, which returns a one-time sign-in URL valid for 5 minutes, or run `npx -y @mysten-incubation/memwal-mcp login --prod` in your terminal. Sign in to the wallet you intend to use before you open the URL. If the URL expires, call the tool again to get a fresh one.
+
+### The MCP tools do not appear
+
+**Symptom:** None of the `memwal_*` tools are available to the agent.
+
+**Cause:** MCP servers load only when the client starts, so a server added during a session does not appear.
+
+**Fix:** Quit the MCP client fully, then start it again. If you registered the server with `claude mcp add`, run `claude mcp list` to confirm `memwal` is registered before you restart.
+
+## Saving and timeouts
+
+This section covers slow or timed-out writes.
+
+### `memwal_analyze` times out while recall works
+
+**Symptom:** Recall returns quickly, but a save through `memwal_analyze` times out, sometimes on repeated attempts.
+
+**Cause:** Recall is a single search request, so it is fast. A save is heavier, and `memwal_analyze` is the heaviest save: it runs a large language model (LLM) extraction over your text, then enqueues each extracted fact as its own background job that embeds, encrypts, uploads to Walrus, and indexes the result. Under load, this fan-out can exceed the MCP host's tool-call timeout even though the relayer keeps working normally.
+
+<Warning>
+A client-side timeout does not mean the save failed. The relayer accepts the work as background jobs and keeps processing after the client stops waiting. Running the same `memwal_analyze` call again can create duplicate memories, so confirm the result before you retry.
+</Warning>
+
+**Fix:**
+
+1. Confirm the result instead of resubmitting. Wait a few seconds, because indexing can lag briefly under load, then run `memwal_recall` for the fact you tried to save. If the fact is present, the save succeeded despite the timeout.
+2. Match the tool to the task. To save one discrete fact, such as a milestone, use `memwal_remember`, which performs a single write. Reserve `memwal_analyze` for longer passages where you want several facts extracted, and keep those passages a reasonable size.
+3. Confirm connectivity first. Run `memwal_health`, which calls the unauthenticated health endpoint and is the fastest way to confirm the relayer is reachable.
+4. Wait correctly in the SDK. The `remember` and `analyze` methods return immediately with job IDs, so wait with `waitForRememberJob` or `analyzeAndWait` and a sensible timeout, or poll the job status, rather than wrapping the whole operation in one short blocking call.
+5. Collect logs if the problem persists. Set `MEMWAL_MCP_DEBUG=1` for the MCP server, or `debug: true` in the SDK, and capture the per-request output.
+
+### Recall returns no results immediately after a save
+
+**Symptom:** You save a memory, and an immediate recall finds nothing.
+
+**Cause:** A save returns once the Walrus upload completes, but the embedding and indexing step can lag a few seconds behind under load, so the memory is briefly unsearchable.
+
+**Fix:** Wait a moment, then retry the recall. If a memory is missing from the search index later, `memwal_restore` rebuilds the index for that namespace from Walrus.
+
+## Quick reference
+
+Use these values for quick configuration and triage:
+
+| **Item** | **Value** |
+| --- | --- |
+| Production relayer | `https://relayer.memory.walrus.xyz` |
+| Staging relayer (testnet) | `https://relayer-staging.memory.walrus.xyz` |
+| Dashboard for accounts and delegate keys | `https://memory.walrus.xyz` |
+| MCP environment presets | `--prod`, `--staging`, `--local` |
+| Local credentials file | `~/.memwal/credentials.json` |
+| Verbose MCP logs | `MEMWAL_MCP_DEBUG=1` |
+| Unauthenticated health check | `memwal_health` |
+| Maximum delegate keys per account | 20 |
+| Request timestamp window | 5 minutes |
+
+## Frequently asked questions
+
+These answers are written for the product page.
+
+### Is there a registration step after I generate a delegate key?
+
+Yes. Generating a delegate key creates the key pair, and it works only after the owner registers its public key on your account onchain, which the dashboard does when you create the key there. The relayer checks for that registration on every request, so a key that is generated but not registered, or registered on a different account or network, fails authentication.
+
+### Why do I get `AUTH_REJECTED` with a brand-new key?
+
+The cause is almost always one of 3 things: the key is not registered on the account yet or is still settling, your account ID does not match the account that owns the key, or your client points at a different network than the one where you created the account. Check those in that order. A skewed system clock can also cause it, because each request carries a timestamp with a 5-minute window.
+
+### Is my testnet account the same as my production account?
+
+No. Accounts and delegate keys are specific to each network. A key created on staging does not authenticate against the production relayer, and the reverse is also true. Confirm that your relayer environment matches where you created the account.
+
+### My save timed out, so did I lose the memory?
+
+Probably not. The relayer processes saves as background jobs and keeps working after the client times out. Do not save again right away, because that can duplicate the memory. Wait a few seconds and recall it to confirm. To save a single fact, use `memwal_remember` rather than `memwal_analyze`, which extracts and stores many facts at once and is the slowest operation.
+
+### Why does recall feel instant while saving feels slow?
+
+Recall is one search request. A save embeds, encrypts, uploads to Walrus, and indexes the result, and `memwal_analyze` does that for every fact it extracts. Saves are expected to take longer, and they run in the background.
+
+### How do I check whether the service is reachable?
+
+Run `memwal_health`. It does not require authentication, so it separates the question of whether the relayer is reachable from whether your credentials are valid.

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -15,9 +15,7 @@ sdk/api-reference, mcp/reference, getting-started/quick-start.
 
 This page collects the support questions that come up most often and the fastest way to resolve each one. Every entry lists the symptom you observe, the cause behind it, and the fix to apply.
 
-
 If your issue is not here, set `MEMWAL_MCP_DEBUG=1` for the Model Context Protocol (MCP) server, or, if you use the `withMemWal()` AI middleware, pass `debug: true` in its options, to get verbose logs, then open an issue on the repository with that output.
-
 
 ## How authentication works
 
@@ -86,9 +84,7 @@ This section covers slow or timed-out writes.
 
 **Symptom:** Recall returns quickly, but a save through `memwal_analyze` times out, sometimes on repeated attempts.
 
-
 **Cause:** Recall is a single search request, so it is fast. A save is heavier, and `memwal_analyze` is the heaviest save: it runs a large language model (LLM) extraction over your text, then embeds and encrypts each extracted fact and enqueues each as its own background job that uploads to Walrus and indexes the result. Under load, this fan-out can exceed the MCP host's tool-call timeout even though the relayer keeps working normally.
-
 
 <Warning>
 A client-side timeout does not mean the save failed. The relayer accepts the work as background jobs and keeps processing after the client stops waiting. Running the same `memwal_analyze` call again can create duplicate memories, so confirm the result before you retry.
@@ -100,9 +96,7 @@ A client-side timeout does not mean the save failed. The relayer accepts the wor
 2. Match the tool to the task. To save one discrete fact, such as a milestone, use `memwal_remember`, which performs a single write. Reserve `memwal_analyze` for longer passages where you want several facts extracted, and keep those passages a reasonable size.
 3. Confirm connectivity first. Run `memwal_health`, which calls the unauthenticated health endpoint and is the fastest way to confirm the relayer is reachable.
 4. Wait correctly in the SDK. The `remember` and `analyze` methods return immediately with job IDs, so wait with `waitForRememberJob` or `analyzeAndWait` and a sensible timeout, or poll the job status, rather than wrapping the whole operation in one short blocking call.
-
 5. Collect logs if the problem persists. Set `MEMWAL_MCP_DEBUG=1` for the MCP server, or pass `debug: true` to the `withMemWal()` AI middleware, and capture the per-request output. The core SDK (`MemWal.create()`) has no built-in debug flag.
-
 
 ### Recall returns no results immediately after a save
 


### PR DESCRIPTION
## Description
Adds a developer guide on how an autonomous agent funds Walrus storage: holding WAL directly versus sponsored storage (BEDU-602, Stage A / storage resource & payment).
**New page** (`docs/fundamentals/architecture/funding-storage.md`)
- Explains that a Walrus write consumes 2 tokens, WAL for storage and SUI for gas, so "sponsored" is ambiguous until you say which half is covered.
- Covers Model A (agent holds WAL directly): CLI and TS SDK, acquiring WAL, ownership of the `Blob` object, and lifecycle/expiry responsibilities.
- Covers Model B (sponsored): publisher (pays WAL and SUI; `send-object-to` for ownership; no public Mainnet publisher), Sui sponsored transactions (gas only), pre-funding via transferable WAL or storage resources, the upload-relay-is-not-a-sponsor clarification, and protocol subsidies (network-level, not per-agent).
- Maps the models to Walrus Memory: public relayer as sponsored, self-hosting as self-funded.
- Adds a decision table and an operational checklist; added to the Fundamentals > Architecture sidebar group.
Grounded in existing docs (Walrus `system-overview/storage-costs`, `network-reference`, `operator-guide/upload-relay`, TypeScript SDK) and MemWal `how-storage-works`. Written to the Sui documentation style guide.
## Test plan
- Local docs preview (`mint dev` in `docs/`) renders the page with working `<Note>`/`<Warning>` components and the decision table.
- The page appears under Fundamentals > Architecture in the sidebar.
- Internal links to `how-storage-works`, `public-relayer`, and `self-hosting` resolve.
## Release notes
Docs-only change; no user-facing storage node, aggregator, publisher, or CLI impact.
- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
