### PR TITLE
docs: quote frontmatter descriptions to fix Docusaurus YAML build

### DIFF
--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -1,7 +1,7 @@
 ---
 title: Agent Storage Loop
-description: A full headless agent storage loop on Testnet: set up the SDK with no interactive steps, batch writes with Quilt, encrypt with SEAL, confirm the write landed, then recall.
-keywords: [agent, headless, autonomous, storage loop, Testnet, rememberBulk, Quilt, SEAL, encryption, recall, verify, MemWal, SDK]
+description: "A full headless agent storage loop on Testnet: set up the SDK with no interactive steps, batch writes with Quilt, encrypt with Seal, confirm the write landed, then recall."
+keywords: [agent, headless, autonomous, storage loop, Testnet, rememberBulk, Quilt, Seal, encryption, recall, verify, MemWal, SDK]
 ---
 
 This guide walks an autonomous agent through the complete storage loop on Testnet: set up the client with no interactive steps, batch many small writes, encrypt agent state, confirm each write landed before depending on it, then recall. Every step uses the real SDK surface, so you can lift the final script straight into a server or agent runtime.

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -1,6 +1,6 @@
 ---
 title: Production Readiness for Agent Storage
-description: Patterns for running Walrus Memory in a production agent: idempotent writes, retries with backoff, confirming durability, bounding cost, key custody, and graceful degradation.
+description: "Patterns for running Walrus Memory in a production agent: idempotent writes, retries with backoff, confirming durability, bounding cost, key custody, and graceful degradation."
 keywords: [production, hardening, idempotency, retries, backoff, cost caps, key custody, failure handling, graceful degradation, agent, reliability, MemWal, SDK]
 ---
 


### PR DESCRIPTION
dev has two page descriptions with an unquoted colon (agent-storage-loop, production-readiness, both from #336), which breaks the Docusaurus build that compiles MemWal docs — including the walrus docs preview, where it currently fails every PR. Wraps both descriptions in quotes and fixes SEAL casing. No other content changes.