### PR TITLE
fix(app): accept JSON-RPC's nested UID shape in registry table lookup (prod hotfix)

### DIFF
--- a/apps/app/src/utils/suiClientCompat.ts
+++ b/apps/app/src/utils/suiClientCompat.ts
@@ -62,7 +62,12 @@ export async function fetchAccountIdForOwner(
     let tableId = registryTableIdCache.get(registryId)
     if (!tableId) {
         const registryJson = await fetchObjectJson(suiClient, registryId)
-        tableId = (registryJson?.accounts as { id?: string } | undefined)?.id
+        // gRPC json flattens the Table's UID to a plain string; JSON-RPC keeps
+        // Move's nested UID shape ({ id: { id: "0x…" } }) even after field
+        // unwrapping. Accept both, or the JSON-RPC path passes an object as
+        // parentId and every lookup dies with "Invalid params".
+        const rawId = (registryJson?.accounts as { id?: string | { id?: string } } | undefined)?.id
+        tableId = typeof rawId === 'string' ? rawId : rawId?.id
         if (!tableId) return null
         registryTableIdCache.set(registryId, tableId)
     }


### PR DESCRIPTION
## Problem

On **prod mainnet** (Railway `app` service → memory.walrus.xyz, deployed from `dev`), every registry account lookup fails:

```
[getAccountObjectId] lookup failed, treating as no-account vb: Invalid params
    at getDynamicFieldObject
```

Visible symptom: **"Use an existing delegate key"** rejects valid keys with *"no Walrus Memory account found for this wallet. generate a new delegate key first."* — and any other flow that resolves the account via the registry treats existing accounts as missing.

## Root cause

`fetchAccountIdForOwner` reads the registry Table's UID as `registryJson?.accounts?.id` and passes it as `parentId`. Under the **JSON-RPC** client (prod mainnet has no `VITE_SUI_GRPC_URL`, so the gRPC path never runs), `unwrapJsonRpcFields` keeps Move's nested UID shape, so `accounts.id` is the **object** `{ id: "0xdb7e…" }`, not a string. The node rejects the request with `Invalid params`, the catch treats it as no-account.

Verified against the deployed bundle (`index-CeqJtKhz.js`): it contains the pre-fix code (`accounts?.id` with no string check).

## Fix

Cherry-pick of d8004faa from `feat/v1-memory-deletion-jsonrpc` (minus unrelated feature code): accept both UID shapes — plain string (gRPC) and `{ id }` (JSON-RPC).

## Verification

- `tsc --noEmit` clean.
- Confirmed `suix_getDynamicFieldObject` with a **string** parentId (`0xdb7e39…`) returns normal results on both the public fullnode and rpc-mainnet.suiscan.xyz.