### PR TITLE
fix(contract): scope seal_approve authorization to the account owner

### DIFF
--- a/services/contract/sources/account.move
+++ b/services/contract/sources/account.move
@@ -539,15 +539,22 @@ module memwal::account {
         // Account must be active
         assert!(account.active, EAccountDeactivated);
 
+        // The requested key ID must be namespaced to this account's owner on
+        // both the owner and delegate paths — this is the binding between `id`
+        // and `account`. The owner is identified by the id suffix; a delegate
+        // is authorized only for the data of the account it is registered on,
+        // never for an arbitrary id passed together with an unrelated account.
+        let owner_bytes = sui::bcs::to_bytes(&account.owner);
+        assert!(has_suffix(&id, &owner_bytes), ENoAccess);
+
         let caller = ctx.sender();
 
-        // Owner check: key ID must end with BCS(owner) and caller must be the owner
-        let owner_bytes = sui::bcs::to_bytes(&account.owner);
-        let is_owner = (caller == account.owner) && has_suffix(&id, &owner_bytes);
-        // Delegate key holders can decrypt
-        let is_delegate = is_delegate_address(account, caller);
+        // Owner can decrypt — return early; this also avoids scanning the
+        // delegate list in the common owner path.
+        if (caller == account.owner) return;
 
-        assert!(is_owner || is_delegate, ENoAccess);
+        // Otherwise the caller must be a registered delegate of this account.
+        assert!(is_delegate_address(account, caller), ENoAccess);
     }
 
     /// Compute the SEAL key ID for a given owner address.

--- a/services/contract/tests/account_tests.move
+++ b/services/contract/tests/account_tests.move
@@ -596,6 +596,50 @@ module memwal::account_tests {
         scenario.end();
     }
 
+    /// A delegate is authorized only for the data of the account it is
+    /// registered on: `seal_approve` must reject a key id that is not
+    /// namespaced to this account's owner, even when the caller is a
+    /// registered delegate. Here OWNER registers themselves as a delegate of
+    /// their own account and then requests an id scoped to an unrelated owner
+    /// (OTHER) with that account — this must abort with ENoAccess.
+    #[test]
+    #[expected_failure(abort_code = account::ENoAccess)]
+    fun test_seal_approve_delegate_rejects_unrelated_id() {
+        let mut scenario = test_scenario::begin(OWNER);
+        setup_with_account(&mut scenario);
+
+        // OWNER registers themselves as a delegate of their own account
+        // (delegate address == owner is permitted).
+        scenario.next_tx(OWNER);
+        {
+            let mut account = scenario.take_shared<MemWalAccount>();
+            let pk = x"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+            let clock = clock::create_for_testing(scenario.ctx());
+            account::add_delegate_key(
+                &mut account,
+                pk,
+                OWNER, // delegate address == account owner
+                string::utf8(b"self delegate"),
+                &clock,
+                scenario.ctx(),
+            );
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(account);
+        };
+
+        // Requesting an id scoped to an unrelated owner (OTHER) while passing
+        // this account must be denied.
+        scenario.next_tx(OWNER);
+        {
+            let account = scenario.take_shared<MemWalAccount>();
+            let unrelated_key_id = sui::bcs::to_bytes(&OTHER);
+            account::seal_approve(unrelated_key_id, &account, scenario.ctx());
+            test_scenario::return_shared(account);
+        };
+
+        scenario.end();
+    }
+
     #[test]
     #[expected_failure(abort_code = account::ENoAccess)]
     fun test_seal_approve_unauthorized() {


### PR DESCRIPTION
## What

`seal_approve` now requires the requested key id to be namespaced to the account owner on **both** the owner and delegate paths, and returns early for the owner. This binds `id` to the passed `account`, so a delegate is only ever authorized for the data of the account it is registered on.

## Test

Adds a regression test (`test_seal_approve_delegate_rejects_unrelated_id`) asserting a delegate is denied an id scoped to an unrelated owner.

`sui move test` → **48/48 pass** (existing owner/delegate/unauthorized cases unchanged).

Code-only change; no deploy in this PR.
