### PR TITLE
fix(mcp): bind /connect/mcp consent to the local bridge (#368)

### DIFF
--- a/apps/app/src/pages/ConnectMcp.tsx
+++ b/apps/app/src/pages/ConnectMcp.tsx
@@ -60,6 +60,41 @@ function hexToBytes(hex: string): number[] {
     return out
 }
 
+/**
+ * Prove the request came from a Walrus Memory MCP bridge running on THIS
+ * machine before we register a delegate key on-chain (issue #368).
+ *
+ * The bridge mints a single-use `connectState` token, keeps it in memory, and
+ * only puts it in the `/connect/mcp` URL it opens itself. We hand that token
+ * back to the bridge's localhost `/handshake`; it answers `{ ok: true }` only
+ * when the token matches the one it minted. A phishing link opened from an
+ * email carries an attacker-chosen token and reaches no local bridge (or a
+ * bridge whose token differs), so this returns false and we refuse to sign.
+ *
+ * Any failure — no listener, wrong token, CORS/PNA block, non-bridge process
+ * on the port — is treated as "not verified". False negatives are safe: they
+ * only ask a legitimate user to restart the MCP login command.
+ */
+/** Compare two relayer URLs ignoring trailing slashes and case. */
+function sameRelayer(a: string, b: string): boolean {
+    const norm = (s: string) => s.replace(/\/+$/, '').toLowerCase()
+    return norm(a) === norm(b)
+}
+
+async function verifyLocalBridge(port: string, state: string): Promise<boolean> {
+    try {
+        const res = await fetch(
+            `http://127.0.0.1:${port}/handshake?state=${encodeURIComponent(state)}`,
+            { method: 'GET' },
+        )
+        if (!res.ok) return false
+        const data = (await res.json().catch(() => null)) as { ok?: unknown } | null
+        return data?.ok === true
+    } catch {
+        return false
+    }
+}
+
 async function resolveAccountId(
     suiClient: ReturnType<typeof useSuiClient>,
     ownerAddress: string,
@@ -129,7 +164,17 @@ export default function ConnectMcp() {
     const [walletPickerOpen, setWalletPickerOpen] = useState(false)
     const [callbackPayload, setCallbackPayload] = useState<McpCallbackPayload | null>(null)
     const [callbackDelivered, setCallbackDelivered] = useState<boolean | null>(null)
+    // Bridge binding (issue #368): null = still checking, true = a local bridge
+    // confirmed it issued this request, false = could not confirm (a phishing
+    // link opened from elsewhere, or the local bridge has exited). We refuse to
+    // sign `add_delegate_key` unless this is true.
+    const [bridgeVerified, setBridgeVerified] = useState<boolean | null>(null)
     const invalidRequestTrackedRef = useRef(false)
+    // True once the user actively started the flow (clicked the consent button).
+    // Gates the wallet-picker auto-proceed effect so a pre-connected wallet does
+    // NOT skip straight past the consent screen on mount — the user must read
+    // and click through the disclosure first (issue #368).
+    const initiatedRef = useRef(false)
 
     // Validate query string up-front.
     const paramsValid = useMemo(() => {
@@ -166,6 +211,9 @@ export default function ConnectMcp() {
     )
 
     const handleConnect = useCallback(async () => {
+        // Mark the flow as user-initiated so the auto-proceed effect below is
+        // allowed to run after the wallet picker closes (issue #368).
+        initiatedRef.current = true
         if (!paramsValid) {
             trackEvent('mcp_connect_failed', { error_type: 'invalid_request' })
             setErrorMsg('Invalid query parameters from MCP client.')
@@ -179,6 +227,30 @@ export default function ConnectMcp() {
         }
 
         trackEvent('mcp_connect_start', { wallet_connected: true })
+
+        // Bind this on-chain write to the local bridge (issue #368). Never sign
+        // add_delegate_key for a request we can't prove a bridge on this port
+        // issued — this is what blocks a consent-phishing link opened from an
+        // email/chat, where no local bridge (or a bridge with a different token)
+        // answers the handshake. Re-checked here right before signing even
+        // though the page already probed on load, in case the bridge exited in
+        // between.
+        const bridgeOk = await verifyLocalBridge(port, state)
+        setBridgeVerified(bridgeOk)
+        if (!bridgeOk) {
+            trackEvent('mcp_connect_failed', { error_type: 'bridge_unverified' })
+            setErrorMsg(
+                'Could not confirm this request came from a Walrus Memory MCP login running on this computer, ' +
+                'so nothing was registered on-chain. ' +
+                'If you did NOT start this yourself — for example you opened a link from an email or chat message — ' +
+                'close this tab: approving would grant someone else ongoing access to all your memories. ' +
+                'If you DID start this, make sure you are running the latest MCP client ' +
+                '(e.g. `npx @mysten-incubation/memwal-mcp@latest login`) and restart the login command, then try again.'
+            )
+            setStep('error')
+            return
+        }
+
         setStep('signing')
         try {
             // Resolve the user's Walrus Memory account object.
@@ -257,6 +329,7 @@ export default function ConnectMcp() {
         publicKey,
         delegateAddress,
         label,
+        port,
         state,
         postCallback,
     ])
@@ -266,6 +339,22 @@ export default function ConnectMcp() {
         invalidRequestTrackedRef.current = true
         trackEvent('mcp_connect_failed', { error_type: 'invalid_request' })
     }, [paramsValid])
+
+    // Probe the local bridge as soon as the request looks well-formed, so the
+    // consent screen can warn — and disable Approve — before the user ever
+    // connects a wallet if this link did not come from a bridge on this machine
+    // (issue #368). handleConnect re-checks right before signing.
+    useEffect(() => {
+        setBridgeVerified(null)
+        if (!paramsValid) return
+        let cancelled = false
+        void verifyLocalBridge(port, state).then((ok) => {
+            if (!cancelled) setBridgeVerified(ok)
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [paramsValid, port, state])
 
     // Persist the connect request so it survives the Google OAuth redirect.
     // Enoki's redirect_uri is pinned to the app root (App.tsx), so signing in
@@ -282,8 +371,10 @@ export default function ConnectMcp() {
     }, [paramsValid, port, publicKey, delegateAddress, label, relayer, state])
 
     // If the wallet popup completes after we asked it to open, auto-proceed.
+    // Gated on initiatedRef so a wallet that was ALREADY connected on mount does
+    // not skip the consent screen — the user must click through it first (#368).
     useEffect(() => {
-        if (!walletPickerOpen && currentAccount && step === 'consent') {
+        if (initiatedRef.current && !walletPickerOpen && currentAccount && step === 'consent') {
             // user picked a wallet — kick off the connect flow.
             void handleConnect()
         }
@@ -325,8 +416,11 @@ export default function ConnectMcp() {
                         <ConsentCard
                             label={label}
                             delegateAddress={delegateAddress}
+                            publicKey={publicKey}
                             relayer={relayer}
+                            relayerIsDefault={sameRelayer(relayer, config.memwalServerUrl)}
                             wallet={currentAccount?.address ?? null}
+                            bridgeVerified={bridgeVerified}
                             onConnect={handleConnect}
                         />
                     )}
@@ -406,33 +500,83 @@ export default function ConnectMcp() {
 function ConsentCard({
     label,
     delegateAddress,
+    publicKey,
     relayer,
+    relayerIsDefault,
     wallet,
+    bridgeVerified,
     onConnect,
 }: {
     label: string
     delegateAddress: string
+    publicKey: string
     relayer: string
+    relayerIsDefault: boolean
     wallet: string | null
+    bridgeVerified: boolean | null
     onConnect: () => void
 }) {
+    // We only enable the on-chain action once a local bridge has confirmed it
+    // issued this request (issue #368). `null` = still probing.
+    const blocked = bridgeVerified !== true
+
+    let buttonText: string
+    if (bridgeVerified === null) buttonText = 'Checking this request…'
+    else if (bridgeVerified === false) buttonText = 'Request could not be verified'
+    else buttonText = wallet ? 'Approve in wallet' : 'Connect Sui wallet'
+
     return (
         <div className="setup-classic-intro">
             <h2 className="setup-classic-title">
-                {label} wants access to your Walrus Memory
+                Authorize an MCP client to access your Walrus Memory
             </h2>
             <p className="setup-classic-description">
-                Review the permissions below, then connect your Sui wallet to register this delegate key on-chain.
+                Something is asking to register a <strong>delegate key</strong> on your Walrus Memory
+                account. Read what this grants before you approve — the request below is not verified by
+                Walrus Memory, only by you.
             </p>
 
+            {/* Bridge-binding status. This is the anti-phishing signal: a request
+                that did not originate from a bridge on this machine cannot pass. */}
+            {bridgeVerified === false && (
+                <div style={dangerBoxStyle}>
+                    <strong>⚠ This request did not come from an MCP login on this computer.</strong>
+                    <p style={{ margin: '6px 0 0' }}>
+                        Walrus Memory could not reach a local Walrus Memory MCP login for this request, so
+                        approving is disabled. If a link was sent to you by someone else,{' '}
+                        <strong>close this tab</strong> — it may be trying to trick you into granting them
+                        access. If you started this yourself, your MCP client may be out of date — update to
+                        the latest and restart the login command.
+                    </p>
+                </div>
+            )}
+            {bridgeVerified === true && (
+                <div style={okBoxStyle}>
+                    ✓ Verified this request came from a Walrus Memory MCP login running on this computer.
+                </div>
+            )}
+
             <div className="card setup-classic-feature-card">
-                <p style={cardLabelStyle}>Permissions requested</p>
+                <p style={cardLabelStyle}>What approving grants</p>
                 <ul style={permListStyle}>
-                    <li>✓ Read your memories (<code style={codeStyle}>memwal_recall</code>)</li>
-                    <li>✓ Save new memories (<code style={codeStyle}>memwal_remember</code>)</li>
-                    <li>✓ Extract facts from text (<code style={codeStyle}>memwal_analyze</code>)</li>
-                    <li>✓ Re-index from Walrus (<code style={codeStyle}>memwal_restore</code>)</li>
+                    <li>✓ Read <strong>and decrypt</strong> every memory in this account — all namespaces</li>
+                    <li>✓ Create, update, and overwrite memories</li>
+                    <li>✓ Extract facts from text and re-index from Walrus storage</li>
                 </ul>
+                <p style={scaryNoteStyle}>
+                    This gives a third party <strong>persistent read, decrypt, and write access to
+                    everything in this account</strong> — through the relayer below — and it lasts until you
+                    revoke the key from your dashboard. It is not limited to one session.
+                </p>
+
+                <div style={dividerStyle} />
+
+                <p style={cardLabelStyle}>The client identifies itself as</p>
+                <div style={untrustedLabelStyle}>{label}</div>
+                <p style={untrustedHintStyle}>
+                    This name is supplied by the requester and is <strong>not verified</strong>. Anyone can
+                    claim any name.
+                </p>
 
                 <div style={dividerStyle} />
 
@@ -440,10 +584,20 @@ function ConsentCard({
                 <div style={detailRowStyle}>
                     <span style={detailLabelStyle}>Relayer</span>
                     <span style={detailValueStyle}>{relayer}</span>
+                    {!relayerIsDefault && (
+                        <span style={relayerWarnStyle}>
+                            ⚠ Non-default relayer — your memories would be served through this host. Only
+                            proceed if you recognize it.
+                        </span>
+                    )}
                 </div>
                 <div style={detailRowStyle}>
-                    <span style={detailLabelStyle}>Delegate address</span>
-                    <span style={detailValueStyle}>{delegateAddress.slice(0, 16)}…{delegateAddress.slice(-6)}</span>
+                    <span style={detailLabelStyle}>Delegate address (full)</span>
+                    <span style={detailValueStyle}>{delegateAddress}</span>
+                </div>
+                <div style={detailRowStyle}>
+                    <span style={detailLabelStyle}>Delegate public key (full)</span>
+                    <span style={detailValueStyle}>{publicKey}</span>
                 </div>
                 <div style={detailRowStyle}>
                     <span style={detailLabelStyle}>Connected wallet</span>
@@ -453,9 +607,20 @@ function ConsentCard({
                 </div>
             </div>
 
+            <div style={safetyNoteStyle}>
+                Only continue if <strong>you</strong> just started this from your own machine. Approving hands
+                the key above ongoing access to all your memories.
+            </div>
+
             <div className="setup-classic-actions">
-                <button onClick={onConnect} className="lp-btn-yellow">
-                    {wallet ? 'Approve in wallet' : 'Connect Sui wallet'}
+                <button
+                    onClick={onConnect}
+                    className="lp-btn-yellow"
+                    disabled={blocked}
+                    aria-disabled={blocked}
+                    style={blocked ? disabledBtnStyle : undefined}
+                >
+                    {buttonText}
                 </button>
             </div>
         </div>
@@ -567,4 +732,73 @@ const detailValueStyle: React.CSSProperties = {
 
 const errorTextStyle: React.CSSProperties = {
     color: '#ff6b6b',
+}
+
+// Red alert box — shown when the request can't be tied to a local bridge.
+const dangerBoxStyle: React.CSSProperties = {
+    background: 'rgba(239, 68, 68, 0.12)',
+    border: '1px solid #ef4444',
+    borderRadius: 8,
+    padding: '12px 14px',
+    margin: '0 0 18px',
+    fontSize: '0.88rem',
+    color: '#ffb4b4',
+}
+
+// Green confirmation box — shown when the bridge handshake succeeded.
+const okBoxStyle: React.CSSProperties = {
+    background: 'rgba(34, 197, 94, 0.12)',
+    border: '1px solid #22c55e',
+    borderRadius: 8,
+    padding: '10px 14px',
+    margin: '0 0 18px',
+    fontSize: '0.85rem',
+    color: '#86efac',
+}
+
+// The blunt "what you're really granting" paragraph inside the card.
+const scaryNoteStyle: React.CSSProperties = {
+    margin: '14px 0 0',
+    fontSize: '0.84rem',
+    lineHeight: 1.5,
+    color: '#f0a3a3',
+}
+
+// Attacker-controlled label — rendered as untrusted free text, never as a
+// verified identity in the heading.
+const untrustedLabelStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: '0.9rem',
+    color: '#faf8f5',
+    background: '#1c1e20',
+    border: '1px solid #2a2c2e',
+    borderRadius: 6,
+    padding: '8px 10px',
+    wordBreak: 'break-all',
+}
+
+const untrustedHintStyle: React.CSSProperties = {
+    margin: '6px 0 0',
+    fontSize: '0.78rem',
+    color: '#8f9294',
+}
+
+const relayerWarnStyle: React.CSSProperties = {
+    marginTop: 4,
+    fontSize: '0.78rem',
+    color: '#f0a3a3',
+    lineHeight: 1.45,
+}
+
+const safetyNoteStyle: React.CSSProperties = {
+    margin: '18px 0 0',
+    fontSize: '0.82rem',
+    lineHeight: 1.5,
+    color: '#c7b48a',
+    textAlign: 'center',
+}
+
+const disabledBtnStyle: React.CSSProperties = {
+    opacity: 0.45,
+    cursor: 'not-allowed',
 }

--- a/packages/mcp/src/login.ts
+++ b/packages/mcp/src/login.ts
@@ -4,10 +4,12 @@
  *   1. Generate Ed25519 keypair locally.
  *   2. Start an HTTP listener on a random localhost port.
  *   3. Open the user's browser at the configured web URL with the public
- *      key + callback port in the query string.
- *   4. Web page asks user to connect Sui wallet → signs `add_delegate_key`
- *      on-chain → POSTs the resulting {accountId, walletAddress, packageId,
- *      txDigest, ...} to `http://localhost:<port>/callback`.
+ *      key + callback port + single-use state token in the query string.
+ *   4. Web page fetches `GET /handshake?state=` first to confirm a real local
+ *      bridge issued this request (binds the on-chain write to this process —
+ *      see issue #368), then asks the user to connect their Sui wallet → signs
+ *      `add_delegate_key` on-chain → POSTs the resulting {accountId,
+ *      walletAddress, packageId, txDigest, ...} to `http://localhost:<port>/callback`.
  *   5. Listener receives the callback, returns 200 + a friendly success
  *      page, then shuts down. We resolve with `MemWalCredentials`.
  *
@@ -227,10 +229,10 @@ export async function loginFlow(opts: LoginOptions = {}): Promise<MemWalCredenti
         void timer;
 
         server.on("request", async (req: IncomingMessage, res: ServerResponse) => {
-            // CORS — only the dashboard origin we control may POST. `*` would
-            // let any web page on the internet talk to this localhost port.
+            // CORS — only the dashboard origin we control may talk to us. `*`
+            // would let any web page on the internet reach this localhost port.
             res.setHeader("access-control-allow-origin", expectedOrigin);
-            res.setHeader("access-control-allow-methods", "POST, OPTIONS");
+            res.setHeader("access-control-allow-methods", "GET, POST, OPTIONS");
             res.setHeader("access-control-allow-headers", "content-type");
             res.setHeader("vary", "origin");
             if (req.method === "OPTIONS") {
@@ -263,6 +265,26 @@ export async function loginFlow(opts: LoginOptions = {}): Promise<MemWalCredenti
             }
 
             const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+
+            // Pre-sign handshake. The consent page fetches this BEFORE it will
+            // sign `add_delegate_key` on chain, to prove a real local bridge
+            // owns this port AND issued the `connectState` carried in its URL.
+            // We answer `{ ok: true }` only when the supplied state matches the
+            // single-use token we minted for this flow. A phishing link (issue
+            // #368) carries an attacker-chosen state and reaches no local bridge
+            // — or a victim bridge whose token differs — so it fails here and
+            // the page never signs. This lifts the existing state-token defense
+            // (previously guarding only the callback) to also gate the on-chain
+            // write. The Origin/Host/PNA checks above already apply.
+            if (url.pathname === "/handshake" && req.method === "GET") {
+                const qState = url.searchParams.get("state") ?? "";
+                const ok = stateEquals(qState, stateToken);
+                if (!ok) log.warn("login.handshake_bad_state", {});
+                res.writeHead(ok ? 200 : 403, { "content-type": "application/json" });
+                res.end(JSON.stringify({ ok }));
+                return;
+            }
+
             if (url.pathname !== "/callback" || req.method !== "POST") {
                 res.writeHead(404, { "content-type": "text/plain" });
                 res.end("Not found");

--- a/packages/mcp/test/login-handshake.test.mjs
+++ b/packages/mcp/test/login-handshake.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * Security test for the pre-sign handshake added in issue #368.
+ *
+ * The consent page must be able to prove a request came from a bridge running
+ * on THIS machine before it signs `add_delegate_key` on-chain. `loginFlow`
+ * exposes `GET /handshake?state=` for exactly that: it answers `{ ok: true }`
+ * only when the supplied state matches the single-use token the bridge minted
+ * and embedded in the URL it opened. A phishing link carries an attacker-chosen
+ * state (or reaches no bridge at all), so it must be rejected.
+ *
+ * We drive the real localhost listener `loginFlow` starts (openBrowser: false),
+ * probe the handshake with correct / wrong / missing tokens, then complete the
+ * flow with a valid callback so the server shuts down cleanly.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loginFlow } from "../dist/login.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+void resolve(__dirname);
+
+const WEB_URL = "http://localhost:41234"; // expected Origin; no real server needed
+const ACCOUNT_ID = "0x" + "a".repeat(64);
+const WALLET = "0x" + "b".repeat(64);
+const PACKAGE_ID = "0x" + "c".repeat(64);
+
+/** POST a JSON callback to the bridge with a controllable Origin header. */
+function postCallback(port, bodyObj, origin = WEB_URL) {
+    const body = JSON.stringify(bodyObj);
+    return new Promise((res, rej) => {
+        const req = http.request(
+            {
+                host: "127.0.0.1",
+                port,
+                path: "/callback",
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "content-length": Buffer.byteLength(body),
+                    origin,
+                },
+            },
+            (r) => {
+                let buf = "";
+                r.on("data", (c) => (buf += c));
+                r.on("end", () => res({ status: r.statusCode, body: buf }));
+            },
+        );
+        req.on("error", rej);
+        req.end(body);
+    });
+}
+
+test("GET /handshake gates the flow on the single-use state token", async (t) => {
+    const home = mkdtempSync(join(tmpdir(), "memwal-handshake-"));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    // saveCreds writes under HOME on a successful callback — keep it off the
+    // real ~/.memwal.
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    t.after(() => {
+        process.env.HOME = prevHome;
+        process.env.USERPROFILE = prevUserProfile;
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    let connectUrl = "";
+    const flow = loginFlow({
+        openBrowser: false,
+        webUrl: WEB_URL,
+        relayerUrl: "http://127.0.0.1:1",
+        label: "Handshake Test",
+        timeoutMs: 20_000,
+        onUrl: (u) => {
+            connectUrl = u;
+        },
+    });
+
+    // Wait for the listener to be ready and surface its URL.
+    await new Promise((r) => setTimeout(r, 100));
+    assert.ok(connectUrl, "loginFlow should surface the connect URL via onUrl");
+
+    const parsed = new URL(connectUrl);
+    const port = parsed.searchParams.get("port");
+    const token = parsed.searchParams.get("connectState");
+    assert.match(port ?? "", /^\d+$/, "URL should carry a numeric port");
+    assert.match(token ?? "", /^[0-9a-f]{64}$/, "URL should carry a 64-hex state token");
+
+    const handshake = (state) =>
+        fetch(`http://127.0.0.1:${port}/handshake?state=${state}`).then(async (r) => ({
+            status: r.status,
+            body: await r.json().catch(() => null),
+        }));
+
+    // Probe before asserting so the server is always torn down via the callback
+    // below even if an expectation fails.
+    const good = await handshake(token);
+    const wrong = await handshake("f".repeat(64));
+    const missing = await fetch(`http://127.0.0.1:${port}/handshake`).then(async (r) => ({
+        status: r.status,
+        body: await r.json().catch(() => null),
+    }));
+
+    // Complete the flow with a legitimate callback so loginFlow resolves and
+    // closes its listener.
+    const cb = await postCallback(port, {
+        accountId: ACCOUNT_ID,
+        walletAddress: WALLET,
+        packageId: PACKAGE_ID,
+        state: token,
+        txDigest: "0x" + "d".repeat(64),
+        label: "Handshake Test",
+    });
+    const creds = await flow;
+
+    // Correct token → authorized.
+    assert.equal(good.status, 200, "correct state should return 200");
+    assert.equal(good.body?.ok, true, "correct state should return { ok: true }");
+
+    // Attacker-chosen token → refused (this is what defeats the phishing link).
+    assert.equal(wrong.status, 403, "wrong state should return 403");
+    assert.equal(wrong.body?.ok, false, "wrong state should return { ok: false }");
+
+    // Missing token → refused.
+    assert.equal(missing.status, 403, "missing state should return 403");
+    assert.equal(missing.body?.ok, false, "missing state should return { ok: false }");
+
+    // Sanity: the legitimate callback still works end-to-end.
+    assert.equal(cb.status, 200, "valid callback should return 200");
+    assert.equal(creds.accountId, ACCOUNT_ID, "credentials should carry the account id");
+});


### PR DESCRIPTION
## Summary

Fixes the consent-phishing surface reported in #368. The `/connect/mcp` page registered a delegate key on the connected wallet's Walrus Memory account based **entirely on query-string parameters**, with no proof the request came from the local MCP bridge it claims to serve. An attacker could send a victim a link on the trusted `memory.walrus.xyz` domain — *"Cursor wants access to your Walrus Memory"* — and, on approval, permanently grant the **attacker's own delegate key** read / decrypt / write access to all the victim's memories until manually revoked.

This is an app-level consent-phishing issue, not a wallet- or contract-level one: the branded first-party consent screen lent credibility to a fully attacker-defined request. The Move contract is **unchanged** — the owner check already passes for a victim-signed tx, and (per the report) the `public_key` / `sui_address` desync is not what enables the attack.

## What changed

**1. Bind the on-chain write to the local bridge (core fix).** Reuses the existing single-use `connectState` token, lifting it from guarding only the callback to also gating the signature:

- `packages/mcp/src/login.ts`: add `GET /handshake?state=` that returns `{ ok: true }` only when the state matches the token the bridge minted (constant-time compare, behind the same Host / Origin / PNA guards as the callback). Allow `GET` in CORS.
- `apps/app/src/pages/ConnectMcp.tsx`: probe the bridge on load and re-verify **immediately before signing**; refuse to sign `add_delegate_key` unless it confirms. A phishing link reaches no local bridge — or one whose token differs — and fails the handshake, so the page never signs.

**2. Make the consent screen honest (report recommendations 2–4).**

- Show the **full** delegate address and public key (were truncated / hidden).
- Render the client `label` as **untrusted free text**, not a verified "*&lt;label&gt; wants access*" identity.
- State plainly that approving grants persistent **read + decrypt + write** to all memories across all namespaces until revoked; warn on a **non-default relayer**.
- Don't auto-skip the consent screen when a wallet is already connected.

## Testing

- `packages/mcp` — new `test/login-handshake.test.mjs` drives the real localhost listener: correct token → `200 {ok:true}`, wrong / missing token → `403 {ok:false}`, and a valid callback still resolves credentials. Full suite: **9/9 pass**.
- `apps/app` — `tsc -b` clean, `eslint` clean.

## Deploy ordering (fail-closed — please read)

The app now rejects an older bridge that lacks `/handshake`. This is intentional and matches the existing "force a bridge upgrade" behaviour of the `connectState` param. **Publish the updated `@mysten-incubation/memwal-mcp` bridge before deploying the app** so legitimate users aren't blocked. The error screen guides users to update the client (`npx @mysten-incubation/memwal-mcp@latest login`).

Fixes #368.
