### PR TITLE
Fix: Bound namespace on the write path [WALM-293]

### DIFF
--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1695,6 +1695,17 @@ impl WalletJobError {
         if has_lock_anchor || corroborated_lock {
             return WalletJobError::ObjectLockedUntilEpoch(msg.to_string());
         }
+        // Postgres B-tree index-row-size failure (e.g. an oversized namespace
+        // producing an over-limit `(owner, namespace)` entry). This is
+        // deterministic: the same input fails the insert on every attempt, so
+        // retrying only re-runs the upload and never indexes. Classify Permanent
+        // so it aborts after one attempt instead of consuming the retry budget.
+        // Anchored before the generic MoveAbort catch (a Postgres error is not a
+        // MoveAbort, but keeping specific anchors above the catch matches the
+        // convention used by the object-lock arm above).
+        if lower.contains("index row requires") && lower.contains("maximum size") {
+            return WalletJobError::Permanent(msg.to_string());
+        }
         if lower.contains("moveabort") || lower.contains("move abort") {
             return WalletJobError::Permanent(msg.to_string());
         }
@@ -2621,6 +2632,21 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
                 msg
             );
         }
+    }
+
+    #[test]
+    fn classify_index_row_size_error_as_permanent() {
+        // A Postgres B-tree index-row-size failure (e.g. an oversized namespace)
+        // is deterministic: retrying only re-runs the paid upload and never
+        // indexes. It must classify Permanent (abort after one attempt), not the
+        // default Transient. The string is the real error from the #493 repro.
+        let msg = "Internal Error: Failed to insert plaintext vector: error \
+                   returned from database: index row requires 21816 bytes, \
+                   maximum size is 8191";
+        assert!(
+            WalletJobError::classify_sidecar_error(msg).is_permanent(),
+            "index-row-size error must be Permanent, not Transient"
+        );
     }
 
     #[test]

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -434,6 +434,12 @@ pub async fn restore(
     if body.namespace.is_empty() {
         return Err(AppError::BadRequest("namespace cannot be empty".into()));
     }
+    // Restore rebuilds the `(owner, namespace)` index from on-chain blobs and
+    // re-inserts each via `insert_vector` below. Reject an oversized namespace
+    // before that download/decrypt/re-embed work — otherwise the same
+    // index-row-size insert failure this guards against would strike here too,
+    // and (unlike remember/analyze) this path is not behind the upload pause.
+    super::validate_namespace(&body.namespace, state.config.max_namespace_bytes)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -79,6 +79,8 @@ pub async fn analyze(
             MAX_ANALYZE_TEXT_BYTES
         )));
     }
+    // Reject an oversized namespace before extraction / any index write.
+    super::validate_namespace(&body.namespace, state.config.max_namespace_bytes)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -53,6 +53,31 @@ pub async fn uploads_paused() -> (axum::http::StatusCode, axum::Json<serde_json:
     )
 }
 
+/// Reject a namespace whose byte length exceeds `max_bytes` before any paid
+/// work (embed / encrypt / upload) runs.
+///
+/// `vector_entries` carries a composite B-tree index on `(owner, namespace)`;
+/// a namespace past the index-entry byte limit makes the final insert fail
+/// *after* the memory was already embedded, encrypted, and uploaded — so the
+/// request must be rejected up front, at every write handler, not discovered
+/// downstream. The bound is a byte count (`len()` on a `str` is UTF-8 bytes),
+/// matching the on-disk index-row constraint. `max_bytes` is caller-supplied
+/// (`config.max_namespace_bytes`) so the cap has a single source of truth.
+///
+/// Length only: the namespace reaches storage exclusively as a bound SQL
+/// parameter, so there is no injection surface a character check would close.
+/// An empty namespace has length 0 and passes (handlers treat empty as the
+/// default namespace).
+pub fn validate_namespace(namespace: &str, max_bytes: usize) -> Result<(), AppError> {
+    if namespace.len() > max_bytes {
+        return Err(AppError::BadRequest(format!(
+            "namespace exceeds maximum length of {} bytes",
+            max_bytes
+        )));
+    }
+    Ok(())
+}
+
 // ============================================================
 // Wallet-job enqueue (used by remember + analyze)
 // ============================================================
@@ -217,7 +242,7 @@ pub(super) fn zip_search_hit_fields_onto_hydrated(
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_bounded_results, truncate_str};
+    use super::{collect_bounded_results, truncate_str, validate_namespace};
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -278,5 +303,47 @@ mod tests {
         let s = "🦀hello";
         let t = truncate_str(s, 2);
         assert_eq!(t, ""); // can't include partial emoji
+    }
+
+    #[test]
+    fn validate_namespace_accepts_at_and_below_cap() {
+        // Exactly the cap passes (boundary); below passes; empty passes.
+        assert!(validate_namespace("", 512).is_ok());
+        assert!(validate_namespace("default", 512).is_ok());
+        assert!(validate_namespace(&"a".repeat(512), 512).is_ok());
+    }
+
+    #[test]
+    fn validate_namespace_rejects_over_cap() {
+        // cap+1 fails (off-by-one guard); a pathological namespace fails hard.
+        assert!(validate_namespace(&"a".repeat(513), 512).is_err());
+        assert!(validate_namespace(&"x".repeat(2 * 1024 * 1024), 512).is_err());
+    }
+
+    #[test]
+    fn validate_namespace_allows_real_data_characters() {
+        // Real production namespaces use `:` (timestamps), `@`, space, `#`.
+        // There is no charset check, so these must all pass under the cap.
+        for ns in [
+            "2026-07-30T12:34:56Z",
+            "user@example.com",
+            "some namespace with spaces",
+            "tag#1",
+        ] {
+            assert!(
+                validate_namespace(ns, 512).is_ok(),
+                "expected ok for real-data namespace: {ns}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_namespace_counts_bytes_not_chars() {
+        // The cap is a byte bound (matches the on-disk index-row limit), so a
+        // multi-byte namespace is measured in UTF-8 bytes: "é" is 2 bytes.
+        let ns = "é".repeat(300); // 600 bytes, 300 chars
+        assert_eq!(ns.len(), 600);
+        assert!(validate_namespace(&ns, 512).is_err()); // 600 > 512
+        assert!(validate_namespace(&ns, 700).is_ok()); // 600 <= 700
     }
 }

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -628,6 +628,10 @@ pub async fn remember(
             MAX_REMEMBER_TEXT_BYTES
         )));
     }
+    // Reject an oversized namespace before any paid work — an over-limit
+    // `(owner, namespace)` index entry would otherwise fail the insert only
+    // after embed/encrypt/upload have already run.
+    super::validate_namespace(&body.namespace, state.config.max_namespace_bytes)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -749,6 +753,13 @@ pub async fn remember_bulk(
                 i, MAX_REMEMBER_TEXT_BYTES
             )));
         }
+        super::validate_namespace(&item.namespace, state.config.max_namespace_bytes)
+            .map_err(|_| {
+                AppError::BadRequest(format!(
+                    "items[{}].namespace exceeds maximum length of {} bytes",
+                    i, state.config.max_namespace_bytes
+                ))
+            })?;
     }
 
     let owner = &auth.owner;
@@ -894,6 +905,8 @@ pub async fn remember_manual(
     if body.vector.is_empty() {
         return Err(AppError::BadRequest("vector cannot be empty".into()));
     }
+    // Reject an oversized namespace before the Walrus upload + index write.
+    super::validate_namespace(&body.namespace, state.config.max_namespace_bytes)?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -1065,6 +1078,7 @@ mod tests {
             walrus_publisher_url: "http://localhost:9001".to_string(),
             walrus_aggregator_url: "http://localhost:9002".to_string(),
             walrus_storage_epochs: 3,
+            max_namespace_bytes: crate::types::DEFAULT_MAX_NAMESPACE_BYTES,
             walrus_aggregator_urls: vec!["http://localhost:9002".to_string()],
             walrus_skip_consistency_check: false,
             walrus_aggregator_race_after_ms: crate::types::DEFAULT_WALRUS_AGGREGATOR_RACE_AFTER_MS,

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -64,6 +64,22 @@ pub(crate) fn configured_walrus_storage_epochs(network: &str) -> u32 {
 /// Delay before racing a cold Walrus read against the next configured aggregator.
 pub const DEFAULT_WALRUS_AGGREGATOR_RACE_AFTER_MS: u64 = 150;
 
+/// Default cap on request `namespace` byte length (env `MAX_NAMESPACE_BYTES`).
+/// ~3x headroom over the largest namespace seen in real data and well under the
+/// composite-index entry limit; rejects no legitimate namespace while stopping
+/// the pathological oversized input that fails the insert after paid work.
+pub const DEFAULT_MAX_NAMESPACE_BYTES: usize = 512;
+
+/// Hard ceiling the `MAX_NAMESPACE_BYTES` env override is clamped to. The whole
+/// point of the cap is that an oversized namespace can never reach the
+/// `(owner, namespace)` B-tree insert; an operator who set the override absurdly
+/// high would silently defeat that, leaving only the retry-classifier backstop.
+/// So the configured value is clamped to this ceiling, which is itself kept well
+/// under the Postgres index-entry limit (~8KB) with room for the `owner` half of
+/// the composite key. Raising the default within [default, ceiling] is fine;
+/// exceeding the ceiling is not a supported configuration.
+pub const MAX_NAMESPACE_BYTES_CEILING: usize = 2048;
+
 pub const MAX_SECURITY_DELETE_EXECUTE_IN_FLIGHT: usize = 64;
 
 /// Process-local admission gate for deletion transactions that all mutate
@@ -251,6 +267,15 @@ pub struct Config {
     pub walrus_aggregator_url: String,
     /// Number of Walrus storage epochs requested for new uploads.
     pub walrus_storage_epochs: u32,
+    /// Maximum byte length accepted for a request `namespace` on the write path.
+    /// A namespace past this is rejected 400 before any embed/encrypt/upload,
+    /// so an oversized `(owner, namespace)` index entry can never fail the
+    /// insert after paid work has run. Env `MAX_NAMESPACE_BYTES`
+    /// (default `DEFAULT_MAX_NAMESPACE_BYTES`), clamped to
+    /// `MAX_NAMESPACE_BYTES_CEILING` so the override can't disable the cap.
+    /// Well under the B-tree index-entry limit; the largest real namespace
+    /// observed is far smaller.
+    pub max_namespace_bytes: usize,
     /// Ordered aggregator candidates used for cold Walrus reads. The primary
     /// `walrus_aggregator_url` is always first; `WALRUS_AGGREGATOR_URLS`
     /// appends additional low-latency/proxy endpoints for tail-race reads.
@@ -360,6 +385,10 @@ impl Config {
             walrus_publisher_url,
             walrus_aggregator_url,
             walrus_storage_epochs: configured_walrus_storage_epochs(&network),
+            // Clamp the override to the ceiling so the cap can't be
+            // misconfigured into a no-op (see MAX_NAMESPACE_BYTES_CEILING).
+            max_namespace_bytes: env_number("MAX_NAMESPACE_BYTES", DEFAULT_MAX_NAMESPACE_BYTES)
+                .min(MAX_NAMESPACE_BYTES_CEILING),
             walrus_aggregator_urls,
             walrus_skip_consistency_check: env_bool("WALRUS_SKIP_CONSISTENCY_CHECK"),
             walrus_aggregator_race_after_ms: std::env::var("WALRUS_AGGREGATOR_RACE_AFTER_MS")
@@ -1483,6 +1512,7 @@ mod tests {
             walrus_publisher_url: "https://publisher.example".into(),
             walrus_aggregator_url: "https://aggregator.example".into(),
             walrus_storage_epochs: 3,
+            max_namespace_bytes: DEFAULT_MAX_NAMESPACE_BYTES,
             walrus_aggregator_urls: vec!["https://aggregator.example".into()],
             walrus_skip_consistency_check: false,
             walrus_aggregator_race_after_ms: 150,


### PR DESCRIPTION

## Summary

### Why

`namespace` on the write path is a caller-controlled string with no length validation. `vector_entries` carries a composite B-tree index on `(owner, namespace)`, and a Postgres B-tree index entry is capped at a fraction of the page size (~8 KB on the deployment builds). A namespace long enough to exceed that limit makes the final `INSERT INTO vector_entries` fail — **after** the memory has already been embedded, SEAL-encrypted, and uploaded to Walrus.

That deterministic DB error reaches `classify_sidecar_error`, which had no branch for it and fell through to the default `Transient` arm. `Transient` means Apalis retries the job up to `MAX_ATTEMPTS = 5`, and each retry re-runs the upload step — so a single oversized-namespace request drives up to 5 real uploads, none of which ever index (the same namespace fails the insert every time). The owner loses the write; the operator absorbs the repeated upload work; and there is no cap on how many distinct oversized namespaces one caller can create. Reported in #493.

### What

- A shared `validate_namespace(namespace, max_bytes)` helper that rejects an oversized namespace with `400` **before any embed/encrypt/upload runs**, wired into every write path that indexes a namespace: `remember`, `remember_manual`, `remember_bulk` (per item), `analyze`, and `restore`.
- A new configuration value, `MAX_NAMESPACE_BYTES` (default `512`), clamped to a fixed server-side ceiling so the override cannot be set high enough to defeat the cap.
- A new arm in `classify_sidecar_error` that recognizes the Postgres index-row-size error and classifies it `Permanent` (abort, no retry) instead of `Transient`.

### Solution

Two small, independent, additive changes; byte-identical behavior for any valid (in-range) input.

- **Length validation at the request boundary.** The check sits at the top of each handler, beside the existing `text` length checks, before any paid work — so a pathological request is a cheap `400`, not a post-upload failure. A single shared helper (one source of truth for the cap) keeps every write path consistent rather than patching one handler and leaving the others open. `restore` is included because it rebuilds the index from on-chain blobs via `insert_vector` and is a live route, so it is a genuine write path for this failure.
- **Length only — no character validation.** `namespace` reaches storage exclusively as a bound SQL parameter, so there is no injection surface a character check would close. Keeping the helper length-only avoids rejecting legitimate namespaces (which routinely contain `:`, `@`, `#`, spaces) and keeps the change minimal.
- **Byte cap under the index limit.** The cap is a byte length (matching the on-disk index-row constraint) set well under the ~8 KB B-tree entry limit, leaving generous headroom even accounting for the `owner` half of the composite key. The ceiling clamp means an env misconfiguration can't silently turn the cap into a no-op.
- **Deterministic-failure classification (defense in depth).** With the length check in place the index-size insert failure should never occur, but classifying it `Permanent` guarantees that if it ever does (e.g. a future code path, or a bypass), it aborts after one attempt instead of consuming the full retry budget and re-uploading five times.
- **No privacy-floor interaction.** `namespace` is request metadata, not encrypted-fact content; no schema change, no migration, no new index, no on-chain surface.
- **Routing is unchanged.** The write handlers remain behind the existing upload-pause response, so this validation is inert until uploads resume, then protects the write path immediately.

## Types of Changes

- [ ] Breaking change (existing functionality would change)
- [ ] New feature (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] Performance optimization
- [ ] Refactor (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Test
- [x] Security / permission-scope change

## Benchmark impact

- [x] No benchmark-affecting change (write/infra only)

The change only rejects pathological input before paid work and reclassifies a deterministic failure; it does not touch the recall, answer, or extraction paths.

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] `cargo test` / harness tests pass

`cargo test --bin memwal-server` → **390 passed, 0 failed, 29 ignored** (the ignored are the pre-existing live-DB/live-network tests). New tests:
- `validate_namespace` — boundary at the cap, over-cap rejection, byte-not-character counting (multi-byte namespace), and a no-regression case confirming real-world characters (`:`, `@`, `#`, space) still pass.
- `classify_sidecar_error` — the real index-row-size error string classifies `Permanent`, not `Transient`.

## Checklist

- [x] Follows the project's commit + code conventions
- [x] No ticket IDs / competitor names / local-doc paths in code comments
- [ ] Docs updated if needed
- [x] Respects the privacy floor (no server-readable plaintext index)
- [x] All new and existing tests pass

## Related

- Closes #493
- Linear: WALM-293

## Additional Notes

- **Length only by design.** The report floated "probably character set" validation; it is deliberately out of scope because storage is parameterized (no injection surface) and a control-character blacklist only adds minor log-hygiene, unrelated to this bug.
- **Known residuals, deferred as separate follow-ups:** (1) the classifier anchor is an English-substring match on the Postgres error text — the pre-existing pattern for every arm in that function, but a non-English `lc_messages` deployment would miss it; (2) reworking the default-`Transient` arm so *any* unrecognized error gets bounded-retries-then-`Permanent`, which the report also raised — broader hardening that touches unrelated error paths and warrants its own change.
- **Deployment ordering.** Because routing is unchanged, this ships ready-but-inert while uploads are paused and begins protecting the write path the moment the pause is lifted — no window in which the write path is live but unvalidated.
