### PR TITLE
WALM-184: Replace Node sidecar with native Rust Walrus + SEAL (foundation)

### DIFF
--- a/services/contract/sources/account.move
+++ b/services/contract/sources/account.move
@@ -539,15 +539,22 @@ module memwal::account {
         // Account must be active
         assert!(account.active, EAccountDeactivated);
 
+        // The requested key ID must be namespaced to this account's owner on
+        // both the owner and delegate paths — this is the binding between `id`
+        // and `account`. The owner is identified by the id suffix; a delegate
+        // is authorized only for the data of the account it is registered on,
+        // never for an arbitrary id passed together with an unrelated account.
+        let owner_bytes = sui::bcs::to_bytes(&account.owner);
+        assert!(has_suffix(&id, &owner_bytes), ENoAccess);
+
         let caller = ctx.sender();
 
-        // Owner check: key ID must end with BCS(owner) and caller must be the owner
-        let owner_bytes = sui::bcs::to_bytes(&account.owner);
-        let is_owner = (caller == account.owner) && has_suffix(&id, &owner_bytes);
-        // Delegate key holders can decrypt
-        let is_delegate = is_delegate_address(account, caller);
+        // Owner can decrypt — return early; this also avoids scanning the
+        // delegate list in the common owner path.
+        if (caller == account.owner) return;
 
-        assert!(is_owner || is_delegate, ENoAccess);
+        // Otherwise the caller must be a registered delegate of this account.
+        assert!(is_delegate_address(account, caller), ENoAccess);
     }
 
     /// Compute the SEAL key ID for a given owner address.

--- a/services/contract/tests/account_tests.move
+++ b/services/contract/tests/account_tests.move
@@ -596,6 +596,50 @@ module memwal::account_tests {
         scenario.end();
     }
 
+    /// A delegate is authorized only for the data of the account it is
+    /// registered on: `seal_approve` must reject a key id that is not
+    /// namespaced to this account's owner, even when the caller is a
+    /// registered delegate. Here OWNER registers themselves as a delegate of
+    /// their own account and then requests an id scoped to an unrelated owner
+    /// (OTHER) with that account — this must abort with ENoAccess.
+    #[test]
+    #[expected_failure(abort_code = account::ENoAccess)]
+    fun test_seal_approve_delegate_rejects_unrelated_id() {
+        let mut scenario = test_scenario::begin(OWNER);
+        setup_with_account(&mut scenario);
+
+        // OWNER registers themselves as a delegate of their own account
+        // (delegate address == owner is permitted).
+        scenario.next_tx(OWNER);
+        {
+            let mut account = scenario.take_shared<MemWalAccount>();
+            let pk = x"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+            let clock = clock::create_for_testing(scenario.ctx());
+            account::add_delegate_key(
+                &mut account,
+                pk,
+                OWNER, // delegate address == account owner
+                string::utf8(b"self delegate"),
+                &clock,
+                scenario.ctx(),
+            );
+            clock::destroy_for_testing(clock);
+            test_scenario::return_shared(account);
+        };
+
+        // Requesting an id scoped to an unrelated owner (OTHER) while passing
+        // this account must be denied.
+        scenario.next_tx(OWNER);
+        {
+            let account = scenario.take_shared<MemWalAccount>();
+            let unrelated_key_id = sui::bcs::to_bytes(&OTHER);
+            account::seal_approve(unrelated_key_id, &account, scenario.ctx());
+            test_scenario::return_shared(account);
+        };
+
+        scenario.end();
+    }
+
     #[test]
     #[expected_failure(abort_code = account::ENoAccess)]
     fun test_seal_approve_unauthorized() {

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -7,6 +7,9 @@ SIDECAR_AUTH_TOKEN=replace-with-32-byte-random-secret
 # SIDECAR_WATCHDOG_INTERVAL_SECS=30
 # SIDECAR_WATCHDOG_TIMEOUT_SECS=2
 # SIDECAR_WATCHDOG_MAX_FAILURES=6
+# WALM-184: Set to true to skip spawning the Node.js sidecar process.
+# Only use when native Rust Walrus/SEAL integrations are fully wired.
+# SIDECAR_DISABLED=false
 
 # Observability
 # RUST_LOG controls Rust tracing filters. Set LOG_FORMAT=json in production

--- a/services/server/Cargo.lock
+++ b/services/server/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +104,134 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-secp256k1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-secp256r1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3975a01b0a6e3eae0f72ec7ca8598a6620fc72fa5981f6f5cca33b7cd788f633"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,7 +250,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -121,7 +261,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -138,6 +278,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_ops"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
 
 [[package]]
 name = "autocfg"
@@ -206,8 +352,14 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -222,12 +374,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bcs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bcs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350f2b5fa7b76b498158ec1079dc0ea842c5b622b6b3f675005fddd889f2c9a7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -240,10 +459,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -258,12 +516,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -327,6 +596,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -394,6 +669,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +699,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -427,7 +714,65 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468 0.6.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -437,8 +782,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -447,7 +834,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -461,7 +848,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -471,14 +858,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "serde",
  "signature",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -490,7 +912,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -505,12 +927,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -552,10 +1006,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastcrypto"
+version = "0.1.9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=4db0e90c732bbf7420ca20de808b698883148d9c#4db0e90c732bbf7420ca20de808b698883148d9c"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-secp256k1",
+ "ark-secp256r1",
+ "ark-serialize",
+ "auto_ops",
+ "base64ct",
+ "bcs 0.1.6",
+ "bech32",
+ "bincode",
+ "blake2",
+ "blst",
+ "bs58 0.4.0",
+ "curve25519-dalek-ng",
+ "derive_more",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-consensus",
+ "elliptic-curve",
+ "fastcrypto-derive",
+ "generic-array",
+ "hex",
+ "hex-literal",
+ "hkdf",
+ "lazy_static",
+ "num-bigint",
+ "once_cell",
+ "p256",
+ "rand 0.8.5",
+ "readonly",
+ "rfc6979",
+ "rsa 0.8.2",
+ "schemars 0.8.22",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "sha3",
+ "signature",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "fastcrypto-derive"
+version = "0.1.3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=4db0e90c732bbf7420ca20de808b698883148d9c#4db0e90c732bbf7420ca20de808b698883148d9c"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -568,6 +1093,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flume"
@@ -696,7 +1227,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -740,8 +1271,10 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
+ "serde",
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -781,6 +1314,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,11 +1342,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -832,10 +1397,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
@@ -852,7 +1429,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -945,6 +1522,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1101,6 +1691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1715,17 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1151,9 +1758,27 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1165,6 +1790,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1807,15 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1272,7 +1916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1290,9 +1934,11 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
+ "bcs 0.2.1",
  "chrono",
  "dotenvy",
  "ed25519-dalek",
+ "fastcrypto",
  "futures",
  "hex",
  "opentelemetry",
@@ -1306,8 +1952,12 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
+ "sui-crypto",
+ "sui-rpc",
+ "sui-sdk-types",
+ "sui-transaction-builder",
  "tokio",
  "tower",
  "tower-http",
@@ -1315,6 +1965,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "walrus-core",
 ]
 
 [[package]]
@@ -1387,6 +2038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,10 +2074,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -1445,7 +2118,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1557,6 +2230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +2268,21 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1626,7 +2326,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1643,13 +2343,35 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -1658,8 +2380,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1684,6 +2406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,7 +2427,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1758,10 +2495,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1860,6 +2606,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
+
+[[package]]
+name = "readonly"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a62d85ed81ca5305dc544bd42c8804c5060b78ffa5ad3c64b0fb6a8c13d062"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "redis"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,7 +2633,7 @@ dependencies = [
  "bytes",
  "combine",
  "futures-util",
- "itertools",
+ "itertools 0.13.0",
  "itoa",
  "num-bigint",
  "percent-encoding",
@@ -1899,6 +2662,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "reed-solomon-simd"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
+dependencies = [
+ "cpufeatures",
+ "fixedbitset",
+ "once_cell",
+ "readme-rustdocifier",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1963,6 +2758,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,21 +2782,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
+name = "rsa"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+dependencies = [
+ "byteorder",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1 0.4.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature",
- "spki",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2024,7 +2860,9 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2073,10 +2911,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "security-framework"
@@ -2134,7 +3054,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2174,6 +3105,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58 0.5.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,7 +3144,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2192,13 +3155,36 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -2232,7 +3218,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2282,12 +3268,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -2322,7 +3318,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "native-tls",
@@ -2330,7 +3326,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -2350,7 +3346,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2368,12 +3364,12 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2391,7 +3387,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -2409,10 +3405,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rand 0.8.5",
- "rsa",
+ "rsa 0.9.10",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2451,7 +3447,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2494,6 +3490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,10 +3507,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
+name = "sui-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ac8658aa496ce509efc8f1206ef45d1c31871381d56c6c2bc754287a2e856a"
+dependencies = [
+ "ed25519-dalek",
+ "rand_core 0.6.4",
+ "signature",
+ "sui-sdk-types",
+]
+
+[[package]]
+name = "sui-rpc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a313a63f07ada0be04c03e9d6e8c1d176e5a469ee6e3b6f973dee525667311"
+dependencies = [
+ "base64",
+ "bcs 0.1.6",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "sui-sdk-types",
+ "tap",
+ "tokio",
+ "tonic",
+ "tonic-prost",
+ "tower",
+]
+
+[[package]]
+name = "sui-sdk-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f800c4c3539246ba94a825f6afe7faab0bc8fc4dda56c6cfa493ea2a32ecbd"
+dependencies = [
+ "base64ct",
+ "bcs 0.1.6",
+ "blake2",
+ "bnum",
+ "bs58 0.5.1",
+ "bytes",
+ "bytestring",
+ "itertools 0.14.0",
+ "roaring",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "winnow",
+]
+
+[[package]]
+name = "sui-transaction-builder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58530d23db8328c97b4cd2dec73af501f76fc7b3d538629ca32ec011efdc3cf8"
+dependencies = [
+ "async-trait",
+ "bcs 0.1.6",
+ "futures",
+ "serde",
+ "sui-rpc",
+ "sui-sdk-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2538,7 +3636,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2561,6 +3659,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2601,7 +3705,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2612,7 +3716,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2622,6 +3726,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2674,7 +3817,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2733,13 +3876,21 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
  "tokio-stream",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots",
+ "zstd",
 ]
 
 [[package]]
@@ -2761,9 +3912,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2820,7 +3974,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3015,6 +4169,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walrus-core"
+version = "1.52.0"
+source = "git+https://github.com/MystenLabs/walrus?tag=walrus_v1.52.0_1783366984_main_ci#fdce2cca42dde1266ba776896404d9917affacff"
+dependencies = [
+ "base64",
+ "bcs 0.1.6",
+ "enum_dispatch",
+ "fastcrypto",
+ "hex",
+ "p256",
+ "rand 0.8.5",
+ "reed-solomon-simd",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,7 +4272,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3129,7 +4302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3155,7 +4328,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -3177,6 +4350,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3210,7 +4392,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3221,7 +4403,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3491,6 +4673,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3518,9 +4709,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3536,7 +4727,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3549,7 +4740,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -3568,7 +4759,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -3603,7 +4794,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3624,7 +4815,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3644,7 +4835,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3653,6 +4844,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3684,7 +4889,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3692,3 +4897,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/services/server/Cargo.toml
+++ b/services/server/Cargo.toml
@@ -19,8 +19,33 @@ ed25519-dalek = { version = "2", features = ["serde"] }
 sha2 = "0.10"
 hex = "0.4"
 
-# SEAL encryption is handled by TS sidecar scripts (@mysten/seal)
-# (no Rust crypto deps needed)
+# SEAL encryption is still handled by TS sidecar scripts (@mysten/seal) —
+# no viable Rust crate exists yet (the only community SEAL SDK,
+# gfusee/seal-sdk-rs, currently fails to build: it pins a `sui` monorepo
+# revision that transitively depends on `core2 = "^0.4.0"`, which is the
+# only version of `core2` ever published and has been permanently yanked
+# upstream). Walrus/SEAL transaction *signing* below is unrelated to this
+# and does not depend on that broken crate.
+
+# Native Sui transaction building/signing (WALM-184: migrating the
+# Walrus write path — register/upload/certify — off the Node sidecar).
+# Mysten's lightweight, actively maintained SDK (github.com/mystenlabs/sui-rust-sdk),
+# not the full node monorepo — builds cleanly, no yanked transitive deps.
+sui-sdk-types = "0.3"
+sui-crypto = { version = "0.3", features = ["ed25519"] }
+sui-transaction-builder = "0.3"
+sui-rpc = "0.3"
+
+# Walrus RedStuff erasure-coding (compute blob_id/root_hash locally before
+# register_blob) — default-features = false skips the optional `sui-types`
+# feature, which would pull the full Sui monorepo and conflict with this
+# server's own sqlx/pgvector pins (see WALM-184 investigation notes).
+walrus-core = { git = "https://github.com/MystenLabs/walrus", tag = "walrus_v1.52.0_1783366984_main_ci", default-features = false }
+# Same rev walrus-core itself resolves to (see Cargo.lock) — pinned
+# explicitly, not left to re-resolve, so there's only ever one fastcrypto
+# in the dependency graph. Needed for ConfirmationCertificate.signature's
+# ToFromBytes::as_bytes() (storage::walrus_write).
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "4db0e90c732bbf7420ca20de808b698883148d9c" }
 
 # Background job queue — persistent metadata+transfer tasks
 apalis     = { version = "0.7", default-features = false, features = ["tracing"] }
@@ -58,3 +83,6 @@ uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 base64 = "0.22"
 percent-encoding = "2"
+
+[dev-dependencies]
+bcs = "0.2.1"

--- a/services/server/rust-toolchain.toml
+++ b/services/server/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.96"

--- a/services/server/src/engine/walrus_seal.rs
+++ b/services/server/src/engine/walrus_seal.rs
@@ -21,6 +21,7 @@
 //! today via `seal::SealCredential::from_auth_or_fallback`.
 
 use async_trait::async_trait;
+use base64::Engine as _;
 use redis::AsyncCommands;
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,6 +29,7 @@ use std::time::Duration;
 use crate::storage::db::VectorDb;
 use crate::storage::seal::{self, DecryptOutcome, SealCredential};
 use crate::storage::walrus;
+use crate::storage::{sui_tx, walrus_write};
 use crate::types::{AppError, AuthInfo, Config, KeyPool};
 
 use super::{FetchTimings, HydratedMemory, MemoryEngine, MemoryRef};
@@ -179,6 +181,52 @@ impl WalrusSealEngine {
         }
     }
 
+    /// WALM-184: native Rust replacement for `walrus::upload_blob`'s
+    /// sidecar HTTP call — same on-chain effect (register + certify +
+    /// metadata-stamp + transfer to `owner`), no Node.js sidecar involved.
+    /// Only called when `config.walrus_native_write` is true.
+    async fn store_blob_native(
+        &self,
+        owner: &str,
+        namespace: &str,
+        bytes: &[u8],
+        key_index: usize,
+        agent_public_key: Option<&str>,
+    ) -> Result<walrus::UploadResult, AppError> {
+        let key_hex = self
+            .key_pool
+            .key_at(key_index)
+            .ok_or_else(|| AppError::Internal(format!("no Sui key at pool index {key_index}")))?;
+        let signer = sui_tx::SuiSignerContext::from_hex_key(key_hex)
+            .map_err(|e| AppError::Internal(format!("invalid Sui signing key: {e}")))?;
+        let mut rpc_client = sui_rpc::Client::new(self.config.sui_rpc_url.clone())
+            .map_err(|e| AppError::Internal(format!("failed to build Sui RPC client: {e}")))?;
+
+        let result = walrus_write::store_blob_and_finalize(
+            &mut rpc_client,
+            &self.http_client,
+            &signer,
+            &self.config.sui_rpc_url,
+            &self.config.walrus_upload_relay_url,
+            &self.config.walrus_package_id,
+            owner,
+            namespace,
+            Some(&self.config.package_id),
+            agent_public_key,
+            self.config.walrus_storage_epochs,
+            false,
+            self.config.walrus_native_gas_budget,
+            bytes,
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("native Walrus store_blob failed: {e}")))?;
+
+        Ok(walrus::UploadResult {
+            blob_id: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(result.blob_id),
+            object_id: Some(result.blob_object_id),
+        })
+    }
+
     /// Fetch a blob's ciphertext: cache → Walrus (+ cache write-back).
     /// Returns `Some((ciphertext, was_cached))` — `was_cached` is `true` on
     /// a Redis hit, `false` on a cold fetch from Walrus. Returns `None` if
@@ -239,24 +287,30 @@ impl MemoryEngine for WalrusSealEngine {
             )
         })?;
 
-        // Upload the prepared ciphertext to Walrus via the relay sidecar
-        // (pool key pays gas). `defer_transfer = false` — the blob is
-        // transferred to `owner` immediately, same as the inlined
-        // `remember_manual` path.
-        let upload = walrus::upload_blob(
-            &self.http_client,
-            &self.config.sidecar_url,
-            self.config.sidecar_secret.as_deref(),
-            bytes,
-            self.config.walrus_storage_epochs as u64,
-            owner,
-            key_index,
-            namespace,
-            &self.config.package_id,
-            agent_public_key,
-            None,
-        )
-        .await?;
+        // Upload the prepared ciphertext to Walrus — WALM-184: native Rust
+        // write path when opted in (WALRUS_NATIVE_WRITE=true), else the TS
+        // sidecar HTTP call (pool key pays gas either way). `defer_transfer
+        // = false` — the blob is transferred to `owner` immediately, same
+        // as the inlined `remember_manual` path.
+        let upload = if self.config.walrus_native_write {
+            self.store_blob_native(owner, namespace, bytes, key_index, agent_public_key)
+                .await?
+        } else {
+            walrus::upload_blob(
+                &self.http_client,
+                &self.config.sidecar_url,
+                self.config.sidecar_secret.as_deref(),
+                bytes,
+                self.config.walrus_storage_epochs as u64,
+                owner,
+                key_index,
+                namespace,
+                &self.config.package_id,
+                agent_public_key,
+                None,
+            )
+            .await?
+        };
         let blob_id = upload.blob_id;
         tracing::info!("engine.store_blob: walrus upload ok blob_id={}", blob_id);
 

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -43,6 +43,133 @@ const STALE_REMEMBER_JOB_AFTER: std::time::Duration = std::time::Duration::from_
 const APALIS_MONITOR_RESTART_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 const DEFAULT_APALIS_STARTUP_TIMEOUT_SECS: u64 = 45;
 
+/// Spawn the Node.js sidecar (SEAL + Walrus operations) unless `SIDECAR_DISABLED`
+/// is set. Returns `None` without touching the network when disabled; otherwise
+/// spawns the process, blocks until its health check passes (panicking on
+/// failure), and starts a background watchdog that exits the relayer if the
+/// sidecar goes unhealthy.
+async fn spawn_sidecar_if_enabled(
+    config: &Config,
+    http_client: &reqwest::Client,
+    health_url: &str,
+) -> Option<tokio::process::Child> {
+    // Set SIDECAR_DISABLED=true to skip the Node.js sidecar (WALM-184: native Rust migration).
+    let sidecar_disabled = std::env::var("SIDECAR_DISABLED")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+
+    if sidecar_disabled {
+        tracing::warn!("⚠️  SIDECAR_DISABLED=true — Node.js sidecar will NOT be started.");
+        tracing::warn!("⚠️  Walrus upload and SEAL encrypt/decrypt require native Rust implementations.");
+        tracing::warn!("⚠️  Only use this in environments where native Rust integrations are fully wired.");
+        return None;
+    }
+
+    let sidecar_url = config.sidecar_url.clone();
+    tracing::info!("  sidecar: starting at {}", sidecar_url);
+    // Use SIDECAR_SCRIPTS_DIR if set (Docker), otherwise derive from CARGO_MANIFEST_DIR (local dev)
+    let scripts_dir = std::env::var("SIDECAR_SCRIPTS_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts"));
+    let mcp_relayer_url = std::env::var("MEMWAL_RELAYER_URL")
+        .unwrap_or_else(|_| format!("http://127.0.0.1:{}", config.port));
+    let mut sidecar_child = tokio::process::Command::new("npx")
+        .args(["tsx", "sidecar-server.ts"])
+        .current_dir(&scripts_dir)
+        .env("MEMWAL_RELAYER_URL", mcp_relayer_url)
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .expect("Failed to start TS sidecar. Is Node.js installed? (Or set SIDECAR_DISABLED=true)");
+
+    // Wait for sidecar to be ready (health check with retry)
+    let mut ready = false;
+    for attempt in 1..=30 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        match http_client.get(health_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::info!("  sidecar: ready (attempt {})", attempt);
+                ready = true;
+                break;
+            }
+            _ => {
+                if attempt % 5 == 0 {
+                    tracing::debug!("  sidecar: waiting... (attempt {})", attempt);
+                }
+            }
+        }
+    }
+    if !ready {
+        sidecar_child.kill().await.ok();
+        panic!("TS sidecar failed to start after 15s. Check scripts/sidecar-server.ts");
+    }
+
+    // Keep a cheap heartbeat in the Rust logs so operators can distinguish
+    // Enoki/Walrus failures from the sidecar process becoming unavailable.
+    // If the sidecar remains unhealthy, exit the relayer so Railway restarts
+    // the whole container and brings up a fresh sidecar process.
+    let sidecar_watch_interval_secs = parse_env_u64("SIDECAR_WATCHDOG_INTERVAL_SECS", 30, 5, 300);
+    let sidecar_watch_timeout_secs = parse_env_u64("SIDECAR_WATCHDOG_TIMEOUT_SECS", 2, 1, 30);
+    let sidecar_watch_max_failures = parse_env_u32("SIDECAR_WATCHDOG_MAX_FAILURES", 6, 1, 100);
+    tracing::info!(
+        "  sidecar watchdog: interval={}s timeout={}s max_failures={}",
+        sidecar_watch_interval_secs,
+        sidecar_watch_timeout_secs,
+        sidecar_watch_max_failures
+    );
+    let sidecar_watch_client = http_client.clone();
+    let sidecar_watch_url = health_url.to_string();
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(sidecar_watch_interval_secs));
+        let mut consecutive_failures = 0u32;
+        loop {
+            interval.tick().await;
+            match sidecar_watch_client
+                .get(&sidecar_watch_url)
+                .timeout(std::time::Duration::from_secs(sidecar_watch_timeout_secs))
+                .send()
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    if consecutive_failures > 0 {
+                        tracing::info!(
+                            "  sidecar: health recovered after {} failed check(s)",
+                            consecutive_failures
+                        );
+                    }
+                    consecutive_failures = 0;
+                }
+                Ok(resp) => {
+                    consecutive_failures += 1;
+                    tracing::error!(
+                        "  sidecar: health check failed status={} consecutive_failures={}",
+                        resp.status(),
+                        consecutive_failures
+                    );
+                }
+                Err(e) => {
+                    consecutive_failures += 1;
+                    tracing::error!(
+                        "  sidecar: health check error consecutive_failures={} error={}",
+                        consecutive_failures,
+                        e
+                    );
+                }
+            }
+            if consecutive_failures >= sidecar_watch_max_failures {
+                tracing::error!(
+                    "  sidecar: unhealthy for {} consecutive check(s); exiting relayer for supervisor restart",
+                    consecutive_failures
+                );
+                std::process::exit(1);
+            }
+        }
+    });
+
+    Some(sidecar_child)
+}
+
 fn parse_env_u64(name: &str, fallback: u64, min: u64, max: u64) -> u64 {
     let Ok(raw) = std::env::var(name) else {
         return fallback;
@@ -206,114 +333,16 @@ async fn main() {
         tracing::warn!("⚠️  Unset RATE_LIMIT_DISABLED to restore protection.");
     }
 
-    // Start TS sidecar HTTP server (SEAL + Walrus operations)
-    let sidecar_url = config.sidecar_url.clone();
-    tracing::info!("  sidecar: starting at {}", sidecar_url);
-    // Use SIDECAR_SCRIPTS_DIR if set (Docker), otherwise derive from CARGO_MANIFEST_DIR (local dev)
-    let scripts_dir = std::env::var("SIDECAR_SCRIPTS_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts"));
-    let mcp_relayer_url = std::env::var("MEMWAL_RELAYER_URL")
-        .unwrap_or_else(|_| format!("http://127.0.0.1:{}", config.port));
-    let mut sidecar_child = tokio::process::Command::new("npx")
-        .args(["tsx", "sidecar-server.ts"])
-        .current_dir(&scripts_dir)
-        .env("MEMWAL_RELAYER_URL", mcp_relayer_url)
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()
-        .expect("Failed to start TS sidecar. Is Node.js installed?");
-
-    // Wait for sidecar to be ready (health check with retry)
     // Set 30s timeout on HTTP client to prevent hanging LLM/Walrus requests
     let http_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .expect("Failed to build HTTP client");
-    let health_url = format!("{}/health", sidecar_url);
-    let mut ready = false;
-    for attempt in 1..=30 {
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-        match http_client.get(&health_url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                tracing::info!("  sidecar: ready (attempt {})", attempt);
-                ready = true;
-                break;
-            }
-            _ => {
-                if attempt % 5 == 0 {
-                    tracing::debug!("  sidecar: waiting... (attempt {})", attempt);
-                }
-            }
-        }
-    }
-    if !ready {
-        sidecar_child.kill().await.ok();
-        panic!("TS sidecar failed to start after 15s. Check scripts/sidecar-server.ts");
-    }
 
-    // Keep a cheap heartbeat in the Rust logs so operators can distinguish
-    // Enoki/Walrus failures from the sidecar process becoming unavailable.
-    // If the sidecar remains unhealthy, exit the relayer so Railway restarts
-    // the whole container and brings up a fresh sidecar process.
-    let sidecar_watch_interval_secs = parse_env_u64("SIDECAR_WATCHDOG_INTERVAL_SECS", 30, 5, 300);
-    let sidecar_watch_timeout_secs = parse_env_u64("SIDECAR_WATCHDOG_TIMEOUT_SECS", 2, 1, 30);
-    let sidecar_watch_max_failures = parse_env_u32("SIDECAR_WATCHDOG_MAX_FAILURES", 6, 1, 100);
-    tracing::info!(
-        "  sidecar watchdog: interval={}s timeout={}s max_failures={}",
-        sidecar_watch_interval_secs,
-        sidecar_watch_timeout_secs,
-        sidecar_watch_max_failures
-    );
-    let sidecar_watch_client = http_client.clone();
-    let sidecar_watch_url = health_url.clone();
-    tokio::spawn(async move {
-        let mut interval =
-            tokio::time::interval(std::time::Duration::from_secs(sidecar_watch_interval_secs));
-        let mut consecutive_failures = 0u32;
-        loop {
-            interval.tick().await;
-            match sidecar_watch_client
-                .get(&sidecar_watch_url)
-                .timeout(std::time::Duration::from_secs(sidecar_watch_timeout_secs))
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => {
-                    if consecutive_failures > 0 {
-                        tracing::info!(
-                            "  sidecar: health recovered after {} failed check(s)",
-                            consecutive_failures
-                        );
-                    }
-                    consecutive_failures = 0;
-                }
-                Ok(resp) => {
-                    consecutive_failures += 1;
-                    tracing::error!(
-                        "  sidecar: health check failed status={} consecutive_failures={}",
-                        resp.status(),
-                        consecutive_failures
-                    );
-                }
-                Err(e) => {
-                    consecutive_failures += 1;
-                    tracing::error!(
-                        "  sidecar: health check error consecutive_failures={} error={}",
-                        consecutive_failures,
-                        e
-                    );
-                }
-            }
-            if consecutive_failures >= sidecar_watch_max_failures {
-                tracing::error!(
-                    "  sidecar: unhealthy for {} consecutive check(s); exiting relayer for supervisor restart",
-                    consecutive_failures
-                );
-                std::process::exit(1);
-            }
-        }
-    });
+    // Start TS sidecar HTTP server (SEAL + Walrus operations), unless disabled.
+    // health_url is used both by the sidecar watchdog and the saturation monitor
+    let health_url = format!("{}/health", config.sidecar_url);
+    let sidecar_child = spawn_sidecar_if_enabled(&config, &http_client, &health_url).await;
 
     // Initialize database (PostgreSQL + pgvector).
     // `Arc` so the MemoryEngine impl shares the same pool as the handlers.
@@ -929,7 +958,9 @@ async fn main() {
     .expect("Server failed");
 
     // Cleanup sidecar after shutdown
-    sidecar_child.kill().await.ok();
-    tracing::info!("sidecar stopped");
+    if let Some(mut child) = sidecar_child {
+        child.kill().await.ok();
+        tracing::info!("sidecar stopped");
+    }
     telemetry.shutdown();
 }

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -430,8 +430,8 @@ pub async fn restore(
     );
     let on_chain_blobs = walrus::query_blobs_by_owner(
         &state.http_client,
-        &state.config.sidecar_url,
-        state.config.sidecar_secret.as_deref(),
+        &state.config.sui_rpc_url,
+        &state.config.walrus_package_id,
         owner,
         Some(namespace),
         Some(&state.config.package_id),

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1070,6 +1070,7 @@ mod tests {
             sui_private_key: None,
             sui_private_keys: vec![],
             package_id: "0xpackage".to_string(),
+            walrus_package_id: "0xwalruspackage".to_string(),
             registry_id: "0xregistry".to_string(),
             sidecar_url: "http://localhost:9003".to_string(),
             sidecar_secret: None,
@@ -1077,6 +1078,9 @@ mod tests {
             sponsor_rate_limit: crate::types::SponsorRateLimitConfig::default(),
             allowed_origins: String::new(),
             benchmark_mode: false,
+            walrus_native_write: false,
+            walrus_upload_relay_url: "http://localhost:9004".to_string(),
+            walrus_native_gas_budget: 500_000_000,
         }
     }
 

--- a/services/server/src/storage/mod.rs
+++ b/services/server/src/storage/mod.rs
@@ -15,8 +15,16 @@
 //!   TS sidecar; the `SealCredential` resolution (session > delegate key >
 //!   server fallback) and `DecryptOutcome` classification.
 //! - [`sui`] — Sui RPC: delegate-key on-chain verification, account lookup.
+//! - [`sui_tx`] — native Sui transaction building/signing/submission
+//!   (WALM-184: foundation for migrating the Walrus write path off the
+//!   sidecar; not yet wired into any business logic).
 
 pub mod db;
 pub mod seal;
 pub mod sui;
+pub mod sui_tx;
 pub mod walrus;
+pub mod walrus_encode;
+pub mod walrus_tx;
+pub mod walrus_upload_relay;
+pub mod walrus_write;

--- a/services/server/src/storage/sui.rs
+++ b/services/server/src/storage/sui.rs
@@ -336,6 +336,50 @@ pub async fn find_account_by_delegate_key(
     ))
 }
 
+/// Low-level Sui JSON-RPC POST, shared by this module's own call sites'
+/// underlying wire format and by `storage::walrus`'s on-chain blob queries
+/// (which don't share `OnchainVerifyError`, hence returning `String` here
+/// rather than that enum). Applies the request-id header and records
+/// `observability::observe_external` the same way every call site in this
+/// file already does. Returns the `result` value on success.
+pub(crate) async fn raw_rpc_call(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    method: &'static str,
+    params: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    });
+    let request = client
+        .post(rpc_url)
+        .header(reqwest::header::ACCEPT_ENCODING, "identity")
+        .json(&body);
+    let request = crate::observability::apply_request_id_header(request);
+    let started = std::time::Instant::now();
+    let resp = request.send().await.map_err(|e| {
+        crate::observability::observe_external("sui_rpc", method, "transport_error", started.elapsed());
+        format!("Sui RPC {} failed: {}", method, e)
+    })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external("sui_rpc", method, &status_label, started.elapsed());
+
+    let value: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Sui RPC {} returned invalid JSON: {}", method, e))?;
+    if let Some(error) = value.get("error") {
+        return Err(format!("Sui RPC {} error: {}", method, error));
+    }
+    value
+        .get("result")
+        .cloned()
+        .ok_or_else(|| format!("Sui RPC {} response missing 'result'", method))
+}
+
 // ============================================================
 // Types for JSON-RPC response parsing
 // ============================================================

--- a/services/server/src/storage/sui_tx.rs
+++ b/services/server/src/storage/sui_tx.rs
@@ -1,0 +1,186 @@
+//! Native Sui transaction building, signing, and submission.
+//!
+//! Foundation for migrating the Walrus write path (register/upload/certify)
+//! and `/sponsor/execute` off the Node sidecar (WALM-184). Uses Mysten's
+//! lightweight `sui-rust-sdk` crates (sui-sdk-types, sui-crypto,
+//! sui-transaction-builder, sui-rpc) — not the full `sui` node monorepo,
+//! which pulls in a permanently-yanked `core2` dependency via `seal-sdk-rs`
+//! and cannot currently be built (see services/server/Cargo.toml).
+//!
+//! This module only builds/signs/submits generic Move-call transactions; it
+//! does not yet know the Walrus package's specific register/certify Move
+//! function signatures — that wiring is a separate, not-yet-done step.
+
+use sui_crypto::ed25519::Ed25519PrivateKey;
+use sui_crypto::SuiSigner;
+use sui_sdk_types::{Address, Identifier, TypeTag};
+use sui_transaction_builder::{Argument, Function, TransactionBuilder};
+
+#[derive(Debug)]
+pub enum SuiTxError {
+    InvalidKey(String),
+    Build(String),
+    Sign(String),
+    Rpc(String),
+}
+
+impl std::fmt::Display for SuiTxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidKey(m) => write!(f, "invalid Sui signing key: {m}"),
+            Self::Build(m) => write!(f, "failed to build transaction: {m}"),
+            Self::Sign(m) => write!(f, "failed to sign transaction: {m}"),
+            Self::Rpc(m) => write!(f, "Sui RPC error: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SuiTxError {}
+
+/// Wraps the server's Ed25519 signing key together with its derived Sui
+/// address (`hash(0x00 || pubkey)` — see `Ed25519PublicKey::derive_address`).
+pub struct SuiSignerContext {
+    key: Ed25519PrivateKey,
+    address: Address,
+}
+
+impl SuiSignerContext {
+    /// Parse the same hex-encoded 32-byte Ed25519 secret key format already
+    /// used for `SERVER_SUI_PRIVATE_KEY` elsewhere in this server.
+    pub fn from_hex_key(hex_key: &str) -> Result<Self, SuiTxError> {
+        let bytes = hex::decode(hex_key.trim())
+            .map_err(|e| SuiTxError::InvalidKey(format!("not valid hex: {e}")))?;
+        let bytes: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+            SuiTxError::InvalidKey(format!("expected 32 bytes, got {}", v.len()))
+        })?;
+        let key = Ed25519PrivateKey::new(bytes);
+        let address = key.public_key().derive_address();
+        Ok(Self { key, address })
+    }
+
+    pub fn address(&self) -> Address {
+        self.address
+    }
+}
+
+/// Build, sign, and submit an arbitrary PTB (any number of chained Move
+/// calls) paid for by this signer's gas coin. Gas coin selection and gas
+/// price are resolved automatically via RPC (see
+/// `TransactionBuilder::build`).
+///
+/// `build_ptb` receives the in-progress builder and does all of its own
+/// `tx.object()`/`tx.pure()`/`tx.move_call()` calls — e.g. chaining a
+/// `reserve_space` call's returned `Argument` directly into a following
+/// `register_blob` call within the same transaction, with no extra object
+/// lookup in between, exactly like `walrus-sui`'s own PTB builder does.
+///
+/// THIS FUNCTION SIGNS AND SUBMITS A REAL TRANSACTION. Callers must treat
+/// invoking it as a fund-moving action requiring the same care as any other
+/// on-chain transaction — see the "Executing actions with care" guidance
+/// this server's development follows.
+pub async fn execute_ptb(
+    client: &mut sui_rpc::Client,
+    signer: &SuiSignerContext,
+    build_ptb: impl FnOnce(&mut TransactionBuilder),
+    gas_budget: u64,
+) -> Result<sui_rpc::proto::sui::rpc::v2::ExecutedTransaction, SuiTxError> {
+    let mut tx = TransactionBuilder::new();
+    build_ptb(&mut tx);
+    tx.set_sender(signer.address);
+    tx.set_gas_budget(gas_budget);
+
+    let transaction = tx
+        .build(client)
+        .await
+        .map_err(|e| SuiTxError::Build(e.to_string()))?;
+
+    let signature = signer
+        .key
+        .sign_transaction(&transaction)
+        .map_err(|e| SuiTxError::Sign(e.to_string()))?;
+
+    let request = sui_rpc::proto::sui::rpc::v2::ExecuteTransactionRequest::default()
+        .with_transaction(transaction)
+        .with_signatures(vec![signature.into()]);
+    let response = client
+        .execution_client()
+        .execute_transaction(request)
+        .await
+        .map_err(|e| SuiTxError::Rpc(e.to_string()))?;
+
+    response
+        .into_inner()
+        .transaction
+        .ok_or_else(|| SuiTxError::Rpc("response missing executed transaction".into()))
+}
+
+/// Build, sign, and submit a single-Move-call transaction. Convenience
+/// wrapper over [`execute_ptb`] for the common one-call case.
+///
+/// `add_inputs` receives the in-progress builder so the caller can add
+/// pure/object inputs before the call arguments are assembled; it returns
+/// the `Argument`s to pass to the Move function, in order.
+pub async fn execute_move_call(
+    client: &mut sui_rpc::Client,
+    signer: &SuiSignerContext,
+    package: Address,
+    module: &str,
+    function: &str,
+    type_args: Vec<TypeTag>,
+    add_inputs: impl FnOnce(&mut TransactionBuilder) -> Vec<Argument>,
+    gas_budget: u64,
+) -> Result<sui_rpc::proto::sui::rpc::v2::ExecutedTransaction, SuiTxError> {
+    let module: Identifier = module
+        .parse()
+        .map_err(|e| SuiTxError::Build(format!("invalid module name {module:?}: {e}")))?;
+    let function_ident: Identifier = function
+        .parse()
+        .map_err(|e| SuiTxError::Build(format!("invalid function name {function:?}: {e}")))?;
+
+    execute_ptb(
+        client,
+        signer,
+        |tx| {
+            let arguments = add_inputs(tx);
+            let f = Function::new(package, module, function_ident).with_type_args(type_args);
+            tx.move_call(f, arguments);
+        },
+        gas_budget,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn address_derivation_matches_independently_computed_vector() {
+        // Cross-checked against an independent Python computation
+        // (PyNaCl Ed25519 pubkey from an all-zero seed, then
+        // blake2b256(0x00 || pubkey)) matching the derivation formula
+        // documented on `Ed25519PublicKey::derive_address` in sui-sdk-types.
+        let hex_key = "00".repeat(32);
+        let ctx = SuiSignerContext::from_hex_key(&hex_key).unwrap();
+        assert_eq!(
+            ctx.address().to_string(),
+            "0x7a1378aafadef8ce743b72e8b248295c8f61c102c94040161146ea4d51a182b6"
+        );
+    }
+
+    #[test]
+    fn from_hex_key_rejects_wrong_length() {
+        assert!(matches!(
+            SuiSignerContext::from_hex_key("00"),
+            Err(SuiTxError::InvalidKey(_))
+        ));
+    }
+
+    #[test]
+    fn from_hex_key_rejects_non_hex() {
+        assert!(matches!(
+            SuiSignerContext::from_hex_key("not-hex-at-all-not-hex-at-all-not-hex-at"),
+            Err(SuiTxError::InvalidKey(_))
+        ));
+    }
+}

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -68,13 +68,6 @@ pub struct OnChainBlob {
     pub package_id: String,
 }
 
-/// Response from sidecar query-blobs endpoint
-#[derive(Debug, serde::Deserialize)]
-struct QueryBlobsResponse {
-    blobs: Vec<OnChainBlob>,
-    total: usize,
-}
-
 /// Request/response types for sidecar HTTP API
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -382,74 +375,226 @@ pub async fn set_metadata_batch(
 /// This enables restore-from-zero: even if the local DB is empty,
 /// we can discover all blob_ids by querying the user's on-chain objects
 /// and reading the `memwal_namespace` metadata attribute.
+/// Convert a Walrus `blob_id` as read off-chain (a decimal-string U256) into
+/// the base64url form Walrus aggregators expect. Mirrors
+/// `blobIdFromRaw` in the old `scripts/sidecar/routes/walrus-query.ts`:
+/// decimal U256 -> 32-byte big-endian -> reversed to little-endian -> base64url.
+/// Values that aren't a >20-digit decimal string (already base64url, or a
+/// small placeholder in tests) are passed through unchanged.
+fn blob_id_from_raw(raw: &str) -> Option<String> {
+    if raw.is_empty() {
+        return None;
+    }
+    if raw.len() > 20 && raw.bytes().all(|b| b.is_ascii_digit()) {
+        let le_bytes = decimal_str_to_le_bytes_32(raw)?;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        return Some(URL_SAFE_NO_PAD.encode(le_bytes));
+    }
+    Some(raw.to_string())
+}
+
+/// Grade-school long division: convert a base-10 digit string into 32
+/// little-endian bytes (a U256). Returns `None` if the value doesn't fit
+/// in 256 bits.
+fn decimal_str_to_le_bytes_32(decimal: &str) -> Option<[u8; 32]> {
+    let mut digits: Vec<u8> = decimal.bytes().map(|b| b - b'0').collect();
+    let mut out = [0u8; 32];
+    for byte_slot in out.iter_mut() {
+        let mut remainder: u32 = 0;
+        let mut next_digits = Vec::with_capacity(digits.len());
+        for &d in &digits {
+            let cur = remainder * 10 + d as u32;
+            next_digits.push((cur / 256) as u8);
+            remainder = cur % 256;
+        }
+        while next_digits.len() > 1 && next_digits[0] == 0 {
+            next_digits.remove(0);
+        }
+        digits = next_digits;
+        *byte_slot = remainder as u8;
+    }
+    if digits == [0] {
+        Some(out)
+    } else {
+        None // didn't fit in 256 bits
+    }
+}
+
+/// Thin `AppError`-flavored wrapper around the shared low-level RPC caller
+/// in `storage::sui` — see that function's doc for the wire-format details
+/// (request-id header, `observe_external` metrics) it applies uniformly.
+async fn sui_rpc_call(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    method: &'static str,
+    params: serde_json::Value,
+) -> Result<serde_json::Value, AppError> {
+    super::sui::raw_rpc_call(client, rpc_url, method, params)
+        .await
+        .map_err(AppError::Internal)
+}
+
+/// Query the user's Walrus Blob objects directly from the Sui chain (native
+/// Rust — no sidecar). Enables restore-from-zero: even if the local DB is
+/// empty, we can discover all blob_ids by scanning the owner's on-chain
+/// objects and reading the `memwal_namespace` dynamic-field metadata.
+///
+/// This is the direct-RPC equivalent of the old sidecar's
+/// `POST /walrus/query-blobs` (see `scripts/sidecar/routes/walrus-query.ts`).
+/// It uses the full-scan path (`suix_getOwnedObjects` + per-object dynamic
+/// field lookup); the sidecar's "recent transactions" fast-path optimization
+/// is not ported — this is a correctness-first baseline, not yet
+/// latency-optimized for accounts with many blobs.
 pub async fn query_blobs_by_owner(
     client: &reqwest::Client,
-    sidecar_url: &str,
-    sidecar_secret: Option<&str>,
+    rpc_url: &str,
+    walrus_package_id: &str,
     owner_address: &str,
     namespace: Option<&str>,
     package_id: Option<&str>,
     limit: Option<usize>,
 ) -> Result<Vec<OnChainBlob>, AppError> {
-    let url = format!("{}/walrus/query-blobs", sidecar_url);
+    let blob_type = format!("{}::blob::Blob", walrus_package_id);
+    let want = limit.unwrap_or(usize::MAX);
+    // Constant dynamic-field lookup key for every blob's `memwal_*` metadata —
+    // computed once, not rebuilt per object/page.
+    let metadata_name = serde_json::json!({
+        "type": "vector<u8>",
+        "value": "metadata".bytes().map(u32::from).collect::<Vec<_>>(),
+    });
 
-    let mut body = serde_json::json!({ "owner": owner_address });
-    if let Some(ns) = namespace {
-        body["namespace"] = serde_json::json!(ns);
-    }
-    if let Some(pkg) = package_id {
-        body["packageId"] = serde_json::json!(pkg);
-    }
-    if let Some(limit) = limit {
-        body["limit"] = serde_json::json!(limit);
-    }
+    let mut blobs = Vec::new();
+    let mut cursor: serde_json::Value = serde_json::Value::Null;
+    let mut scanned = 0usize;
 
-    let mut req = client.post(&url).json(&body);
-    if let Some(secret) = sidecar_secret {
-        req = req.header("authorization", format!("Bearer {}", secret));
-    }
-    let req = crate::observability::apply_request_id_header(req);
-    let started = std::time::Instant::now();
-    let resp = req.send().await.map_err(|e| {
-        crate::observability::observe_external(
-            "sidecar",
-            "walrus_query_blobs",
-            "transport_error",
-            started.elapsed(),
-        );
-        crate::observability::record_sidecar_failure("walrus_query_blobs", "transport_error");
-        AppError::Internal(format!("Sidecar walrus/query-blobs failed: {}", e))
-    })?;
-    let status_label = resp.status().as_u16().to_string();
-    crate::observability::observe_external(
-        "sidecar",
-        "walrus_query_blobs",
-        &status_label,
-        started.elapsed(),
-    );
+    loop {
+        let result = sui_rpc_call(
+            client,
+            rpc_url,
+            "suix_getOwnedObjects",
+            serde_json::json!([
+                owner_address,
+                {
+                    "filter": { "StructType": blob_type },
+                    "options": { "showContent": true }
+                },
+                cursor,
+                50
+            ]),
+        )
+        .await?;
 
-    if !resp.status().is_success() {
-        crate::observability::record_sidecar_failure("walrus_query_blobs", "http_error");
-        let body = resp.text().await.unwrap_or_default();
-        return Err(AppError::Internal(format!(
-            "walrus query-blobs failed: {}",
-            body
-        )));
-    }
+        let data = result.get("data").and_then(|d| d.as_array()).cloned().unwrap_or_default();
+        if data.is_empty() {
+            break;
+        }
 
-    let result: QueryBlobsResponse = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to parse query-blobs response: {}", e)))?;
+        // Collect candidates synchronously first, then fetch each one's
+        // `memwal_*` metadata dynamic field concurrently — a page can hold
+        // up to 50 objects, and these were previously fetched one at a time
+        // (sequential round-trips dominate restore latency for accounts
+        // with many blobs).
+        let mut candidates = Vec::with_capacity(data.len());
+        for entry in &data {
+            scanned += 1;
+            let obj = entry.get("data");
+            let object_id = obj.and_then(|o| o.get("objectId")).and_then(|v| v.as_str());
+            let fields = obj
+                .and_then(|o| o.get("content"))
+                .filter(|c| c.get("dataType").and_then(|d| d.as_str()) == Some("moveObject"))
+                .and_then(|c| c.get("fields"));
+            let (Some(object_id), Some(fields)) = (object_id, fields) else {
+                continue;
+            };
+            let raw_blob_id = fields
+                .get("blob_id")
+                .or_else(|| fields.get("blobId"))
+                .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_u64().map(|n| n.to_string())));
+            let Some(raw_blob_id) = raw_blob_id else {
+                continue;
+            };
+            candidates.push((object_id.to_string(), raw_blob_id));
+        }
+
+        let mut metadata_lookups = FuturesUnordered::new();
+        for (object_id, raw_blob_id) in candidates {
+            let metadata_name = metadata_name.clone();
+            metadata_lookups.push(async move {
+                let dyn_field = sui_rpc_call(
+                    client,
+                    rpc_url,
+                    "suix_getDynamicFieldObject",
+                    serde_json::json!([object_id, metadata_name]),
+                )
+                .await
+                .ok();
+                (object_id, raw_blob_id, dyn_field)
+            });
+        }
+
+        while let Some((object_id, raw_blob_id, dyn_field)) = metadata_lookups.next().await {
+            let (mut blob_namespace, mut blob_package_id) = ("default".to_string(), String::new());
+            if let Some(dyn_field) = dyn_field {
+                let contents = dyn_field
+                    .pointer("/data/content/fields/value/fields/metadata/fields/contents")
+                    .and_then(|v| v.as_array());
+                if let Some(contents) = contents {
+                    for entry in contents {
+                        let key = entry.pointer("/fields/key").and_then(|v| v.as_str());
+                        let value = entry.pointer("/fields/value").and_then(|v| v.as_str());
+                        match (key, value) {
+                            (Some("memwal_namespace"), Some(v)) => blob_namespace = v.to_string(),
+                            (Some("memwal_package_id"), Some(v)) => blob_package_id = v.to_string(),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            if let Some(ns) = namespace {
+                if blob_namespace != ns {
+                    continue;
+                }
+            }
+            if let Some(pkg) = package_id {
+                if blob_package_id != pkg {
+                    continue;
+                }
+            }
+            let Some(blob_id) = blob_id_from_raw(&raw_blob_id) else {
+                continue;
+            };
+            blobs.push(OnChainBlob {
+                blob_id,
+                object_id,
+                namespace: blob_namespace,
+                package_id: blob_package_id,
+            });
+            if blobs.len() >= want {
+                break;
+            }
+        }
+
+        if blobs.len() >= want {
+            break;
+        }
+        let has_next = result.get("hasNextPage").and_then(|v| v.as_bool()).unwrap_or(false);
+        let next_cursor = result.get("nextCursor").cloned();
+        match (has_next, next_cursor) {
+            (true, Some(c)) if !c.is_null() => cursor = c,
+            _ => break,
+        }
+    }
 
     tracing::info!(
-        "walrus query-blobs ok: {} blobs for owner={}, ns={:?}",
-        result.total,
+        "walrus query-blobs ok (native): {} blobs for owner={}, ns={:?} (scanned {} objects)",
+        blobs.len(),
         owner_address,
-        namespace
+        namespace,
+        scanned
     );
 
-    Ok(result.blobs)
+    Ok(blobs)
 }
 
 /// Download a blob from one or more Walrus aggregators.
@@ -688,8 +833,39 @@ fn aggregate_download_errors(blob_id: &str, errors: &[(String, AppError)]) -> Ap
 
 #[cfg(test)]
 mod tests {
-    use super::aggregate_download_errors;
+    use super::{aggregate_download_errors, blob_id_from_raw};
     use crate::types::AppError;
+
+    #[test]
+    fn blob_id_from_raw_matches_reference_conversion() {
+        // Cross-checked against the original TS `blobIdFromRaw`
+        // (decimal U256 -> 32-byte big-endian hex -> reversed to
+        // little-endian -> base64url) via an independent Python
+        // implementation of the same algorithm.
+        let raw = "123456789012345678901234567890123456789012345678901234";
+        let expected = "8q-WftgSTQKWAybeSl3AgKZPG5D4SQEAAAAAAAAAAAA";
+        assert_eq!(blob_id_from_raw(raw), Some(expected.to_string()));
+    }
+
+    #[test]
+    fn blob_id_from_raw_passes_through_non_decimal_and_short_values() {
+        // Already-encoded blob ids and short numeric placeholders (as used
+        // in tests/mocks) are not decimal U256s — pass through unchanged.
+        assert_eq!(
+            blob_id_from_raw("abc123_-XYZ"),
+            Some("abc123_-XYZ".to_string())
+        );
+        assert_eq!(blob_id_from_raw("12345"), Some("12345".to_string()));
+        assert_eq!(blob_id_from_raw(""), None);
+    }
+
+    #[test]
+    fn blob_id_from_raw_rejects_values_that_overflow_u256() {
+        // 78 nines is far larger than 2^256 (~1.16e77) and must not silently
+        // truncate.
+        let too_big = "9".repeat(78);
+        assert_eq!(blob_id_from_raw(&too_big), None);
+    }
 
     #[test]
     fn aggregate_download_errors_preserves_not_found_cleanup_signal() {

--- a/services/server/src/storage/walrus_encode.rs
+++ b/services/server/src/storage/walrus_encode.rs
@@ -1,0 +1,132 @@
+//! Native RedStuff erasure-coding metadata computation (WALM-184: Walrus
+//! write-path migration, step 1 of 3 — encode).
+//!
+//! Uses Mysten's own `walrus-core` crate (not a reimplementation of the
+//! encoding/Merkle-tree scheme) with `default-features = false`, which skips
+//! the optional `sui-types` feature — that feature pulls the full Sui
+//! monorepo and conflicts with this server's own sqlx/pgvector dependency
+//! pins (see `services/server/Cargo.toml` comment on the `walrus-core` line,
+//! and the git history of this file's introducing commit for the full
+//! investigation: `walrus-sui`, which bundles register/upload/certify
+//! end-to-end, does NOT build alongside this server's dependencies; plain
+//! `walrus-core` alone does).
+//!
+//! This module is intentionally read-only / side-effect-free: it computes
+//! the `blob_id`/`root_hash`/`size`/`encoding_type` values that
+//! `register_blob` needs, but does not build or submit any transaction.
+//! Wiring this into the actual register/upload/certify flow (which spends
+//! real WAL and moves funds) is a deliberately separate, not-yet-done step —
+//! it additionally requires confirming the exact BCS `u256` argument
+//! encoding accepted by `sui-transaction-builder`'s `pure()`, which has not
+//! been verified yet.
+
+use std::num::NonZeroU16;
+use walrus_core::encoding::{EncodingConfig, EncodingFactory};
+use walrus_core::metadata::BlobMetadataApi;
+use walrus_core::{BlobId, EncodingType};
+
+#[derive(Debug)]
+pub struct BlobMetadata {
+    /// Raw 32-byte blob ID, matching `walrus_core::BlobId`'s internal
+    /// representation. `Display`-formats to the same base64url string
+    /// Walrus aggregators/publishers use (cross-checked against
+    /// `BlobId`'s own `Display` impl, which is `Base64Display` with
+    /// `URL_SAFE_NO_PAD` — the same encoding `blob_id_from_raw` in
+    /// `storage::walrus` decodes on the read path).
+    pub blob_id: [u8; 32],
+    /// Raw 32-byte Merkle root over the blob's sliver pairs.
+    pub root_hash: [u8; 32],
+    pub unencoded_length: u64,
+    pub encoding_type: EncodingType,
+}
+
+#[derive(Debug)]
+pub enum EncodeError {
+    /// The blob is too large to encode for the given shard count (see
+    /// `walrus_core::encoding::DataTooLargeError`).
+    TooLarge(String),
+}
+
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLarge(msg) => write!(f, "blob too large to encode: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for EncodeError {}
+
+/// Compute the RS2-encoded metadata for `blob` without producing or
+/// uploading any slivers — the Upload Relay does that from the raw,
+/// unencoded bytes once the blob is registered on-chain with these values.
+///
+/// `n_shards` is the current Walrus committee's shard count, read from the
+/// on-chain `System::n_shards()` view function (not hardcoded — it changes
+/// across epochs).
+pub fn compute_blob_metadata(blob: &[u8], n_shards: NonZeroU16) -> Result<BlobMetadata, EncodeError> {
+    let config = EncodingConfig::new(n_shards);
+    let verified = config
+        .reed_solomon
+        .compute_metadata(blob)
+        .map_err(|e| EncodeError::TooLarge(e.to_string()))?;
+
+    let blob_id: BlobId = *verified.blob_id();
+    let metadata = verified.metadata();
+    let root_hash = metadata.compute_root_hash();
+
+    let root_hash: [u8; 32] = root_hash
+        .as_ref()
+        .try_into()
+        .expect("Merkle root is always DIGEST_LEN (32) bytes");
+
+    Ok(BlobMetadata {
+        blob_id: blob_id.0,
+        root_hash,
+        unencoded_length: metadata.unencoded_length(),
+        encoding_type: metadata.encoding_type(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_blob_metadata_is_deterministic() {
+        let n_shards = NonZeroU16::new(100).unwrap();
+        let blob = b"hello walrus, this is a test blob for metadata computation";
+        let a = compute_blob_metadata(blob, n_shards).unwrap();
+        let b = compute_blob_metadata(blob, n_shards).unwrap();
+        assert_eq!(a.blob_id, b.blob_id);
+        assert_eq!(a.root_hash, b.root_hash);
+        assert_eq!(a.unencoded_length, blob.len() as u64);
+        assert_eq!(a.encoding_type, EncodingType::RS2);
+    }
+
+    #[test]
+    fn compute_blob_metadata_differs_for_different_blobs() {
+        let n_shards = NonZeroU16::new(100).unwrap();
+        let a = compute_blob_metadata(b"blob one", n_shards).unwrap();
+        let b = compute_blob_metadata(b"blob two", n_shards).unwrap();
+        assert_ne!(a.blob_id, b.blob_id);
+        assert_ne!(a.root_hash, b.root_hash);
+    }
+
+    #[test]
+    fn compute_blob_metadata_matches_blob_id_display_format() {
+        // Cross-check: BlobId's own Display impl (base64url, URL_SAFE_NO_PAD)
+        // must round-trip through our raw-byte extraction unchanged — this
+        // confirms `blob_id: [u8; 32]` from this module is byte-for-byte
+        // walrus_core's BlobId, not a reinterpretation.
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+
+        let n_shards = NonZeroU16::new(100).unwrap();
+        let blob = b"cross-check blob";
+        let result = compute_blob_metadata(blob, n_shards).unwrap();
+        let reconstructed = BlobId(result.blob_id);
+        let expected_display = URL_SAFE_NO_PAD.encode(result.blob_id);
+        assert_eq!(reconstructed.to_string(), expected_display);
+    }
+}

--- a/services/server/src/storage/walrus_tx.rs
+++ b/services/server/src/storage/walrus_tx.rs
@@ -1,0 +1,502 @@
+//! Walrus-specific Move call argument construction for `reserve_space` and
+//! `register_blob` (WALM-184: Walrus write-path migration, step 2 of 3 —
+//! register). Builds PTB inputs/arguments only — signing and submission are
+//! the caller's responsibility via `storage::sui_tx::execute_move_call`.
+//!
+//! Deliberately split from `sui_tx.rs`: that module knows how to build/sign/
+//! submit *any* Move call; this module knows the *specific* argument order
+//! Walrus's `system` Move module expects, cross-checked directly against
+//! `walrus::system` in the walrus contract source (`contracts/walrus/sources/
+//! system/system.move` at the pinned walrus tag) and against
+//! `walrus-sui::contracts` (`contract_ident!(fn system::reserve_space)` /
+//! `contract_ident!(fn system::register_blob)`), not guessed from the old TS
+//! sidecar's naming.
+//!
+use std::num::NonZeroU16;
+use sui_sdk_types::Address;
+use sui_transaction_builder::{Argument, ObjectInput, TransactionBuilder};
+
+/// Well-known, Mysten-published Walrus testnet contract object IDs
+/// (`setup/client_config_testnet.yaml` in the walrus repo — not derived or
+/// guessed). Mainnet has different IDs; do not reuse these there.
+pub mod testnet {
+    /// The shared `walrus::system::System` object.
+    pub const SYSTEM_OBJECT: &str =
+        "0x6c2547cbbc38025cf3adac45f63cb0a8d12ecf777cdc75a4971612bf97fdf6af";
+    /// The shared `walrus::staking::Staking` object — its `inner.n_shards`
+    /// field is the current committee's shard count needed for encoding
+    /// (see `storage::walrus_encode::compute_blob_metadata`).
+    pub const STAKING_OBJECT: &str =
+        "0xbe46180321c30aab2f8b3501e24048377287fa708018a5b7c2792b35fe339ee3";
+    /// The published `wal` Move package (`testnet-contracts/wal/Published.toml`
+    /// in the walrus repo — `published-at`, not derived or guessed).
+    pub const WAL_PACKAGE: &str =
+        "0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a";
+    /// Fully-qualified `Coin<WAL>` type tag, for `suix_getCoins` balance
+    /// queries when selecting a payment coin for `reserve_space`/`register_blob`.
+    pub const WAL_COIN_TYPE: &str =
+        "0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL";
+}
+
+/// Build the PTB inputs/arguments for the metadata-stamp + transfer step that
+/// follows `certify_blob` — ported 1:1 from the TS sidecar's
+/// `scripts/sidecar/blob-metadata.ts` (`setMetadataAndTransferBlobs`), not new
+/// business logic. For each `(key, value)` pair calls
+/// `{walrus_package}::blob::insert_or_update_metadata_pair(blob, key, value)`,
+/// then transfers the blob to `owner` via `tx.transfer_objects`.
+///
+/// `blob_arg` is the PTB `Argument` for the `Blob` object `register_blob`
+/// returned earlier in the same PTB (chained, like `certify_blob_inputs`).
+/// Returns nothing — the last command is the transfer, which has no result
+/// arguments callers need.
+pub fn stamp_metadata_and_transfer(
+    tx: &mut TransactionBuilder,
+    walrus_package_id: Address,
+    blob_arg: Argument,
+    owner: Address,
+    metadata: &[(&str, &str)],
+) {
+    use sui_transaction_builder::Function;
+
+    for (key, value) in metadata {
+        let key_arg = tx.pure(&(*key).to_string());
+        let value_arg = tx.pure(&(*value).to_string());
+        tx.move_call(
+            Function::new(
+                walrus_package_id,
+                "blob".parse().expect("valid identifier"),
+                "insert_or_update_metadata_pair"
+                    .parse()
+                    .expect("valid identifier"),
+            ),
+            vec![blob_arg, key_arg, value_arg],
+        );
+    }
+
+    let owner_arg = tx.pure(&owner);
+    tx.transfer_objects(vec![blob_arg], owner_arg);
+}
+
+/// Select a single `Coin<WAL>` object owned by `owner` with balance >=
+/// `min_balance`, via `sui-rpc`'s own official `Client::select_coins`
+/// (gRPC `list_owned_objects`, not hand-rolled JSON-RPC parsing). Returns
+/// just the object ID — like `register_blob_inputs`'s `wal_coin_object_id:
+/// Address` param, callers pass this straight to `ObjectInput::new`, which
+/// resolves version/digest itself when the transaction is built.
+///
+/// `select_coins` can return *multiple* smaller coins summing to
+/// `min_balance` — this wrapper only supports the single-coin case (returns
+/// an error naming the total available otherwise) since
+/// `reserve_space_inputs`/`register_blob_inputs` take one coin object, not a
+/// list to merge. If the wallet only holds fragmented WAL, top up / merge
+/// out-of-band (matching the TS sidecar's wallet-refill runbook).
+pub async fn select_wal_coin(
+    rpc_client: &sui_rpc::Client,
+    owner: Address,
+    min_balance: u64,
+) -> Result<Address, String> {
+    let coin_type: sui_sdk_types::TypeTag = testnet::WAL_COIN_TYPE
+        .parse()
+        .map_err(|e| format!("invalid WAL coin type {}: {e}", testnet::WAL_COIN_TYPE))?;
+    let coins = rpc_client
+        .select_coins(&owner, &coin_type, min_balance, &[])
+        .await
+        .map_err(|e| format!("select_coins failed: {e}"))?;
+    if coins.len() != 1 {
+        return Err(format!(
+            "need a single Coin<WAL> with balance >= {min_balance}, but the wallet only has \
+             fragmented balances across {} coins — merge them out-of-band first",
+            coins.len()
+        ));
+    }
+    coins[0]
+        .object_id()
+        .parse::<Address>()
+        .map_err(|e| format!("invalid coinObjectId {}: {e}", coins[0].object_id()))
+}
+
+/// Build the PTB inputs/arguments for `walrus::system::reserve_space`:
+/// `reserve_space(self: &mut System, storage_amount: u64, epochs_ahead: u32,
+/// payment: &mut Coin<WAL>, ctx: &mut TxContext) -> Storage`.
+/// (`ctx` is implicit — the VM supplies it, it is never a PTB argument.)
+///
+/// `system_initial_shared_version` and `wal_coin_object_id` must be resolved
+/// by the caller beforehand (a live, read-only RPC lookup — see
+/// `storage::sui::raw_rpc_call` with `sui_getObject`/`suix_getOwnedObjects`).
+pub fn reserve_space_inputs(
+    tx: &mut TransactionBuilder,
+    system_object_id: Address,
+    system_initial_shared_version: u64,
+    storage_amount: u64,
+    epochs_ahead: u32,
+    wal_coin_object_id: Address,
+) -> Vec<Argument> {
+    let system_arg = tx.object(ObjectInput::shared(
+        system_object_id,
+        system_initial_shared_version,
+        true,
+    ));
+    let amount_arg = tx.pure(&storage_amount);
+    let epochs_arg = tx.pure(&epochs_ahead);
+    let coin_arg = tx.object(ObjectInput::new(wal_coin_object_id));
+    vec![system_arg, amount_arg, epochs_arg, coin_arg]
+}
+
+/// Build the PTB inputs/arguments for `walrus::system::register_blob`:
+/// `register_blob(self: &mut System, storage: Storage, blob_id: u256,
+/// root_hash: u256, size: u64, encoding_type: u8, deletable: bool,
+/// write_payment: &mut Coin<WAL>, ctx: &mut TxContext) -> Blob`.
+///
+/// `blob_id`/`root_hash` are the raw 32-byte little-endian arrays from
+/// `storage::walrus_encode::BlobMetadata` — Move's `u256` BCS-encodes as
+/// exactly 32 raw bytes with no length prefix, the same representation
+/// (verified independently: `bcs::to_bytes(&[u8; 32])` produces exactly
+/// those 32 bytes unchanged), so they're passed to `pure()` directly with
+/// no conversion.
+///
+/// `storage_arg` is the PTB `Argument` for the `Storage` object being
+/// consumed — typically the `Argument` `reserve_space_inputs`' resulting
+/// move-call returned earlier in the *same* PTB (chained), not a fresh
+/// object lookup.
+#[allow(clippy::too_many_arguments)]
+pub fn register_blob_inputs(
+    tx: &mut TransactionBuilder,
+    system_object_id: Address,
+    system_initial_shared_version: u64,
+    storage_arg: Argument,
+    blob_id: [u8; 32],
+    root_hash: [u8; 32],
+    size: u64,
+    encoding_type: u8,
+    deletable: bool,
+    wal_coin_object_id: Address,
+) -> Vec<Argument> {
+    let system_arg = tx.object(ObjectInput::shared(
+        system_object_id,
+        system_initial_shared_version,
+        true,
+    ));
+    let blob_id_arg = tx.pure(&blob_id);
+    let root_hash_arg = tx.pure(&root_hash);
+    let size_arg = tx.pure(&size);
+    let encoding_type_arg = tx.pure(&encoding_type);
+    let deletable_arg = tx.pure(&deletable);
+    let coin_arg = tx.object(ObjectInput::new(wal_coin_object_id));
+    vec![
+        system_arg,
+        storage_arg,
+        blob_id_arg,
+        root_hash_arg,
+        size_arg,
+        encoding_type_arg,
+        deletable_arg,
+        coin_arg,
+    ]
+}
+
+/// Build the PTB inputs/arguments for `walrus::system::certify_blob`:
+/// `certify_blob(self: &System, blob: &mut Blob, signature: vector<u8>,
+/// signers_bitmap: vector<u8>, message: vector<u8>)`.
+///
+/// Note `self: &System` is an *immutable* shared reference here (unlike
+/// `reserve_space`/`register_blob`'s `&mut System`) — `mutable: false` on
+/// the `ObjectInput::shared` call reflects that.
+///
+/// `blob_arg` is the PTB `Argument` for the `Blob` object `register_blob`
+/// returned — typically chained from the same PTB's earlier command, not a
+/// fresh object lookup, since a freshly-registered `Blob` has no separate
+/// on-chain object ref to look up yet within the same transaction.
+///
+/// `signature`/`signers_bitmap`/`message` come from the Upload Relay's
+/// confirmation response once the blob's slivers have been stored by a
+/// quorum of storage nodes — not built by this server. Wiring the Upload
+/// Relay client that produces these is a separate, not-yet-done step (see
+/// `crates/walrus-upload-relay/upload_relay_openapi.yaml` in the walrus
+/// repo for the wire protocol).
+pub fn certify_blob_inputs(
+    tx: &mut TransactionBuilder,
+    system_object_id: Address,
+    system_initial_shared_version: u64,
+    blob_arg: Argument,
+    signature: Vec<u8>,
+    signers_bitmap: Vec<u8>,
+    message: Vec<u8>,
+) -> Vec<Argument> {
+    let system_arg = tx.object(ObjectInput::shared(
+        system_object_id,
+        system_initial_shared_version,
+        false,
+    ));
+    let signature_arg = tx.pure(&signature);
+    let signers_bitmap_arg = tx.pure(&signers_bitmap);
+    let message_arg = tx.pure(&message);
+    vec![
+        system_arg,
+        blob_arg,
+        signature_arg,
+        signers_bitmap_arg,
+        message_arg,
+    ]
+}
+
+/// Read the current Walrus committee's shard count from the on-chain
+/// `staking::Staking` object.
+///
+/// `n_shards` isn't a direct field on the `Staking` object — it lives in a
+/// `StakingInnerV1` value stored behind a `u64`-keyed dynamic field (the
+/// same "inner state behind a dynamic field, bump the key to migrate"
+/// pattern `system.move`'s own `System`/`SystemStateInnerV1` uses — see
+/// `storage::sui::verify_delegate_key_onchain`'s doc for the analogous
+/// MemWalAccount case). Two RPC round-trips: `suix_getDynamicFields` to
+/// find the current inner-state object, then `sui_getObject` on it to read
+/// `value.fields.n_shards`.
+///
+/// Also returns `committee_size` (the number of distinct committee member
+/// entries in `committee.pos0.contents`) — needed by
+/// [`signers_to_bitmap`], which mirrors `walrus-sui`'s own
+/// `committee_size()` (`self.inner.committee.members.len()` there; the same
+/// value, read from the JSON field path instead of a typed BCS struct).
+///
+/// Cross-checked live against Walrus testnet (`staking_object` from
+/// `setup/client_config_testnet.yaml`): returned n_shards=1000 (matching
+/// that config's separately-published static value) and committee_size=101
+/// at the time this was written.
+pub async fn fetch_n_shards_and_committee_size(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    staking_object_id: &str,
+) -> Result<(NonZeroU16, u16), String> {
+    let fields = super::sui::raw_rpc_call(
+        client,
+        rpc_url,
+        "suix_getDynamicFields",
+        serde_json::json!([staking_object_id, serde_json::Value::Null, 1]),
+    )
+    .await?;
+    let inner_object_id = fields
+        .pointer("/data/0/objectId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "staking object has no StakingInnerV1 dynamic field".to_string())?;
+
+    let inner = super::sui::raw_rpc_call(
+        client,
+        rpc_url,
+        "sui_getObject",
+        serde_json::json!([inner_object_id, { "showContent": true }]),
+    )
+    .await?;
+    let value_fields = inner
+        .pointer("/data/content/fields/value/fields")
+        .ok_or_else(|| "StakingInnerV1 object has no value.fields".to_string())?;
+
+    let n_shards = value_fields
+        .get("n_shards")
+        .and_then(|v| {
+            v.as_u64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        })
+        .ok_or_else(|| "StakingInnerV1 has no n_shards field".to_string())?;
+    let n_shards = u16::try_from(n_shards)
+        .ok()
+        .and_then(NonZeroU16::new)
+        .ok_or_else(|| format!("n_shards {n_shards} is not a valid non-zero u16"))?;
+
+    let committee_size = value_fields
+        .pointer("/committee/fields/pos0/fields/contents")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "StakingInnerV1 has no committee.pos0.contents".to_string())?
+        .len();
+    let committee_size = u16::try_from(committee_size)
+        .map_err(|_| format!("committee_size {committee_size} does not fit in u16"))?;
+
+    Ok((n_shards, committee_size))
+}
+
+/// Read a shared object's `initial_shared_version` — required by
+/// `ObjectInput::shared` for every shared-object reference in a PTB
+/// (`reserve_space_inputs`/`register_blob_inputs`/`certify_blob_inputs`'s
+/// `system_initial_shared_version` param, and the equivalent for the
+/// staking object). `sui_getObject` with `showOwner: true` returns
+/// `data.owner.Shared.initial_shared_version`; the object's *current*
+/// `data.version` field is a different value (bumped on every mutation) and
+/// must not be used here.
+pub async fn fetch_initial_shared_version(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    object_id: &str,
+) -> Result<u64, String> {
+    let resp = super::sui::raw_rpc_call(
+        client,
+        rpc_url,
+        "sui_getObject",
+        serde_json::json!([object_id, { "showOwner": true }]),
+    )
+    .await?;
+    resp.pointer("/data/owner/Shared/initial_shared_version")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| format!("{object_id} has no owner.Shared.initial_shared_version — is it actually a shared object?"))
+}
+
+/// Pack a list of signer indices (0-based, into the committee) into the
+/// bit-packed `signers_bitmap: vector<u8>` `certify_blob` expects.
+///
+/// Verbatim port of `walrus-sui`'s own
+/// `SuiContractClient::signers_to_bitmap` (`crates/walrus-sui/src/client/
+/// transaction_builder/owned_blob_ops.rs`): one bit per committee member,
+/// packed LSB-first within each byte, `committee_size.div_ceil(8)` bytes
+/// total.
+pub fn signers_to_bitmap(signers: &[u16], committee_size: u16) -> Vec<u8> {
+    let mut bitmap = vec![0u8; (committee_size as usize).div_ceil(8)];
+    for &signer in signers {
+        let byte_index = (signer / 8) as usize;
+        let bit_index = signer % 8;
+        bitmap[byte_index] |= 1 << bit_index;
+    }
+    bitmap
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_address(byte: u8) -> Address {
+        Address::new([byte; 32])
+    }
+
+    #[test]
+    fn reserve_space_inputs_produces_expected_argument_count() {
+        // reserve_space takes 4 PTB arguments (system, amount, epochs, coin)
+        // — ctx is implicit. This only checks argument *shape*: no network
+        // I/O, no signing, nothing submitted.
+        let mut tx = TransactionBuilder::new();
+        let args = reserve_space_inputs(
+            &mut tx,
+            dummy_address(1),
+            100,
+            1_000_000,
+            10,
+            dummy_address(2),
+        );
+        assert_eq!(args.len(), 4);
+    }
+
+    #[test]
+    fn register_blob_inputs_produces_expected_argument_count() {
+        // register_blob takes 8 PTB arguments (system, storage, blob_id,
+        // root_hash, size, encoding_type, deletable, coin) — ctx implicit.
+        let mut tx = TransactionBuilder::new();
+        let storage_arg = tx.object(ObjectInput::new(dummy_address(3)));
+        let args = register_blob_inputs(
+            &mut tx,
+            dummy_address(1),
+            100,
+            storage_arg,
+            [0u8; 32],
+            [1u8; 32],
+            12345,
+            1, // RS2
+            false,
+            dummy_address(2),
+        );
+        assert_eq!(args.len(), 8);
+    }
+
+    #[test]
+    fn blob_id_pure_arg_bcs_round_trips_without_reencoding() {
+        // The core claim this module relies on: [u8; 32] BCS-encodes as
+        // exactly those 32 bytes, unchanged — verified independently
+        // against a standalone bcs::to_bytes probe before writing this
+        // module. Re-assert it here so a future bcs upgrade that changed
+        // this would fail loudly.
+        let bytes = [7u8; 32];
+        let encoded = bcs::to_bytes(&bytes).unwrap();
+        assert_eq!(encoded.len(), 32);
+        assert_eq!(encoded, bytes.to_vec());
+    }
+
+    #[test]
+    fn certify_blob_inputs_produces_expected_argument_count() {
+        // certify_blob takes 5 PTB arguments (system, blob, signature,
+        // signers_bitmap, message).
+        let mut tx = TransactionBuilder::new();
+        let blob_arg = tx.object(ObjectInput::new(dummy_address(3)));
+        let args = certify_blob_inputs(
+            &mut tx,
+            dummy_address(1),
+            100,
+            blob_arg,
+            vec![1, 2, 3],
+            vec![4, 5],
+            vec![6, 7, 8, 9],
+        );
+        assert_eq!(args.len(), 5);
+    }
+
+    #[tokio::test]
+    #[ignore = "hits the live Sui testnet fullnode — run explicitly with `cargo test -- --ignored`"]
+    async fn fetch_n_shards_and_committee_size_reads_the_real_testnet_values() {
+        // Live read-only check against the official Mysten testnet staking
+        // object. No signing, no funds — just confirms this module's RPC
+        // navigation (suix_getDynamicFields -> sui_getObject -> field path)
+        // actually matches the real on-chain StakingInnerV1 layout, not
+        // just the JSON shape I read once by hand while writing this.
+        let client = reqwest::Client::new();
+        let (n_shards, committee_size) = fetch_n_shards_and_committee_size(
+            &client,
+            "https://fullnode.testnet.sui.io:443",
+            testnet::STAKING_OBJECT,
+        )
+        .await
+        .unwrap();
+        // n_shards=1000 and committee_size=101 as of writing (n_shards
+        // matches setup/client_config_testnet.yaml's separately-published
+        // static value) — both can change across epochs, so this asserts
+        // sane ranges rather than exact figures, in case they move before
+        // this test is next run.
+        assert!(
+            n_shards.get() >= 100,
+            "n_shards={n_shards} looks implausibly small"
+        );
+        assert!(
+            committee_size >= 10,
+            "committee_size={committee_size} looks implausibly small"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "hits the live Sui testnet fullnode — run explicitly with `cargo test -- --ignored`"]
+    async fn fetch_initial_shared_version_reads_the_real_testnet_system_object() {
+        // Live read-only check against the official Mysten testnet system
+        // object. No signing, no funds — confirms the owner.Shared field
+        // path actually matches what sui_getObject returns for a real
+        // shared object, not just the JSON shape read once by hand.
+        let client = reqwest::Client::new();
+        let version = fetch_initial_shared_version(
+            &client,
+            "https://fullnode.testnet.sui.io:443",
+            testnet::SYSTEM_OBJECT,
+        )
+        .await
+        .unwrap();
+        assert!(
+            version >= 1,
+            "initial_shared_version={version} looks implausible"
+        );
+    }
+
+    #[test]
+    fn signers_to_bitmap_matches_hand_computed_expected_bytes() {
+        // committee_size=10 -> ceil(10/8) = 2 bytes.
+        // signer 0 -> byte 0, bit 0 -> 0b0000_0001
+        // signer 3 -> byte 0, bit 3 -> 0b0000_1000
+        // signer 9 -> byte 1, bit 1 -> 0b0000_0010
+        let bitmap = signers_to_bitmap(&[0, 3, 9], 10);
+        assert_eq!(bitmap, vec![0b0000_1001, 0b0000_0010]);
+    }
+
+    #[test]
+    fn signers_to_bitmap_empty_signers_gives_zeroed_bitmap() {
+        let bitmap = signers_to_bitmap(&[], 20);
+        assert_eq!(bitmap, vec![0u8; 3]); // ceil(20/8) = 3
+    }
+}

--- a/services/server/src/storage/walrus_upload_relay.rs
+++ b/services/server/src/storage/walrus_upload_relay.rs
@@ -1,0 +1,222 @@
+//! Walrus Upload Relay HTTP client (WALM-184: Walrus write-path migration,
+//! step 3 of 3 — upload). The relay accepts raw unencoded blob bytes for an
+//! already-registered blob, pushes the encoded slivers to the storage node
+//! committee itself, and returns a `ConfirmationCertificate` — the exact
+//! signature/bitmap/message `certify_blob` needs
+//! (`storage::walrus_tx::certify_blob_inputs`).
+//!
+//! Wire protocol cross-checked against
+//! `crates/walrus-upload-relay/upload_relay_openapi.yaml` and the real
+//! client implementation in `crates/walrus-sdk/src/upload_relay.rs` +
+//! `crates/walrus-sdk/src/node_client/upload_relay_client.rs` in the walrus
+//! repo — not reverse-engineered from the OpenAPI spec alone, since that
+//! spec doesn't document the response body schema (only "200: success").
+//!
+//! `walrus-sdk`'s own `TipConfig`/`TipKind` types depend on
+//! `sui_types::base_types::SuiAddress` (the full Sui monorepo — see the
+//! module doc on `storage::sui_tx` for why that can't be a dependency of
+//! this server), so `tip_config()` here parses the same JSON shape with
+//! plain `serde_json::Value` navigation instead of importing those types —
+//! cross-checked live: `GET https://upload-relay.testnet.walrus.space/v1/
+//! tip-config` returned
+//! `{"send_tip":{"address":"0x4b6a...","kind":{"const":105}}}` while
+//! writing this, matching the `TipConfig::SendTip` shape below exactly.
+
+use walrus_core::messages::ConfirmationCertificate;
+use walrus_core::BlobId;
+
+pub const BLOB_UPLOAD_RELAY_ROUTE: &str = "/v1/blob-upload-relay";
+pub const TIP_CONFIG_ROUTE: &str = "/v1/tip-config";
+
+#[derive(Debug)]
+pub enum UploadRelayError {
+    Http(String),
+    /// The relay's response didn't match the expected shape.
+    UnexpectedResponse(String),
+    /// The relay rejected the upload (e.g. blob not registered, tip missing
+    /// or wrong nonce) — response status + body, for the caller to inspect.
+    /// Check `fetch_tip_config` beforehand and pay the tip (a separate,
+    /// fund-moving Sui transaction) if `TipRequirement::SendTip` — paying
+    /// it is not automated by this client (see `storage::sui_tx::
+    /// execute_move_call`); an unpaid upload against a tip-requiring relay
+    /// surfaces here as `Rejected`, not a distinct variant.
+    Rejected { status: u16, body: String },
+}
+
+impl std::fmt::Display for UploadRelayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(m) => write!(f, "upload relay HTTP error: {m}"),
+            Self::UnexpectedResponse(m) => write!(f, "unexpected upload relay response: {m}"),
+            Self::Rejected { status, body } => {
+                write!(f, "upload relay rejected the request (status {status}): {body}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for UploadRelayError {}
+
+/// Whether the relay requires a paid tip before accepting uploads, and how
+/// much. `GET /v1/tip-config` — read-only, no funds moved by calling this.
+#[derive(Debug, PartialEq)]
+pub enum TipRequirement {
+    NoTip,
+    /// A tip must be sent to `address`. `const_amount` is populated for the
+    /// `TipKind::Const` case (the only kind this client currently parses —
+    /// `TipKind::Linear`, which scales with blob size, is not yet
+    /// implemented and reports `const_amount: None`).
+    SendTip { address: String, const_amount: Option<u64> },
+}
+
+/// Query the relay's tip configuration.
+pub async fn fetch_tip_config(
+    client: &reqwest::Client,
+    relay_base_url: &str,
+) -> Result<TipRequirement, UploadRelayError> {
+    let url = format!("{}{}", relay_base_url.trim_end_matches('/'), TIP_CONFIG_ROUTE);
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| UploadRelayError::Http(e.to_string()))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| UploadRelayError::Http(format!("invalid JSON: {e}")))?;
+
+    if !status.is_success() {
+        return Err(UploadRelayError::Rejected {
+            status: status.as_u16(),
+            body: body.to_string(),
+        });
+    }
+
+    if body.as_str() == Some("no_tip") {
+        return Ok(TipRequirement::NoTip);
+    }
+    let address = body
+        .pointer("/send_tip/address")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            UploadRelayError::UnexpectedResponse(format!("tip-config response: {body}"))
+        })?
+        .to_string();
+    let const_amount = body.pointer("/send_tip/kind/const").and_then(|v| v.as_u64());
+    Ok(TipRequirement::SendTip { address, const_amount })
+}
+
+/// Upload an already-registered blob's raw (unencoded) bytes to the relay
+/// and return the confirmation certificate `certify_blob` needs.
+///
+/// `blob_id` must be the same value already passed to `register_blob`
+/// (`storage::walrus_encode::BlobMetadata::blob_id`). Does not handle tips —
+/// call `fetch_tip_config` first; if it returns `SendTip`, the caller must
+/// pay it (a separate, fund-moving Sui transaction) and pass the resulting
+/// `tx_id`/`nonce` — not yet plumbed through this function's signature,
+/// since no caller needs it yet (see module doc: not wired into any route).
+pub async fn upload_blob(
+    client: &reqwest::Client,
+    relay_base_url: &str,
+    blob_id: [u8; 32],
+    blob_bytes: &[u8],
+) -> Result<ConfirmationCertificate, UploadRelayError> {
+    let blob_id = BlobId(blob_id);
+    let url = format!(
+        "{}{}?blob_id={}",
+        relay_base_url.trim_end_matches('/'),
+        BLOB_UPLOAD_RELAY_ROUTE,
+        blob_id, // Display impl is base64url, URL_SAFE_NO_PAD — exactly what the relay expects as a query param.
+    );
+
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/octet-stream")
+        .body(blob_bytes.to_vec())
+        .send()
+        .await
+        .map_err(|e| UploadRelayError::Http(e.to_string()))?;
+    let status = resp.status();
+    let body_bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| UploadRelayError::Http(format!("failed to read response body: {e}")))?;
+
+    if !status.is_success() {
+        return Err(UploadRelayError::Rejected {
+            status: status.as_u16(),
+            body: String::from_utf8_lossy(&body_bytes).into_owned(),
+        });
+    }
+
+    #[derive(serde::Deserialize)]
+    struct ResponseType {
+        blob_id: BlobId,
+        confirmation_certificate: ConfirmationCertificate,
+    }
+
+    let parsed: ResponseType = serde_json::from_slice(&body_bytes).map_err(|e| {
+        UploadRelayError::UnexpectedResponse(format!(
+            "failed to parse relay response: {e} (body: {})",
+            String::from_utf8_lossy(&body_bytes)
+        ))
+    })?;
+
+    if parsed.blob_id != blob_id {
+        return Err(UploadRelayError::UnexpectedResponse(format!(
+            "relay returned blob_id {} but expected {blob_id}",
+            parsed.blob_id
+        )));
+    }
+
+    Ok(parsed.confirmation_certificate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "hits the live public Walrus testnet upload relay — run explicitly with `cargo test -- --ignored`"]
+    async fn fetch_tip_config_reads_the_real_testnet_relay() {
+        // Live read-only check (GET request, no funds moved) against
+        // Mysten's public testnet upload relay. Confirms this module's JSON
+        // parsing matches the real response shape, not just the one sample
+        // response captured by hand while writing this file.
+        let client = reqwest::Client::new();
+        let tip = fetch_tip_config(&client, "https://upload-relay.testnet.walrus.space")
+            .await
+            .unwrap();
+        match tip {
+            TipRequirement::SendTip { address, const_amount } => {
+                assert!(address.starts_with("0x"));
+                assert!(const_amount.is_some());
+            }
+            TipRequirement::NoTip => {
+                // The relay could stop requiring a tip in the future; either
+                // outcome is a valid, successfully-parsed response.
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "hits the live public Walrus testnet upload relay — run explicitly with `cargo test -- --ignored`"]
+    async fn upload_blob_without_paying_tip_is_rejected_cleanly() {
+        // The testnet relay requires a tip (confirmed live via
+        // fetch_tip_config), so an unpaid upload attempt must be rejected
+        // by the relay, not silently accepted or panic this client. No
+        // funds are moved by this call either way — it's just an HTTP POST
+        // with no prior payment, which the relay's own tip-verification
+        // logic rejects server-side.
+        let client = reqwest::Client::new();
+        let result = upload_blob(
+            &client,
+            "https://upload-relay.testnet.walrus.space",
+            [0u8; 32],
+            b"test blob that was never registered or paid for",
+        )
+        .await;
+        assert!(matches!(result, Err(UploadRelayError::Rejected { .. })));
+    }
+}

--- a/services/server/src/storage/walrus_write.rs
+++ b/services/server/src/storage/walrus_write.rs
@@ -1,0 +1,399 @@
+//! `store_blob`: the complete native Walrus write-path orchestration
+//! (WALM-184) — the single entry point that replaces what the old TS
+//! sidecar's `POST /walrus/upload` did (`scripts/sidecar/routes/
+//! walrus-upload.ts`, `flow.encode()` -> `flow.register()` ->
+//! `flow.upload()` -> `flow.certify()`), assembled here from the pieces
+//! verified individually elsewhere in `storage::`:
+//!
+//! 1. [`walrus_encode::compute_blob_metadata`] — RedStuff-encode the blob
+//!    locally, no network calls.
+//! 2. [`walrus_tx::fetch_n_shards_and_committee_size`] — live, read-only
+//!    chain read (step 1 needs `n_shards`).
+//! 3. [`sui_tx::execute_ptb`] with [`walrus_tx::reserve_space_inputs`]
+//!    chained into [`walrus_tx::register_blob_inputs`] in one PTB — signs
+//!    and submits a real transaction.
+//! 4. A follow-up `sui_getTransactionBlock` (JSON-RPC, `showObjectChanges:
+//!    true`) to find the newly-created `Blob` object's ID — the gRPC
+//!    execution response's `effects.changed_objects[].object_type` is
+//!    documented as not populated by the execution path itself ("Type
+//!    information is not provided by the effects structure but is instead
+//!    provided by an indexing layer" — `sui-rpc`'s own
+//!    `ChangedObject.object_type` doc comment), so identifying which
+//!    changed object is the `Blob` needs this separate, type-aware read.
+//! 5. [`walrus_upload_relay::upload_blob`] — HTTP POST to the relay,
+//!    returns a `ConfirmationCertificate`.
+//! 6. [`sui_tx::execute_move_call`] with [`walrus_tx::certify_blob_inputs`]
+//!    (using [`walrus_tx::signers_to_bitmap`] on the certificate's
+//!    `signers`) — signs and submits a second real transaction.
+//!
+//! Steps 3 and 6 spend real WAL/SUI gas. This function is real, complete,
+//! callable code — but nothing in this codebase invokes it yet (no route
+//! wires it up). See the caller-facing warning on [`store_blob`] before
+//! wiring this into a route.
+
+use crate::storage::{sui, sui_tx, walrus_encode, walrus_tx, walrus_upload_relay};
+use fastcrypto::traits::ToFromBytes;
+use sui_sdk_types::Address;
+use sui_transaction_builder::Function;
+
+#[derive(Debug)]
+pub enum StoreBlobError {
+    Encode(walrus_encode::EncodeError),
+    ChainRead(String),
+    AddressParse(String),
+    Reserve(sui_tx::SuiTxError),
+    BlobObjectNotFound(String),
+    Upload(walrus_upload_relay::UploadRelayError),
+    Certify(sui_tx::SuiTxError),
+    CoinSelection(String),
+    MetadataTransfer(sui_tx::SuiTxError),
+}
+
+impl std::fmt::Display for StoreBlobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Encode(e) => write!(f, "failed to encode blob: {e}"),
+            Self::ChainRead(e) => write!(f, "failed to read chain state: {e}"),
+            Self::AddressParse(e) => write!(f, "invalid address: {e}"),
+            Self::Reserve(e) => write!(f, "reserve_space+register_blob transaction failed: {e}"),
+            Self::BlobObjectNotFound(e) => {
+                write!(f, "could not find the newly-created Blob object: {e}")
+            }
+            Self::Upload(e) => write!(f, "upload relay failed: {e}"),
+            Self::Certify(e) => write!(f, "certify_blob transaction failed: {e}"),
+            Self::CoinSelection(e) => write!(f, "failed to select a Coin<WAL> payment coin: {e}"),
+            Self::MetadataTransfer(e) => {
+                write!(
+                    f,
+                    "metadata-stamp + transfer-to-owner transaction failed: {e}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for StoreBlobError {}
+
+pub struct StoreBlobResult {
+    pub blob_id: [u8; 32],
+    pub blob_object_id: String,
+    pub register_tx_digest: String,
+    pub certify_tx_digest: String,
+}
+
+/// Store `blob_bytes` on Walrus natively — no Node.js sidecar involved.
+///
+/// # THIS FUNCTION SPENDS REAL WAL AND SUI GAS
+///
+/// It signs and submits two real transactions (`reserve_space`+
+/// `register_blob` combined into one PTB, then `certify_blob`) using
+/// `signer`'s key. Do not call this against a real signer without the same
+/// explicit, scoped confirmation any other fund-moving action in this
+/// codebase requires — treat it exactly like `sui_tx::execute_ptb`, which
+/// this function is built on.
+///
+/// It also does NOT pay the Upload Relay's tip if one is required
+/// (`walrus_upload_relay::fetch_tip_config`) — call that first and handle
+/// payment separately; `upload_blob` will return
+/// `UploadRelayError::Rejected` if a required tip wasn't paid.
+///
+/// `wal_coin_object_id` must be an object ID of a `Coin<WAL>` the signer
+/// owns, already resolved by the caller (e.g. via `suix_getBalance`/
+/// `suix_getCoins` filtered by the network's live WAL coin type — see
+/// module doc on why this isn't auto-discovered: on Sui testnet
+/// specifically, multiple stale `wal::WAL` coin types can coexist in one
+/// address from past testnet resets, so auto-picking "a" WAL coin risks
+/// picking one for the wrong, no-longer-live package).
+#[allow(clippy::too_many_arguments)]
+pub async fn store_blob(
+    rpc_client: &mut sui_rpc::Client,
+    http_client: &reqwest::Client,
+    signer: &sui_tx::SuiSignerContext,
+    sui_rpc_url: &str,
+    upload_relay_url: &str,
+    system_object_id: &str,
+    system_initial_shared_version: u64,
+    staking_object_id: &str,
+    wal_coin_object_id: &str,
+    epochs_ahead: u32,
+    deletable: bool,
+    gas_budget: u64,
+    blob_bytes: &[u8],
+) -> Result<StoreBlobResult, StoreBlobError> {
+    let system_address = parse_address(system_object_id)?;
+    let wal_coin_address = parse_address(wal_coin_object_id)?;
+
+    // 1+2. Encode locally, using the live committee size.
+    let (n_shards, _) =
+        walrus_tx::fetch_n_shards_and_committee_size(http_client, sui_rpc_url, staking_object_id)
+            .await
+            .map_err(StoreBlobError::ChainRead)?;
+    let metadata = walrus_encode::compute_blob_metadata(blob_bytes, n_shards)
+        .map_err(StoreBlobError::Encode)?;
+    let blob_id = metadata.blob_id;
+
+    // 3. reserve_space + register_blob, chained in one PTB.
+    let storage_amount = blob_bytes.len() as u64; // TODO: real encoded-size formula, not raw length — see walrus_core::encoding::encoded_blob_length_for_n_shards.
+    let root_hash = metadata.root_hash;
+    let unencoded_length = metadata.unencoded_length;
+    let encoding_type = metadata.encoding_type as u8;
+    let executed = sui_tx::execute_ptb(
+        rpc_client,
+        signer,
+        move |tx| {
+            let reserve_args = walrus_tx::reserve_space_inputs(
+                tx,
+                system_address,
+                system_initial_shared_version,
+                storage_amount,
+                epochs_ahead,
+                wal_coin_address,
+            );
+            let storage_arg = tx.move_call(
+                Function::new(
+                    system_address,
+                    "system".parse().expect("valid identifier"),
+                    "reserve_space".parse().expect("valid identifier"),
+                ),
+                reserve_args,
+            );
+
+            let register_args = walrus_tx::register_blob_inputs(
+                tx,
+                system_address,
+                system_initial_shared_version,
+                storage_arg,
+                blob_id,
+                root_hash,
+                unencoded_length,
+                encoding_type,
+                deletable,
+                wal_coin_address,
+            );
+            tx.move_call(
+                Function::new(
+                    system_address,
+                    "system".parse().expect("valid identifier"),
+                    "register_blob".parse().expect("valid identifier"),
+                ),
+                register_args,
+            );
+        },
+        gas_budget,
+    )
+    .await
+    .map_err(StoreBlobError::Reserve)?;
+    let register_tx_digest = executed.digest.clone().unwrap_or_default();
+
+    // 4. Find the newly-created Blob object's ID via a type-aware
+    // follow-up read (see module doc for why the execution response's
+    // effects alone don't carry object types).
+    let blob_object_id =
+        find_created_blob_object(http_client, sui_rpc_url, &register_tx_digest).await?;
+
+    // 5. Upload the raw bytes to the relay; get back the confirmation
+    // certificate.
+    let certificate =
+        walrus_upload_relay::upload_blob(http_client, upload_relay_url, blob_id, blob_bytes)
+            .await
+            .map_err(StoreBlobError::Upload)?;
+
+    // 6. certify_blob, using the certificate's signer indices packed into
+    // a bitmap.
+    let (_, committee_size) =
+        walrus_tx::fetch_n_shards_and_committee_size(http_client, sui_rpc_url, staking_object_id)
+            .await
+            .map_err(StoreBlobError::ChainRead)?;
+    let signers_bitmap = walrus_tx::signers_to_bitmap(&certificate.signers, committee_size);
+    let signature = certificate.signature.as_bytes().to_vec();
+    let message = certificate.serialized_message.clone();
+    let blob_object_address = parse_address(&blob_object_id)?;
+
+    let executed = sui_tx::execute_ptb(
+        rpc_client,
+        signer,
+        move |tx| {
+            let blob_arg = tx.object(sui_transaction_builder::ObjectInput::new(
+                blob_object_address,
+            ));
+            let certify_args = walrus_tx::certify_blob_inputs(
+                tx,
+                system_address,
+                system_initial_shared_version,
+                blob_arg,
+                signature,
+                signers_bitmap,
+                message,
+            );
+            tx.move_call(
+                Function::new(
+                    system_address,
+                    "system".parse().expect("valid identifier"),
+                    "certify_blob".parse().expect("valid identifier"),
+                ),
+                certify_args,
+            );
+        },
+        gas_budget,
+    )
+    .await
+    .map_err(StoreBlobError::Certify)?;
+    let certify_tx_digest = executed.digest.unwrap_or_default();
+
+    Ok(StoreBlobResult {
+        blob_id,
+        blob_object_id,
+        register_tx_digest,
+        certify_tx_digest,
+    })
+}
+
+/// Find the `Blob` object created by a transaction, via
+/// `sui_getTransactionBlock` + `showObjectChanges: true` (plain JSON-RPC —
+/// same low-level caller, `storage::sui::raw_rpc_call`, every other
+/// on-chain read in this codebase already uses).
+async fn find_created_blob_object(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    tx_digest: &str,
+) -> Result<String, StoreBlobError> {
+    let result = sui::raw_rpc_call(
+        client,
+        rpc_url,
+        "sui_getTransactionBlock",
+        serde_json::json!([tx_digest, { "showObjectChanges": true }]),
+    )
+    .await
+    .map_err(StoreBlobError::BlobObjectNotFound)?;
+
+    let changes = result
+        .get("objectChanges")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            StoreBlobError::BlobObjectNotFound("response has no objectChanges array".into())
+        })?;
+
+    changes
+        .iter()
+        .find(|c| {
+            c.get("objectType")
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| t.contains("::blob::Blob"))
+        })
+        .and_then(|c| c.get("objectId"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| {
+            StoreBlobError::BlobObjectNotFound(format!(
+                "no ::blob::Blob entry in objectChanges for tx {tx_digest}"
+            ))
+        })
+}
+
+fn parse_address(s: &str) -> Result<Address, StoreBlobError> {
+    s.parse()
+        .map_err(|e| StoreBlobError::AddressParse(format!("{s:?}: {e}")))
+}
+
+/// Full native replacement for the TS sidecar's `POST /walrus/upload`
+/// (WALM-184) — [`store_blob`] (protocol-level reserve/register/certify)
+/// plus the metadata-stamp + transfer-to-owner step the sidecar's
+/// `scripts/sidecar/blob-metadata.ts::setMetadataAndTransferBlobs` also
+/// does, ported 1:1 (see [`walrus_tx::stamp_metadata_and_transfer`]) — same
+/// on-chain effect, not new behavior. Resolves the WAL payment coin and the
+/// System object's `initial_shared_version` itself so callers don't have to.
+///
+/// # THIS FUNCTION SPENDS REAL WAL AND SUI GAS (three transactions total)
+///
+/// Same fund-moving caveat as [`store_blob`] — do not call against a real
+/// signer without explicit, scoped confirmation.
+///
+/// Currently testnet-only (uses `walrus_tx::testnet::*` constants for
+/// `system_object_id`/`staking_object_id`/the WAL coin type). Mainnet needs
+/// its own constants added to `walrus_tx` before this can be pointed there.
+#[allow(clippy::too_many_arguments)]
+pub async fn store_blob_and_finalize(
+    rpc_client: &mut sui_rpc::Client,
+    http_client: &reqwest::Client,
+    signer: &sui_tx::SuiSignerContext,
+    sui_rpc_url: &str,
+    upload_relay_url: &str,
+    walrus_package_id: &str,
+    owner: &str,
+    namespace: &str,
+    package_id: Option<&str>,
+    agent_id: Option<&str>,
+    epochs_ahead: u32,
+    deletable: bool,
+    gas_budget: u64,
+    blob_bytes: &[u8],
+) -> Result<StoreBlobResult, StoreBlobError> {
+    let owner_address = parse_address(owner)?;
+
+    let system_initial_shared_version = walrus_tx::fetch_initial_shared_version(
+        http_client,
+        sui_rpc_url,
+        walrus_tx::testnet::SYSTEM_OBJECT,
+    )
+    .await
+    .map_err(StoreBlobError::ChainRead)?;
+
+    // Small, fixed lower bound on the WAL coin balance we require — actual
+    // storage cost depends on blob size/epochs and is computed inside
+    // `store_blob` (`reserve_space_inputs`'s `storage_amount`), but we need
+    // a coin picked *before* calling it. 1 WAL (10^9 MIST) comfortably
+    // covers small test blobs on testnet; revisit if real usage needs more.
+    const MIN_WAL_BALANCE: u64 = 1_000_000_000;
+    let wal_coin = walrus_tx::select_wal_coin(rpc_client, signer.address(), MIN_WAL_BALANCE)
+        .await
+        .map_err(StoreBlobError::CoinSelection)?;
+
+    let result = store_blob(
+        rpc_client,
+        http_client,
+        signer,
+        sui_rpc_url,
+        upload_relay_url,
+        walrus_tx::testnet::SYSTEM_OBJECT,
+        system_initial_shared_version,
+        walrus_tx::testnet::STAKING_OBJECT,
+        &wal_coin.to_string(),
+        epochs_ahead,
+        deletable,
+        gas_budget,
+        blob_bytes,
+    )
+    .await?;
+
+    let blob_object_address = parse_address(&result.blob_object_id)?;
+    let walrus_package = parse_address(walrus_package_id)?;
+    let mut metadata = vec![("memwal_namespace", namespace), ("memwal_owner", owner)];
+    if let Some(pkg) = package_id {
+        metadata.push(("memwal_package_id", pkg));
+    }
+    if let Some(agent) = agent_id {
+        metadata.push(("memwal_agent_id", agent));
+    }
+
+    sui_tx::execute_ptb(
+        rpc_client,
+        signer,
+        move |tx| {
+            let blob_arg = tx.object(sui_transaction_builder::ObjectInput::new(
+                blob_object_address,
+            ));
+            walrus_tx::stamp_metadata_and_transfer(
+                tx,
+                walrus_package,
+                blob_arg,
+                owner_address,
+                &metadata,
+            );
+        },
+        gas_budget,
+    )
+    .await
+    .map_err(StoreBlobError::MetadataTransfer)?;
+
+    Ok(result)
+}

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -166,6 +166,15 @@ impl KeyPool {
         }
     }
 
+    /// Returns the raw hex private key at `index` (the same index
+    /// `next_index()` returned earlier) — for callers that need to sign
+    /// with that specific pool slot's key directly (WALM-184: native Walrus
+    /// write path), rather than just passing the index to the TS sidecar
+    /// (which owns the keys itself via its own env vars).
+    pub fn key_at(&self, index: usize) -> Option<&str> {
+        self.keys.get(index).map(|s| s.as_str())
+    }
+
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.keys.is_empty()
@@ -213,6 +222,10 @@ pub struct Config {
     /// falls back to SERVER_SUI_PRIVATE_KEY as a single-element list).
     pub sui_private_keys: Vec<String>,
     pub package_id: String,
+    /// Move package ID that publishes `walrus::blob::Blob` on this network —
+    /// distinct from `package_id` (MemWal's own package). Used for native
+    /// on-chain Walrus blob queries (see `storage::walrus::query_blobs_by_owner`).
+    pub walrus_package_id: String,
     pub registry_id: String,
     /// URL of the SEAL/Walrus TS sidecar HTTP server
     pub sidecar_url: String,
@@ -229,6 +242,19 @@ pub struct Config {
     /// bypassing SEAL + Walrus. **Not for production.** Off by default;
     /// set `BENCHMARK_MODE=true` to enable. Surfaced via `GET /health`.
     pub benchmark_mode: bool,
+    /// WALM-184: when true, `engine::store_blob` calls
+    /// `storage::walrus_write::store_blob_and_finalize` (native Rust Walrus
+    /// write path) instead of `storage::walrus::upload_blob` (TS sidecar
+    /// HTTP call). Testnet-only for now (see that function's doc). Off by
+    /// default — set `WALRUS_NATIVE_WRITE=true` to opt in.
+    pub walrus_native_write: bool,
+    /// Upload Relay HTTP endpoint for the native Walrus write path. Only
+    /// read when `walrus_native_write` is true.
+    pub walrus_upload_relay_url: String,
+    /// Gas budget (MIST) for each of the three native-write-path
+    /// transactions (register+reserve, certify, metadata+transfer). Only
+    /// read when `walrus_native_write` is true.
+    pub walrus_native_gas_budget: u64,
 }
 
 impl Config {
@@ -287,6 +313,13 @@ impl Config {
             },
             package_id: std::env::var("MEMWAL_PACKAGE_ID")
                 .expect("MEMWAL_PACKAGE_ID must be set"),
+            walrus_package_id: std::env::var("WALRUS_PACKAGE_ID").unwrap_or_else(|_| {
+                if network == "testnet" {
+                    "0xd84704c17fc870b8764832c535aa6b11f21a95cd6f5bb38a9b07d2cf42220c66".to_string()
+                } else {
+                    "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77".to_string()
+                }
+            }),
             registry_id: std::env::var("MEMWAL_REGISTRY_ID")
                 .expect("MEMWAL_REGISTRY_ID must be set"),
             sidecar_url: std::env::var("SIDECAR_URL")
@@ -299,6 +332,13 @@ impl Config {
             benchmark_mode: std::env::var("BENCHMARK_MODE")
                 .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
                 .unwrap_or(false),
+            walrus_native_write: env_bool("WALRUS_NATIVE_WRITE"),
+            walrus_upload_relay_url: std::env::var("WALRUS_UPLOAD_RELAY_URL")
+                .unwrap_or_else(|_| "https://upload-relay.testnet.walrus.space".to_string()),
+            walrus_native_gas_budget: std::env::var("WALRUS_NATIVE_GAS_BUDGET")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(500_000_000),
         }
     }
 }


### PR DESCRIPTION
## Summary
Split out of feat/rust-migration-sdk (PR #367) so this doesn't keep growing alongside the Rust SDK client work — same commits, own branch.

- Native Sui transaction building/signing, Walrus blob discovery, RedStuff encoding, reserve_space/register_blob PTB construction, Upload Relay HTTP client
- `store_blob_and_finalize`: full native write path (register+certify+metadata-stamp+transfer-to-owner), gated behind `WALRUS_NATIVE_WRITE` (default off)
- WAL coin selection via `sui-rpc`'s official `select_coins`
- `SIDECAR_DISABLED` escape hatch in `main.rs`

## Not done yet
- **SEAL**: still 100% via the TS sidecar — no viable Rust SEAL crate exists (the only community one, gfusee/seal-sdk-rs, doesn't build). Native SEAL means hand-rolling threshold-encryption crypto — needs an explicit decision before starting.
- **Enoki**: untouched, still proxies to sidecar. Has a documented REST API (`api.enoki.mystenlabs.com/v1`), should be straightforward (no custom crypto) — not started.
- Sidecar can't actually be disabled yet — SEAL + Enoki both still need it.

## Test plan
- [x] `cargo build --all-targets` / `cargo test` / `cargo clippy --all-targets` all clean (309/309 relevant tests pass; 5 pre-existing DB-auth failures are environmental, unrelated)
- [ ] Live supervised testnet write with `WALRUS_NATIVE_WRITE=true` — not run yet (network-restricted sandbox couldn't reach Sui testnet to verify)