### PR TITLE
Fix: default mainnet to the dedicated JSON-RPC endpoint

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -46,7 +46,10 @@ VITE_POSTHOG_UI_HOST=https://us.posthog.com
 # ▷ INACTIVE: MAINNET  (uncomment below, comment out TESTNET above)
 # ══════════════════════════════════════════════════════════════
 # VITE_SUI_NETWORK=mainnet
-# Required Sui RPC v2 gRPC-Web endpoint. There is no JSON-RPC fallback.
+# Dedicated JSON-RPC for the app's Sui client (mirrors relayer SUI_RPC_URL);
+# empty falls back to the public fullnode, which is slow/stale on mainnet.
+# VITE_SUI_RPC_URL=https://rpc-mainnet.suiscan.xyz
+# Sui RPC v2 gRPC-Web endpoint used by the security-delete subsystem.
 # VITE_SUI_GRPC_URL=https://fullnode.mainnet.sui.io:443
 # VITE_MEMWAL_PACKAGE_ID=0xcee7a6fd8de52ce645c38332bde23d4a30fd9426bc4681409733dd50958a24c6
 # VITE_MEMWAL_REGISTRY_ID=0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75a7edd

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -45,9 +45,19 @@ import '@mysten/dapp-kit/dist/index.css'
 // gRPC is scoped to the deletion subsystem, which owns its own client. The Seal
 // and Walrus SDKs the deletion preview uses accept either transport, so nothing
 // in that path needs the shared client to be gRPC.
+// VITE_SUI_RPC_URL overrides the public fullnode for the active network only
+// (mirrors the relayer's SUI_RPC_URL — the public mainnet pool serves
+// stale/slow reads under load). Other networks keep the public default.
+function jsonRpcUrlFor(network: 'testnet' | 'mainnet'): string {
+  if (network === config.suiNetwork && config.suiRpcUrl) {
+    return config.suiRpcUrl
+  }
+  return getJsonRpcFullnodeUrl(network)
+}
+
 const { networkConfig } = createNetworkConfig({
-  testnet: { url: getJsonRpcFullnodeUrl('testnet'), network: 'testnet' },
-  mainnet: { url: getJsonRpcFullnodeUrl('mainnet'), network: 'mainnet' },
+  testnet: { url: jsonRpcUrlFor('testnet'), network: 'testnet' },
+  mainnet: { url: jsonRpcUrlFor('mainnet'), network: 'mainnet' },
   localnet: { url: config.suiRpcUrl || 'http://127.0.0.1:9000', network: 'localnet' },
 })
 

--- a/apps/app/src/config.ts
+++ b/apps/app/src/config.ts
@@ -43,12 +43,12 @@ export const config = {
     // protocol package defaults still intentionally use suiNetwork above.
     suiClientNetwork: localE2eJsonRpc ? 'localnet' as const :
         (import.meta.env.VITE_SUI_NETWORK as 'testnet' | 'mainnet' || 'testnet'),
-    // JSON-RPC exists only for the local devstack browser suite. Real
-    // testnet/mainnet builds must use the gRPC endpoint below.
+    // JSON-RPC endpoint override for the app's shared Sui client. For a real
+    // network it applies only to the active network; the local browser suite
+    // also uses it for its explicit localnet escape hatch.
     suiRpcUrl: import.meta.env.VITE_SUI_RPC_URL as string || '',
     localE2eJsonRpc,
-    // Required gRPC endpoint for real networks. Client construction fails
-    // closed when this is absent; there is no JSON-RPC fallback.
+    // gRPC endpoint used by the security-delete subsystem's dedicated client.
     suiGrpcUrl: import.meta.env.VITE_SUI_GRPC_URL as string || '',
     sealKeyServers,
     // Same cutover rationale as legacyMemwalPackageId: legacy blobs were


### PR DESCRIPTION
Syncs `fix/registry-table-id-invalid-params` into the security-delete branch.

Defaults mainnet to the dedicated suiscan JSON-RPC endpoint instead of the public fullnode.

- `apps/app/src/App.tsx`
- `apps/app/src/config.ts`
- `apps/app/.env.example`