### PR TITLE
docs: add agent-memory developer guides (headless setup, verifiable memory, codebase memory)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,7 +68,8 @@
             "group": "Concepts",
             "pages": [
               "fundamentals/concepts/memory-space",
-              "fundamentals/concepts/ownership-and-access"
+              "fundamentals/concepts/ownership-and-access",
+              "fundamentals/concepts/verifiable-memory"
             ]
           },
           {
@@ -90,6 +91,7 @@
             "pages": [
               "sdk/overview",
               "sdk/quick-start",
+              "sdk/headless-setup",
               {
                 "group": "Usage",
                 "root": "sdk/usage",
@@ -102,6 +104,7 @@
               "sdk/advanced-usage",
               "sdk/ai-integration",
               "sdk/cookbook-multi-tenant",
+              "sdk/codebase-memory",
               "sdk/cloudflare-workers",
               "sdk/agent-storage-loop",
               "sdk/production-readiness",

--- a/docs/fundamentals/concepts/verifiable-memory.md
+++ b/docs/fundamentals/concepts/verifiable-memory.md
@@ -4,7 +4,7 @@ description: "Why memory stored on Walrus Memory is both durable and verifiable:
 keywords: [verifiable memory, persistent memory, content addressing, blob id, onchain ownership, durability, availability, AI agents, trust]
 ---
 
-An AI agent is only as trustworthy as the memory it acts on. If memory can be silently altered, or if the service holding it can rewrite history or lock you out, the agent's decisions cannot be trusted. Walrus Memory gives agents memory that is both **persistent** (it outlives any single process or provider) and **verifiable** (you can prove what was stored and who controls it). This page explains where those guarantees come from and how to check each one yourself.
+An AI agent is only as trustworthy as the memory it acts on. If memory can be silently altered, or if the service holding it can rewrite history or lock you out, the agent's decisions cannot be trusted. Walrus Memory gives agents memory that is both **persistent** (it outlives any single process or provider) and **verifiable** (you can confirm the stored data is intact and who controls it). This page explains where those guarantees come from and how to check each one yourself.
 
 Verifiability here rests on three independent properties. None of them requires you to trust the relayer.
 
@@ -34,8 +34,8 @@ The encrypted blobs live on Walrus, which stores data across a decentralized net
 
 You do not have to take these guarantees on faith. You can inspect all three properties directly:
 
-- **Availability:** call `health()` to confirm the relayer and its Walrus and Sui dependencies are reachable before you rely on them.
-- **Integrity:** read the `blob_id` off a `recall` result. It is a content-addressed handle to the exact stored bytes, and a blob ID that resolves confirms those bytes are unchanged.
+- **Availability:** call `health()` to confirm the relayer is reachable before you rely on it. This is an unauthenticated liveness check, not a validation of your credentials.
+- **Integrity:** read the `blob_id` off a `recall` result. It is a content-addressed handle to the exact stored ciphertext, so a blob ID that resolves confirms that encrypted blob is intact and unchanged. This is blob-level integrity; the plaintext inside is protected by Seal encryption, not by content-addressing.
 - **Ownership:** take your `MemWalAccount` object ID and open it in a Sui explorer. The account, its owner, and its delegate authorizations are public onchain state that anyone can inspect, independent of the relayer.
 
 <Note>

--- a/docs/fundamentals/concepts/verifiable-memory.md
+++ b/docs/fundamentals/concepts/verifiable-memory.md
@@ -4,7 +4,7 @@ description: "Why memory stored on Walrus Memory is both durable and verifiable:
 keywords: [verifiable memory, persistent memory, content addressing, blob id, onchain ownership, durability, availability, AI agents, trust]
 ---
 
-An AI agent is only as trustworthy as the memory it acts on. If memory can be silently altered, or if the service holding it can rewrite history or lock you out, the agent's decisions cannot be trusted. Walrus Memory gives agents memory that is both **persistent** (it outlives any single process or provider) and **verifiable** (you can confirm the stored data is intact and who controls it). This page explains where those guarantees come from and how to check each one yourself.
+An AI agent is only as trustworthy as the memory it acts on. If memory can be silently altered, or if the service holding it can rewrite history or lock you out, the agent's decisions cannot be trusted. Walrus Memory gives agents memory that is both **persistent** (it outlives any single process or provider) and **verifiable** (you can confirm the stored data is intact and who controls it).
 
 Verifiability here rests on three independent properties. None of them requires you to trust the relayer.
 
@@ -15,7 +15,7 @@ Every write to Walrus produces a **blob ID derived from the stored bytes**. The 
 Each memory you store carries its own blob ID. The result of `rememberAndWait` includes a `blob_id`, and every hit returned by `recall` carries the `blob_id` of the memory it matched, so you always have a durable handle to the exact revision that was stored.
 
 <Note>
-A blob ID addresses the **Seal ciphertext** that Walrus stores, not your plaintext. It proves the encrypted bytes are intact and unchanged. Confidentiality comes from Seal encryption; content-addressing provides integrity and immutability on top of it.
+A blob ID addresses the **Seal ciphertext** that Walrus stores, not your plaintext. It proves the encrypted bytes are intact and unchanged. Confidentiality comes from Seal encryption. Content-addressing provides integrity and immutability on top of it.
 </Note>
 
 Because a new version is a new blob with a new ID, the chain of blob IDs over time is an immutable lineage of revisions. For the versioning pattern built on this property, see [Versioned datasets](/sdk/versioned-datasets).
@@ -32,11 +32,11 @@ The encrypted blobs live on Walrus, which stores data across a decentralized net
 
 ## Verify it yourself
 
-You do not have to take these guarantees on faith. You can inspect all three properties directly:
+You can check all three properties yourself. Inspect each one directly:
 
-- **Availability:** call `health()` to confirm the relayer is reachable before you rely on it. This is an unauthenticated liveness check, not a validation of your credentials.
-- **Integrity:** read the `blob_id` off a `recall` result. It is a content-addressed handle to the exact stored ciphertext, so a blob ID that resolves confirms that encrypted blob is intact and unchanged. This is blob-level integrity; the plaintext inside is protected by Seal encryption, not by content-addressing.
-- **Ownership:** take your `MemWalAccount` object ID and open it in a Sui explorer. The account, its owner, and its delegate authorizations are public onchain state that anyone can inspect, independent of the relayer.
+- **Availability:** Call `health()` to confirm the relayer is reachable before you rely on it. This is an unauthenticated liveness check, not a validation of your credentials.
+- **Integrity:** Read the `blob_id` off a `recall` result. It is a content-addressed handle to the exact stored ciphertext, so a blob ID that resolves confirms that encrypted blob is intact and unchanged. This is blob-level integrity, and the plaintext inside is protected by Seal encryption, not by content-addressing.
+- **Ownership:** Take your `MemWalAccount` object ID and open it in a Sui explorer. The account, its owner, and its delegate authorizations are public onchain state that anyone can inspect, independent of the relayer.
 
 <Note>
 A dedicated `verify()` helper that reconstructs a memory from its onchain blob object is on the roadmap. Until it ships, verifiability comes from the three properties above: content-addressed blob IDs, onchain-enforced ownership you can inspect on a Sui explorer, and durability backed by Walrus. It is a property of the architecture, not a single SDK call.

--- a/docs/fundamentals/concepts/verifiable-memory.md
+++ b/docs/fundamentals/concepts/verifiable-memory.md
@@ -1,0 +1,51 @@
+---
+title: Persistent, Verifiable Memory
+description: "Why memory stored on Walrus Memory is both durable and verifiable: content-addressed blob IDs, onchain-enforced ownership, and decentralized availability, and how to inspect each property yourself."
+keywords: [verifiable memory, persistent memory, content addressing, blob id, onchain ownership, durability, availability, AI agents, trust]
+---
+
+An AI agent is only as trustworthy as the memory it acts on. If memory can be silently altered, or if the service holding it can rewrite history or lock you out, the agent's decisions cannot be trusted. Walrus Memory gives agents memory that is both **persistent** (it outlives any single process or provider) and **verifiable** (you can prove what was stored and who controls it). This page explains where those guarantees come from and how to check each one yourself.
+
+Verifiability here rests on three independent properties. None of them requires you to trust the relayer.
+
+## Content-addressed writes
+
+Every write to Walrus produces a **blob ID derived from the stored bytes**. The identifier is a function of the content, so the same bytes always produce the same blob ID, and any change to the bytes produces a different one. A blob ID that still resolves is therefore proof that the stored bytes were not altered after the write.
+
+Each memory you store carries its own blob ID. The result of `rememberAndWait` includes a `blob_id`, and every hit returned by `recall` carries the `blob_id` of the memory it matched, so you always have a durable handle to the exact revision that was stored.
+
+<Note>
+A blob ID addresses the **Seal ciphertext** that Walrus stores, not your plaintext. It proves the encrypted bytes are intact and unchanged. Confidentiality comes from Seal encryption; content-addressing provides integrity and immutability on top of it.
+</Note>
+
+Because a new version is a new blob with a new ID, the chain of blob IDs over time is an immutable lineage of revisions. For the versioning pattern built on this property, see [Versioned datasets](/sdk/versioned-datasets).
+
+## Onchain-enforced ownership
+
+Your memory is anchored to a `MemWalAccount` object on Sui. Ownership of that account, and the authorization of the delegate keys that can act on it, are enforced onchain by the smart contract, not by the relayer. A compromised or malicious relayer cannot change who owns an account or forge delegate permissions. It can serve requests, but it cannot rewrite the ownership record.
+
+This is what makes the memory portable and censorship-resistant: control follows the onchain account, so you can move to a different relayer, or self-host one, without losing ownership. For the full enforcement model, see [Ownership and access](/fundamentals/concepts/ownership-and-access) and the [data flow and security model](/fundamentals/architecture/data-flow-security-model).
+
+## Decentralized durability
+
+The encrypted blobs live on Walrus, which stores data across a decentralized network with no single point of failure. Walrus is the permanent record: the relayer keeps a vector index for fast search, but that index is a cache. If it is lost, `restore` rebuilds it by reading your blobs back from Walrus, decrypting, and re-indexing. The memory survives the loss of the relayer's database because the source of truth is onchain and on Walrus, not in the relayer. For how blobs are written, funded, and read back, see [How storage works](/fundamentals/architecture/how-storage-works).
+
+## Verify it yourself
+
+You do not have to take these guarantees on faith. You can inspect all three properties directly:
+
+- **Availability:** call `health()` to confirm the relayer and its Walrus and Sui dependencies are reachable before you rely on them.
+- **Integrity:** read the `blob_id` off a `recall` result. It is a content-addressed handle to the exact stored bytes, and a blob ID that resolves confirms those bytes are unchanged.
+- **Ownership:** take your `MemWalAccount` object ID and open it in a Sui explorer. The account, its owner, and its delegate authorizations are public onchain state that anyone can inspect, independent of the relayer.
+
+<Note>
+A dedicated `verify()` helper that reconstructs a memory from its onchain blob object is on the roadmap. Until it ships, verifiability comes from the three properties above: content-addressed blob IDs, onchain-enforced ownership you can inspect on a Sui explorer, and durability backed by Walrus. It is a property of the architecture, not a single SDK call.
+</Note>
+
+## References
+
+- [Versioned datasets](/sdk/versioned-datasets)
+- [Ownership and access](/fundamentals/concepts/ownership-and-access)
+- [Data flow and security model](/fundamentals/architecture/data-flow-security-model)
+- [How storage works](/fundamentals/architecture/how-storage-works)
+- [Agent Storage Loop](/sdk/agent-storage-loop)

--- a/docs/sdk/codebase-memory.md
+++ b/docs/sdk/codebase-memory.md
@@ -1,0 +1,98 @@
+---
+title: Codebase Memory for Coding Assistants
+description: "Give an AI coding assistant persistent memory of a codebase with the Walrus Memory SDK: scope memory per repository with namespaces, store code context, and recall the relevant pieces at query time."
+keywords: [codebase memory, coding assistant, cursor, code context, namespace, remember, recall, rememberBulk, RAG, SDK]
+---
+
+AI coding assistants like Cursor feel like they "remember" a codebase because they retrieve relevant context at query time rather than holding an entire repository in the model's context window. You can build the same persistent, cross-session memory on Walrus Memory: store code and project context as memories, then recall the pieces that matter for each question. This guide shows the pattern with the TypeScript SDK.
+
+## How it fits together
+
+The loop has three parts:
+
+1. **Scope** memory to a repository with a namespace, so one assistant can hold many codebases without mixing them.
+2. **Store** chunks of code and project context as memories.
+3. **Recall** the most relevant chunks by semantic similarity whenever the assistant needs context, and pass them to the model.
+
+Set up the client first. In an editor extension or a backend service, initialize it headlessly from the environment, as described in [Headless SDK Setup](/sdk/headless-setup).
+
+## Scope memory per repository
+
+Give each repository its own namespace so recall never crosses codebases. Derive the namespace deterministically from the repository identity, so the same repo always maps to the same space:
+
+```ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+function repoNamespace(owner: string, name: string): string {
+  return `repo-${owner}-${name}`.toLowerCase();
+}
+
+const memwal = MemWal.create({
+  key: process.env.MEMWAL_PRIVATE_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+  serverUrl: "https://relayer.memory.walrus.xyz",
+  namespace: repoNamespace("acme", "billing-service"),
+});
+```
+
+## Store codebase context
+
+Break code and project knowledge into focused chunks, then write them in batches. Each chunk should be small and self-contained: a function with a short note on what it does, a module summary, an architectural decision, or a convention the team follows. Include the file path and symbol name in the text so recall can match on them.
+
+`rememberBulk` accepts up to 20 items per call, so chunk your input and send it in batches:
+
+```ts
+const chunks = [
+  { text: "src/auth/session.ts - createSession(userId): issues a signed session token, 30 min TTL. Uses jose for signing." },
+  { text: "src/billing/invoice.ts - Invoice totals are computed in cents as integers to avoid float drift." },
+  { text: "Convention: all API handlers validate input with zod schemas in src/schemas before touching the database." },
+];
+
+// Batches of 20 or fewer. Chunk larger inputs and call once per batch.
+const result = await memwal.rememberBulkAndWait(chunks);
+```
+
+For longer material such as a design document or a pull request description, `analyze` extracts discrete facts from the text and stores them as separate memories, which recall better than one large blob:
+
+```ts
+await memwal.analyzeAndWait(pullRequestDescription);
+```
+
+## Recall relevant context at query time
+
+When the assistant is about to answer, recall the most relevant memories for the current question and add them to the prompt. `recall` embeds the query, searches the repository's namespace, and returns the closest matches by cosine distance, where a lower distance means a closer match:
+
+```ts
+const recalled = await memwal.recall({
+  query: "How are session tokens issued and how long do they last?",
+  limit: 5,
+  // Drop weak matches so only genuinely relevant context reaches the model.
+  maxDistance: 0.5,
+});
+
+const context = recalled.results.map((m) => m.text).join("\n");
+// Prepend `context` to the model prompt.
+```
+
+Each result carries the matched `text`, its `distance`, and the `blob_id` that durably addresses the stored chunk. Tune `limit` and `maxDistance` to balance recall against prompt size.
+
+## Organizing without tags
+
+Walrus Memory scopes and groups memories by **namespace**. There is no separate tags parameter. When you need finer-grained organization than one namespace per repository, you have two options:
+
+- **Sub-namespaces:** encode the category into the namespace, for example `repo-acme-billing:tests` or `repo-acme-billing:api`, and pass the specific namespace on the `recall` call. This keeps categories in fully separate search spaces.
+- **Keywords in the text:** because recall is semantic, category words you include in a memory's text (for example, a leading `[tests]` or `[security]`) are searchable through the query itself.
+
+Choose sub-namespaces when categories should never be searched together, and keywords when you want one search to span them.
+
+## SDK compared with the Cursor MCP server
+
+This guide builds codebase memory yourself with the SDK, which is the right path when you are writing an assistant or an editor integration. If instead you want to give an existing tool like Cursor access to Walrus Memory without writing code, connect the Walrus Memory MCP server. See [Cursor](/mcp/cursor) for that setup. The two paths can coexist: build repository memory with the SDK, and expose it to an editor through MCP.
+
+## References
+
+- [Headless SDK Setup](/sdk/headless-setup)
+- [Walrus Memory client](/sdk/usage/memwal)
+- [Memory space](/fundamentals/concepts/memory-space)
+- [Multi-tenant cookbook](/sdk/cookbook-multi-tenant)
+- [Cursor MCP server](/mcp/cursor)

--- a/docs/sdk/codebase-memory.md
+++ b/docs/sdk/codebase-memory.md
@@ -85,7 +85,7 @@ Walrus Memory scopes and groups memories by **namespace**. There is no separate 
 
 Choose sub-namespaces when categories should never be searched together, and keywords when you want one search to span them.
 
-## SDK compared with the Cursor MCP server
+## When to use the SDK instead of the MCP server
 
 This guide builds codebase memory yourself with the SDK, which is the right path when you are writing an assistant or an editor integration. If instead you want to give an existing tool like Cursor access to Walrus Memory without writing code, connect the Walrus Memory MCP server. See [Cursor](/mcp/cursor) for that setup. The two paths can coexist: build repository memory with the SDK, and expose it to an editor through MCP.
 

--- a/docs/sdk/codebase-memory.md
+++ b/docs/sdk/codebase-memory.md
@@ -4,7 +4,7 @@ description: "Give an AI coding assistant persistent memory of a codebase with t
 keywords: [codebase memory, coding assistant, cursor, code context, namespace, remember, recall, rememberBulk, RAG, SDK]
 ---
 
-AI coding assistants like Cursor feel like they "remember" a codebase because they retrieve relevant context at query time rather than holding an entire repository in the model's context window. You can build the same persistent, cross-session memory on Walrus Memory: store code and project context as memories, then recall the pieces that matter for each question. This guide shows the pattern with the TypeScript SDK.
+AI coding assistants like Cursor appear to remember a codebase because they retrieve relevant context at query time rather than holding an entire repository in the model's context window. You can build the same persistent, cross-session memory on Walrus Memory with the TypeScript SDK: store code and project context as memories, then recall the pieces that matter for each question.
 
 ## How it fits together
 
@@ -80,14 +80,14 @@ Each result carries the matched `text`, its `distance`, and the `blob_id` that d
 
 Walrus Memory scopes and groups memories by **namespace**. There is no separate tags parameter. When you need finer-grained organization than one namespace per repository, you have two options:
 
-- **Sub-namespaces:** encode the category into the namespace, for example `repo-acme-billing:tests` or `repo-acme-billing:api`, and pass the specific namespace on the `recall` call. This keeps categories in fully separate search spaces.
-- **Keywords in the text:** because recall is semantic, category words you include in a memory's text (for example, a leading `[tests]` or `[security]`) are searchable through the query itself.
+- **Sub-namespaces:** Encode the category into the namespace, for example `repo-acme-billing:tests` or `repo-acme-billing:api`, and pass the specific namespace on the `recall` call. This keeps categories in fully separate search spaces.
+- **Keywords in the text:** Because recall is semantic, category words you include in a memory's text, for example a leading `[tests]` or `[security]`, are searchable through the query itself.
 
 Choose sub-namespaces when categories should never be searched together, and keywords when you want one search to span them.
 
 ## When to use the SDK instead of the MCP server
 
-This guide builds codebase memory yourself with the SDK, which is the right path when you are writing an assistant or an editor integration. If instead you want to give an existing tool like Cursor access to Walrus Memory without writing code, connect the Walrus Memory MCP server. See [Cursor](/mcp/cursor) for that setup. The two paths can coexist: build repository memory with the SDK, and expose it to an editor through MCP.
+Building codebase memory yourself with the SDK is the right path when you are writing an assistant or an editor integration. If instead you want to give an existing tool like Cursor access to Walrus Memory without writing code, connect the Walrus Memory MCP server. See [Cursor](/mcp/cursor) for that setup. The two paths can coexist: build repository memory with the SDK, and expose it to an editor through MCP.
 
 ## References
 

--- a/docs/sdk/headless-setup.md
+++ b/docs/sdk/headless-setup.md
@@ -4,7 +4,7 @@ description: "Initialize the Walrus Memory SDK in a server or agent runtime with
 keywords: [headless, server, agent runtime, setup, MemWal.create, environment variables, delegate key, accountId, MemWalManual, SDK]
 ---
 
-A server or agent runtime has no human to click through a wallet or paste a key at a prompt. This page shows how to initialize the Walrus Memory SDK entirely from configuration, so you can drop it into a backend service, a cron job, or an autonomous agent. For the full write-confirm-recall loop that builds on this setup, see [Agent Storage Loop](/sdk/agent-storage-loop).
+A server or agent runtime has no human to click through a wallet or paste a key at a prompt. The Walrus Memory SDK initializes entirely from configuration, so you can drop it into a backend service, a cron job, or an autonomous agent. For the full write-confirm-recall loop that builds on this setup, see [Agent Storage Loop](/sdk/agent-storage-loop).
 
 ## Generate credentials once
 
@@ -44,9 +44,9 @@ await memwal.health();
 `health()` is an unauthenticated liveness and version check. It confirms the relayer is reachable, but it does not validate your delegate key or account ID. A bad key or account ID surfaces on the first authenticated call, such as `remember` or `recall`. If you want to validate credentials at boot, make a cheap authenticated call, for example a `recall` with a trivial query, and handle its error.
 </Note>
 
-The `MemWal.create` config takes four fields:
+The `MemWal.create` config takes 4 fields:
 
-| Property | Type | Required | Description |
+| **Property** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `key` | `string` | Yes | Ed25519 delegate private key in hex |
 | `accountId` | `string` | Yes | `MemWalAccount` object ID on Sui |
@@ -63,7 +63,7 @@ Recall is scoped per **account plus namespace**. Never hardcode an account ID co
 
 ## When to use the manual client
 
-The default `MemWal` client lets the relayer handle embedding and Seal encryption on your behalf, which is the right choice for most runtimes. Use `MemWalManual` only when the runtime must hold its own keys and keep plaintext entirely client-side. With the manual client, the runtime embeds and Seal-encrypts locally, then the relayer uploads the resulting ciphertext to Walrus and stores the vector row, so the relayer never sees plaintext. It requires a few more fields, including a Sui key that authorizes SEAL:
+The default `MemWal` client lets the relayer handle embedding and Seal encryption on your behalf, which is the right choice for most runtimes. Use `MemWalManual` only when the runtime must hold its own keys and keep plaintext entirely client-side. With the manual client, the runtime embeds and Seal-encrypts locally, then the relayer uploads the resulting ciphertext to Walrus and stores the vector row, so the relayer never sees plaintext. It requires a few more fields, including a Sui key that authorizes Seal:
 
 ```ts
 import { MemWalManual } from "@mysten-incubation/memwal/manual";
@@ -73,7 +73,7 @@ const manual = MemWalManual.create({
   accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
   packageId: requireEnv("MEMWAL_PACKAGE_ID"),
   serverUrl: "https://relayer.memory.walrus.xyz",
-  // The Sui key authorizes SEAL encryption and decryption. The relayer still
+  // The Sui key authorizes Seal encryption and decryption. The relayer still
   // handles the Walrus upload, registration, search, and restore.
   suiPrivateKey: requireEnv("SUI_PRIVATE_KEY"),
   embeddingApiKey: requireEnv("OPENAI_API_KEY"),

--- a/docs/sdk/headless-setup.md
+++ b/docs/sdk/headless-setup.md
@@ -17,7 +17,7 @@ This is the only step that involves a browser. Your runtime never opens one.
 
 ## Initialize from the environment
 
-Load the credentials from environment variables and construct the client at startup. Call `health()` immediately so a bad key or an unreachable relayer fails at boot rather than on the first write:
+Load the credentials from environment variables and construct the client at startup. Call `health()` to confirm the relayer is reachable before your service starts serving traffic:
 
 ```ts service.ts
 import { MemWal } from "@mysten-incubation/memwal";
@@ -36,9 +36,13 @@ const memwal = MemWal.create({
   namespace: "service-memory",
 });
 
-// Fail fast at boot instead of on the first write mid-run.
+// Confirm the relayer is reachable at boot.
 await memwal.health();
 ```
+
+<Note>
+`health()` is an unauthenticated liveness and version check. It confirms the relayer is reachable, but it does not validate your delegate key or account ID. A bad key or account ID surfaces on the first authenticated call, such as `remember` or `recall`. If you want to validate credentials at boot, make a cheap authenticated call, for example a `recall` with a trivial query, and handle its error.
+</Note>
 
 The `MemWal.create` config takes four fields:
 
@@ -59,7 +63,7 @@ Recall is scoped per **account plus namespace**. Never hardcode an account ID co
 
 ## When to use the manual client
 
-The default `MemWal` client lets the relayer handle embedding and Seal encryption on your behalf, which is the right choice for most runtimes. Use `MemWalManual` only when the runtime must hold its own keys and keep plaintext entirely client-side. The manual client requires a few more fields, because it performs Seal encryption and signs Sui operations itself:
+The default `MemWal` client lets the relayer handle embedding and Seal encryption on your behalf, which is the right choice for most runtimes. Use `MemWalManual` only when the runtime must hold its own keys and keep plaintext entirely client-side. With the manual client, the runtime embeds and Seal-encrypts locally, then the relayer uploads the resulting ciphertext to Walrus and stores the vector row, so the relayer never sees plaintext. It requires a few more fields, including a Sui key that authorizes SEAL:
 
 ```ts
 import { MemWalManual } from "@mysten-incubation/memwal/manual";
@@ -69,7 +73,8 @@ const manual = MemWalManual.create({
   accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
   packageId: requireEnv("MEMWAL_PACKAGE_ID"),
   serverUrl: "https://relayer.memory.walrus.xyz",
-  // The runtime signs Seal and Walrus operations with its own Sui key.
+  // The Sui key authorizes SEAL encryption and decryption. The relayer still
+  // handles the Walrus upload, registration, search, and restore.
   suiPrivateKey: requireEnv("SUI_PRIVATE_KEY"),
   embeddingApiKey: requireEnv("OPENAI_API_KEY"),
   suiNetwork: "mainnet",

--- a/docs/sdk/headless-setup.md
+++ b/docs/sdk/headless-setup.md
@@ -1,0 +1,88 @@
+---
+title: Headless SDK Setup
+description: "Initialize the Walrus Memory SDK in a server or agent runtime with no interactive or browser steps, loading credentials from the environment."
+keywords: [headless, server, agent runtime, setup, MemWal.create, environment variables, delegate key, accountId, MemWalManual, SDK]
+---
+
+A server or agent runtime has no human to click through a wallet or paste a key at a prompt. This page shows how to initialize the Walrus Memory SDK entirely from configuration, so you can drop it into a backend service, a cron job, or an autonomous agent. For the full write-confirm-recall loop that builds on this setup, see [Agent Storage Loop](/sdk/agent-storage-loop).
+
+## Generate credentials once
+
+The SDK authenticates every request with an Ed25519 delegate key tied to a `MemWalAccount` object on Sui. Generate the account ID and delegate key once through the dashboard, then store them as secrets:
+
+- **Mainnet:** [memory.walrus.xyz](https://memory.walrus.xyz)
+- **Testnet:** [staging.memory.walrus.xyz](https://staging.memory.walrus.xyz)
+
+This is the only step that involves a browser. Your runtime never opens one.
+
+## Initialize from the environment
+
+Load the credentials from environment variables and construct the client at startup. Call `health()` immediately so a bad key or an unreachable relayer fails at boot rather than on the first write:
+
+```ts service.ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+const memwal = MemWal.create({
+  key: requireEnv("MEMWAL_PRIVATE_KEY"),
+  accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+  // Mainnet relayer. Use https://relayer-staging.memory.walrus.xyz for Testnet.
+  serverUrl: "https://relayer.memory.walrus.xyz",
+  namespace: "service-memory",
+});
+
+// Fail fast at boot instead of on the first write mid-run.
+await memwal.health();
+```
+
+The `MemWal.create` config takes four fields:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `key` | `string` | Yes | Ed25519 delegate private key in hex |
+| `accountId` | `string` | Yes | `MemWalAccount` object ID on Sui |
+| `serverUrl` | `string` | No | Relayer URL for your network. Pass it explicitly so the target network is unambiguous |
+| `namespace` | `string` | No | Default namespace, falls back to `"default"` |
+
+<Note>
+The SDK reads the delegate key from the `key` config field, not from any specific environment variable. The examples in these docs use both `MEMWAL_PRIVATE_KEY` and `MEMWAL_KEY` as the variable name for that value. Pick one name and use it consistently across your project.
+</Note>
+
+<Warning>
+Recall is scoped per **account plus namespace**. Never hardcode an account ID copied from docs or another project, and never share one delegate key across tenants that should not read each other's memories. Load every credential from the environment.
+</Warning>
+
+## When to use the manual client
+
+The default `MemWal` client lets the relayer handle embedding and Seal encryption on your behalf, which is the right choice for most runtimes. Use `MemWalManual` only when the runtime must hold its own keys and keep plaintext entirely client-side. The manual client requires a few more fields, because it performs Seal encryption and signs Sui operations itself:
+
+```ts
+import { MemWalManual } from "@mysten-incubation/memwal/manual";
+
+const manual = MemWalManual.create({
+  key: requireEnv("MEMWAL_PRIVATE_KEY"),
+  accountId: requireEnv("MEMWAL_ACCOUNT_ID"),
+  packageId: requireEnv("MEMWAL_PACKAGE_ID"),
+  serverUrl: "https://relayer.memory.walrus.xyz",
+  // The runtime signs Seal and Walrus operations with its own Sui key.
+  suiPrivateKey: requireEnv("SUI_PRIVATE_KEY"),
+  embeddingApiKey: requireEnv("OPENAI_API_KEY"),
+  suiNetwork: "mainnet",
+  namespace: "service-memory",
+});
+```
+
+For the complete client-managed flow, see [MemWalManual](/sdk/usage/memwal-manual).
+
+## References
+
+- [Agent Storage Loop](/sdk/agent-storage-loop)
+- [Walrus Memory client](/sdk/usage/memwal)
+- [Public relayer](/relayer/public-relayer)
+- [Environment Variables](/reference/environment-variables)
+- [API Reference](/sdk/api-reference)


### PR DESCRIPTION
## Description

Adds three net-new Walrus Memory developer guides from the "prompt optimizations" backlog, each grounded in the current `@mysten-incubation/memwal` SDK surface (I audited the SDK source and existing docs before writing, so no APIs are invented):

- **`sdk/headless-setup`** — non-interactive SDK initialization for a server or agent runtime: `MemWal.create` from environment variables, a `health()` boot check to fail fast, the config-field table, and when to reach for `MemWalManual` (BEDU-604).
- **`fundamentals/concepts/verifiable-memory`** — the flagship "persistent, verifiable memory" narrative: why memory on Walrus is durable and verifiable through content-addressed blob IDs, onchain-enforced ownership, and decentralized durability, plus how to inspect each property yourself. Cross-links the mechanics rather than duplicating them (BEDU-867).
- **`sdk/codebase-memory`** — a Cursor-style worked guide: give a coding assistant persistent codebase memory with per-repo namespaces, `rememberBulk`, and `recall` (BEDU-868).

All three are registered in `docs.json` (Concepts group, and the TypeScript SDK group).

**Already covered, no new page (verified during the audit):**
- BEDU-603 (content-addressing → versioning) is thoroughly covered by `sdk/versioned-datasets`.
- BEDU-611 (full agent storage loop on Testnet) is covered by `sdk/agent-storage-loop`.

## Open questions and doc issues found

While grounding these guides in the SDK, I found a few things worth confirming. I wrote around all of them rather than guessing:

- **No `verify()` method.** `agent-storage-loop` notes a reconstruct-from-onchain `verify()` is on the roadmap. The verifiable-memory guide frames "verifiable" as content-addressing + onchain inspection + durability, not an SDK call. Correct?
- **No `tags` concept in the SDK** — only `namespace`. The codebase-memory guide says so explicitly and shows sub-namespaces or in-text keywords instead. Confirm there is no tags parameter planned that I should mention.
- **`ask()` is Python-only.** `fundamentals/architecture/core-components` and `getting-started/what-is-memwal` list `ask` for the TypeScript SDK, but it does not exist in the TS SDK source. I avoided referencing it. This looks like a pre-existing doc bug worth a separate fix.
- **Delegate-key env var name is inconsistent** across existing docs (`MEMWAL_KEY` vs `MEMWAL_PRIVATE_KEY`; the SDK reads the `key` config field). The new setup page uses `MEMWAL_PRIVATE_KEY` and adds a note that the name is a convention. Which should be canonical?

## Test plan

- Grounded every API name, config field, and endpoint in the SDK source (`packages/sdk/src`) and existing docs; no invented methods.
- Validated `docs.json` parses and every internal link in the new pages resolves to an existing page.
- Applied the docs style conventions (sentence-case headings, no em dashes or Latin abbreviations, `## References`, relative links, frontmatter `title`/`description`).
- Did not run a local Mintlify build (toolchain not set up here); please let docs CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oS4PdhkXAzbfhJx2ZhRvh

---
_Generated by [Claude Code](https://claude.ai/code/session_017oS4PdhkXAzbfhJx2ZhRvh)_