### PR TITLE
docs: agent storage loop + agent-state encryption

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,6 +87,7 @@
               },
               "sdk/cookbook-multi-tenant",
               "sdk/cloudflare-workers",
+              "sdk/agent-storage-loop",
               "sdk/api-reference",
               "sdk/changelog"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,6 +88,7 @@
               "sdk/cookbook-multi-tenant",
               "sdk/cloudflare-workers",
               "sdk/agent-storage-loop",
+              "sdk/production-readiness",
               "sdk/api-reference",
               "sdk/changelog"
             ]

--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -56,7 +56,7 @@ The `MemWal.create` config takes four fields:
 
 Agents tend to produce many small state blobs: observations, intermediate results, per-step notes. Writing them one at a time means a separate round trip and Sui transaction set for each. The SDK batches them instead, backed by Walrus Quilt under the hood.
 
-`rememberBulk` accepts up to 20 items per call. The relayer embeds and SEAL-encrypts every item concurrently, uploads the blobs to Walrus in parallel, and collapses what would be `N` separate transaction sets into roughly `2N + K`, where `K` is bounded by the relayer wallet pool. For an agent writing dozens of small memories a minute, that is the difference between a workable cost profile and an unworkable one.
+`rememberBulk` accepts up to 20 items per call. The relayer embeds and Seal-encrypts every item concurrently and uploads them to Walrus in parallel, so the whole batch shares far fewer Sui transactions than writing each item on its own would. For an agent writing dozens of small memories a minute, that is the difference between a workable cost profile and an unworkable one.
 
 ```ts
 const items = [
@@ -75,7 +75,7 @@ Keep each batch at 20 items or fewer. If you have more, chunk the array and call
 
 ## Encrypt agent state
 
-All blobs on Walrus are public, so private agent state must be encrypted. There are two models, and which one you want depends on who should hold the keys.
+All blobs on Walrus are public, so you must encrypt private agent state. There are two models, and which one you want depends on who should hold the keys.
 
 1. **Relayer-managed encryption (default):** With the standard `MemWal` client used above, the relayer encrypts every item with Seal before it reaches Walrus. You do not manage keys, and this is the right default for most agents.
 
@@ -101,16 +101,16 @@ await manual.rememberManual("Private: internal risk score for account 0xabc is 0
 ```
 
 <Warning>
-Client-managed encryption means the agent is responsible for its key material. If the delegate key is lost, the encrypted memories cannot be recovered. Treat the key as you would any production secret, and rotate it through the dashboard if it may be exposed.
+Client-managed encryption means the agent is responsible for its key material. If the delegate key is lost, you cannot recover the encrypted memories. Treat the key as you would any production secret, and rotate it through the dashboard if it might be exposed.
 </Warning>
 
 For the full client-managed flow, including local embeddings and recall, see [MemWalManual](/sdk/usage/memwal-manual).
 
 ## Confirm a write before depending on it
 
-An autonomous agent should not act on a memory it only believes it wrote. Before the agent reads state back or makes a decision that assumes the write persisted, confirm the write reached a durable state.
+An autonomous agent should not act on a memory it only believes it wrote. Before the agent reads state back or makes a decision that assumes the write persisted, confirm that the write reached a durable state.
 
-The `*AndWait` helpers already block until the relayer reports each job `done`, which is the signal that the memory was embedded, encrypted, and uploaded to Walrus. When you need to write without blocking and confirm later, capture the job IDs and wait on them explicitly:
+The `*AndWait` helpers already block until the relayer reports each job `done`, which is the signal that the relayer embedded, encrypted, and uploaded the memory to Walrus. When you need to write without blocking and confirm later, capture the job IDs and wait on them explicitly:
 
 ```ts
 const accepted = await memwal.rememberBulkAsync(items);
@@ -131,7 +131,7 @@ A dedicated `verify()` helper that reconstructs a memory from its onchain blob o
 
 ## Recall the stored context
 
-With writes confirmed, recall pulls the relevant memories back by semantic similarity. The relayer verifies the request, embeds the query, searches, downloads from Walrus, decrypts, and returns plaintext.
+After you confirm the writes, recall pulls the relevant memories back by semantic similarity. The relayer verifies the request, embeds the query, searches, downloads from Walrus, decrypts, and returns plaintext.
 
 ```ts
 const recalled = await memwal.recall({

--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -77,7 +77,7 @@ Keep each batch at 20 items or fewer. If you have more, chunk the array and call
 
 All blobs on Walrus are public, so private agent state must be encrypted. There are two models, and which one you want depends on who should hold the keys.
 
-**Relayer-managed encryption (default).** With the standard `MemWal` client used above, the relayer SEAL-encrypts every item before it reaches Walrus. You do not manage keys, and this is the right default for most agents.
+1. **Relayer-managed encryption (default):** With the standard `MemWal` client used above, the relayer encrypts every item with Seal before it reaches Walrus. You do not manage keys, and this is the right default for most agents.
 
 **Client-managed encryption.** When the agent must hold its own keys and never delegate decryption to the relayer, use the manual entry point. `MemWalManual` performs SEAL encryption client-side, so plaintext never leaves the agent process.
 

--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -126,7 +126,7 @@ if (failed.length > 0) {
 ```
 
 <Note>
-A dedicated `verify()` helper that reconstructs a memory from its on-chain blob object is on the roadmap. Until it ships, a job reaching `done` is the durability signal to gate on, and the memory's Walrus blob object on Sui is the on-chain record of the write.
+A dedicated `verify()` helper that reconstructs a memory from its onchain blob object is on the roadmap. Until it ships, a job reaching `done` is the durability signal to gate on, and the memory's Walrus blob object on Sui is the onchain record of the write.
 </Note>
 
 ## Recall the stored context

--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -1,0 +1,207 @@
+---
+title: Agent Storage Loop
+description: A full headless agent storage loop on Testnet: set up the SDK with no interactive steps, batch writes with Quilt, encrypt with SEAL, confirm the write landed, then recall.
+keywords: [agent, headless, autonomous, storage loop, Testnet, rememberBulk, Quilt, SEAL, encryption, recall, verify, MemWal, SDK]
+---
+
+This guide walks an autonomous agent through the complete storage loop on Testnet: set up the client with no interactive steps, batch many small writes, encrypt agent state, confirm each write landed before depending on it, then recall. Every step uses the real SDK surface, so you can lift the final script straight into a server or agent runtime.
+
+The loop has four stages:
+
+1. **Set up** the client from environment variables, with no browser or prompt in the path.
+2. **Write** many small state blobs in one batched call.
+3. **Confirm** each write reached a durable `done` state before the agent acts on it.
+4. **Recall** the stored context back into the agent.
+
+## Set up in an agent runtime
+
+An agent runtime has no human to click through a wallet or paste a key at a prompt. Generate the account ID and delegate key once at [staging.memory.walrus.xyz](https://staging.memory.walrus.xyz) for Testnet, store them as secrets, and load them from the environment at startup.
+
+```ts agent.ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+const memwal = MemWal.create({
+  key: requireEnv("MEMWAL_KEY"),
+  accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+  // Testnet relayer. Use https://relayer.memory.walrus.xyz for Mainnet.
+  serverUrl: "https://relayer-staging.memory.walrus.xyz",
+  namespace: "agent-state",
+});
+
+// Fail fast at boot if the relayer is unreachable or the key is rejected,
+// rather than discovering it on the first write mid-run.
+await memwal.health();
+```
+
+<Note>
+Read every credential from the environment. Never hardcode an account ID copied from docs or another project: recall is scoped per **account plus namespace**, so a shared ID puts your agent's memories in a space other readers can see.
+</Note>
+
+The `MemWal.create` config takes four fields:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `key` | `string` | Yes | Ed25519 delegate private key in hex |
+| `accountId` | `string` | Yes | MemWalAccount object ID on Sui |
+| `serverUrl` | `string` | No | Relayer URL for your network |
+| `namespace` | `string` | No | Default namespace, falls back to `"default"` |
+
+## Batch many small writes with Quilt
+
+Agents tend to produce many small state blobs: observations, intermediate results, per-step notes. Writing them one at a time means a separate round trip and Sui transaction set for each. The SDK batches them instead, backed by Walrus Quilt under the hood.
+
+`rememberBulk` accepts up to 20 items per call. The relayer embeds and SEAL-encrypts every item concurrently, uploads the blobs to Walrus in parallel, and collapses what would be `N` separate transaction sets into roughly `2N + K`, where `K` is bounded by the relayer wallet pool. For an agent writing dozens of small memories a minute, that is the difference between a workable cost profile and an unworkable one.
+
+```ts
+const items = [
+  { text: "Observed: user prefers concise summaries." },
+  { text: "Step 1 result: parsed 42 records, 3 flagged." },
+  { text: "Hypothesis: the spike correlates with the Tuesday deploy." },
+];
+
+// Fire the batch and wait for every item to finish.
+const result = await memwal.rememberBulkAndWait(items);
+```
+
+<Note>
+Keep each batch at 20 items or fewer. If you have more, chunk the array and call `rememberBulkAndWait` per chunk. To fan out without blocking, use `rememberBulkAsync` and collect the returned `job_ids` to confirm later.
+</Note>
+
+## Encrypt agent state
+
+All blobs on Walrus are public, so private agent state must be encrypted. There are two models, and which one you want depends on who should hold the keys.
+
+**Relayer-managed encryption (default).** With the standard `MemWal` client used above, the relayer SEAL-encrypts every item before it reaches Walrus. You do not manage keys, and this is the right default for most agents.
+
+**Client-managed encryption.** When the agent must hold its own keys and never delegate decryption to the relayer, use the manual entry point. `MemWalManual` performs SEAL encryption client-side, so plaintext never leaves the agent process.
+
+```ts
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
+
+const manual = MemWalManual.create({
+  key: requireEnv("MEMWAL_KEY"),
+  accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+  packageId: requireEnv("MEMWAL_PACKAGE_ID"),
+  serverUrl: "https://relayer-staging.memory.walrus.xyz",
+  // The agent signs SEAL and Walrus operations with its own Sui key, no wallet popup.
+  suiPrivateKey: requireEnv("SUI_PRIVATE_KEY"),
+  embeddingApiKey: requireEnv("OPENAI_API_KEY"),
+  suiNetwork: "testnet",
+  namespace: "agent-state",
+});
+
+// Encrypts locally, then relays the ciphertext. The relayer never sees plaintext.
+await manual.rememberManual("Private: internal risk score for account 0xabc is 0.82.");
+```
+
+<Warning>
+Client-managed encryption means the agent is responsible for its key material. If the delegate key is lost, the encrypted memories cannot be recovered. Treat the key as you would any production secret, and rotate it through the dashboard if it may be exposed.
+</Warning>
+
+For the full client-managed flow, including local embeddings and recall, see [MemWalManual](/sdk/usage/memwal-manual).
+
+## Confirm a write before depending on it
+
+An autonomous agent should not act on a memory it only believes it wrote. Before the agent reads state back or makes a decision that assumes the write persisted, confirm the write reached a durable state.
+
+The `*AndWait` helpers already block until the relayer reports each job `done`, which is the signal that the memory was embedded, encrypted, and uploaded to Walrus. When you need to write without blocking and confirm later, capture the job IDs and wait on them explicitly:
+
+```ts
+const accepted = await memwal.rememberBulkAsync(items);
+
+// ... agent does other work ...
+
+// Block until every job reaches `done` before relying on the memories.
+const settled = await memwal.waitForRememberJobs(accepted.job_ids);
+const failed = settled.results.filter((r) => r.status !== "done");
+if (failed.length > 0) {
+  throw new Error(`${failed.length} memories did not persist; do not proceed.`);
+}
+```
+
+<Note>
+A dedicated `verify()` helper that reconstructs a memory from its on-chain blob object is on the roadmap. Until it ships, a job reaching `done` is the durability signal to gate on, and the memory's Walrus blob object on Sui is the on-chain record of the write.
+</Note>
+
+## Recall the stored context
+
+With writes confirmed, recall pulls the relevant memories back by semantic similarity. The relayer verifies the request, embeds the query, searches, downloads from Walrus, decrypts, and returns plaintext.
+
+```ts
+const recalled = await memwal.recall({
+  query: "What do we know about the Tuesday spike?",
+  limit: 5,
+});
+
+for (const memory of recalled.results) {
+  console.log(memory.distance.toFixed(3), memory.text);
+}
+```
+
+Recall is scoped to the client's namespace by default. Pass `namespace` to read from a different one, and `limit` to cap how many memories return.
+
+## The full loop
+
+Putting the four stages together, here is a complete headless agent that runs end to end on Testnet:
+
+```ts agent.ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+async function main() {
+  // 1. Set up from the environment, no interactive steps.
+  const memwal = MemWal.create({
+    key: requireEnv("MEMWAL_KEY"),
+    accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+    serverUrl: "https://relayer-staging.memory.walrus.xyz",
+    namespace: "agent-state",
+  });
+  await memwal.health();
+
+  // 2. Batch many small state blobs in one call.
+  const items = [
+    { text: "Observed: user prefers concise summaries." },
+    { text: "Step 1 result: parsed 42 records, 3 flagged." },
+    { text: "Hypothesis: the spike correlates with the Tuesday deploy." },
+  ];
+
+  // 3. Write and confirm every item reached `done` before continuing.
+  const settled = await memwal.rememberBulkAndWait(items);
+  const failed = settled.results.filter((r) => r.status !== "done");
+  if (failed.length > 0) {
+    throw new Error(`${failed.length} memories did not persist; aborting.`);
+  }
+
+  // 4. Recall the stored context.
+  const recalled = await memwal.recall({
+    query: "What do we know about the Tuesday spike?",
+    limit: 5,
+  });
+  for (const memory of recalled.results) {
+    console.log(memory.distance.toFixed(3), memory.text);
+  }
+}
+
+main().catch((err) => {
+  console.error("Agent storage loop failed:", err);
+  process.exit(1);
+});
+```
+
+## Next steps
+
+- [Walrus Memory client](/sdk/usage/memwal): full method signatures for the default client
+- [MemWalManual](/sdk/usage/memwal-manual): the client-managed encryption flow
+- [Public relayer](/relayer/public-relayer): managed Mainnet and Testnet relayer endpoints
+- [API Reference](/sdk/api-reference): every config field and return type

--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -79,7 +79,7 @@ All blobs on Walrus are public, so private agent state must be encrypted. There 
 
 1. **Relayer-managed encryption (default):** With the standard `MemWal` client used above, the relayer encrypts every item with Seal before it reaches Walrus. You do not manage keys, and this is the right default for most agents.
 
-**Client-managed encryption.** When the agent must hold its own keys and never delegate decryption to the relayer, use the manual entry point. `MemWalManual` performs SEAL encryption client-side, so plaintext never leaves the agent process.
+2. **Client-managed encryption.** When the agent must hold its own keys and never delegate decryption to the relayer, use the manual entry point. `MemWalManual` performs Seal encryption client-side, so plaintext never leaves the agent process.
 
 ```ts
 import { MemWalManual } from "@mysten-incubation/memwal/manual";

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -10,7 +10,7 @@ Several of these are patterns you implement around the client today. Where a cap
 
 ## Make writes idempotent
 
-The relayer does not deduplicate writes. A `remember` call that is retried after a network blip, or fired twice by an at-least-once job queue, stores the same text twice and pollutes later recall. Until content-based deduplication is available natively, gate writes on a key your agent controls so a repeat is a no-op.
+The relayer does not deduplicate writes. A `remember` call that retries after a network blip, or fired twice by an at-least-once job queue, stores the same text twice and pollutes later recall. Until content-based deduplication is available natively, gate writes on a key your agent controls so a repeat is a no-op.
 
 ```ts
 import { createHash } from "crypto";
@@ -33,7 +33,7 @@ Persist the idempotency set outside the process (Redis, a database row, a Sui ob
 
 ## Retry with backoff, but only retryable failures
 
-The client does not retry for you. Wrap calls in exponential backoff, and be careful to retry only failures that a retry can fix. A transient network error or relayer timeout is worth retrying. A `401 AUTH_REJECTED` is a configuration problem that will fail identically on every attempt, so retrying it just delays the real fix.
+The client does not retry for you. Wrap calls in exponential backoff, and be careful to retry only failures that a retry can fix. A transient network error or relayer timeout is worth retrying. A `401 AUTH_REJECTED` is a configuration problem that fails identically on every attempt, so retrying it just delays the real fix.
 
 ```ts
 async function withRetry<T>(fn: () => Promise<T>, attempts = 4): Promise<T> {
@@ -63,7 +63,7 @@ Built-in retry and backoff inside the client is on the roadmap. When it ships, y
 
 ## Confirm durability before acting on a memory
 
-An autonomous agent should not make a decision that assumes a write persisted until it has confirmed the write reached a terminal state. The `*AndWait` helpers block until each job reports `done`; when you write without blocking, capture the job IDs and wait on them before depending on the data.
+An autonomous agent should not make a decision that assumes a write persisted until it confirms the write reached a terminal state. The `*AndWait` helpers block until each job reports `done`; when you write without blocking, capture the job IDs and wait on them before depending on the data.
 
 ```ts
 const accepted = await memwal.rememberBulkAsync(items);
@@ -76,7 +76,7 @@ if (settled.failed > 0) {
 ```
 
 <Warning>
-A job reaching `done` confirms the memory was stored, but the vector index can briefly lag behind that signal, so a `recall` fired in the same instant may not return the memory yet. For read-after-write critical paths, tolerate a short delay or re-query rather than treating an empty first result as a missing memory.
+A job reaching `done` confirms that the relayer stored the memory, but the vector index can briefly lag behind that signal, so a `recall` fired in the same instant might not return the memory yet. For read-after-write critical paths, tolerate a short delay or re-query rather than treating an empty first result as a missing memory.
 </Warning>
 
 For the full write, confirm, and recall sequence in context, see [Agent Storage Loop](/sdk/agent-storage-loop).
@@ -86,7 +86,7 @@ For the full write, confirm, and recall sequence in context, see [Agent Storage 
 Every write registers storage on Walrus and costs gas and WAL. An agent in a tight loop can run up spend quickly, so put ceilings in the agent, not just in your head.
 
 - **Batch with Quilt.** `rememberBulkAndWait` (up to 20 items) collapses many small writes into far fewer transactions. Buffer small state blobs and flush them as a batch instead of writing one at a time.
-- **Do not store what you will never recall.** Ephemeral scratch state that never feeds a future `recall` does not belong in durable storage. Keep it in process memory.
+- **Do not store what you never recall.** Ephemeral scratch state that never feeds a future `recall` does not belong in durable storage. Keep it in process memory.
 - **Cap writes per cycle.** Give the agent loop a budget, for example a maximum number of memories per run or per hour, and have it drop or summarize past the cap rather than write unbounded.
 
 ```ts
@@ -103,12 +103,12 @@ async function budgetedRemember(memwal: MemWal, text: string) {
 
 ## Custody the agent's keys
 
-A headless agent holds secrets no human will rotate by hand, so treat them with production discipline.
+A headless agent holds secrets no human rotates by hand, so treat them with production discipline.
 
 - The **delegate key** authenticates the agent to the relayer.
-- For client-managed encryption, the **Sui key** signs the SEAL and Walrus operations. See [holding your own keys](/sdk/usage/memwal-manual#agent-state-holding-your-own-keys).
+- For client-managed encryption, the **Sui key** signs the Seal and Walrus operations. See [holding your own keys](/sdk/usage/memwal-manual#agent-state-holding-your-own-keys).
 
-Load both from a secret manager, never from source or logs. Scope each agent to its own delegate key so you can revoke one without taking down the rest, and rotate through the dashboard if a key may be exposed. If the Sui key behind client-managed encryption is lost, the encrypted memories cannot be recovered, so back it up with the same care as any data-encryption key.
+Load both from a secret manager, never from source or logs. Scope each agent to its own delegate key so you can revoke one without taking down the rest, and rotate through the dashboard if a key might be exposed. If the Sui key behind client-managed encryption is lost, you cannot recover the encrypted memories, so back it up with the same care as any data-encryption key.
 
 ## Degrade gracefully when memory is unavailable
 
@@ -134,7 +134,7 @@ This is the same defensive pattern the [Cloudflare Workers guide](/sdk/cloudflar
 
 ## Mind the recall result cap
 
-`recall` returns up to `limit` results, defaulting to `10`. When more memories match than the cap, the extra results are simply not returned, with no signal that the set was truncated. If a decision depends on seeing every match, set `limit` explicitly to a value above what you expect, and treat a result count equal to `limit` as a sign there may be more.
+`recall` returns up to `limit` results, defaulting to `10`. When more memories match than the cap, the relayer does not return the extra results, with no signal that it truncated the set. If a decision depends on seeing every match, set `limit` explicitly to a value above what you expect, and treat a result count equal to `limit` as a sign there might be more.
 
 ```ts
 const result = await memwal.recall({ query: "open incidents", limit: 50 });

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -1,0 +1,151 @@
+---
+title: Production Readiness for Agent Storage
+description: Patterns for running Walrus Memory in a production agent: idempotent writes, retries with backoff, confirming durability, bounding cost, key custody, and graceful degradation.
+keywords: [production, hardening, idempotency, retries, backoff, cost caps, key custody, failure handling, graceful degradation, agent, reliability, MemWal, SDK]
+---
+
+The SDK gives you the storage primitives. Running them in a long-lived agent, where there is no human to retry a failed write or notice a runaway bill, takes a few patterns on top. This guide collects the ones that matter most.
+
+Several of these are patterns you implement around the client today. Where a capability is on the roadmap as a native feature, this guide says so, so you know which code is permanent and which is a stopgap.
+
+## Make writes idempotent
+
+The relayer does not deduplicate writes. A `remember` call that is retried after a network blip, or fired twice by an at-least-once job queue, stores the same text twice and pollutes later recall. Until content-based deduplication is available natively, gate writes on a key your agent controls so a repeat is a no-op.
+
+```ts
+import { createHash } from "crypto";
+
+const written = new Set<string>(); // back this with Redis or a DB in production
+
+async function rememberOnce(memwal: MemWal, text: string, namespace?: string) {
+  const id = createHash("sha256").update(`${namespace ?? "default"}:${text}`).digest("hex");
+  if (written.has(id)) return; // already stored this exact memory
+
+  const job = await memwal.remember(text, namespace);
+  await memwal.waitForRememberJob(job.job_id);
+  written.add(id);
+}
+```
+
+<Note>
+Persist the idempotency set outside the process (Redis, a database row, a Sui object), not in memory. An in-memory set resets on restart, which is exactly when a retry storm is most likely.
+</Note>
+
+## Retry with backoff, but only retryable failures
+
+The client does not retry for you. Wrap calls in exponential backoff, and be careful to retry only failures that a retry can fix. A transient network error or relayer timeout is worth retrying. A `401 AUTH_REJECTED` is a configuration problem that will fail identically on every attempt, so retrying it just delays the real fix.
+
+```ts
+async function withRetry<T>(fn: () => Promise<T>, attempts = 4): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const status = (err as { status?: number }).status;
+      // Do not retry auth or client errors; they will not succeed on a retry.
+      if (status === 401 || (status && status >= 400 && status < 500)) throw err;
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 2 ** i * 500 + Math.random() * 250));
+    }
+  }
+  throw lastErr;
+}
+
+await withRetry(() => rememberOnce(memwal, "Observed: deploy at 14:03 UTC."));
+```
+
+Pairing retry with the idempotency guard above is deliberate: a retry that fires after the write actually succeeded server-side stays safe, because `rememberOnce` short-circuits on the key.
+
+<Note>
+Built-in retry and backoff inside the client is on the roadmap. When it ships, you can drop the wrapper for the calls it covers and keep only the idempotency guard.
+</Note>
+
+## Confirm durability before acting on a memory
+
+An autonomous agent should not make a decision that assumes a write persisted until it has confirmed the write reached a terminal state. The `*AndWait` helpers block until each job reports `done`; when you write without blocking, capture the job IDs and wait on them before depending on the data.
+
+```ts
+const accepted = await memwal.rememberBulkAsync(items);
+const settled = await memwal.waitForRememberJobs(accepted.job_ids);
+
+if (settled.failed > 0) {
+  const bad = settled.results.filter((r) => r.status !== "done");
+  throw new Error(`${settled.failed} writes did not persist: ${bad.map((b) => b.status).join(", ")}`);
+}
+```
+
+<Warning>
+A job reaching `done` confirms the memory was stored, but the vector index can briefly lag behind that signal, so a `recall` fired in the same instant may not return the memory yet. For read-after-write critical paths, tolerate a short delay or re-query rather than treating an empty first result as a missing memory.
+</Warning>
+
+For the full write, confirm, and recall sequence in context, see [Agent Storage Loop](/sdk/agent-storage-loop).
+
+## Bound cost
+
+Every write registers storage on Walrus and costs gas and WAL. An agent in a tight loop can run up spend quickly, so put ceilings in the agent, not just in your head.
+
+- **Batch with Quilt.** `rememberBulkAndWait` (up to 20 items) collapses many small writes into far fewer transactions. Buffer small state blobs and flush them as a batch instead of writing one at a time.
+- **Do not store what you will never recall.** Ephemeral scratch state that never feeds a future `recall` does not belong in durable storage. Keep it in process memory.
+- **Cap writes per cycle.** Give the agent loop a budget, for example a maximum number of memories per run or per hour, and have it drop or summarize past the cap rather than write unbounded.
+
+```ts
+let writesThisCycle = 0;
+const MAX_WRITES_PER_CYCLE = 50;
+
+async function budgetedRemember(memwal: MemWal, text: string) {
+  if (writesThisCycle >= MAX_WRITES_PER_CYCLE) return false;
+  await rememberOnce(memwal, text);
+  writesThisCycle++;
+  return true;
+}
+```
+
+## Custody the agent's keys
+
+A headless agent holds secrets no human will rotate by hand, so treat them with production discipline.
+
+- The **delegate key** authenticates the agent to the relayer.
+- For client-managed encryption, the **Sui key** signs the SEAL and Walrus operations. See [holding your own keys](/sdk/usage/memwal-manual#agent-state-holding-your-own-keys).
+
+Load both from a secret manager, never from source or logs. Scope each agent to its own delegate key so you can revoke one without taking down the rest, and rotate through the dashboard if a key may be exposed. If the Sui key behind client-managed encryption is lost, the encrypted memories cannot be recovered, so back it up with the same care as any data-encryption key.
+
+## Degrade gracefully when memory is unavailable
+
+A memory layer that is down should slow your agent, not stop it. Check reachability at startup and guard the memory paths so the agent keeps serving when the relayer is unreachable for a cycle.
+
+```ts
+let memory: MemWal | null = null;
+try {
+  memory = MemWal.create({ key, accountId, serverUrl, namespace });
+  await memory.health();
+} catch (err) {
+  console.log("Memory unavailable, continuing without it this cycle:", err);
+  memory = null;
+}
+
+// Guard every read and write on memory being live.
+if (memory) {
+  await budgetedRemember(memory, "...");
+}
+```
+
+This is the same defensive pattern the [Cloudflare Workers guide](/sdk/cloudflare-workers) uses to keep a Worker healthy when the memory dependency has a bad moment.
+
+## Mind the recall result cap
+
+`recall` returns up to `limit` results, defaulting to `10`. When more memories match than the cap, the extra results are simply not returned, with no signal that the set was truncated. If a decision depends on seeing every match, set `limit` explicitly to a value above what you expect, and treat a result count equal to `limit` as a sign there may be more.
+
+```ts
+const result = await memwal.recall({ query: "open incidents", limit: 50 });
+if (result.results.length === 50) {
+  console.warn("Recall hit the limit; there may be more matches than returned.");
+}
+```
+
+## Next steps
+
+- [Agent Storage Loop](/sdk/agent-storage-loop): the write, confirm, and recall loop these patterns harden
+- [MemWalManual](/sdk/usage/memwal-manual): client-managed encryption and key custody
+- [Troubleshooting](/troubleshooting/overview): auth, timeout, and read-after-write symptoms
+- [Public relayer](/relayer/public-relayer): managed Mainnet and Testnet endpoints

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -105,7 +105,7 @@ const manual = MemWalManual.create({
 
 Every blob on Walrus is public, so private agent state must be encrypted before it is stored. For an autonomous agent that has no human to approve a wallet popup, `MemWalManual` is the path that keeps the agent in control of its own key material: encryption happens client-side, and the relayer never receives plaintext.
 
-A headless agent signs SEAL and Walrus operations with its own Sui key rather than a connected wallet. Provide `suiPrivateKey` instead of `walletSigner`, set `suiNetwork` for your environment, and load every secret from the environment:
+A headless agent signs Seal and Walrus operations with its own Sui key rather than a connected wallet. Provide `suiPrivateKey` instead of `walletSigner`, set `suiNetwork` for your environment, and load every secret from the environment:
 
 ```ts
 import { MemWalManual } from "@mysten-incubation/memwal/manual";

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -7,19 +7,19 @@ keywords: [MemWalManual, client-side encryption, SEAL, agent state, key manageme
 Use when the client must handle embedding calls and local SEAL operations. The relayer still handles
 upload relay, vector registration, search, and restore.
 
-This is the recommended path for Web3-native users who want to minimize trust in the relayer, since it never sees your plaintext data.
+This is the recommended path for Web3-native users who want to minimize trust in the relayer, because it never sees your plaintext data.
 
 ## What the client handles versus what the relayer handles
 
 | Operation | Client (MemWalManual) | Relayer |
 |-----------|----------------------|---------|
-| Embedding | Client calls OpenAI/compatible API | n/a |
-| SEAL encryption | Client encrypts locally | n/a |
-| Walrus upload | n/a | Server uploads via sidecar (server pays gas) |
-| Vector registration | n/a | Server stores `{blob_id, vector}` in PostgreSQL |
-| Recall search | n/a | Server searches vectors, returns `{blob_id, distance}` |
-| Walrus download | Client downloads from aggregator | n/a |
-| SEAL decryption | Client decrypts locally (SessionKey) | n/a |
+| Embedding | Client calls OpenAI/compatible API | — |
+| SEAL encryption | Client encrypts locally | — |
+| Walrus upload | — | Server uploads through a sidecar (server pays gas) |
+| Vector registration | — | Server stores `{blob_id, vector}` in PostgreSQL |
+| Recall search | — | Server searches vectors, returns `{blob_id, distance}` |
+| Walrus download | Client downloads from aggregator | — |
+| SEAL decryption | Client decrypts locally (SessionKey) | — |
 
 ## Setup
 
@@ -103,7 +103,7 @@ const manual = MemWalManual.create({
 
 ## Agent state: holding your own keys
 
-Every blob on Walrus is public, so private agent state must be encrypted before it is stored. For an autonomous agent that has no human to approve a wallet popup, `MemWalManual` is the path that keeps the agent in control of its own key material: encryption happens client-side, and the relayer never receives plaintext.
+Every blob on Walrus is public, so you must encrypt private agent state before storing it. For an autonomous agent that has no human to approve a wallet popup, `MemWalManual` is the path that keeps the agent in control of its own key material: encryption happens client-side, and the relayer never receives plaintext.
 
 A headless agent signs Seal and Walrus operations with its own Sui key rather than a connected wallet. Provide `suiPrivateKey` instead of `walletSigner`, set `suiNetwork` for your environment, and load every secret from the environment:
 
@@ -136,7 +136,7 @@ The agent holds two distinct secrets:
 - The **Sui key** (`suiPrivateKey`) signs the Seal and Walrus operations that encrypt and store the data.
 
 <Warning>
-With client-managed encryption the agent owns its key material. If the Sui key is lost, the encrypted memories cannot be recovered, so treat it as a production secret and rotate the delegate key through the dashboard if it may be exposed.
+With client-managed encryption the agent owns its key material. If the Sui key is lost, you cannot recover the encrypted memories, so treat it as a production secret and rotate the delegate key through the dashboard if it might be exposed.
 </Warning>
 
 For the full headless write, confirm, and recall loop that builds on this, see [Agent Storage Loop](/sdk/agent-storage-loop).

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -130,7 +130,7 @@ for (const memory of hits.results) {
 }
 ```
 
-The agent holds two distinct secrets, and it is worth keeping their roles clear:
+The agent holds two distinct secrets:
 
 - The **delegate key** (`key`) authenticates the agent to the relayer.
 - The **Sui key** (`suiPrivateKey`) signs the Seal and Walrus operations that encrypt and store the data.

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -1,24 +1,25 @@
 ---
 title: "MemWalManual"
 description: "Client-managed embeddings and local SEAL operations."
+keywords: [MemWalManual, client-side encryption, SEAL, agent state, key management, autonomous agent, suiPrivateKey, walletSigner, embeddings, recall]
 ---
 
 Use when the client must handle embedding calls and local SEAL operations. The relayer still handles
 upload relay, vector registration, search, and restore.
 
-This is the recommended path for Web3-native users who want to minimize trust in the relayer — it never sees your plaintext data.
+This is the recommended path for Web3-native users who want to minimize trust in the relayer, since it never sees your plaintext data.
 
-## What the client handles vs. what the relayer handles
+## What the client handles versus what the relayer handles
 
 | Operation | Client (MemWalManual) | Relayer |
 |-----------|----------------------|---------|
-| Embedding | Client calls OpenAI/compatible API | — |
-| SEAL encryption | Client encrypts locally | — |
-| Walrus upload | — | Server uploads via sidecar (server pays gas) |
-| Vector registration | — | Server stores `{blob_id, vector}` in PostgreSQL |
-| Recall search | — | Server searches vectors, returns `{blob_id, distance}` |
-| Walrus download | Client downloads from aggregator | — |
-| SEAL decryption | Client decrypts locally (SessionKey) | — |
+| Embedding | Client calls OpenAI/compatible API | n/a |
+| SEAL encryption | Client encrypts locally | n/a |
+| Walrus upload | n/a | Server uploads via sidecar (server pays gas) |
+| Vector registration | n/a | Server stores `{blob_id, vector}` in PostgreSQL |
+| Recall search | n/a | Server searches vectors, returns `{blob_id, distance}` |
+| Walrus download | Client downloads from aggregator | n/a |
+| SEAL decryption | Client decrypts locally (SessionKey) | n/a |
 
 ## Setup
 
@@ -74,7 +75,7 @@ console.log(manual.isWalletMode);
 
 ## Browser Integration (wallet signer)
 
-Use `walletSigner` instead of `suiPrivateKey` when integrating with a connected wallet (e.g., `@mysten/dapp-kit`):
+Use `walletSigner` instead of `suiPrivateKey` when integrating with a connected wallet (for example, `@mysten/dapp-kit`):
 
 ```ts
 const manual = MemWalManual.create({
@@ -98,4 +99,44 @@ const manual = MemWalManual.create({
 - Walrus publisher, aggregator, and upload relay defaults follow `suiNetwork`
 - `embeddingModel` defaults to `text-embedding-3-small` (or `openai/text-embedding-3-small` for OpenRouter)
 - `walrusEpochs` defaults to `50` (storage duration)
-- All `@mysten/*` peer dependencies are loaded dynamically — users who only use the default `MemWal` client don't need them installed
+- All `@mysten/*` peer dependencies are loaded dynamically, so users who only use the default `MemWal` client do not need them installed
+
+## Agent state: holding your own keys
+
+Every blob on Walrus is public, so private agent state must be encrypted before it is stored. For an autonomous agent that has no human to approve a wallet popup, `MemWalManual` is the path that keeps the agent in control of its own key material: encryption happens client-side, and the relayer never receives plaintext.
+
+A headless agent signs SEAL and Walrus operations with its own Sui key rather than a connected wallet. Provide `suiPrivateKey` instead of `walletSigner`, set `suiNetwork` for your environment, and load every secret from the environment:
+
+```ts
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
+
+const manual = MemWalManual.create({
+  key: process.env.MEMWAL_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+  packageId: process.env.MEMWAL_PACKAGE_ID!,
+  serverUrl: "https://relayer-staging.memory.walrus.xyz",
+  suiPrivateKey: process.env.SUI_PRIVATE_KEY!,
+  embeddingApiKey: process.env.OPENAI_API_KEY!,
+  suiNetwork: "testnet",
+  namespace: "agent-state",
+});
+
+// Encrypts locally, then relays only ciphertext to the server.
+await manual.rememberManual("Private: internal risk score for account 0xabc is 0.82.");
+
+const hits = await manual.recallManual("risk score for account 0xabc", 5);
+for (const memory of hits.results) {
+  console.log(memory.text, memory.distance);
+}
+```
+
+The agent holds two distinct secrets, and it is worth keeping their roles clear:
+
+- The **delegate key** (`key`) authenticates the agent to the relayer.
+- The **Sui key** (`suiPrivateKey`) signs the SEAL and Walrus operations that encrypt and store the data.
+
+<Warning>
+With client-managed encryption the agent owns its key material. If the Sui key is lost, the encrypted memories cannot be recovered, so treat it as a production secret and rotate the delegate key through the dashboard if it may be exposed.
+</Warning>
+
+For the full headless write, confirm, and recall loop that builds on this, see [Agent Storage Loop](/sdk/agent-storage-loop).

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -133,7 +133,7 @@ for (const memory of hits.results) {
 The agent holds two distinct secrets, and it is worth keeping their roles clear:
 
 - The **delegate key** (`key`) authenticates the agent to the relayer.
-- The **Sui key** (`suiPrivateKey`) signs the SEAL and Walrus operations that encrypt and store the data.
+- The **Sui key** (`suiPrivateKey`) signs the Seal and Walrus operations that encrypt and store the data.
 
 <Warning>
 With client-managed encryption the agent owns its key material. If the Sui key is lost, the encrypted memories cannot be recovered, so treat it as a production secret and rotate the delegate key through the dashboard if it may be exposed.


### PR DESCRIPTION
Adds the agent storage loop, agent-state encryption, and production-readiness guides for autonomous agents. Closes BEDU-611, BEDU-604, BEDU-762, BEDU-763, BEDU-765.