### PR TITLE
Fix: recover Walrus register destroy_zero from stale WAL price

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "CommandOSSLabs/MemWal" }
+    { "repo": "MystenLabs/MemWal" }
   ],
   "commit": true,
   "fixed": [],

--- a/.github/workflows/github-issues-monitor.yml
+++ b/.github/workflows/github-issues-monitor.yml
@@ -1,0 +1,47 @@
+name: GitHub Issues Monitor
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Comment to New Issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin@v7.0.1
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Thank you for opening this issue, a team member will review it shortly."
+            })
+
+  notify-slack:
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL secret not set — skipping Slack notification."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg text ":new: New issue in *$REPO* by *$ISSUE_AUTHOR*: <$ISSUE_URL|#$ISSUE_NUMBER — $ISSUE_TITLE>" \
+            '{text: $text}')
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -79,7 +79,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           npm view @mysten-incubation/memwal-mcp@$VERSION version 2>/dev/null \
             && echo "Version $VERSION already published, skipping" && echo "published=false" >> $GITHUB_OUTPUT && exit 0
-          cd packages/mcp && npm publish --provenance --access public
+          cd packages/mcp && pnpm publish --provenance --access public --no-git-checks
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -126,7 +126,7 @@ jobs:
           echo "Publishing @mysten-incubation/memwal-mcp@${NEW_VERSION}"
           cd packages/mcp
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag rc --provenance --access public
+          pnpm publish --tag rc --provenance --access public --no-git-checks
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
@@ -148,4 +148,4 @@ jobs:
           echo "Publishing @mysten-incubation/memwal-mcp@${NEW_VERSION}"
           cd packages/mcp
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag dev --provenance --access public
+          pnpm publish --tag dev --provenance --access public --no-git-checks

--- a/.github/workflows/release-oc-memwal.yml
+++ b/.github/workflows/release-oc-memwal.yml
@@ -77,7 +77,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           npm view @mysten-incubation/oc-memwal@$VERSION version 2>/dev/null \
             && echo "Version $VERSION already published, skipping" && echo "published=false" >> $GITHUB_OUTPUT && exit 0
-          cd packages/openclaw-memory-memwal && npm publish --provenance --access public
+          cd packages/openclaw-memory-memwal && pnpm publish --provenance --access public --no-git-checks
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -123,7 +123,7 @@ jobs:
           echo "Publishing @mysten-incubation/oc-memwal@${NEW_VERSION}"
           cd packages/openclaw-memory-memwal
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag rc --provenance --access public
+          pnpm publish --tag rc --provenance --access public --no-git-checks
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
@@ -144,4 +144,4 @@ jobs:
           echo "Publishing @mysten-incubation/oc-memwal@${NEW_VERSION}"
           cd packages/openclaw-memory-memwal
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag dev --provenance --access public
+          pnpm publish --tag dev --provenance --access public --no-git-checks

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -76,7 +76,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           npm view @mysten-incubation/memwal@$VERSION version 2>/dev/null \
             && echo "Version $VERSION already published, skipping" && echo "published=false" >> $GITHUB_OUTPUT && exit 0
-          cd packages/sdk && npm publish --provenance --access public
+          cd packages/sdk && pnpm publish --provenance --access public --no-git-checks
           echo "published=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -123,7 +123,7 @@ jobs:
           echo "Publishing @mysten-incubation/memwal@${NEW_VERSION}"
           cd packages/sdk
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag rc --provenance --access public
+          pnpm publish --tag rc --provenance --access public --no-git-checks
 
       # ── dev branch → prerelease (dev tag, auto-increment) ──
       - name: Publish dev prerelease
@@ -144,4 +144,4 @@ jobs:
           echo "Publishing @mysten-incubation/memwal@${NEW_VERSION}"
           cd packages/sdk
           node -e "const p=require('./package.json');p.version='${NEW_VERSION}';require('fs').writeFileSync('./package.json',JSON.stringify(p,null,4)+'\n')"
-          npm publish --tag dev --provenance --access public
+          pnpm publish --tag dev --provenance --access public --no-git-checks

--- a/SKILL.md
+++ b/SKILL.md
@@ -581,6 +581,6 @@ If you're writing user-facing copy, prefer "Walrus Memory". If you're writing an
 
 - **Docs**: https://memory.walrus.xyz
 - **SDK on npm**: https://www.npmjs.com/package/@mysten-incubation/memwal
-- **GitHub**: https://github.com/CommandOSSLabs/MemWal
+- **GitHub**: https://github.com/MystenLabs/MemWal
 - **Dashboard**: https://memory.walrus.xyz
 - **llms.txt**: https://docs.wal.app/walrus-memory/llms.txt

--- a/docs/contributing/run-repo-locally.md
+++ b/docs/contributing/run-repo-locally.md
@@ -18,7 +18,7 @@ If you only work on TypeScript apps or docs, you don't need Rust.
 ## Step 1 — Clone and Install
 
 ```bash
-git clone https://github.com/CommandOSSLabs/MemWal.git
+git clone https://github.com/MystenLabs/MemWal.git
 cd MemWal
 pnpm install
 ```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,6 +88,8 @@
               },
               "sdk/cookbook-multi-tenant",
               "sdk/cloudflare-workers",
+              "sdk/agent-storage-loop",
+              "sdk/production-readiness",
               "sdk/versioned-datasets",
               "sdk/api-reference",
               "sdk/changelog"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,6 +64,7 @@
             "pages": [
               "fundamentals/architecture/core-components",
               "fundamentals/architecture/how-storage-works",
+              "fundamentals/architecture/funding-storage",
               "fundamentals/architecture/data-flow-security-model"
             ]
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,6 +88,7 @@
               },
               "sdk/cookbook-multi-tenant",
               "sdk/cloudflare-workers",
+              "sdk/versioned-datasets",
               "sdk/api-reference",
               "sdk/changelog"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -206,6 +206,17 @@
         ]
       },
       {
+        "tab": "Troubleshooting",
+        "groups": [
+          {
+            "group": "Troubleshooting",
+            "pages": [
+              "troubleshooting/overview"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Contributing",
         "groups": [
           {

--- a/docs/fundamentals/architecture/funding-storage.md
+++ b/docs/fundamentals/architecture/funding-storage.md
@@ -1,0 +1,130 @@
+---
+title: "How an Agent Funds Walrus Storage"
+description: "How an autonomous agent pays for Walrus storage, either by holding WAL directly or through sponsored storage such as the relayer."
+keywords: [funding, WAL, SUI, gas, sponsored storage, publisher, storage resources, upload relay, blob lifecycle, autonomous agent, MemWal, Walrus]
+---
+
+Walrus Memory writes your encrypted memories to Walrus as blobs, as described in [How Storage Works](/fundamentals/architecture/how-storage-works). Someone has to pay for that storage. This page explains who, and the trade-offs between an agent holding WAL itself and having a third party sponsor the cost.
+
+<Note>
+In a typical Walrus Memory setup, the relayer operates the Walrus write path for you, so most agents never touch WAL directly. Whether the storage is sponsored or self-funded then depends on how the relayer is deployed: a [public relayer](/relayer/public-relayer) abstracts funding away from the agent, while [self-hosting](/relayer/self-hosting) means you fund the writes. The models below explain what sits underneath either choice.
+</Note>
+
+## What a write costs: 2 tokens, not 1
+
+A Walrus write consumes 2 different tokens, and any funding design accounts for both:
+
+- **WAL:** Pays for storage. You pay per encoded storage unit per epoch, plus a one-time write fee for each blob. Walrus prices storage at a fixed fiat rate (about 0.023 USD per GB per month) and adjusts the WAL amount automatically as the WAL price changes. The smallest unit of WAL is FROST, where 1 WAL equals 1 billion FROST.
+- **SUI:** Pays gas for the Sui transactions that coordinate the write, such as `reserve_space`, `register_blob`, and `certify_blob`, plus any later `extend`, `delete`, or `burn`. The smallest unit of SUI is MIST, where 1 SUI equals 1 billion MIST.
+
+WAL cost scales with blob size and the number of epochs. SUI gas stays roughly fixed for each transaction. A typical store runs as 2 transactions: one for `reserve_space` and `register_blob`, which changes both your SUI and WAL balances, and one for `certify_blob`, which changes only your SUI balance.
+
+<Note>
+The funding question is really 2 questions: who supplies the WAL, and who supplies the SUI gas. Different sponsored mechanisms cover different halves, so be explicit about which part a given mechanism handles.
+</Note>
+
+A successful write also produces a `Blob` object on Sui. Whoever owns that object controls the blob lifecycle, such as extending its lifetime, deleting it, adding attributes, or burning it to reclaim Sui storage. Ownership matters as much as payment, so track it deliberately, especially in sponsored flows.
+
+## Model A: the agent holds WAL directly
+
+The agent has its own Sui address (key pair) that holds both SUI and WAL, and it signs and pays for its own writes. This is the default model for a long-lived, autonomous agent that owns and manages its own data.
+
+Store through the CLI:
+
+```bash
+$ walrus store memory.json --epochs 10
+```
+
+Store through the TypeScript SDK, where the agent's key pair is the `signer` that pays both gas and storage fees:
+
+```ts
+await client.walrus.writeFiles({
+  files: [file],
+  epochs: 10,
+  deletable: true,
+  signer: keypair, // must hold enough SUI for gas and enough WAL for storage and the write fee
+});
+```
+
+The agent's address needs WAL before it can write. The most basic path swaps SUI for WAL onchain:
+
+```bash
+$ walrus get-wal --amount AMOUNT_IN_FROST
+```
+
+You can also receive WAL through a transfer from another wallet, a bridge, or an exchange. On Testnet, WAL has no value and you obtain it 1:1 from Testnet SUI, which makes this model easy to develop against before any real funding exists.
+
+This model gives the agent full autonomy, because no external service sits in the write path, and the agent owns the resulting `Blob` object outright, so it can extend, delete, or burn it at any time. In exchange, the agent takes on 2 responsibilities:
+
+- Keep both balances funded. Running out of either SUI or WAL stalls writes.
+- Manage the blob lifecycle. Blobs expire after the paid number of epochs (an epoch is about 2 weeks on Mainnet and about 1 day on Testnet, and you can buy up to about 2 years in advance), so the agent extends them before expiry or the network drops the data.
+
+## Model B: sponsored storage
+
+Sponsored storage is not a single feature. Several distinct patterns exist, and they sponsor different parts of the cost. Choose based on how much you want the agent to hold and own.
+
+### Publisher: sponsor pays WAL and SUI
+
+A publisher is an HTTP service that accepts raw bytes and runs the entire write flow for the caller. Its sub-wallets hold SUI and WAL and pay for everything, so the agent needs no tokens at all and only sends the data. A Walrus Memory relayer plays this role for your memories.
+
+- This is the most complete form of sponsorship, because the sponsoring application carries 100% of the WAL and SUI cost.
+- By default, the publisher's sub-wallet owns the resulting `Blob` object. To let the agent keep ownership, set the publisher's `send-object-to` parameter to the agent's Sui address so the publisher transfers the blob after upload.
+
+<Warning>
+Mainnet has no public, unauthenticated publisher, because each upload spends the operator's real WAL and SUI. In production, this is a private, authenticated publisher that the sponsoring application runs and gates for its own agents.
+</Warning>
+
+Use a publisher when the agent runs in a constrained or untrusted environment, or when you do not want the agent to custody tokens.
+
+### Sui sponsored transactions: sponsor pays SUI gas only
+
+Sui natively supports sponsored transactions, where a sponsor account provides the gas coin for a transaction the agent signs. This covers only the SUI side. The WAL storage fee still comes from somewhere else, either the agent's own WAL or a publisher.
+
+Use sponsored transactions when the agent can hold WAL but you do not want it to manage SUI gas, for example when a separate service handles all gas.
+
+### Pre-funding: transfer WAL or storage resources
+
+Because WAL is a coin and storage resources are transferable Sui objects, a sponsor can fund an agent ahead of time without sitting in the write path:
+
+- Send WAL to the agent's address, and the agent then writes through Model A.
+- Buy storage resources in bulk and transfer them to the agent. You can split, merge, transfer, and even trade storage resources on marketplaces. The agent then pays only SUI gas to call `register_blob` and `certify_blob` against pre-bought capacity. Buying larger resources once and splitting them amortizes gas, which suits predictable, high-volume agents.
+
+Use pre-funding for fleets of agents or batch workloads where a treasury provisions capacity centrally.
+
+### What an upload relay does not do
+
+An upload relay is easy to mistake for a sponsor, but it is not one. A relay only distributes the encoded slivers to storage nodes for the client, which helps in browser, mobile, or edge environments where opening thousands of connections is impractical. The agent still registers and certifies the blob onchain and still pays the WAL and SUI. A relay can also charge a tip, configured as `const` (a flat amount for each blob) or `linear` (an amount that scales with blob size), paid in MIST or WAL.
+
+In short, an upload relay reduces the agent's network load, not its funding load. Do not confuse a Walrus upload relay with the Walrus Memory relayer: the Walrus Memory relayer runs the full write flow and can fund it, while a bare Walrus upload relay only forwards slivers.
+
+### Protocol subsidies are network-level, not per-agent
+
+Walrus reserves a portion of WAL supply as subsidies that supplement storage-node rewards while the network grows. This lowers effective costs across the whole network, but it is not a way for one party to fund a specific agent's blob. Do not model subsidies as sponsored storage in your architecture.
+
+## Choose a model
+
+| **If the agent** | **Use** | **Pays WAL** | **Pays SUI gas** | **Owns the blob** |
+| --- | --- | --- | --- | --- |
+| Is long-lived, owns its data, and manages its own lifecycle | Hold WAL directly | Agent | Agent | Agent |
+| Holds no tokens, such as in a browser or untrusted environment | Publisher or relayer | Sponsor | Sponsor | Sponsor, unless you set `send-object-to` the agent |
+| Holds WAL but should not manage gas | Sui sponsored transactions | Agent | Sponsor | Agent |
+| Is one of many, funded from a central treasury | Pre-funded WAL or storage resources | Sponsor (upfront) | Agent | Agent |
+| Needs help distributing slivers and still self-funds | Upload relay | Agent | Agent | Agent |
+
+## Operate an agent that funds its own storage
+
+- Watch both balances. Monitor SUI and WAL together, because running dry on either blocks writes. The publisher reference design keeps each sub-wallet between 0.5 and 1.0 SUI and WAL in steady state with an automatic refill loop, which is a good pattern to copy for any self-funded agent.
+- Plan for expiry. Blobs live only for the epochs you pay for. An agent that needs durable memory runs an extend-before-expiry loop, or hands that responsibility to its sponsor.
+- Track ownership. Whoever owns the `Blob` object controls extend and delete. In sponsored uploads, confirm the object lands at the agent's address through `send-object-to` if the agent is meant to manage it.
+- Estimate before you spend. The `walrus info` command shows current storage and write prices, and `walrus store --dry-run` reports the encoded size used for the WAL cost. Neither command submits a transaction.
+- Develop on Testnet first. Free Testnet WAL that you swap 1:1 from Testnet SUI lets you exercise the full funding and lifecycle flow before you connect real treasury funds. Testnet might wipe data and uses 1-day epochs.
+
+## Related links
+
+- [How Storage Works](/fundamentals/architecture/how-storage-works)
+- [Public relayer](/relayer/public-relayer)
+- [Self-hosting the relayer](/relayer/self-hosting)
+- [Walrus storage costs](https://docs.wal.app/docs/system-overview/storage-costs)
+- [Walrus network reference](https://docs.wal.app/docs/network-reference)
+- [Walrus upload relay](https://docs.wal.app/docs/operator-guide/upload-relay)
+- [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -462,5 +462,5 @@ MEMWAL_REGISTRY_ID=0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75
 
 - **Docs**: https://docs.wal.app/walrus-memory/getting-started/what-is-memwal
 - **SDK on npm**: https://www.npmjs.com/package/@mysten-incubation/memwal
-- **GitHub**: https://github.com/CommandOSSLabs/MemWal
+- **GitHub**: https://github.com/MystenLabs/MemWal
 - **Dashboard**: https://memory.walrus.xyz

--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -1,7 +1,7 @@
 ---
 title: Agent Storage Loop
-description: A full headless agent storage loop on Testnet: set up the SDK with no interactive steps, batch writes with Quilt, encrypt with SEAL, confirm the write landed, then recall.
-keywords: [agent, headless, autonomous, storage loop, Testnet, rememberBulk, Quilt, SEAL, encryption, recall, verify, MemWal, SDK]
+description: "A full headless agent storage loop on Testnet: set up the SDK with no interactive steps, batch writes with Quilt, encrypt with Seal, confirm the write landed, then recall."
+keywords: [agent, headless, autonomous, storage loop, Testnet, rememberBulk, Quilt, Seal, encryption, recall, verify, MemWal, SDK]
 ---
 
 This guide walks an autonomous agent through the complete storage loop on Testnet: set up the client with no interactive steps, batch many small writes, encrypt agent state, confirm each write landed before depending on it, then recall. Every step uses the real SDK surface, so you can lift the final script straight into a server or agent runtime.

--- a/docs/sdk/agent-storage-loop.md
+++ b/docs/sdk/agent-storage-loop.md
@@ -1,0 +1,207 @@
+---
+title: Agent Storage Loop
+description: A full headless agent storage loop on Testnet: set up the SDK with no interactive steps, batch writes with Quilt, encrypt with SEAL, confirm the write landed, then recall.
+keywords: [agent, headless, autonomous, storage loop, Testnet, rememberBulk, Quilt, SEAL, encryption, recall, verify, MemWal, SDK]
+---
+
+This guide walks an autonomous agent through the complete storage loop on Testnet: set up the client with no interactive steps, batch many small writes, encrypt agent state, confirm each write landed before depending on it, then recall. Every step uses the real SDK surface, so you can lift the final script straight into a server or agent runtime.
+
+The loop has four stages:
+
+1. **Set up** the client from environment variables, with no browser or prompt in the path.
+2. **Write** many small state blobs in one batched call.
+3. **Confirm** each write reached a durable `done` state before the agent acts on it.
+4. **Recall** the stored context back into the agent.
+
+## Set up in an agent runtime
+
+An agent runtime has no human to click through a wallet or paste a key at a prompt. Generate the account ID and delegate key once at [staging.memory.walrus.xyz](https://staging.memory.walrus.xyz) for Testnet, store them as secrets, and load them from the environment at startup.
+
+```ts agent.ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+const memwal = MemWal.create({
+  key: requireEnv("MEMWAL_KEY"),
+  accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+  // Testnet relayer. Use https://relayer.memory.walrus.xyz for Mainnet.
+  serverUrl: "https://relayer-staging.memory.walrus.xyz",
+  namespace: "agent-state",
+});
+
+// Fail fast at boot if the relayer is unreachable or the key is rejected,
+// rather than discovering it on the first write mid-run.
+await memwal.health();
+```
+
+<Note>
+Read every credential from the environment. Never hardcode an account ID copied from docs or another project: recall is scoped per **account plus namespace**, so a shared ID puts your agent's memories in a space other readers can see.
+</Note>
+
+The `MemWal.create` config takes four fields:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `key` | `string` | Yes | Ed25519 delegate private key in hex |
+| `accountId` | `string` | Yes | MemWalAccount object ID on Sui |
+| `serverUrl` | `string` | No | Relayer URL for your network |
+| `namespace` | `string` | No | Default namespace, falls back to `"default"` |
+
+## Batch many small writes with Quilt
+
+Agents tend to produce many small state blobs: observations, intermediate results, per-step notes. Writing them one at a time means a separate round trip and Sui transaction set for each. The SDK batches them instead, backed by Walrus Quilt under the hood.
+
+`rememberBulk` accepts up to 20 items per call. The relayer embeds and Seal-encrypts every item concurrently and uploads them to Walrus in parallel, so the whole batch shares far fewer Sui transactions than writing each item on its own would. For an agent writing dozens of small memories a minute, that is the difference between a workable cost profile and an unworkable one.
+
+```ts
+const items = [
+  { text: "Observed: user prefers concise summaries." },
+  { text: "Step 1 result: parsed 42 records, 3 flagged." },
+  { text: "Hypothesis: the spike correlates with the Tuesday deploy." },
+];
+
+// Fire the batch and wait for every item to finish.
+const result = await memwal.rememberBulkAndWait(items);
+```
+
+<Note>
+Keep each batch at 20 items or fewer. If you have more, chunk the array and call `rememberBulkAndWait` per chunk. To fan out without blocking, use `rememberBulkAsync` and collect the returned `job_ids` to confirm later.
+</Note>
+
+## Encrypt agent state
+
+All blobs on Walrus are public, so you must encrypt private agent state. There are two models, and which one you want depends on who should hold the keys.
+
+1. **Relayer-managed encryption (default):** With the standard `MemWal` client used above, the relayer encrypts every item with Seal before it reaches Walrus. You do not manage keys, and this is the right default for most agents.
+
+2. **Client-managed encryption.** When the agent must hold its own keys and never delegate decryption to the relayer, use the manual entry point. `MemWalManual` performs Seal encryption client-side, so plaintext never leaves the agent process.
+
+```ts
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
+
+const manual = MemWalManual.create({
+  key: requireEnv("MEMWAL_KEY"),
+  accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+  packageId: requireEnv("MEMWAL_PACKAGE_ID"),
+  serverUrl: "https://relayer-staging.memory.walrus.xyz",
+  // The agent signs SEAL and Walrus operations with its own Sui key, no wallet popup.
+  suiPrivateKey: requireEnv("SUI_PRIVATE_KEY"),
+  embeddingApiKey: requireEnv("OPENAI_API_KEY"),
+  suiNetwork: "testnet",
+  namespace: "agent-state",
+});
+
+// Encrypts locally, then relays the ciphertext. The relayer never sees plaintext.
+await manual.rememberManual("Private: internal risk score for account 0xabc is 0.82.");
+```
+
+<Warning>
+Client-managed encryption means the agent is responsible for its key material. If the delegate key is lost, you cannot recover the encrypted memories. Treat the key as you would any production secret, and rotate it through the dashboard if it might be exposed.
+</Warning>
+
+For the full client-managed flow, including local embeddings and recall, see [MemWalManual](/sdk/usage/memwal-manual).
+
+## Confirm a write before depending on it
+
+An autonomous agent should not act on a memory it only believes it wrote. Before the agent reads state back or makes a decision that assumes the write persisted, confirm that the write reached a durable state.
+
+The `*AndWait` helpers already block until the relayer reports each job `done`, which is the signal that the relayer embedded, encrypted, and uploaded the memory to Walrus. When you need to write without blocking and confirm later, capture the job IDs and wait on them explicitly:
+
+```ts
+const accepted = await memwal.rememberBulkAsync(items);
+
+// ... agent does other work ...
+
+// Block until every job reaches `done` before relying on the memories.
+const settled = await memwal.waitForRememberJobs(accepted.job_ids);
+const failed = settled.results.filter((r) => r.status !== "done");
+if (failed.length > 0) {
+  throw new Error(`${failed.length} memories did not persist; do not proceed.`);
+}
+```
+
+<Note>
+A dedicated `verify()` helper that reconstructs a memory from its onchain blob object is on the roadmap. Until it ships, a job reaching `done` is the durability signal to gate on, and the memory's Walrus blob object on Sui is the onchain record of the write.
+</Note>
+
+## Recall the stored context
+
+After you confirm the writes, recall pulls the relevant memories back by semantic similarity. The relayer verifies the request, embeds the query, searches, downloads from Walrus, decrypts, and returns plaintext.
+
+```ts
+const recalled = await memwal.recall({
+  query: "What do we know about the Tuesday spike?",
+  limit: 5,
+});
+
+for (const memory of recalled.results) {
+  console.log(memory.distance.toFixed(3), memory.text);
+}
+```
+
+Recall is scoped to the client's namespace by default. Pass `namespace` to read from a different one, and `limit` to cap how many memories return.
+
+## The full loop
+
+Putting the four stages together, here is a complete headless agent that runs end to end on Testnet:
+
+```ts agent.ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+async function main() {
+  // 1. Set up from the environment, no interactive steps.
+  const memwal = MemWal.create({
+    key: requireEnv("MEMWAL_KEY"),
+    accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+    serverUrl: "https://relayer-staging.memory.walrus.xyz",
+    namespace: "agent-state",
+  });
+  await memwal.health();
+
+  // 2. Batch many small state blobs in one call.
+  const items = [
+    { text: "Observed: user prefers concise summaries." },
+    { text: "Step 1 result: parsed 42 records, 3 flagged." },
+    { text: "Hypothesis: the spike correlates with the Tuesday deploy." },
+  ];
+
+  // 3. Write and confirm every item reached `done` before continuing.
+  const settled = await memwal.rememberBulkAndWait(items);
+  const failed = settled.results.filter((r) => r.status !== "done");
+  if (failed.length > 0) {
+    throw new Error(`${failed.length} memories did not persist; aborting.`);
+  }
+
+  // 4. Recall the stored context.
+  const recalled = await memwal.recall({
+    query: "What do we know about the Tuesday spike?",
+    limit: 5,
+  });
+  for (const memory of recalled.results) {
+    console.log(memory.distance.toFixed(3), memory.text);
+  }
+}
+
+main().catch((err) => {
+  console.error("Agent storage loop failed:", err);
+  process.exit(1);
+});
+```
+
+## Next steps
+
+- [Walrus Memory client](/sdk/usage/memwal): full method signatures for the default client
+- [MemWalManual](/sdk/usage/memwal-manual): the client-managed encryption flow
+- [Public relayer](/relayer/public-relayer): managed Mainnet and Testnet relayer endpoints
+- [API Reference](/sdk/api-reference): every config field and return type

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -1,6 +1,6 @@
 ---
 title: Production Readiness for Agent Storage
-description: Patterns for running Walrus Memory in a production agent: idempotent writes, retries with backoff, confirming durability, bounding cost, key custody, and graceful degradation.
+description: "Patterns for running Walrus Memory in a production agent: idempotent writes, retries with backoff, confirming durability, bounding cost, key custody, and graceful degradation."
 keywords: [production, hardening, idempotency, retries, backoff, cost caps, key custody, failure handling, graceful degradation, agent, reliability, MemWal, SDK]
 ---
 

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -1,0 +1,151 @@
+---
+title: Production Readiness for Agent Storage
+description: Patterns for running Walrus Memory in a production agent: idempotent writes, retries with backoff, confirming durability, bounding cost, key custody, and graceful degradation.
+keywords: [production, hardening, idempotency, retries, backoff, cost caps, key custody, failure handling, graceful degradation, agent, reliability, MemWal, SDK]
+---
+
+The SDK gives you the storage primitives. Running them in a long-lived agent, where there is no human to retry a failed write or notice a runaway bill, takes a few patterns on top. This guide collects the ones that matter most.
+
+Several of these are patterns you implement around the client today. Where a capability is on the roadmap as a native feature, this guide says so, so you know which code is permanent and which is a stopgap.
+
+## Make writes idempotent
+
+The relayer does not deduplicate writes. A `remember` call that retries after a network blip, or fired twice by an at-least-once job queue, stores the same text twice and pollutes later recall. Until content-based deduplication is available natively, gate writes on a key your agent controls so a repeat is a no-op.
+
+```ts
+import { createHash } from "crypto";
+
+const written = new Set<string>(); // back this with Redis or a DB in production
+
+async function rememberOnce(memwal: MemWal, text: string, namespace?: string) {
+  const id = createHash("sha256").update(`${namespace ?? "default"}:${text}`).digest("hex");
+  if (written.has(id)) return; // already stored this exact memory
+
+  const job = await memwal.remember(text, namespace);
+  await memwal.waitForRememberJob(job.job_id);
+  written.add(id);
+}
+```
+
+<Note>
+Persist the idempotency set outside the process (Redis, a database row, a Sui object), not in memory. An in-memory set resets on restart, which is exactly when a retry storm is most likely.
+</Note>
+
+## Retry with backoff, but only retryable failures
+
+The client does not retry for you. Wrap calls in exponential backoff, and be careful to retry only failures that a retry can fix. A transient network error or relayer timeout is worth retrying. A `401 AUTH_REJECTED` is a configuration problem that fails identically on every attempt, so retrying it just delays the real fix.
+
+```ts
+async function withRetry<T>(fn: () => Promise<T>, attempts = 4): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const status = (err as { status?: number }).status;
+      // Do not retry auth or client errors; they will not succeed on a retry.
+      if (status === 401 || (status && status >= 400 && status < 500)) throw err;
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 2 ** i * 500 + Math.random() * 250));
+    }
+  }
+  throw lastErr;
+}
+
+await withRetry(() => rememberOnce(memwal, "Observed: deploy at 14:03 UTC."));
+```
+
+Pairing retry with the idempotency guard above is deliberate: a retry that fires after the write actually succeeded server-side stays safe, because `rememberOnce` short-circuits on the key.
+
+<Note>
+Built-in retry and backoff inside the client is on the roadmap. When it ships, you can drop the wrapper for the calls it covers and keep only the idempotency guard.
+</Note>
+
+## Confirm durability before acting on a memory
+
+An autonomous agent should not make a decision that assumes a write persisted until it confirms the write reached a terminal state. The `*AndWait` helpers block until each job reports `done`; when you write without blocking, capture the job IDs and wait on them before depending on the data.
+
+```ts
+const accepted = await memwal.rememberBulkAsync(items);
+const settled = await memwal.waitForRememberJobs(accepted.job_ids);
+
+if (settled.failed > 0) {
+  const bad = settled.results.filter((r) => r.status !== "done");
+  throw new Error(`${settled.failed} writes did not persist: ${bad.map((b) => b.status).join(", ")}`);
+}
+```
+
+<Warning>
+A job reaching `done` confirms that the relayer stored the memory, but the vector index can briefly lag behind that signal, so a `recall` fired in the same instant might not return the memory yet. For read-after-write critical paths, tolerate a short delay or re-query rather than treating an empty first result as a missing memory.
+</Warning>
+
+For the full write, confirm, and recall sequence in context, see [Agent Storage Loop](/sdk/agent-storage-loop).
+
+## Bound cost
+
+Every write registers storage on Walrus and costs gas and WAL. An agent in a tight loop can run up spend quickly, so put ceilings in the agent, not just in your head.
+
+- **Batch with Quilt.** `rememberBulkAndWait` (up to 20 items) collapses many small writes into far fewer transactions. Buffer small state blobs and flush them as a batch instead of writing one at a time.
+- **Do not store what you never recall.** Ephemeral scratch state that never feeds a future `recall` does not belong in durable storage. Keep it in process memory.
+- **Cap writes per cycle.** Give the agent loop a budget, for example a maximum number of memories per run or per hour, and have it drop or summarize past the cap rather than write unbounded.
+
+```ts
+let writesThisCycle = 0;
+const MAX_WRITES_PER_CYCLE = 50;
+
+async function budgetedRemember(memwal: MemWal, text: string) {
+  if (writesThisCycle >= MAX_WRITES_PER_CYCLE) return false;
+  await rememberOnce(memwal, text);
+  writesThisCycle++;
+  return true;
+}
+```
+
+## Custody the agent's keys
+
+A headless agent holds secrets no human rotates by hand, so treat them with production discipline.
+
+- The **delegate key** authenticates the agent to the relayer.
+- For client-managed encryption, the **Sui key** signs the Seal and Walrus operations. See [holding your own keys](/sdk/usage/memwal-manual#agent-state-holding-your-own-keys).
+
+Load both from a secret manager, never from source or logs. Scope each agent to its own delegate key so you can revoke one without taking down the rest, and rotate through the dashboard if a key might be exposed. If the Sui key behind client-managed encryption is lost, you cannot recover the encrypted memories, so back it up with the same care as any data-encryption key.
+
+## Degrade gracefully when memory is unavailable
+
+A memory layer that is down should slow your agent, not stop it. Check reachability at startup and guard the memory paths so the agent keeps serving when the relayer is unreachable for a cycle.
+
+```ts
+let memory: MemWal | null = null;
+try {
+  memory = MemWal.create({ key, accountId, serverUrl, namespace });
+  await memory.health();
+} catch (err) {
+  console.log("Memory unavailable, continuing without it this cycle:", err);
+  memory = null;
+}
+
+// Guard every read and write on memory being live.
+if (memory) {
+  await budgetedRemember(memory, "...");
+}
+```
+
+This is the same defensive pattern the [Cloudflare Workers guide](/sdk/cloudflare-workers) uses to keep a Worker healthy when the memory dependency has a bad moment.
+
+## Mind the recall result cap
+
+`recall` returns up to `limit` results, defaulting to `10`. When more memories match than the cap, the relayer does not return the extra results, with no signal that it truncated the set. If a decision depends on seeing every match, set `limit` explicitly to a value above what you expect, and treat a result count equal to `limit` as a sign there might be more.
+
+```ts
+const result = await memwal.recall({ query: "open incidents", limit: 50 });
+if (result.results.length === 50) {
+  console.warn("Recall hit the limit; there may be more matches than returned.");
+}
+```
+
+## Next steps
+
+- [Agent Storage Loop](/sdk/agent-storage-loop): the write, confirm, and recall loop these patterns harden
+- [MemWalManual](/sdk/usage/memwal-manual): client-managed encryption and key custody
+- [Troubleshooting](/troubleshooting/overview): auth, timeout, and read-after-write symptoms
+- [Public relayer](/relayer/public-relayer): managed Mainnet and Testnet endpoints

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -1,20 +1,21 @@
 ---
 title: "MemWalManual"
 description: "Client-managed embeddings and local SEAL operations."
+keywords: [MemWalManual, client-side encryption, SEAL, agent state, key management, autonomous agent, suiPrivateKey, walletSigner, embeddings, recall]
 ---
 
 Use when the client must handle embedding calls and local SEAL operations. The relayer still handles
 upload relay, vector registration, search, and restore.
 
-This is the recommended path for Web3-native users who want to minimize trust in the relayer — it never sees your plaintext data.
+This is the recommended path for Web3-native users who want to minimize trust in the relayer, because it never sees your plaintext data.
 
-## What the client handles vs. what the relayer handles
+## What the client handles versus what the relayer handles
 
 | Operation | Client (MemWalManual) | Relayer |
 |-----------|----------------------|---------|
 | Embedding | Client calls OpenAI/compatible API | — |
 | SEAL encryption | Client encrypts locally | — |
-| Walrus upload | — | Server uploads via sidecar (server pays gas) |
+| Walrus upload | — | Server uploads through a sidecar (server pays gas) |
 | Vector registration | — | Server stores `{blob_id, vector}` in PostgreSQL |
 | Recall search | — | Server searches vectors, returns `{blob_id, distance}` |
 | Walrus download | Client downloads from aggregator | — |
@@ -74,7 +75,7 @@ console.log(manual.isWalletMode);
 
 ## Browser Integration (wallet signer)
 
-Use `walletSigner` instead of `suiPrivateKey` when integrating with a connected wallet (e.g., `@mysten/dapp-kit`):
+Use `walletSigner` instead of `suiPrivateKey` when integrating with a connected wallet (for example, `@mysten/dapp-kit`):
 
 ```ts
 const manual = MemWalManual.create({
@@ -98,4 +99,44 @@ const manual = MemWalManual.create({
 - Walrus publisher, aggregator, and upload relay defaults follow `suiNetwork`
 - `embeddingModel` defaults to `text-embedding-3-small` (or `openai/text-embedding-3-small` for OpenRouter)
 - `walrusEpochs` defaults to `50` (storage duration)
-- All `@mysten/*` peer dependencies are loaded dynamically — users who only use the default `MemWal` client don't need them installed
+- All `@mysten/*` peer dependencies are loaded dynamically, so users who only use the default `MemWal` client do not need them installed
+
+## Agent state: holding your own keys
+
+Every blob on Walrus is public, so you must encrypt private agent state before storing it. For an autonomous agent that has no human to approve a wallet popup, `MemWalManual` is the path that keeps the agent in control of its own key material: encryption happens client-side, and the relayer never receives plaintext.
+
+A headless agent signs Seal and Walrus operations with its own Sui key rather than a connected wallet. Provide `suiPrivateKey` instead of `walletSigner`, set `suiNetwork` for your environment, and load every secret from the environment:
+
+```ts
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
+
+const manual = MemWalManual.create({
+  key: process.env.MEMWAL_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+  packageId: process.env.MEMWAL_PACKAGE_ID!,
+  serverUrl: "https://relayer-staging.memory.walrus.xyz",
+  suiPrivateKey: process.env.SUI_PRIVATE_KEY!,
+  embeddingApiKey: process.env.OPENAI_API_KEY!,
+  suiNetwork: "testnet",
+  namespace: "agent-state",
+});
+
+// Encrypts locally, then relays only ciphertext to the server.
+await manual.rememberManual("Private: internal risk score for account 0xabc is 0.82.");
+
+const hits = await manual.recallManual("risk score for account 0xabc", 5);
+for (const memory of hits.results) {
+  console.log(memory.text, memory.distance);
+}
+```
+
+The agent holds two distinct secrets:
+
+- The **delegate key** (`key`) authenticates the agent to the relayer.
+- The **Sui key** (`suiPrivateKey`) signs the Seal and Walrus operations that encrypt and store the data.
+
+<Warning>
+With client-managed encryption the agent owns its key material. If the Sui key is lost, you cannot recover the encrypted memories, so treat it as a production secret and rotate the delegate key through the dashboard if it might be exposed.
+</Warning>
+
+For the full headless write, confirm, and recall loop that builds on this, see [Agent Storage Loop](/sdk/agent-storage-loop).

--- a/docs/sdk/versioned-datasets.md
+++ b/docs/sdk/versioned-datasets.md
@@ -1,0 +1,106 @@
+---
+title: Versioned Datasets and Lineage
+description: How Walrus content-addressing gives agent datasets immutable version history and tamper-evident lineage for free, with a worked example.
+keywords: [versioning, lineage, content addressing, immutable, dataset, provenance, blob id, audit, AI workflows, agent, MemWal, SDK]
+---
+
+When an agent stores a dataset, a model artifact, or a snapshot of its own state, it usually needs more than the latest copy. It needs the history: which version it acted on, what changed between revisions, and proof that a past version has not been altered. On Walrus, that history comes for free from how storage works, with no version table to maintain.
+
+## How content-addressing gives versioning for free
+
+Every write to Walrus produces a **blob ID derived from the stored bytes**. Two properties follow directly:
+
+- **Blobs are immutable.** You never overwrite a blob in place. Storing a changed version creates a new blob with a new ID, and the previous blob keeps its own ID and its own bytes. Nothing is lost on update, so the full version history is retained automatically.
+- **The blob ID is a verifiable handle.** Because the ID is derived from the content, it pins down exactly those bytes. A blob ID that resolves is proof the bytes were not altered after the fact, which is what makes the lineage tamper-evident.
+
+Put together, you get an append-only version history without building one: each revision is a separate, permanent, independently addressable object, and the chain of blob IDs is the lineage.
+
+<Warning>
+Memories are SEAL-encrypted before they reach Walrus, so the blob ID addresses the **ciphertext**, not the plaintext. Treat every write as a new immutable version, and do not assume identical input produces an identical blob ID. Automatic deduplication of identical content is a separate capability that is not available today, so the content-addressing here gives you version history and lineage, not free dedup.
+</Warning>
+
+## Capturing a version handle
+
+`rememberAndWait` returns the blob ID once the write is durable, and every recalled memory carries the blob ID it came from. Those are the two places you collect the permanent handle for a version.
+
+```ts
+// On write: capture the blob ID as the version's permanent handle.
+const v1 = await memwal.rememberAndWait(JSON.stringify(datasetV1), "dataset");
+console.log(v1.blob_id); // immutable handle for version 1
+
+// On recall: each hit reports which blob it came from.
+const result = await memwal.recall({ query: "latest dataset snapshot", namespace: "dataset" });
+for (const memory of result.results) {
+  console.log(memory.blob_id, memory.text);
+}
+```
+
+## Worked example: a versioned agent dataset
+
+This agent revises a dataset over time and keeps an auditable lineage. Each revision is written as a new immutable blob, and the agent records a small lineage entry that links the new version to its parent. The dataset content lives in one namespace; the lineage records live in another, so the history is queryable on its own.
+
+```ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+type LineageEntry = {
+  version: number;
+  blobId: string;
+  parentBlobId: string | null;
+  storedAt: string;
+};
+
+class VersionedDataset {
+  private version = 0;
+  private head: string | null = null;
+
+  constructor(private memwal: MemWal) {}
+
+  // Store a new revision and append a lineage record pointing at the parent.
+  async commit(content: unknown): Promise<LineageEntry> {
+    const stored = await this.memwal.rememberAndWait(JSON.stringify(content), "dataset");
+
+    const entry: LineageEntry = {
+      version: ++this.version,
+      blobId: stored.blob_id,
+      parentBlobId: this.head,
+      storedAt: new Date().toISOString(),
+    };
+
+    // Persist the lineage entry as its own memory so the history is durable too.
+    await this.memwal.rememberAndWait(JSON.stringify(entry), "dataset-lineage");
+    this.head = stored.blob_id;
+    return entry;
+  }
+}
+
+// A configured client — see the SDK setup for how to supply credentials.
+const memwal = MemWal.create({
+  key: process.env.MEMWAL_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+});
+
+const dataset = new VersionedDataset(memwal);
+const v1 = await dataset.commit({ rows: 100, schema: "v1" });
+const v2 = await dataset.commit({ rows: 142, schema: "v1" });
+
+// v2.parentBlobId === v1.blobId, so the chain is recorded, and both
+// versions remain permanently addressable by their blob IDs.
+```
+
+Because each `blobId` permanently and verifiably addresses one exact revision, an agent (or an auditor reviewing it later) can point to the precise dataset a decision was made against, and confirm it has not changed since.
+
+<Note>
+Keep the lineage index wherever your agent already keeps durable state. Storing it as a memory, as shown here, keeps everything inside Walrus Memory. A database row or a Sui object works equally well, because the blob IDs are the durable handles either way.
+</Note>
+
+## When this pattern fits
+
+- **Dataset and artifact versioning:** retain every revision of a training set, prompt library, or config without a version-control system.
+- **Provenance and audit:** prove which exact input an agent acted on at a point in time.
+- **Reproducibility:** pin a workflow to a specific blob ID so a rerun reads the same bytes, not a mutated current copy.
+
+## Next steps
+
+- [How storage works](/fundamentals/architecture/how-storage-works): where blob IDs come from in the write path
+- [Walrus Memory client](/sdk/usage/memwal): full signatures for `rememberAndWait` and `recall`
+- [API Reference](/sdk/api-reference): return types, including the blob ID on every result

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -1,0 +1,151 @@
+---
+title: Troubleshooting and FAQ
+description: Resolve common Walrus Memory problems, including delegate-key authentication errors, MCP connection issues, and save timeouts.
+keywords: [Walrus Memory, MemWal, troubleshooting, AUTH_REJECTED, delegate key, MCP, timeout, memwal_analyze]
+---
+
+<!--
+Source: BEDU-612, seeded from a Walrus Memory Discord support thread.
+The 401 reporter self-resolved without recording the exact fix, so the AUTH_REJECTED
+entry documents all known causes from the authentication model rather than a single
+confirmed one. Confirm the specific fix with the reporter before treating that entry
+as final. Grounded in: contract/delegate-key-management, relayer/api-reference,
+sdk/api-reference, mcp/reference, getting-started/quick-start.
+-->
+
+This page collects the support questions that come up most often and the fastest way to resolve each one. Every entry lists the symptom you observe, the cause behind it, and the fix to apply.
+
+If your issue is not here, set `MEMWAL_MCP_DEBUG=1` for the Model Context Protocol (MCP) server, or, if you use the `withMemWal()` AI middleware, pass `debug: true` in its options, to get verbose logs, then open an issue on the repository with that output.
+
+## How authentication works
+
+Read this section first, because most authentication problems make sense once the model is clear. Walrus Memory does not use your owner wallet for day-to-day calls. Instead:
+
+1. You generate a delegate key pair, an Ed25519 key, for example from the [Walrus Memory dashboard](https://memory.walrus.xyz).
+2. The account owner registers the delegate public key onchain in your `MemWalAccount`. See [Delegate Key Management](/contract/delegate-key-management).
+3. The SDK or MCP client signs each request with the delegate private key.
+4. On every request, the relayer verifies the signature, then looks up that public key in your account's onchain `delegate_keys` list to resolve the owner.
+
+The key word is **registered**. A delegate key that exists locally but is not added to your account onchain, or is added to a different account, or is added on a different network, fails authentication. That single fact explains most `AUTH_REJECTED` reports.
+
+Every signed request also carries a timestamp with a 5-minute validity window and a one-time nonce for replay protection, which is the second most common source of unexpected rejections.
+
+## Authentication and delegate keys
+
+This section covers credential and authorization errors.
+
+### 401 `AUTH_REJECTED` errors
+
+**Symptom:** You generated a delegate key, often from the dashboard, confirmed your account ID, and every authenticated call returns `AUTH_REJECTED` with HTTP status 401. A health check still succeeds, because the health endpoint needs no authentication, so the relayer is reachable but your signed requests are not accepted.
+
+**Cause:** The relayer cannot match your signed request to an active, registered delegate key on the account you named. It verifies the Ed25519 signature, then resolves the owner by finding your public key in that account's onchain `delegate_keys`. Anything that breaks that lookup returns the same 401. The following causes are ordered by how often they apply to a freshly generated key, and each row pairs the check with its fix:
+
+| **Cause** | **How to check** | **How to fix** |
+| --- | --- | --- |
+| The delegate key is not registered onchain yet, or its registration transaction is not indexed | Confirm the key appears under your account in the dashboard, and that any `addDelegateKey` call succeeded. | Register the public key onchain through the dashboard or `addDelegateKey`, then wait a few seconds for indexing and retry. |
+| The account ID does not match the account that owns the key | Compare the `accountId` in your configuration against the account that lists this delegate key in the dashboard. A stale value in `localStorage` is a common source. | Use the account ID that you generated and that owns this delegate key, and do not reuse an account ID copied from another project. |
+| The client points at a different network than the one where the account lives | Confirm your `serverUrl` or environment preset matches where you created the account. Production is `https://relayer.memory.walrus.xyz` and staging is `https://relayer-staging.memory.walrus.xyz`. | Point the client at the relayer for the correct network, or recreate the account and key in the environment you intend to use. |
+| The system clock is outside the 5-minute signing window | Confirm the machine clock is accurate and synchronized using the Network Time Protocol (NTP). | Synchronize the clock and retry. |
+| The delegate key is revoked, or the account is deactivated | Confirm the key is present and the account is active in the dashboard. | Re-add the delegate key, or reactivate the account, which only the owner can do. |
+
+<Tip>
+To triage quickly, confirm 3 things in order: the key is listed under the correct account in the dashboard, your account ID matches that account exactly, and your relayer environment matches where you created the account.
+</Tip>
+
+<Info>
+A version mismatch is rarely the cause here. The relayer reports its minimum supported SDK version, which is TypeScript 0.0.4 at the time of writing, so 0.0.7 is supported. A true version mismatch surfaces as `MemWalCompatibilityError` rather than `AUTH_REJECTED`.
+</Info>
+
+## MCP connection issues
+
+This section covers problems that appear before the memory tools work.
+
+### Only `memwal_login` appears
+
+**Symptom:** After you connect the MCP server, the agent sees only `memwal_login`, or the memory tools return an authentication-required error.
+
+**Cause:** No credentials file exists at `~/.memwal/credentials.json`. When an MCP host launches the package without credentials, it starts in an authentication-required mode. The tool list still advertises the core memory tools alongside `memwal_login`, but only `memwal_login` runs until you authenticate; the other tools return an authentication-required error when called, which is why it can look like `memwal_login` is the only tool available.
+
+**Fix:** Ask the agent to call `memwal_login`, which returns a one-time sign-in URL valid for 5 minutes, or run `npx -y @mysten-incubation/memwal-mcp login --prod` in your terminal. Sign in to the wallet you intend to use before you open the URL. If the URL expires, call the tool again to get a fresh one.
+
+### The MCP tools do not appear
+
+**Symptom:** None of the `memwal_*` tools are available to the agent.
+
+**Cause:** MCP servers load only when the client starts, so a server added during a session does not appear.
+
+**Fix:** Quit the MCP client fully, then start it again. If you registered the server with `claude mcp add`, run `claude mcp list` to confirm `memwal` is registered before you restart.
+
+## Saving and timeouts
+
+This section covers slow or timed-out writes.
+
+### `memwal_analyze` times out while recall works
+
+**Symptom:** Recall returns quickly, but a save through `memwal_analyze` times out, sometimes on repeated attempts.
+
+**Cause:** Recall is a single search request, so it is fast. A save is heavier, and `memwal_analyze` is the heaviest save: it runs a large language model (LLM) extraction over your text, then embeds and encrypts each extracted fact and enqueues each as its own background job that uploads to Walrus and indexes the result. Under load, this fan-out can exceed the MCP host's tool-call timeout even though the relayer keeps working normally.
+
+<Warning>
+A client-side timeout does not mean the save failed. The relayer accepts the work as background jobs and keeps processing after the client stops waiting. Running the same `memwal_analyze` call again can create duplicate memories, so confirm the result before you retry.
+</Warning>
+
+**Fix:**
+
+1. Confirm the result instead of resubmitting. Wait a few seconds, because indexing can lag briefly under load, then run `memwal_recall` for the fact you tried to save. If the fact is present, the save succeeded despite the timeout.
+2. Match the tool to the task. To save one discrete fact, such as a milestone, use `memwal_remember`, which performs a single write. Reserve `memwal_analyze` for longer passages where you want several facts extracted, and keep those passages a reasonable size.
+3. Confirm connectivity first. Run `memwal_health`, which calls the unauthenticated health endpoint and is the fastest way to confirm the relayer is reachable.
+4. Wait correctly in the SDK. The `remember` and `analyze` methods return immediately with job IDs, so wait with `waitForRememberJob` or `analyzeAndWait` and a sensible timeout, or poll the job status, rather than wrapping the whole operation in one short blocking call.
+5. Collect logs if the problem persists. Set `MEMWAL_MCP_DEBUG=1` for the MCP server, or pass `debug: true` to the `withMemWal()` AI middleware, and capture the per-request output. The core SDK (`MemWal.create()`) has no built-in debug flag.
+
+### Recall returns no results immediately after a save
+
+**Symptom:** You save a memory, and an immediate recall finds nothing.
+
+**Cause:** A save returns once the Walrus upload completes, but the embedding and indexing step can lag a few seconds behind under load, so the memory is briefly unsearchable.
+
+**Fix:** Wait a moment, then retry the recall. If a memory is missing from the search index later, `memwal_restore` rebuilds the index for that namespace from Walrus.
+
+## Quick reference
+
+Use these values for quick configuration and triage:
+
+| **Item** | **Value** |
+| --- | --- |
+| Production relayer | `https://relayer.memory.walrus.xyz` |
+| Staging relayer (Testnet) | `https://relayer-staging.memory.walrus.xyz` |
+| Dashboard for accounts and delegate keys | `https://memory.walrus.xyz` |
+| MCP environment presets | `--prod`, `--staging`, `--local` |
+| Local credentials file | `~/.memwal/credentials.json` |
+| Verbose MCP logs | `MEMWAL_MCP_DEBUG=1` |
+| Unauthenticated health check | `memwal_health` |
+| Maximum delegate keys per account | 20 |
+| Request timestamp window | 5 minutes |
+
+## Frequently asked questions
+
+These answers are written for the product page.
+
+### Is there a registration step after I generate a delegate key?
+
+Yes. Generating a delegate key creates the key pair, and it works only after the owner registers its public key on your account onchain, which the dashboard does when you create the key there. The relayer checks for that registration on every request, so a key that is generated but not registered, or registered on a different account or network, fails authentication.
+
+### Why do I get `AUTH_REJECTED` with a brand-new key?
+
+The cause is almost always one of 3 things: the key is not registered on the account yet or is still settling, your account ID does not match the account that owns the key, or your client points at a different network than the one where you created the account. Check those in that order. A skewed system clock can also cause it, because each request carries a timestamp with a 5-minute window.
+
+### Is my Testnet account the same as my production account?
+
+No. Accounts and delegate keys are specific to each network. A key created on staging does not authenticate against the production relayer, and the reverse is also true. Confirm that your relayer environment matches where you created the account.
+
+### My save timed out, so did I lose the memory?
+
+Probably not. The relayer processes saves as background jobs and keeps working after the client times out. Do not save again right away, because that can duplicate the memory. Wait a few seconds and recall it to confirm. To save a single fact, use `memwal_remember` rather than `memwal_analyze`, which extracts and stores many facts at once and is the slowest operation.
+
+### Why does recall feel instant while saving feels slow?
+
+Recall is one search request. A save embeds, encrypts, uploads to Walrus, and indexes the result, and `memwal_analyze` does that for every fact it extracts. Saves are expected to take longer, and they run in the background.
+
+### How do I check whether the service is reachable?
+
+Run `memwal_health`. It does not require authentication, so it separates the question of whether the relayer is reachable from whether your credentials are valid.

--- a/packages/openclaw-memory-memwal/CHANGELOG.md
+++ b/packages/openclaw-memory-memwal/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @mysten-incubation/oc-memwal
 
+## 0.0.5
+
+### Patch Changes
+
+- Fix unresolvable `workspace:*` dependency in the published package. The release
+  workflow used `npm publish`, which ships `package.json` verbatim and cannot
+  rewrite the `workspace:` protocol, so the published artifact carried
+  `"@mysten-incubation/memwal": "workspace:*"` and failed to install outside the
+  monorepo (`Unsupported URL Type 'workspace:'`). Switched the release workflows
+  to `pnpm publish`, which rewrites `workspace:*` to the concrete dependency
+  version at pack time.
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/openclaw-memory-memwal/package.json
+++ b/packages/openclaw-memory-memwal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mysten-incubation/oc-memwal",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "description": "NemoClaw/OpenClaw memory plugin — encrypted, decentralized long-term memory via Walrus Memory",
   "license": "Apache-2.0",

--- a/services/server/scripts/__tests__/walrus-wal-destroy-zero.test.ts
+++ b/services/server/scripts/__tests__/walrus-wal-destroy-zero.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isMoveAbortBalanceSplit, isMoveAbortWalDestroyZero } from "../sidecar/enoki.js";
+
+// Production format reference (issue #351): the Walrus register PTB pre-funds an
+// exact WAL payment from the client's cached storage price, then asserts the
+// coin is empty via `0x2::coin::destroy_zero`. When the on-chain price drops
+// between the cached read and execution, the contract deducts less WAL and the
+// leftover trips `destroy_zero` with ENonZero (abort code 0). Enoki surfaces it
+// during its budget dry-run as a 400 dry_run_failed.
+
+const PROD_DESTROY_ZERO_ERROR =
+    'Enoki API error (400): {"errors":[{"code":"dry_run_failed","message":"Dry run failed, ' +
+    "could not automatically determine a budget: MoveAbort(MoveLocation { module: ModuleId { " +
+    "address: 0000000000000000000000000000000000000000000000000000000000000002, name: " +
+    'Identifier(\\"balance\\") }, function: 9, instruction: 8, function_name: ' +
+    'Some(\\"destroy_zero\\") }, 0) in command 2"}]}';
+
+test("matches the verbatim prod destroy_zero abort", () => {
+    assert.equal(isMoveAbortWalDestroyZero(PROD_DESTROY_ZERO_ERROR), true);
+});
+
+test("matches the compact MoveLocation shape", () => {
+    assert.equal(
+        isMoveAbortWalDestroyZero(
+            "MoveAbort(MoveLocation { module: coin, function_name: Some(\"destroy_zero\") }, 0) in command 9",
+        ),
+        true,
+    );
+});
+
+test("is case-insensitive on both anchors", () => {
+    assert.equal(isMoveAbortWalDestroyZero("moveabort ... destroy_zero"), true);
+});
+
+test("bare destroy_zero without MoveAbort context is rejected", () => {
+    // Guards against unrelated log lines that merely mention the function.
+    assert.equal(isMoveAbortWalDestroyZero("calling coin::destroy_zero"), false);
+});
+
+test("balance::split abort does not match this detector", () => {
+    // The stale-price destroy_zero path must stay disjoint from the gas-budget
+    // balance::split path so the two handlers never double-fire.
+    const balanceSplit =
+        "MoveAbort(MoveLocation { module: balance, function_name: Some(\"split\") }, 2) in command 1";
+    assert.equal(isMoveAbortWalDestroyZero(balanceSplit), false);
+    assert.equal(isMoveAbortBalanceSplit(balanceSplit), true);
+});
+
+test("the destroy_zero abort is NOT matched by the balance-split detector", () => {
+    // The prod message contains the `balance` module name but no `split`, so the
+    // existing isMoveAbortBalanceSplit stays false — this is exactly the gap the
+    // new detector closes.
+    assert.equal(isMoveAbortBalanceSplit(PROD_DESTROY_ZERO_ERROR), false);
+});
+
+test("unrelated errors do not match", () => {
+    assert.equal(isMoveAbortWalDestroyZero("connection refused"), false);
+    assert.equal(isMoveAbortWalDestroyZero("HTTP 500 from upload relay"), false);
+    assert.equal(isMoveAbortWalDestroyZero(""), false);
+});

--- a/services/server/scripts/sidecar/config.ts
+++ b/services/server/scripts/sidecar/config.ts
@@ -30,7 +30,11 @@ export function parsePositiveIntEnv(
 // ============================================================
 
 export const SUI_NETWORK = (process.env.SUI_NETWORK || "mainnet") as "mainnet" | "testnet";
-export const SUI_RPC_URL = getJsonRpcFullnodeUrl(SUI_NETWORK);
+// Honor an explicit SUI_RPC_URL override (e.g. a dedicated / premium RPC) so we
+// can move off the public fullnode when its pool degrades — the public endpoint
+// has served stale reads (a certified blob read back as "does not exist"),
+// which fails uploads at get_blob / certify. Falls back to the network default.
+export const SUI_RPC_URL = process.env.SUI_RPC_URL?.trim() || getJsonRpcFullnodeUrl(SUI_NETWORK);
 export const SUI_TYPE = "0x2::sui::SUI";
 
 // ============================================================

--- a/services/server/scripts/sidecar/config.ts
+++ b/services/server/scripts/sidecar/config.ts
@@ -123,9 +123,16 @@ export function clampWalrusEpochs(rawEpochs: unknown): number {
     return Math.min(Math.floor(parsed), MAX_WALRUS_EPOCHS);
 }
 
+// The cached WalrusClient snapshots `systemState` (storage/write price,
+// committee) at creation and reuses it for its whole lifetime. The register
+// PTB pre-funds an *exact* WAL payment from that cached price, so when mainnet
+// price drifts the split leaves change and `coin::destroy_zero` aborts. Keep
+// the client young so the cached price tracks the live price closely; the
+// register-path `destroy_zero` handler also recreates it on demand. Was 30 min,
+// which let the cached price fall far behind a live-drifting mainnet price.
 export const WALRUS_CLIENT_MAX_AGE_MS = (() => {
     const parsed = Number.parseInt(process.env.WALRUS_CLIENT_MAX_AGE_MS || "", 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 30 * 60 * 1000;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 60 * 1000;
 })();
 
 // Mirror of services/server/src/alerts.rs SIDECAR_WALRUS_DEP_VERSION.

--- a/services/server/scripts/sidecar/enoki.ts
+++ b/services/server/scripts/sidecar/enoki.ts
@@ -53,6 +53,22 @@ export function isMoveAbortBalanceSplit(message: string): boolean {
     return /moveabort/i.test(message) && /balance.*split|split.*balance/i.test(message);
 }
 
+/**
+ * Detect the `0x2::coin::destroy_zero` abort (ENonZero, abort code 0) that the
+ * Walrus register PTB raises when the WAL payment coin still holds a non-zero
+ * remainder. The `@mysten/walrus` `#withWal` helper pre-funds an *exact* WAL
+ * amount (`storageUnits × price × epochs`) computed from the client's cached
+ * `systemState`, then asserts the coin is empty via `destroy_zero`. When the
+ * on-chain storage/write price drops between the cached read and execution, the
+ * contract deducts less WAL than we split off, leaving change that trips
+ * `destroy_zero`. It is not input-specific — refreshing the Walrus client so the
+ * next attempt re-reads the live price clears it, so callers treat it as
+ * transient rather than a permanent MoveAbort.
+ */
+export function isMoveAbortWalDestroyZero(message: string): boolean {
+    return /moveabort/i.test(message) && /destroy_zero/i.test(message);
+}
+
 export async function callEnoki<T>(path: string, payload: unknown): Promise<T> {
     if (!ENOKI_API_KEY) {
         throw new Error("ENOKI_API_KEY is not configured");

--- a/services/server/scripts/sidecar/routes/walrus-upload.ts
+++ b/services/server/scripts/sidecar/routes/walrus-upload.ts
@@ -45,7 +45,7 @@ import {
     sleep,
     truncateForLog,
 } from "../util.js";
-import { isMoveAbortBalanceSplit } from "../enoki.js";
+import { isMoveAbortBalanceSplit, isMoveAbortWalDestroyZero } from "../enoki.js";
 import {
     patchGasCoinIntents,
     submitRebuildableWalletTransaction,
@@ -361,6 +361,15 @@ export function registerWalrusUploadRoute(app: Express): void {
             }
             if (phase === "register_sponsor" && isMoveAbortBalanceSplit(message)) {
                 refreshWalrusClient("register_sponsor_balance_split");
+            }
+            // `coin::destroy_zero` (ENonZero) means the WAL payment coin the
+            // register PTB pre-funded from the cached storage price wasn't fully
+            // consumed on-chain — the live price dropped between the cached read
+            // and execution. Recreate the client so the retry re-reads the
+            // current price and splits the exact amount. The Rust worker
+            // classifies this abort Transient so Apalis actually retries.
+            if (isMoveAbortWalDestroyZero(message)) {
+                refreshWalrusClient("walrus_wal_payment_destroy_zero");
             }
             if (isWalrusPackageVersionMismatch(message)) {
                 // EWrongVersion is phase-independent: can fire from register / upload / certify

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1511,6 +1511,9 @@ async fn maybe_alert_walrus_upload_exhausted(
 ///
 /// Mapping rules (enforced at the point of error origination):
 /// - `MoveAbort(_)` → `Permanent` (deterministic Move-level failure)
+/// - Walrus register `0x2::coin::destroy_zero` ENonZero → `Transient` (WAL
+///   payment over-funded from a stale cached price; the sidecar refreshes the
+///   client so the retry re-reads the live price and splits the exact amount)
 /// - Enoki dry-run `0x2::balance::split` ENotEnough → `GasPoolExhausted`
 ///   (abort: pool SUI gas coins are fragmented/insufficient; retrying rotates
 ///   to the next starved wallet — needs ops gas consolidation/top-up)
@@ -1602,6 +1605,20 @@ impl WalletJobError {
             && lower.contains("split")
     }
 
+    /// True if `msg` is the Walrus register PTB's `0x2::coin::destroy_zero`
+    /// abort (ENonZero). The `@mysten/walrus` `#withWal` helper splits an exact
+    /// WAL payment from the client's cached storage/write price and asserts the
+    /// coin is empty afterwards; when mainnet price drops between the cached read
+    /// and execution the contract deducts less WAL, leaving change that trips
+    /// `destroy_zero`. Recoverable: retrying against a client that re-read the
+    /// live price splits the correct amount, so this is Transient — never a
+    /// Permanent MoveAbort.
+    pub fn is_walrus_wal_payment_price_abort(msg: &str) -> bool {
+        let lower = msg.to_ascii_lowercase();
+        (lower.contains("moveabort") || lower.contains("move abort"))
+            && lower.contains("destroy_zero")
+    }
+
     /// Heuristic classification from the sidecar's error string. The sidecar
     /// surfaces Sui execution errors verbatim (Move abort codes, lock errors).
     /// Until the sidecar emits structured error codes, we match on substrings.
@@ -1644,6 +1661,17 @@ impl WalletJobError {
         if (lower.contains("moveabort") || lower.contains("move abort"))
             && (lower.contains("::system::inner_mut") || lower.contains("ewrongversion"))
         {
+            return WalletJobError::Transient(msg.to_string());
+        }
+        // Walrus register PTB `0x2::coin::destroy_zero` abort (ENonZero). The
+        // `@mysten/walrus` `#withWal` helper pre-funds an exact WAL payment from
+        // the client's cached storage price, then asserts the coin is empty. When
+        // the on-chain price drops between the cached read and execution the
+        // contract deducts less WAL, leaving change that trips `destroy_zero`.
+        // Not input-specific: the sidecar recreates the client on this error, so
+        // classifying Transient lets Apalis retry against the refreshed (live)
+        // price instead of Dead-marking a job the next attempt will succeed on.
+        if Self::is_walrus_wal_payment_price_abort(msg) {
             return WalletJobError::Transient(msg.to_string());
         }
         // Sui owned-object lock / equivocation. The referenced object+version
@@ -2393,6 +2421,22 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
             WalletJobError::classify_sidecar_error(ewrong),
             WalletJobError::Transient(_)
         ));
+    }
+
+    #[test]
+    fn walrus_register_destroy_zero_is_transient() {
+        // Verbatim prod error (issue #351): the register PTB over-funds the WAL
+        // payment from a stale cached price and `coin::destroy_zero` aborts with
+        // ENonZero. Must be Transient (retry re-reads the live price), NOT swept
+        // into the MoveAbort→Permanent catch that would Dead-mark every write.
+        let destroy_zero = "walrus upload failed: Enoki API error (400): {\"errors\":[{\"code\":\"dry_run_failed\",\"message\":\"Dry run failed, could not automatically determine a budget: MoveAbort(MoveLocation { module: ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier(\\\"balance\\\") }, function: 9, instruction: 8, function_name: Some(\\\"destroy_zero\\\") }, 0) in command 2\"}]}";
+        assert!(WalletJobError::is_walrus_wal_payment_price_abort(
+            destroy_zero
+        ));
+        let classified = WalletJobError::classify_sidecar_error(destroy_zero);
+        assert!(matches!(classified, WalletJobError::Transient(_)));
+        assert!(!classified.is_permanent());
+        assert!(!classified.aborts_retries());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Merges `fix/walrus-register-destroy-zero-stale-price` into the security-delete branch.

**Two code changes:**

- `b75c0476` — recover Walrus register `destroy_zero` from a stale WAL price (#351). A `coin::destroy_zero` MoveAbort is reclassified from Permanent to Transient so the job retries, paired with a Walrus client refresh in the sidecar.
- `542071f3` — honor `SUI_RPC_URL` so the relayer can move off a degraded public fullnode.

The remaining 10 commits are documentation and CI (troubleshooting guide, agent-storage docs, a GitHub Issues monitor workflow, canonical repo URL).

## Conflicts

Conflicts are confined to **docs and CI** — no source file conflicts:

- `.changeset/config.json`
- `.github/workflows/github-issues-monitor.yml`
- `docs/**` (7 files)

The two code commits touch `services/server/src/jobs.rs` and the sidecar, neither of which conflicts.

## Note

`b75c0476` is the same `destroy_zero` reclassification already carried by the security-delete branch. Landing it from its own branch means the delete PR no longer introduces an unrelated change to the existing write path.