### PR TITLE
fix(app): update delete memory tabs

### DIFF
--- a/apps/app/e2e/securityDelete.spec.ts
+++ b/apps/app/e2e/securityDelete.spec.ts
@@ -173,14 +173,14 @@ test('security delete: connect, table, Seal preview, delete selected, progress, 
 	await page.getByRole('button', { name: /^Delete selected/ }).click()
 	await page.getByRole('dialog', { name: /Permanently delete/ }).getByRole('button', { name: 'Delete forever' }).click()
 
-	// 5. Rows move to the Progress tab as `deleted`; the 3rd (untouched) row
+	// 5. Rows move to the Deleted tab as `deleted`; the 3rd (untouched) row
 	// stays in "Stored". Real wallet-tx completion + real server submit,
 	// polled via the UI's own refresh — no client-side pretending.
 	await expect(page.getByTitle(seededBlobIds[0], { exact: true })).toHaveCount(0, { timeout: 30_000 })
 	await expect(page.getByTitle(seededBlobIds[1], { exact: true })).toHaveCount(0, { timeout: 30_000 })
 	await expect(page.getByTitle(seededBlobIds[2], { exact: true })).toBeVisible()
 
-	await page.getByRole('tab', { name: 'Progress' }).click()
+	await page.getByRole('tab', { name: 'Deleted' }).click()
 	for (const blobId of [seededBlobIds[0], seededBlobIds[1]]) {
 		const row = page.locator('tr', { has: page.getByTitle(blobId, { exact: true }) })
 		await expect(row).toBeVisible({ timeout: 30_000 })

--- a/apps/app/src/components/SecurityDeleteSection.test.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.test.tsx
@@ -56,7 +56,7 @@ it('loads the read-only progress state set after tab switch', async () => {
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
     await screen.findByTitle('blob-one-long-identifier')
-    await user.click(screen.getByRole('tab', { name: 'Progress' }))
+    await user.click(screen.getByRole('tab', { name: 'Deleted' }))
     await waitFor(() => expect(mocks.listBlobs).toHaveBeenLastCalledWith('token', expect.objectContaining({ state: 'deleting,deleted,deleted_external,not_owner,expired' })))
 })
 
@@ -104,7 +104,7 @@ it('clears rows and ignores an old tab response during a tab switch', async () =
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
     await waitFor(() => expect(mocks.listBlobs).toHaveBeenCalledOnce())
-    await user.click(screen.getByRole('tab', { name: 'Progress' }))
+    await user.click(screen.getByRole('tab', { name: 'Deleted' }))
     expect(await screen.findByTitle('progress-blob')).toBeInTheDocument()
     releaseRisk({ items: risk, counts, limits: { deleteBatchMax: 900 }, nextCursor: null })
     await Promise.resolve()

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -224,7 +224,7 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
         <div className="sd-counts"><strong>{visibleCounts.deletable}</strong> stored, <strong>{visibleCounts.deleting}</strong> in progress, <strong>{visibleCounts.deleted + visibleCounts.deletedExternal}</strong> deleted</div>
         <div className="sd-tabs" role="tablist">
             <button role="tab" aria-selected={tab === 'risk'} aria-controls="sd-tab-panel" className={`btn ${tab === 'risk' ? 'btn-secondary' : ''}`} onClick={() => selectTab('risk')}>Stored</button>
-            <button role="tab" aria-selected={tab === 'progress'} aria-controls="sd-tab-panel" className={`btn ${tab === 'progress' ? 'btn-secondary' : ''}`} onClick={() => selectTab('progress')}>Progress</button>
+            <button role="tab" aria-selected={tab === 'progress'} aria-controls="sd-tab-panel" className={`btn ${tab === 'progress' ? 'btn-secondary' : ''}`} onClick={() => selectTab('progress')}>Deleted</button>
         </div>
         {error && <div className="dashboard-cleanup-error" role="alert">{error}</div>}
         {deletion.phase.kind === 'error' && <div className="dashboard-cleanup-error" role="alert">{deletion.phase.message} <code>{deletion.phase.code}</code></div>}

--- a/apps/app/src/hooks/useSecurityDeletion.ts
+++ b/apps/app/src/hooks/useSecurityDeletion.ts
@@ -120,7 +120,7 @@ export function useSecurityDeletion({ onStateChanged }: { onStateChanged: () => 
                     'REFETCH',
                     true,
                     statusError instanceof SdApiError ? statusError.status : 0,
-                    'Submission status is temporarily unavailable. Check the Progress tab.',
+                    'Submission status is temporarily unavailable. Check the Deleted tab.',
                 )
             }
             if (status.state === 'completed') return { state: 'completed' as const, deleted: status.blobCount, digest: status.digest ?? '' }
@@ -132,7 +132,7 @@ export function useSecurityDeletion({ onStateChanged }: { onStateChanged: () => 
                 if (retryError.code === 'SPONSOR_FUNDS_UNAVAILABLE') throw retryError
                 throw new SdApiError('BATCH_RECOVERED_FAILED', 'RE_PREPARE', true, 409, 'The batch must be prepared again.')
             }
-            throw new SdApiError('BATCH_EXECUTING', 'REFETCH', true, 409, 'Deletion is still executing. Check the Progress tab.')
+            throw new SdApiError('BATCH_EXECUTING', 'REFETCH', true, 409, 'Deletion is still executing. Check the Deleted tab.')
         }
     }, [authed])
 

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -13,6 +13,7 @@
 }
 .dash-page .sd-warning { margin-bottom: 1rem; color: #7d5400; }
 .dash-page .sd-counts, .dash-page .sd-tabs, .dash-page .sd-actions { margin-bottom: 1rem; }
+.dash-page .sd-tabs .btn[aria-selected='true'] { border-color: #faf8f5; background: #faf8f5; color: #000000; }
 .dash-page .sd-table-wrap { overflow-x: auto; }
 .dash-page .sd-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
 .dash-page .sd-table th, .dash-page .sd-table td { padding: 0.65rem; border-bottom: 1px solid rgba(0,0,0,.12); text-align: left; white-space: nowrap; }


### PR DESCRIPTION
## Summary

- rename the delete-memory `Progress` tab to `Deleted`
- render the selected delete-memory tab with a white background and black text
- update related recovery messages and test selectors

## Why

The tab label did not match the deleted-memory view, and the shared secondary-button styling gave the active tab a black background. The selected state is now scoped to the delete-memory tab group so other buttons are unaffected.

## Impact

Users see clearer tab naming and an active-tab treatment consistent with the intended dashboard design.

## Validation

- `pnpm --filter @memwal/app test -- src/components/SecurityDeleteSection.test.tsx src/hooks/useSecurityDeletion.test.ts`
- targeted ESLint checks for the changed frontend files
- `pnpm --filter @memwal/app build`
