### PR TITLE
docs: fix MCP setup docs gaps (ChatGPT, Claude Desktop, Codex, env vars)

### DIFF
--- a/apps/app/public/skills/setup
+++ b/apps/app/public/skills/setup
@@ -22,10 +22,12 @@ user explicitly asks for developer integration.
 
 ## Setup Rules
 
-1. Identify the AI client first. ChatGPT (or another client that cannot run a
-   local MCP command but supports custom connector headers) uses the Remote
-   MCP section below. Every other client (Claude Desktop, Claude Code, Cursor,
-   Codex, other local apps) uses the Local MCP Server section.
+1. Identify the AI client first. A client that cannot run a local MCP command
+   but can attach two custom connector headers uses the Remote MCP section
+   below. Every other client (Claude Desktop, Claude Code, Cursor, Codex,
+   other local apps) uses the Local MCP Server section. ChatGPT is not
+   supported today: its connector UI exposes only a single bearer field and
+   cannot supply the required `x-memwal-account-id` header.
 2. Decide whether you have local shell and filesystem access.
 3. If you can edit local user config files, do the setup yourself after showing
    the config you will add.
@@ -252,23 +254,23 @@ Use memwal_recall to search for: "setup verification succeeded"
 If the tools support a `namespace` argument, use a setup-only namespace such as
 `setup-verification`.
 
-## Remote MCP (ChatGPT and other header-capable clients)
+## Remote MCP (header-capable clients)
 
 Some clients connect to a remote MCP server URL instead of running a local
-command. Use this path only when the client supports custom request headers.
-ChatGPT (developer mode) supports this today.
+command. Use this path only when the client can attach BOTH custom request
+headers shown below. A client that exposes only a single bearer/token field
+cannot use this path.
+
+ChatGPT is not supported today. Its connector UI exposes only one bearer slot,
+so the required `x-memwal-account-id` header cannot be provided. Do not attempt
+ChatGPT setup; offer a local client (Claude Desktop, Claude Code, Cursor, or
+Codex) instead.
 
 Prerequisite: credentials must already exist. Have the user run the login once
 on their computer (see Recommended Login). The Remote MCP path needs Node.js
 only for that one step.
 
-For ChatGPT:
-
-1. Settings > Connectors > enable Developer mode.
-2. Add a connector with URL `https://relayer.memory.walrus.xyz/api/mcp`.
-3. Add the two headers shown in the template below.
-
-For config-file clients that support remote servers with headers, merge:
+For config-file clients that support remote servers with two headers, merge:
 
 ```json
 {
@@ -295,10 +297,10 @@ cat ~/.memwal/credentials.json
 settings, never into the chat. You (the agent) must not read or print this
 file. Treat the bearer token like an API key and never save it in a repo file.
 
-If the client cannot attach custom headers, remote MCP is not available for it
-today. Tell the user which clients are supported (ChatGPT developer mode,
-Claude Desktop, Claude Code, Cursor, Codex) and offer to set one of those up
-instead. Do not re-run this skill for the same client.
+If the client cannot attach both custom headers, remote MCP is not available
+for it today. Tell the user which clients are supported (Claude Desktop, Claude
+Code, Cursor, Codex) and offer to set one of those up instead. Do not re-run
+this skill for the same client.
 
 ## Troubleshooting
 

--- a/apps/app/public/skills/setup
+++ b/apps/app/public/skills/setup
@@ -136,7 +136,11 @@ Edit:
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Merge:
+Newer Claude Desktop versions pre-populate this file, so it may already contain
+other top-level keys (for example `preferences`) and no `mcpServers` block. Add
+`mcpServers` as a new sibling of those keys; do not replace the file. If an
+`mcpServers` block already exists, add the `memwal` entry inside it next to any
+other servers.
 
 ```json
 {

--- a/docs/mcp/claude-desktop.md
+++ b/docs/mcp/claude-desktop.md
@@ -30,6 +30,10 @@ Add the server to your Claude Desktop config:
 }
 ```
 
+<Note>
+Newer Claude Desktop versions pre-populate `claude_desktop_config.json` with other top-level keys (such as `preferences`) and no `mcpServers` block. Add `mcpServers` as a sibling of the existing keys rather than replacing the file. If an `mcpServers` block already exists, add the `memwal` entry inside it alongside any other servers.
+</Note>
+
 Quit and reopen Claude Desktop (`Cmd+Q` on macOS; closing the window is not enough), then ask the agent to run `memwal_login` on first use.
 
 ## Available tools

--- a/docs/mcp/codex.md
+++ b/docs/mcp/codex.md
@@ -1,10 +1,10 @@
 ---
 title: Codex
-description: Add portable Walrus Memory to OpenAI Codex as a full plugin with automatic memory, or as a plain MCP server.
+description: Add portable Walrus Memory to OpenAI Codex as a plain MCP server (recommended), or as a full plugin with automatic-memory hooks.
 keywords: [MCP, Codex, Walrus Memory, MemWal, plugin, automatic memory]
 ---
 
-Add MemWal to Codex so it recalls context and saves durable facts as you work. Install it as a **plugin** (recommended; adds automatic-memory hooks) or as **MCP-only** (just the tools).
+Add MemWal to Codex so it recalls context and saves durable facts as you work. Install it as **MCP-only** (recommended; just the tools, one config block, no repo to clone) or as a full **plugin** (adds automatic-memory hooks, but currently requires cloning the repo).
 
 ## Prerequisites
 
@@ -14,7 +14,21 @@ Add MemWal to Codex so it recalls context and saves durable facts as you work. I
 ## Installation
 
 <Tabs>
-  <Tab title="Plugin (recommended)">
+  <Tab title="MCP-only (recommended)">
+    Add to `~/.codex/config.toml`:
+    ```toml
+    [mcp_servers.memwal]
+    command = "npx"
+    args = ["-y", "@mysten-incubation/memwal-mcp"]
+    ```
+    Restart Codex, then ask the agent to run `memwal_login` on first use. The
+    memory tools are proactive, so this is enough for automatic save and recall.
+  </Tab>
+  <Tab title="Plugin (automatic-memory hooks)">
+    The plugin adds lifecycle hooks on top of the MCP server. There is no Codex
+    marketplace install yet, so it currently requires a cloned repo. If you just
+    want memory in Codex, use the MCP-only tab instead.
+
     <Steps>
       <Step title="Install the hooks + MCP server">
         From a cloned repo:
@@ -34,15 +48,6 @@ Add MemWal to Codex so it recalls context and saves durable facts as you work. I
         Restart Codex. On first use the agent runs `memwal_login` to connect your wallet.
       </Step>
     </Steps>
-  </Tab>
-  <Tab title="MCP-only">
-    Add to `~/.codex/config.toml`:
-    ```toml
-    [mcp_servers.memwal]
-    command = "npx"
-    args = ["-y", "@mysten-incubation/memwal-mcp"]
-    ```
-    Restart Codex, then ask the agent to run `memwal_login` on first use.
   </Tab>
 </Tabs>
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -2,12 +2,52 @@
 title: "Environment Variables"
 ---
 
-Use this page when you run your own relayer.
-For setup steps and deployment context, see [Self-Hosting](/relayer/self-hosting).
+This page lists every environment variable MemWal reads, grouped by where it runs:
 
-Environment variables documented here are public relayer contract items. Renaming, removing, or changing their meaning follows the deprecation process in [Versioning and Compatibility](/relayer/versioning-and-compatibility).
+- **[Client, CLI, and MCP](#client-cli-and-mcp)** — what you set when integrating the SDK, running the CLI, or configuring the MCP server (`@mysten-incubation/memwal-mcp`).
+- **[Relayer (self-hosting)](#relayer-self-hosting)** — what you set when you run your own relayer.
 
-## Required
+If a variable is not listed on this page, MemWal does not read it. The client, CLI, and MCP server read your credentials from `~/.memwal/credentials.json` after `memwal_login`, so most integrations need few or no environment variables.
+
+## Client, CLI, and MCP
+
+These apply to the MemWal SDK, the CLI, and the MCP server that AI clients run. They are separate from the relayer variables in the next section.
+
+### MCP server
+
+The MCP server (`npx -y @mysten-incubation/memwal-mcp`) reads these automatically. Each has an equivalent command-line flag.
+
+| Variable | Default | Flag | Notes |
+| --- | --- | --- | --- |
+| `MEMWAL_SERVER_URL` | `https://relayer.memory.walrus.xyz` | `--relayer` | Relayer URL the MCP server and login flow talk to |
+| `MEMWAL_WEB_URL` | `https://memory.walrus.xyz` | `--web-url` | Dashboard URL opened in the browser during login |
+| `MEMWAL_NAMESPACE` | unset (relayer uses `default`) | `--namespace` | Default namespace applied to `remember`, `recall`, `analyze`, and `restore` when a call omits one. An explicit per-call namespace always wins |
+| `MEMWAL_CLIENT_LABEL` | `MCP Client` | `--label` | Friendly label registered on-chain for the delegate key. The login flow uses `Walrus Memory MCP` when unset |
+| `MEMWAL_MCP_DEBUG` | unset | — | Set to `1` for verbose logging to stderr |
+| `MEMWAL_MCP_SSE_IDLE_MS` | `30000` | — | Idle timeout in milliseconds before the MCP bridge reconnects a stalled relayer SSE stream. Values below `500` are ignored. Mostly for tests |
+
+### SDK and CLI credentials
+
+The SDK takes its configuration as a config object (see [Configuration](/reference/configuration)); it does not read these names on its own. The names below are the conventions used across the SDK examples and the CLI. Set them in your own environment, then pass them into `MemWal.create()` or `MemWalManual.create()`.
+
+| Variable | Config field | Notes |
+| --- | --- | --- |
+| `MEMWAL_PRIVATE_KEY` / `MEMWAL_DELEGATE_KEY` | `key` | Ed25519 delegate private key in hex |
+| `MEMWAL_ACCOUNT_ID` | `accountId` | `MemWalAccount` object ID on Sui |
+| `SUI_PRIVATE_KEY` | `suiPrivateKey` | `suiprivkey1…` key for SEAL and Walrus signing in the manual client |
+| `OPENAI_API_KEY` | `embeddingApiKey` | OpenAI-compatible embedding key for the manual client. This is the client-side embedding key, distinct from the relayer's server-side `OPENAI_API_KEY` below |
+
+<Note>
+Credentials created by `memwal_login` live in `~/.memwal/credentials.json`, not in environment variables. Do not print, log, or commit that file.
+</Note>
+
+## Relayer (self-hosting)
+
+Use this section when you run your own relayer. For setup steps and deployment context, see [Self-Hosting](/relayer/self-hosting).
+
+Relayer variables documented here are public relayer contract items. Renaming, removing, or changing their meaning follows the deprecation process in [Versioning and Compatibility](/relayer/versioning-and-compatibility).
+
+### Required
 
 | Variable | Notes |
 | --- | --- |
@@ -16,7 +56,7 @@ Environment variables documented here are public relayer contract items. Renamin
 | `MEMWAL_REGISTRY_ID` | Onchain registry object ID. See [Contract Overview](/contract/overview) |
 | `SIDECAR_AUTH_TOKEN` | Shared secret for Rust-to-sidecar calls. The sidecar refuses to start without it |
 
-## Usually Required
+### Usually Required
 
 These are not all enforced at boot, but most real deployments need them.
 
@@ -25,7 +65,7 @@ These are not all enforced at boot, but most real deployments need them.
 | `SERVER_SUI_PRIVATE_KEY` | Primary server key for backend decrypt and Walrus actions |
 | `OPENAI_API_KEY` | Server-side key used to call the embedding and fact-extraction provider |
 
-## Optional
+### Optional
 
 | Variable | Default | Notes |
 | --- | --- | --- |
@@ -70,7 +110,7 @@ These are not all enforced at boot, but most real deployments need them.
 | `MCP_MAX_SESSIONS_PER_IP` | `16` | Maximum active MCP sessions from one source IP |
 | `MCP_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | Maximum new MCP sessions opened by one source IP per minute |
 
-## Notes
+### Notes
 
 - If both `SERVER_SUI_PRIVATE_KEYS` and `SERVER_SUI_PRIVATE_KEY` are set, the key pool takes priority for uploads. Upload jobs use the pool in round-robin order.
 - Keep `ENOKI_FALLBACK_TO_DIRECT_SIGN=false` in production if the server wallet should not pay gas when sponsorship is missing, expired, or rejected.


### PR DESCRIPTION
## Summary

Fixes four reported documentation gaps in the MCP setup flow. Each is a self-contained commit. Rebased onto the latest `main`.

| Ticket | Change |
|---|---|
| [BEDU-792](https://linear.app/mysten-labs/issue/BEDU-792) | **Remove ChatGPT from the setup skill.** ChatGPT's connector UI exposes only a single bearer field, so the required `x-memwal-account-id` header cannot be provided and the integration does not work today. Replaced the ChatGPT path with an explicit not-supported note that points users to a local client. |
| [BEDU-790](https://linear.app/mysten-labs/issue/BEDU-790) | **Clarify the Claude Desktop config merge.** Newer Claude Desktop versions pre-populate `claude_desktop_config.json` with other top-level keys and no `mcpServers` block, so a bare example is ambiguous. Now states explicitly to add `mcpServers` as a sibling of the existing keys, merging into any existing block rather than replacing the file. |
| [BEDU-791](https://linear.app/mysten-labs/issue/BEDU-791) | **Make MCP-only the recommended Codex install.** The plugin path requires cloning the repo and running `install_codex_hooks.mjs` (there is no Codex marketplace install yet). Reordered the install tabs so the one-config-block MCP-only path is the default recommendation, and flagged the plugin's clone requirement. |
| [BEDU-775](https://linear.app/mysten-labs/issue/BEDU-775) | **Document client, CLI, and MCP env vars.** The reference only covered relayer self-hosting vars, so developers kept asking about non-existent client variable names. Split the page into Client/CLI/MCP and Relayer sections and documented the six MCP-server vars (with flags and defaults) plus the SDK/CLI credential conventions. |

## Files touched

- `apps/app/public/skills/setup` — BEDU-792, BEDU-790
- `docs/mcp/claude-desktop.md` — BEDU-790
- `docs/mcp/codex.md` — BEDU-791
- `docs/reference/environment-variables.md` — BEDU-775

## Notes

- BEDU-775 values were verified against source (`packages/mcp/src/*`, `packages/sdk/src/*`), not inferred, since the ticket is specifically about developers citing variable names that do not exist.
- No code changes; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGnVrkhGgGkakumyqPHmu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGnVrkhGgGkakumyqPHmu5)_