### PR TITLE
fix(relayer): resolve client IP via trusted proxy hops to stop X-Forwarded-For spoofing (#360)

### DIFF
--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -111,6 +111,14 @@ ENOKI_INVALIDATED_MAX_ATTEMPTS=4
 ENOKI_INVALIDATED_BASE_DELAY_MS=1000
 ENOKI_INVALIDATED_MAX_DELAY_MS=8000
 
+# Number of trusted reverse proxies in front of the relayer. Controls how the
+# real client IP is resolved from X-Forwarded-For for per-IP rate limiting
+# (MCP proxy + /sponsor). MUST equal the actual hop count — a value larger
+# than reality lets clients spoof their rate-limit bucket (issue #360).
+#   1 = one edge proxy (Railway) — correct in production (default if unset)
+#   0 = relayer directly exposed; ignore X-Forwarded-For, use the socket peer
+TRUSTED_PROXY_HOPS=1
+
 # Sponsor endpoint rate limiting (per IP + per sender, sliding window)
 SPONSOR_RATE_LIMIT_PER_MINUTE=10
 SPONSOR_RATE_LIMIT_PER_HOUR=30

--- a/services/server/scripts/mcp/__tests__/rateLimit.test.ts
+++ b/services/server/scripts/mcp/__tests__/rateLimit.test.ts
@@ -141,16 +141,27 @@ test("stats snapshot reflects acquired/released slots", () => {
     // current behavior produces (ip 1.1.1.1 still has an `opens` entry).
 });
 
-test("clientIpFromRequest prefers first hop in x-forwarded-for", () => {
+test("clientIpFromRequest uses the relayer's single sanitized value", () => {
+    // Normal case: the relayer forwards exactly one resolved client IP.
     assert.equal(
-        clientIpFromRequest(fakeReq({ xff: "203.0.113.5, 10.0.0.1, 127.0.0.1" })),
+        clientIpFromRequest(fakeReq({ xff: "203.0.113.5" })),
         "203.0.113.5"
     );
 });
 
-test("clientIpFromRequest trims whitespace around the first hop", () => {
+test("clientIpFromRequest takes the rightmost hop, never the client-forgeable leftmost", () => {
+    // Defense-in-depth: if a multi-value chain ever reaches the sidecar, the
+    // leftmost value is attacker-controlled — we must take the rightmost
+    // (nearest-to-relayer) entry instead. See issue #360.
     assert.equal(
-        clientIpFromRequest(fakeReq({ xff: "  203.0.113.5  , 10.0.0.1" })),
+        clientIpFromRequest(fakeReq({ xff: "1.2.3.4, 10.0.0.1, 203.0.113.5" })),
+        "203.0.113.5"
+    );
+});
+
+test("clientIpFromRequest trims whitespace around the value", () => {
+    assert.equal(
+        clientIpFromRequest(fakeReq({ xff: "  203.0.113.5  " })),
         "203.0.113.5"
     );
 });
@@ -167,9 +178,11 @@ test("clientIpFromRequest falls back to req.ip when XFF is empty string", () => 
 });
 
 test("clientIpFromRequest handles array-valued XFF (rare but legal)", () => {
+    // Array = multiple XFF headers; use the last header, then its rightmost
+    // (nearest-to-relayer) hop.
     assert.equal(
-        clientIpFromRequest(fakeReq({ xff: ["203.0.113.5, 10.0.0.1"] })),
-        "203.0.113.5"
+        clientIpFromRequest(fakeReq({ xff: ["1.2.3.4", "203.0.113.5, 10.0.0.1"] })),
+        "10.0.0.1"
     );
 });
 

--- a/services/server/scripts/mcp/rateLimit.ts
+++ b/services/server/scripts/mcp/rateLimit.ts
@@ -67,16 +67,29 @@ export function loadRateLimitConfigFromEnv(): RateLimitConfig {
 }
 
 /**
- * Best-effort client IP. Honor the relayer's `x-forwarded-for` (first hop is
- * the original caller), fall back to express's `req.ip`. Returns "unknown"
- * if neither is available — counters still apply, just bucketed together.
+ * Best-effort client IP for per-IP bucketing.
+ *
+ * Trust boundary: the sidecar is reachable ONLY over loopback from the Rust
+ * relayer, which resolves the real client IP behind its trusted proxies and
+ * forwards it as a SINGLE-value `x-forwarded-for` (see
+ * `services/server/src/mcp_proxy.rs::inject_forwarded_for`). So that value is
+ * authoritative here. We must NOT take the leftmost hop of a multi-value
+ * chain — that was the spoofable path in issue #360. As defense-in-depth
+ * against any regression that lets a chain through, take the RIGHTMOST
+ * (nearest-to-relayer) entry, never the leftmost/client-controlled one. Falls
+ * back to express's `req.ip` (loopback in tests), then "unknown".
  */
 export function clientIpFromRequest(req: Request): string {
     const fwd = req.headers["x-forwarded-for"];
-    const raw = Array.isArray(fwd) ? fwd[0] : fwd;
+    // Multiple XFF headers arrive as an array; the last one is nearest to us.
+    const raw = Array.isArray(fwd) ? fwd[fwd.length - 1] : fwd;
     if (typeof raw === "string" && raw.length > 0) {
-        const first = raw.split(",")[0]?.trim();
-        if (first) return first;
+        const parts = raw
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        const last = parts[parts.length - 1];
+        if (last) return last;
     }
     return req.ip ?? "unknown";
 }

--- a/services/server/src/client_ip.rs
+++ b/services/server/src/client_ip.rs
@@ -1,0 +1,164 @@
+//! Trusted-proxy-aware client IP resolution.
+//!
+//! `X-Forwarded-For` grows left→right: every reverse proxy **appends** the
+//! address it received the connection from. So the rightmost entries are the
+//! closest (trusted) hops we control and the leftmost entry is whatever the
+//! original — possibly malicious — client chose to send. Taking the leftmost
+//! value (the historical behavior) let any client forge its own rate-limit
+//! bucket by sending a fresh fake `X-Forwarded-For` each request. See
+//! GitHub issue #360.
+//!
+//! [`resolve_client_ip`] mirrors express's numeric `trust proxy` semantics:
+//! it counts a configured number of trusted hops in from the socket end and
+//! returns the first address the client could not have forged.
+
+use std::net::IpAddr;
+
+/// Resolve the real client IP from an inbound `X-Forwarded-For` header value
+/// and the direct socket peer, trusting exactly `trusted_hops` reverse
+/// proxies in front of this server.
+///
+/// The address chain is built nearest-hop-first as `[peer, xff reversed…]`
+/// (index 0 = the hop that physically opened the connection to us). We then
+/// return the address `trusted_hops` positions in — i.e. we skip that many
+/// trusted proxies and take the next address, which is the furthest-out
+/// address we still trust.
+///
+/// * `trusted_hops = 0` → ignore `X-Forwarded-For` entirely and use the raw
+///   socket peer. Safe default for a directly-exposed server: nothing the
+///   client sends is trusted.
+/// * `trusted_hops = 1` → one reverse proxy in front (e.g. Railway's edge).
+///   Returns the address that edge observed for the client, which a client
+///   cannot forge past because edge always appends the true socket address to
+///   the right of any client-supplied value.
+///
+/// If `trusted_hops` exceeds the real chain length (misconfiguration) the
+/// index is clamped to the leftmost (oldest) address — the best we can see —
+/// so a too-large hop count degrades gracefully rather than panicking. Set
+/// `trusted_hops` to the *actual* number of proxies in front of the relayer;
+/// a value larger than reality re-opens the spoofing hole.
+///
+/// Returns `None` only when there is neither a socket peer nor any usable
+/// `X-Forwarded-For` entry.
+pub fn resolve_client_ip(
+    xff: Option<&str>,
+    peer: Option<IpAddr>,
+    trusted_hops: usize,
+) -> Option<String> {
+    // Address chain, nearest hop first: the socket peer, then the XFF entries
+    // in reverse (rightmost = most-recently-appended = nearest hop).
+    let mut chain: Vec<&str> = Vec::new();
+    let peer_str;
+    if let Some(p) = peer {
+        peer_str = p.to_string();
+        chain.push(&peer_str);
+    }
+    if let Some(raw) = xff {
+        for entry in raw.split(',').rev() {
+            let trimmed = entry.trim();
+            if !trimmed.is_empty() {
+                chain.push(trimmed);
+            }
+        }
+    }
+
+    if chain.is_empty() {
+        return None;
+    }
+
+    // Skip `trusted_hops` trusted proxies from the near end; clamp so a
+    // misconfigured (too-large) hop count can never index past the chain.
+    let idx = trusted_hops.min(chain.len() - 1);
+    Some(chain[idx].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn zero_hops_ignores_xff_and_uses_socket_peer() {
+        // A directly-exposed server must never trust a client-supplied header.
+        let got = resolve_client_ip(Some("1.2.3.4"), Some(ip("203.0.113.7")), 0);
+        assert_eq!(got.as_deref(), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn one_hop_returns_edge_observed_client_not_spoof() {
+        // Attacker sends `X-Forwarded-For: 1.2.3.4`; the edge proxy appends the
+        // real socket address (203.0.113.9); our socket peer is the edge's
+        // internal address (10.0.0.1). With one trusted hop we must land on the
+        // real client, never the spoofed leftmost value.
+        let got = resolve_client_ip(
+            Some("1.2.3.4, 203.0.113.9"),
+            Some(ip("10.0.0.1")),
+            1,
+        );
+        assert_eq!(got.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn one_hop_no_client_xff_returns_client() {
+        // Honest client sends no XFF; edge appends its real address.
+        let got = resolve_client_ip(Some("203.0.113.9"), Some(ip("10.0.0.1")), 1);
+        assert_eq!(got.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn two_hops_peels_two_trusted_proxies() {
+        // chain (near→far): [proxyB(peer), proxyA, realclient, spoof]
+        let got = resolve_client_ip(
+            Some("9.9.9.9, 203.0.113.9, 10.0.0.2"),
+            Some(ip("10.0.0.1")),
+            2,
+        );
+        assert_eq!(got.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn hops_larger_than_chain_clamps_to_oldest() {
+        // Misconfiguration: more trusted hops than addresses. Clamp to the
+        // leftmost known address rather than panic / underflow.
+        let got = resolve_client_ip(Some("203.0.113.9"), Some(ip("10.0.0.1")), 9);
+        assert_eq!(got.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn no_xff_falls_back_to_peer() {
+        let got = resolve_client_ip(None, Some(ip("203.0.113.7")), 1);
+        assert_eq!(got.as_deref(), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn whitespace_and_empty_entries_are_skipped() {
+        let got = resolve_client_ip(Some("  , 203.0.113.9 ,  "), Some(ip("10.0.0.1")), 1);
+        assert_eq!(got.as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn ipv6_peer_and_entries() {
+        let got = resolve_client_ip(
+            Some("2001:db8::5, 2001:db8::9"),
+            Some(ip("2001:db8::1")),
+            1,
+        );
+        assert_eq!(got.as_deref(), Some("2001:db8::9"));
+    }
+
+    #[test]
+    fn no_peer_uses_xff_only() {
+        // Defensive: no ConnectInfo available (should not happen in prod).
+        let got = resolve_client_ip(Some("1.2.3.4, 203.0.113.9"), None, 1);
+        assert_eq!(got.as_deref(), Some("1.2.3.4"));
+    }
+
+    #[test]
+    fn nothing_available_returns_none() {
+        assert_eq!(resolve_client_ip(None, None, 1), None);
+        assert_eq!(resolve_client_ip(Some("   "), None, 1), None);
+    }
+}

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1,5 +1,6 @@
 mod alerts;
 mod auth;
+mod client_ip;
 mod compatibility;
 mod engine;
 mod jobs;

--- a/services/server/src/mcp_proxy.rs
+++ b/services/server/src/mcp_proxy.rs
@@ -76,25 +76,25 @@ fn build_forwarded_headers(inbound: &HeaderMap) -> reqwest::header::HeaderMap {
 
 /// Inject the real client IP into the upstream request as `x-forwarded-for`
 /// so the sidecar's per-IP MCP rate limiter buckets per actual caller and
-/// not per loopback. We honor an inbound `x-forwarded-for` (if the relayer
-/// itself is behind a real proxy / load balancer) by appending the relayer's
-/// observed peer address; otherwise we set the header to that peer alone.
+/// not per loopback.
+///
+/// We must NOT pass the inbound `x-forwarded-for` through verbatim: its
+/// leftmost value is client-controlled, and the sidecar keys its rate limiter
+/// on the IP we forward. Instead we resolve the real client IP through the
+/// configured number of trusted proxies (`trusted_hops`) and forward exactly
+/// that single, sanitized value. The sidecar is reachable only over loopback
+/// from us, so it treats this one value as authoritative. Forwarding a
+/// client-controlled chain here is exactly the spoofing bug in issue #360.
 fn inject_forwarded_for(
     headers: &mut reqwest::header::HeaderMap,
     inbound: &HeaderMap,
     peer: SocketAddr,
+    trusted_hops: usize,
 ) {
-    let peer_ip = peer.ip().to_string();
-    let value = match inbound
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-    {
-        Some(existing) => format!("{}, {}", existing, peer_ip),
-        None => peer_ip,
-    };
-    if let Ok(v) = reqwest::header::HeaderValue::from_str(&value) {
+    let xff = inbound.get("x-forwarded-for").and_then(|v| v.to_str().ok());
+    let client_ip = crate::client_ip::resolve_client_ip(xff, Some(peer.ip()), trusted_hops)
+        .unwrap_or_else(|| peer.ip().to_string());
+    if let Ok(v) = reqwest::header::HeaderValue::from_str(&client_ip) {
         out_set(headers, "x-forwarded-for", v);
     }
 }
@@ -127,7 +127,7 @@ pub async fn sse_proxy(
     // open until the client itself closes it. `read_timeout` keeps a
     // per-chunk watchdog (heartbeats fire every 3s, so 60s is plenty).
     let mut forwarded = build_forwarded_headers(&headers);
-    inject_forwarded_for(&mut forwarded, &headers, peer);
+    inject_forwarded_for(&mut forwarded, &headers, peer, state.config.trusted_proxy_hops);
     let req = state
         .http_client
         .get(&url)
@@ -218,7 +218,7 @@ pub async fn messages_proxy(
     );
 
     let mut forwarded = build_forwarded_headers(&headers);
-    inject_forwarded_for(&mut forwarded, &headers, peer);
+    inject_forwarded_for(&mut forwarded, &headers, peer, state.config.trusted_proxy_hops);
     let upstream = state
         .http_client
         .post(&url)
@@ -316,7 +316,7 @@ pub async fn streamable_proxy(
         req = req.body(body.to_vec());
     }
     let mut forwarded = build_forwarded_headers(&headers);
-    inject_forwarded_for(&mut forwarded, &headers, peer);
+    inject_forwarded_for(&mut forwarded, &headers, peer, state.config.trusted_proxy_hops);
     req = req.headers(forwarded);
 
     // Same 24h request timeout as the SSE proxy — a streamable response
@@ -436,23 +436,37 @@ mod tests {
         let inbound = axum_headers(&[]);
         let peer: SocketAddr = "203.0.113.7:54321".parse().unwrap();
 
-        inject_forwarded_for(&mut out, &inbound, peer);
+        // No XFF: the single trusted edge hop reduces to the socket peer.
+        inject_forwarded_for(&mut out, &inbound, peer, 1);
 
         assert_eq!(xff(&out).as_deref(), Some("203.0.113.7"));
     }
 
     #[test]
-    fn inject_forwarded_for_appends_peer_to_existing_chain() {
+    fn inject_forwarded_for_forwards_single_resolved_client_ip() {
+        // Attacker prepends a spoofed IP; the edge appends the real client
+        // (203.0.113.9); our socket peer is the edge's internal address.
+        // With one trusted hop we must forward ONLY the real client, never
+        // the spoofed leftmost value and never a pass-through chain.
         let mut out = reqwest::header::HeaderMap::new();
-        let inbound = axum_headers(&[("x-forwarded-for", "198.51.100.4, 10.0.0.1")]);
-        let peer: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        let inbound = axum_headers(&[("x-forwarded-for", "1.2.3.4, 203.0.113.9")]);
+        let peer: SocketAddr = "10.0.0.1:9000".parse().unwrap();
 
-        inject_forwarded_for(&mut out, &inbound, peer);
+        inject_forwarded_for(&mut out, &inbound, peer, 1);
 
-        assert_eq!(
-            xff(&out).as_deref(),
-            Some("198.51.100.4, 10.0.0.1, 127.0.0.1")
-        );
+        assert_eq!(xff(&out).as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn inject_forwarded_for_zero_hops_ignores_client_xff() {
+        // Directly-exposed relayer: never trust a client-supplied header.
+        let mut out = reqwest::header::HeaderMap::new();
+        let inbound = axum_headers(&[("x-forwarded-for", "1.2.3.4")]);
+        let peer: SocketAddr = "203.0.113.7:5000".parse().unwrap();
+
+        inject_forwarded_for(&mut out, &inbound, peer, 0);
+
+        assert_eq!(xff(&out).as_deref(), Some("203.0.113.7"));
     }
 
     #[test]
@@ -461,7 +475,7 @@ mod tests {
         let inbound = axum_headers(&[("x-forwarded-for", "   ")]);
         let peer: SocketAddr = "203.0.113.7:1".parse().unwrap();
 
-        inject_forwarded_for(&mut out, &inbound, peer);
+        inject_forwarded_for(&mut out, &inbound, peer, 1);
 
         assert_eq!(xff(&out).as_deref(), Some("203.0.113.7"));
     }
@@ -472,7 +486,7 @@ mod tests {
         let inbound = axum_headers(&[]);
         let peer: SocketAddr = "[2001:db8::1]:443".parse().unwrap();
 
-        inject_forwarded_for(&mut out, &inbound, peer);
+        inject_forwarded_for(&mut out, &inbound, peer, 1);
 
         assert_eq!(xff(&out).as_deref(), Some("2001:db8::1"));
     }

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -860,20 +860,23 @@ pub async fn sponsor_rate_limit_middleware(
         return next.run(request).await;
     }
 
-    // Extract client IP from X-Forwarded-For (set by reverse proxy) or
-    // fall back to the direct connection address stored by axum.
-    let ip: Option<String> = request
+    // Resolve the real client IP through the configured number of trusted
+    // proxies. We must NOT take the leftmost `X-Forwarded-For` value — it is
+    // client-controlled and would let a single host forge unlimited rate-limit
+    // buckets (GitHub issue #360). `resolve_client_ip` counts `trusted_hops`
+    // in from the socket end and returns the first address the client could
+    // not have forged, falling back to the socket peer when no proxy is
+    // configured or no header is present.
+    let peer = request
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip());
+    let xff = request
         .headers()
         .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.split(',').next())
-        .map(|s| s.trim().to_string())
-        .or_else(|| {
-            request
-                .extensions()
-                .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-                .map(|ci| ci.0.ip().to_string())
-        });
+        .and_then(|v| v.to_str().ok());
+    let ip: Option<String> =
+        crate::client_ip::resolve_client_ip(xff, peer, state.config.trusted_proxy_hops);
 
     let ip = match ip {
         Some(ip) => ip,

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1073,6 +1073,7 @@ mod tests {
             registry_id: "0xregistry".to_string(),
             sidecar_url: "http://localhost:9003".to_string(),
             sidecar_secret: None,
+            trusted_proxy_hops: 1,
             rate_limit: crate::rate_limit::RateLimitConfig::default(),
             sponsor_rate_limit: crate::types::SponsorRateLimitConfig::default(),
             allowed_origins: String::new(),

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -218,6 +218,14 @@ pub struct Config {
     pub sidecar_url: String,
     /// Shared secret for authenticating Rust→sidecar calls (X-Sidecar-Secret header)
     pub sidecar_secret: Option<String>,
+    /// Number of trusted reverse proxies sitting in front of the relayer.
+    /// Used to resolve the real client IP from `X-Forwarded-For` for per-IP
+    /// rate limiting (see [`crate::client_ip::resolve_client_ip`]). On Railway
+    /// the edge proxy is one hop, so `1` is correct in production; `0` means
+    /// the relayer is directly exposed and no `X-Forwarded-For` value is
+    /// trusted. Set it to the *actual* hop count — a value larger than reality
+    /// lets clients spoof their rate-limit bucket (GitHub issue #360).
+    pub trusted_proxy_hops: usize,
     /// Rate limiting configuration
     pub rate_limit: RateLimitConfig,
     /// Sponsor-specific rate limiting and concurrency config
@@ -292,6 +300,13 @@ impl Config {
             sidecar_url: std::env::var("SIDECAR_URL")
                 .unwrap_or_else(|_| "http://localhost:9000".to_string()),
             sidecar_secret: std::env::var("SIDECAR_AUTH_TOKEN").ok(),
+            // Default 1 = one edge proxy (Railway) in front of the relayer in
+            // production. Override with TRUSTED_PROXY_HOPS=0 when the relayer is
+            // directly exposed. An invalid / non-numeric value falls back to 1.
+            trusted_proxy_hops: std::env::var("TRUSTED_PROXY_HOPS")
+                .ok()
+                .and_then(|v| v.trim().parse::<usize>().ok())
+                .unwrap_or(1),
             rate_limit: RateLimitConfig::from_env(),
             sponsor_rate_limit: SponsorRateLimitConfig::from_env(),
             allowed_origins: std::env::var("ALLOWED_ORIGINS")


### PR DESCRIPTION
## Summary

Fixes #360.

The MCP proxy routes (`/api/mcp/sse`, `/api/mcp/messages`, `/api/mcp`) intentionally skip signed-request auth **and** per-key rate limiting, so the per-IP session cap in the Node sidecar is the **only** per-source defense against an unauthenticated session flood. Both that limiter and the `/sponsor` IP limiter derived the client IP from the **first (leftmost)** value of `X-Forwarded-For` — which is fully client-controlled. A single host could send a fresh fake `X-Forwarded-For` on each request, land in a brand-new per-IP bucket every time, and sail past `maxSessionsPerIp` / `maxNewSessionsPerIpPerMin`.

This PR resolves the real client IP by counting a configured number of trusted reverse proxies **in from the socket end** (express-style `trust proxy` semantics) and never trusting the leftmost value.

## Changes

- **`client_ip::resolve_client_ip(xff, peer, trusted_hops)`** — new shared helper. Builds the address chain `[socket_peer, XFF reversed…]`, skips `trusted_hops` trusted proxies, and returns the first address the client cannot forge past. Clamps a too-large hop count instead of underflowing. Unit-tested (spoof-defeat, 0/1/2 hops, IPv6, misconfig).
- **`TRUSTED_PROXY_HOPS`** — new config (default `1` = Railway's single edge proxy; `0` = relayer directly exposed → ignore `X-Forwarded-For`). Documented in `.env.example`.
- **`mcp_proxy::inject_forwarded_for`** — now forwards **one** sanitized client IP to the sidecar instead of appending the peer to a client-controlled chain. The sidecar is loopback-only from the relayer, so that single value is authoritative.
- **`sponsor_rate_limit_middleware`** — uses the same resolver (secondary route; per-sender limit already backstops it, but fixed for consistency / defense-in-depth).
- **Sidecar `clientIpFromRequest`** — takes the rightmost (nearest-relayer) hop as defense-in-depth and documents the trust boundary.

⚠️ **Deploy note:** default is `TRUSTED_PROXY_HOPS=1`, correct for the current Railway topology (one edge proxy). Any environment that exposes the relayer without a proxy in front must set `TRUSTED_PROXY_HOPS=0`; a value larger than the real hop count re-opens the spoofing hole.

## Testing

- `cargo test` — `client_ip` 10/10, `mcp_proxy` inject 5/5, `rate_limit` 26/26 pass.
- Node sidecar — 17/17 rate-limit tests pass.
- `cargo clippy` — no new warnings.

Scope is entirely relayer + sidecar; the Move contract is untouched.