### PR TITLE
fix(api): pause memory uploads

### DIFF
--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -911,7 +911,7 @@ async fn main() {
     // caps are enforced independently and a mismatch silently rejects valid
     // requests.
     let protected_routes = Router::new()
-        .route("/api/remember", post(routes::remember))
+        .route("/api/remember", post(routes::uploads_paused))
         .route(
             "/api/remember/{job_id}",
             axum::routing::get(routes::remember_status),
@@ -921,14 +921,14 @@ async fn main() {
             post(routes::remember_bulk_status),
         )
         .route("/api/recall", post(routes::recall))
-        .route("/api/remember/manual", post(routes::remember_manual))
+        .route("/api/remember/manual", post(routes::uploads_paused))
         .route("/api/recall/manual", post(routes::recall_manual))
         // Bulk remember — higher body limit (20 items × max 64 KiB each ≈ 1.5 MB)
         .route(
             "/api/remember/bulk",
-            post(routes::remember_bulk).layer(DefaultBodyLimit::max(2 * 1024 * 1024)),
+            post(routes::uploads_paused).layer(DefaultBodyLimit::max(2 * 1024 * 1024)),
         )
-        .route("/api/analyze", post(routes::analyze))
+        .route("/api/analyze", post(routes::uploads_paused))
         .route("/api/ask", post(routes::ask))
         .route("/api/restore", post(routes::restore))
         // admin/harness endpoints — namespace delete + stats.

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -39,6 +39,20 @@ use crate::types::*;
 
 use apalis::prelude::Storage as _;
 
+/// Temporary response for every endpoint that can create a new Walrus memory.
+///
+/// Keep this at the routing boundary so paused requests cannot start request
+/// validation, extraction, database writes, or background upload jobs.
+pub const UPLOADS_PAUSED_MESSAGE: &str =
+    "New uploads to Walrus Memory are paused while we conduct a security upgrade";
+
+pub async fn uploads_paused() -> (axum::http::StatusCode, axum::Json<serde_json::Value>) {
+    (
+        axum::http::StatusCode::NOT_FOUND,
+        axum::Json(serde_json::json!({ "error": UPLOADS_PAUSED_MESSAGE })),
+    )
+}
+
 // ============================================================
 // Wallet-job enqueue (used by remember + analyze)
 // ============================================================
@@ -108,6 +122,24 @@ where
         .into_iter()
         .map(|(_, result)| result)
         .collect()
+}
+
+#[cfg(test)]
+mod uploads_paused_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn returns_security_upgrade_message_with_not_found_status() {
+        let (status, axum::Json(body)) = uploads_paused().await;
+
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "error": "New uploads to Walrus Memory are paused while we conduct a security upgrade"
+            })
+        );
+    }
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- pause all four client-facing memory write endpoints at the routing boundary
- return HTTP 404 with the security-upgrade message in the standard JSON error shape
- keep recall, status polling, and restore endpoints available

## Why

New Walrus Memory uploads need to be suspended while a security upgrade is conducted. Routing write requests directly to the pause handler prevents validation, extraction, database inserts, and background upload jobs from starting.

## Impact

The following endpoints now return `404` with `{"error":"New uploads to Walrus Memory are paused while we conduct a security upgrade"}`:

- `POST /api/remember`
- `POST /api/remember/bulk`
- `POST /api/remember/manual`
- `POST /api/analyze`

## Validation

- `cargo fmt --manifest-path services/server/Cargo.toml -- --check`
- `cargo test --manifest-path services/server/Cargo.toml uploads_paused_tests`
- `git diff --check`
