### PR TITLE
docs: remove Seal encryption claims from Walrus Memory overview

### DIFF
--- a/docs/getting-started/choose-your-path.md
+++ b/docs/getting-started/choose-your-path.md
@@ -12,7 +12,7 @@ These paths aren't mutually exclusive. You can combine them - for example, use t
 
 Use `@mysten-incubation/memwal` when you want the fastest working integration.
 
-- relayer handles embedding, encryption, retrieval, and restore
+- relayer handles embedding, retrieval, and restore
 - best starting point for most teams
 
 Go to: [SDK Overview](/sdk/overview)

--- a/docs/getting-started/what-is-memwal.md
+++ b/docs/getting-started/what-is-memwal.md
@@ -55,11 +55,8 @@ AI agents today lose context between sessions — every conversation starts from
 ### Ownership & Access Control
 
 <CardGroup cols={2}>
-  <Card title="End-to-End Encryption" icon="lock">
-    All content is encrypted via SEAL before it reaches Walrus. Only the owner and authorized delegates can decrypt it.
-  </Card>
   <Card title="Decentralized Storage" icon="globe">
-    Encrypted blobs stored on Walrus — no single point of failure, no central operator holding your data.
+    Blobs stored on Walrus — no single point of failure, no central operator holding your data.
   </Card>
   <Card title="Programmable Permissions" icon="key">
     Ownership and access rules are enforced by Sui smart contracts, giving you explicit, programmable control over who can read and write.
@@ -83,7 +80,7 @@ AI agents today lose context between sessions — every conversation starts from
 ## What's Included
 
 - **TypeScript SDK**: integrate memory into any app with a few lines of code
-- **Relayer**: handles encryption, storage, and retrieval behind a simple API
+- **Relayer**: handles storage and retrieval behind a simple API
 - **Smart Contract**: enforces ownership and delegate access onchain
 - **Indexer**: keeps onchain state synced for fast lookups
 - **Dashboard**: manage accounts, memory, and delegate keys visually


### PR DESCRIPTION
Removes the end-to-end encryption card from the Walrus Memory overview, plus encryption mentions in the storage card, the relayer description, and the default SDK path.
Changed: docs/getting-started/what-is-memwal.md, docs/getting-started/choose-your-path.md. Two files.
Deliberately out of scope (no changes here, flagging so it isn't assumed complete):
Ten reference files still document Seal-related API surface (x-seal-session, x-delegate-key, SERVER_SUI_PRIVATE_KEY) across the relayer, contract, environment variables, and SDK API reference. Removing those would leave shipped auth headers undocumented, so they need engineering review first. sdk/changelog.mdx is a historical record and shouldn't be rewritten. getting-started/quick-start.md references @mysten/seal only as a peer-dependency install for the manual client flow.
fundamentals/architecture/data-flow-security-model.md and choose-your-path.md section 3 both state the relayer never sees plaintext in the manual flow. Unchanged pending confirmation of current behavior.