### PR TITLE
docs: backport selected documentation updates to staging

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,17 +50,6 @@
         ]
       },
       {
-        "tab": "Guides",
-        "groups": [
-          {
-            "group": "Guides",
-            "pages": [
-              "guides/delete-old-memories"
-            ]
-          }
-        ]
-      },
-      {
         "tab": "Fundamentals",
         "groups": [
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,6 +50,17 @@
         ]
       },
       {
+        "tab": "Guides",
+        "groups": [
+          {
+            "group": "Guides",
+            "pages": [
+              "guides/delete-old-memories"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Fundamentals",
         "groups": [
           {

--- a/docs/getting-started/choose-your-path.md
+++ b/docs/getting-started/choose-your-path.md
@@ -12,7 +12,7 @@ These paths aren't mutually exclusive. You can combine them - for example, use t
 
 Use `@mysten-incubation/memwal` when you want the fastest working integration.
 
-- relayer handles embedding, encryption, retrieval, and restore
+- relayer handles embedding, retrieval, and restore
 - best starting point for most teams
 
 Go to: [SDK Overview](/sdk/overview)

--- a/docs/getting-started/what-is-memwal.md
+++ b/docs/getting-started/what-is-memwal.md
@@ -55,11 +55,8 @@ AI agents today lose context between sessions — every conversation starts from
 ### Ownership & Access Control
 
 <CardGroup cols={2}>
-  <Card title="End-to-End Encryption" icon="lock">
-    All content is encrypted via SEAL before it reaches Walrus. Only the owner and authorized delegates can decrypt it.
-  </Card>
   <Card title="Decentralized Storage" icon="globe">
-    Encrypted blobs stored on Walrus — no single point of failure, no central operator holding your data.
+    Blobs stored on Walrus — no single point of failure, no central operator holding your data.
   </Card>
   <Card title="Programmable Permissions" icon="key">
     Ownership and access rules are enforced by Sui smart contracts, giving you explicit, programmable control over who can read and write.
@@ -83,7 +80,7 @@ AI agents today lose context between sessions — every conversation starts from
 ## What's Included
 
 - **TypeScript SDK**: integrate memory into any app with a few lines of code
-- **Relayer**: handles encryption, storage, and retrieval behind a simple API
+- **Relayer**: handles storage and retrieval behind a simple API
 - **Smart Contract**: enforces ownership and delegate access onchain
 - **Indexer**: keeps onchain state synced for fast lookups
 - **Dashboard**: manage accounts, memory, and delegate keys visually

--- a/docs/guides/delete-old-memories.md
+++ b/docs/guides/delete-old-memories.md
@@ -1,0 +1,80 @@
+---
+title: "Delete old memories"
+description: "Review and permanently delete memories from your Walrus Memory account."
+---
+
+## Overview
+
+As part of ongoing security improvements, we're giving you the option to review and remove
+memories you no longer want stored on Walrus Memory. This guide shows you how to preview
+your memories and delete any you'd like to clear.
+
+<Warning>
+  Deleting a memory is permanent and you cannot undo it. Preview your memories before you
+  delete them.
+</Warning>
+
+## Before you begin
+
+Connect the wallet that owns the memories you want to review. After you connect, the
+dashboard opens at `/dashboard`.
+
+## Navigate to the Delete memories panel
+
+On the dashboard, scroll down to the **Delete memories** panel. The panel shows how many
+memories your wallet has stored and their current status:
+
+- **At risk**: stored memories that you can delete.
+- **In progress**: memories that you have selected for deletion and that Walrus Memory is
+  in the process of deleting.
+- **Deleted**: memories that Walrus Memory has removed.
+
+Each memory appears as a row with these columns:
+
+| Column | Description |
+| --- | --- |
+| Select | Checkbox that you use to choose the memory for deletion. |
+| Blob | The blob ID of the stored memory. |
+| Object | The onchain object ID. |
+| Created | The date you stored the memory. |
+| State | The memory state, for example `deletable` (recommended). |
+| Preview | Opens a preview of the memory content. |
+
+## Preview a memory before deleting
+
+To check what a memory contains before you delete it, select the **Preview** control on its
+row. The **Memory preview** window opens and shows the stored content. Close the preview
+when you finish.
+
+<Note>
+  Previewing helps you confirm that you are deleting the right memories, since you cannot
+  reverse a deletion.
+</Note>
+
+## Select memories to delete
+
+Use the checkboxes in the **Select** column to choose the memories you want to delete.
+
+- To select every memory on the current page, choose **Select page**.
+- The **Delete selected** button updates to show how many memories you chose, for example
+  **Delete selected (4)**.
+
+## Delete memories
+
+You can delete your selected memories, or delete all memories at once.
+
+- **Delete selected (n)**: permanently deletes the memories you checked.
+- **Delete all (n)**: permanently deletes every memory on the list.
+
+<Warning>
+  Both actions are permanent. You cannot recover deleted memories.
+</Warning>
+
+After you start a deletion, the panel shows progress as it works through the memories, for
+example `Deleting batch 1...`. When it finishes, you see a confirmation like **Deleted 4
+memories**. The deleted memories now show the `deleted` state.
+
+## Verify the deletion
+
+Check the count line at the top of the panel to confirm the deletion. The memories you
+removed now show the `deleted` state, and the **Deleted** count includes them.


### PR DESCRIPTION
## Summary

- backport selected documentation updates from `dev` to `staging`
- add the delete-old-memories guide while keeping it hidden from docs navigation
- remove Seal encryption claims from the Walrus Memory overview
- preserve the four-commit topology from PRs #442 and #446

## Included source commits

- `6c96fb2` — docs: add guide for deleting old memories
- `d765edc` — merge PR #442
- `eb3a666` — docs: hide delete-old-memories guide from navigation
- `393ee57` — merge PR #446
- `03bacc8` — docs: remove Seal encryption claims from Walrus Memory overview

## Verification

- PR range contains exactly 5 commits
- backported file contents match the source commits
- `docs/docs.json` is unchanged from `staging`
- `git diff --check` passes