### PR TITLE
docs: restore first person in frontmatter search questions

### DIFF
--- a/docs/examples/example-apps.md
+++ b/docs/examples/example-apps.md
@@ -26,9 +26,9 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - "What example apps are included in the Walrus Memory repo?"
-  - "How does the MemWal Chatbot app integrate AI middleware with memory?"
-  - "How do I run the MemWal demo apps locally?"
+  - What example apps are included in the Walrus Memory repo?
+  - How does the MemWal Chatbot app integrate AI middleware with memory?
+  - How do I run the MemWal demo apps locally?
 answer: >-
   The MemWal repo includes four demo apps: Playground (full SDK playground), Chatbot
   (AI middleware with persistent memory), Noter (note-to-memory extraction using analyze),

--- a/docs/examples/example-apps.md
+++ b/docs/examples/example-apps.md
@@ -28,7 +28,7 @@ goal:
 questions:
   - "What example apps are included in the Walrus Memory repo?"
   - "How does the MemWal Chatbot app integrate AI middleware with memory?"
-  - "How do you run the MemWal demo apps locally?"
+  - "How do I run the MemWal demo apps locally?"
 answer: >-
   The MemWal repo includes four demo apps: Playground (full SDK playground), Chatbot
   (AI middleware with persistent memory), Noter (note-to-memory extraction using analyze),

--- a/docs/fundamentals/architecture/data-flow-security-model.md
+++ b/docs/fundamentals/architecture/data-flow-security-model.md
@@ -28,7 +28,7 @@ goal:
       label: Needs answer summary for AI citation
 questions:
   - How does Walrus Memory handle security and trust?
-  - What does the MemWal relayer see and how can you reduce that trust?
+  - What does the MemWal relayer see and how can I reduce that trust?
   - How does authentication work in Walrus Memory?
 answer: >-
   Walrus Memory splits security between onchain enforcement (ownership, delegate authorization,

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -25,9 +25,9 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - How do you get started with Walrus Memory?
-  - How do you install the MemWal TypeScript SDK?
-  - How do you store and recall your first memory with MemWal?
+  - How do I get started with Walrus Memory?
+  - How do I install the MemWal TypeScript SDK?
+  - How do I store and recall my first memory with MemWal?
 answer: >-
   To get started with Walrus Memory, install the @mysten-incubation/memwal TypeScript SDK,
   generate an account ID and delegate key from the Walrus Memory Playground, choose a relayer


### PR DESCRIPTION
## Description

Follow-up to the review guidance on #490: the frontmatter `questions:` entries mimic user search queries, where "How do I..." is the house style — the second-person rule applies to page prose only. A style pass over-corrected five entries to second person before #488 and #498 merged; this restores them:

- `data-flow-security-model.md`: "how can I reduce that trust?"
- `quick-start.md`: three "How do I..." entries (including "my first memory")
- `example-apps.md`: "How do I run the MemWal demo apps locally?"

Frontmatter only; no rendered page prose changes. The automated style gate has been updated to exempt `questions:` blocks from first-person checks, so this class of over-correction stops recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_