### PR TITLE
fix(api): return 503 for paused uploads

### DIFF
--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -48,7 +48,7 @@ pub const UPLOADS_PAUSED_MESSAGE: &str =
 
 pub async fn uploads_paused() -> (axum::http::StatusCode, axum::Json<serde_json::Value>) {
     (
-        axum::http::StatusCode::NOT_FOUND,
+        axum::http::StatusCode::SERVICE_UNAVAILABLE,
         axum::Json(serde_json::json!({ "error": UPLOADS_PAUSED_MESSAGE })),
     )
 }
@@ -129,10 +129,10 @@ mod uploads_paused_tests {
     use super::*;
 
     #[tokio::test]
-    async fn returns_security_upgrade_message_with_not_found_status() {
+    async fn returns_security_upgrade_message_with_service_unavailable_status() {
         let (status, axum::Json(body)) = uploads_paused().await;
 
-        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(status, axum::http::StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             body,
             serde_json::json!({


### PR DESCRIPTION
## Summary

- return HTTP 503 from the shared paused-upload handler
- apply the response to `/api/remember`, `/api/remember/bulk`, `/api/remember/manual`, and `/api/analyze`
- update the focused unit test to assert `Service Unavailable`

## Why

These routes are temporarily paused during a security upgrade. Returning 404 incorrectly indicates that the endpoints do not exist and may prevent clients from treating the failure as retryable. HTTP 503 accurately communicates temporary service unavailability while preserving the existing error message.

## Impact

Clients receive a retryable service-unavailable response for paused memory writes and analysis requests. Other routes and response bodies are unchanged.

## Validation

- `cargo test --manifest-path services/server/Cargo.toml uploads_paused_tests`
- `cargo fmt --manifest-path services/server/Cargo.toml -- --check`
- `git diff --check`