### PR TITLE
docs: hide delete-old-memories guide from navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,17 +50,6 @@
         ]
       },
       {
-        "tab": "Guides",
-        "groups": [
-          {
-            "group": "Guides",
-            "pages": [
-              "guides/delete-old-memories"
-            ]
-          }
-        ]
-      },
-      {
         "tab": "Fundamentals",
         "groups": [
           {


### PR DESCRIPTION
## Summary

Temporarily hides the [Delete old memories](https://docs.wal.app/walrus-memory/guides/delete-old-memories) guide from the docs site ahead of the Go/No-Go meeting, **without deleting the content**.

- Removes the **Guides** tab from `docs/docs.json` navigation. It contained only `guides/delete-old-memories`, and an empty tab breaks the Mintlify build, so the whole tab is removed.
- The `docs/guides/delete-old-memories.md` file is left untouched — content is fully preserved.

## Reverting (if it's a Go)

Restore the navigation block in `docs/docs.json`:

```json
{
  "tab": "Guides",
  "groups": [
    { "group": "Guides", "pages": ["guides/delete-old-memories"] }
  ]
},
```

## Note

This removes the page from all site navigation and search. The page file still exists, so its direct URL may still resolve for anyone holding the link. If the URL itself must not load, a follow-up to remove/gate the file is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ARRUn69UZpxyvaFFUfuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4ARRUn69UZpxyvaFFUfuQ)_