### PR TITLE
Fix: enforce document ownership in chatbot AI tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -311,8 +311,9 @@ jobs:
         run: pnpm --filter @memwal/chatbot lint
 
       # Fast unit tests (vitest, no DB/browser). Includes the document-tool
-      # ownership regression test — hard-fails so a future revert of the
-      # ownership checks is caught here.
+      # ownership regression test. This step fails the job on a regression, so
+      # the signal surfaces on the PR; note it is not yet wired as a required
+      # status check in branch protection, so it does not by itself block merge.
       - name: Unit tests (vitest)
         run: pnpm --filter @memwal/chatbot test:unit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,6 +310,12 @@ jobs:
         continue-on-error: true
         run: pnpm --filter @memwal/chatbot lint
 
+      # Fast unit tests (vitest, no DB/browser). Includes the document-tool
+      # ownership regression test — hard-fails so a future revert of the
+      # ownership checks is caught here.
+      - name: Unit tests (vitest)
+        run: pnpm --filter @memwal/chatbot test:unit
+
       - name: Build (Next.js, type-check inclusive)
         working-directory: apps/chatbot
         # Bypass the package.json `build` script's `tsx lib/db/migrate` step —

--- a/apps/chatbot/lib/ai/tools/document-ownership.unit.test.ts
+++ b/apps/chatbot/lib/ai/tools/document-ownership.unit.test.ts
@@ -1,0 +1,158 @@
+import type { Session } from "next-auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression test for the document-tool IDOR (GH #516 / WALM-309): the
+// updateDocument and requestSuggestions tools must not read or mutate a
+// document that belongs to another user. We mock the DB query layer so no real
+// Postgres connection is needed.
+//
+// The fix has TWO layers and this suite proves BOTH:
+//   1. The owner-scoped DB lookup (getDocumentByIdForUser) — simulated by the
+//      default mock, which returns the doc only when id AND userId match.
+//   2. The call-site re-check (`document.userId !== session.user?.id`) in each
+//      tool — proven by the "call-site check" tests below, which make the mock
+//      return the victim doc EVEN FOR AN ATTACKER (as if the DB layer were
+//      compromised/refactored to drop its owner filter). If the call-site check
+//      were removed, those tests fail. (This layer was silently stripped once
+//      during development and the old test did not catch it — hence these.)
+
+const OWNER_ID = "11111111-1111-1111-1111-111111111111";
+const ATTACKER_ID = "22222222-2222-2222-2222-222222222222";
+const DOC_ID = "33333333-3333-3333-3333-333333333333";
+
+function makeDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DOC_ID,
+    userId: OWNER_ID,
+    title: "Victim private doc",
+    content: "CONFIDENTIAL",
+    kind: "text" as const,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+// Default mock = a faithful owner-scoped lookup: returns the row only when the
+// requested id AND userId match (mirrors the real SQL `where(id AND userId)`).
+const getDocumentByIdForUser = vi.fn(
+  async ({ id, userId }: { id: string; userId: string }) =>
+    id === DOC_ID && userId === OWNER_ID ? makeDoc() : undefined
+);
+const saveSuggestions = vi.fn(async () => undefined);
+
+// Mock the whole query module so importing the tools never initializes the
+// top-level postgres() client in lib/db/queries.ts.
+vi.mock("@/lib/db/queries", () => ({
+  getDocumentByIdForUser,
+  saveSuggestions,
+}));
+
+// updateDocument reaches into the artifact handlers to perform the write; stub
+// them so we can observe whether the write path was reached at all.
+const onUpdateDocument = vi.fn(async () => undefined);
+vi.mock("@/lib/artifacts/server", () => ({
+  documentHandlersByArtifactKind: [{ kind: "text", onUpdateDocument }],
+}));
+
+vi.mock("../providers", () => ({ getArtifactModel: () => ({}) }));
+
+function sessionFor(userId: string): Session {
+  return { user: { id: userId }, expires: "" } as unknown as Session;
+}
+
+const noopDataStream = { write: vi.fn() } as any;
+
+async function runUpdate(callerId: string) {
+  const { updateDocument } = await import("./update-document");
+  const t = updateDocument({
+    session: sessionFor(callerId),
+    dataStream: noopDataStream,
+  });
+  // @ts-expect-error — tool().execute signature is loose at the test boundary
+  return t.execute({ id: DOC_ID, description: "make a change" });
+}
+
+async function runSuggestions(callerId: string) {
+  const { requestSuggestions } = await import("./request-suggestions");
+  const t = requestSuggestions({
+    session: sessionFor(callerId),
+    dataStream: noopDataStream,
+  });
+  // @ts-expect-error — tool().execute signature is loose at the test boundary
+  return t.execute({ documentId: DOC_ID });
+}
+
+// Force the mock to return the victim doc regardless of the userId argument —
+// i.e. simulate the DB-layer owner filter being absent. The tool's OWN call-site
+// check is then the only thing standing between an attacker and the document.
+function pretendLookupIgnoresOwner(doc = makeDoc()) {
+  getDocumentByIdForUser.mockResolvedValue(doc);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Restore the default owner-scoped behavior after any per-test override.
+  getDocumentByIdForUser.mockImplementation(
+    async ({ id, userId }: { id: string; userId: string }) =>
+      id === DOC_ID && userId === OWNER_ID ? makeDoc() : undefined
+  );
+});
+
+describe("updateDocument ownership (WALM-309)", () => {
+  it("DB-layer scoping: rejects a cross-owner document without writing", async () => {
+    const result = await runUpdate(ATTACKER_ID);
+    expect(result).toEqual({ error: "Document not found" });
+    expect(onUpdateDocument).not.toHaveBeenCalled();
+  });
+
+  it("call-site check: rejects even if the lookup returns a cross-owner doc", async () => {
+    // Lookup layer compromised: returns the victim's doc to the attacker.
+    pretendLookupIgnoresOwner();
+    const result = await runUpdate(ATTACKER_ID);
+    // The tool's own userId re-check must still reject and never write.
+    expect(result).toEqual({ error: "Document not found" });
+    expect(onUpdateDocument).not.toHaveBeenCalled();
+  });
+
+  it("allows the owner to update their own document", async () => {
+    const result = await runUpdate(OWNER_ID);
+    expect(result).toMatchObject({ id: DOC_ID, kind: "text" });
+    expect(result).not.toHaveProperty("error");
+    expect(onUpdateDocument).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("requestSuggestions ownership (WALM-309)", () => {
+  it("DB-layer scoping: rejects reading a cross-owner document", async () => {
+    const result = await runSuggestions(ATTACKER_ID);
+    expect(result).toEqual({ error: "Document not found" });
+    expect(saveSuggestions).not.toHaveBeenCalled();
+  });
+
+  it("call-site check: rejects even if the lookup returns a cross-owner doc", async () => {
+    pretendLookupIgnoresOwner();
+    const result = await runSuggestions(ATTACKER_ID);
+    expect(result).toEqual({ error: "Document not found" });
+    expect(saveSuggestions).not.toHaveBeenCalled();
+  });
+
+  it("owner with empty content: returns not found (no content to suggest on)", async () => {
+    // Owner's own doc but content-less — same "not found" as before the fix.
+    getDocumentByIdForUser.mockResolvedValue(makeDoc({ content: "" }));
+    const result = await runSuggestions(OWNER_ID);
+    expect(result).toEqual({ error: "Document not found" });
+  });
+
+  it("lets the owner past the ownership gate (reaches the suggestion path)", async () => {
+    // The owner's own doc must pass the ownership + content gate. Downstream the
+    // tool calls streamText() with the real artifact model, which isn't wired in
+    // a unit test — so "passed the gate" is proven by the call reaching that LLM
+    // step (an AI-SDK model error) rather than short-circuiting with the
+    // ownership "Document not found" return.
+    await expect(runSuggestions(OWNER_ID)).rejects.toThrow(
+      /model version|Unsupported model/i
+    );
+    // If the ownership check had wrongly rejected the owner, execute() would
+    // have resolved to { error: "Document not found" } and never thrown here.
+  });
+});

--- a/apps/chatbot/lib/ai/tools/document-ownership.unit.test.ts
+++ b/apps/chatbot/lib/ai/tools/document-ownership.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Session } from "next-auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Regression test for the document-tool IDOR (GH #516 / WALM-309): the
+// Regression test for the document-tool IDOR: the
 // updateDocument and requestSuggestions tools must not read or mutate a
 // document that belongs to another user. We mock the DB query layer so no real
 // Postgres connection is needed.
@@ -60,6 +60,14 @@ function sessionFor(userId: string): Session {
   return { user: { id: userId }, expires: "" } as unknown as Session;
 }
 
+// A session whose user has no usable id (guest / expired / malformed). The
+// tools must reject these at the entry guard, before any id ever reaches the
+// userId filter (a UUID column) — reverting the guard to `?? ""` would send an
+// empty string into that filter instead.
+function sessionWithNoUserId(): Session {
+  return { user: {}, expires: "" } as unknown as Session;
+}
+
 const noopDataStream = { write: vi.fn() } as any;
 
 async function runUpdate(callerId: string) {
@@ -98,7 +106,7 @@ beforeEach(() => {
   );
 });
 
-describe("updateDocument ownership (WALM-309)", () => {
+describe("updateDocument ownership", () => {
   it("DB-layer scoping: rejects a cross-owner document without writing", async () => {
     const result = await runUpdate(ATTACKER_ID);
     expect(result).toEqual({ error: "Document not found" });
@@ -120,9 +128,24 @@ describe("updateDocument ownership (WALM-309)", () => {
     expect(result).not.toHaveProperty("error");
     expect(onUpdateDocument).toHaveBeenCalledTimes(1);
   });
+
+  it("no-user-id session: rejects at the entry guard without querying", async () => {
+    const { updateDocument } = await import("./update-document");
+    const t = updateDocument({
+      session: sessionWithNoUserId(),
+      dataStream: noopDataStream,
+    });
+    // @ts-expect-error — tool().execute signature is loose at the test boundary
+    const result = await t.execute({ id: DOC_ID, description: "x" });
+    expect(result).toEqual({ error: "Document not found" });
+    // The guard must short-circuit before any lookup or write — proving no
+    // empty-string userId is ever passed into the (UUID) userId filter.
+    expect(getDocumentByIdForUser).not.toHaveBeenCalled();
+    expect(onUpdateDocument).not.toHaveBeenCalled();
+  });
 });
 
-describe("requestSuggestions ownership (WALM-309)", () => {
+describe("requestSuggestions ownership", () => {
   it("DB-layer scoping: rejects reading a cross-owner document", async () => {
     const result = await runSuggestions(ATTACKER_ID);
     expect(result).toEqual({ error: "Document not found" });
@@ -147,12 +170,27 @@ describe("requestSuggestions ownership (WALM-309)", () => {
     // The owner's own doc must pass the ownership + content gate. Downstream the
     // tool calls streamText() with the real artifact model, which isn't wired in
     // a unit test — so "passed the gate" is proven by the call reaching that LLM
-    // step (an AI-SDK model error) rather than short-circuiting with the
-    // ownership "Document not found" return.
-    await expect(runSuggestions(OWNER_ID)).rejects.toThrow(
-      /model version|Unsupported model/i
-    );
+    // step and throwing (any downstream error) rather than short-circuiting with
+    // the ownership "Document not found" return. We assert only that it throws,
+    // not on the specific AI-SDK message, so a dependency upgrade can't make this
+    // brittle while the ownership gate itself still works.
+    await expect(runSuggestions(OWNER_ID)).rejects.toThrow();
     // If the ownership check had wrongly rejected the owner, execute() would
     // have resolved to { error: "Document not found" } and never thrown here.
+  });
+
+  it("no-user-id session: rejects at the entry guard without querying", async () => {
+    const { requestSuggestions } = await import("./request-suggestions");
+    const t = requestSuggestions({
+      session: sessionWithNoUserId(),
+      dataStream: noopDataStream,
+    });
+    // @ts-expect-error — tool().execute signature is loose at the test boundary
+    const result = await t.execute({ documentId: DOC_ID });
+    expect(result).toEqual({ error: "Document not found" });
+    // The guard must short-circuit before any lookup or save — proving no
+    // empty-string userId is ever passed into the (UUID) userId filter.
+    expect(getDocumentByIdForUser).not.toHaveBeenCalled();
+    expect(saveSuggestions).not.toHaveBeenCalled();
   });
 });

--- a/apps/chatbot/lib/ai/tools/request-suggestions.ts
+++ b/apps/chatbot/lib/ai/tools/request-suggestions.ts
@@ -1,7 +1,7 @@
 import { Output, streamText, tool, type UIMessageStreamWriter } from "ai";
 import type { Session } from "next-auth";
 import { z } from "zod";
-import { getDocumentById, saveSuggestions } from "@/lib/db/queries";
+import { getDocumentByIdForUser, saveSuggestions } from "@/lib/db/queries";
 import type { Suggestion } from "@/lib/db/schema";
 import type { ChatMessage } from "@/lib/types";
 import { generateUUID } from "@/lib/utils";
@@ -27,9 +27,22 @@ export const requestSuggestions = ({
         ),
     }),
     execute: async ({ documentId }) => {
-      const document = await getDocumentById({ id: documentId });
+      // Scope the lookup to the calling user so this tool cannot read another
+      // user's document content — mirrors the ownership check the HTTP route
+      // (app/(chat)/api/document/route.ts) enforces on the same resource.
+      const document = await getDocumentByIdForUser({
+        id: documentId,
+        userId: session.user?.id ?? "",
+      });
 
-      if (!document || !document.content) {
+      // Defense in depth: re-assert ownership after the scoped lookup so a
+      // future refactor cannot reopen the gap. Non-owners get the same
+      // "not found" shape as a missing id.
+      if (
+        !document ||
+        document.userId !== session.user?.id ||
+        !document.content
+      ) {
         return {
           error: "Document not found",
         };

--- a/apps/chatbot/lib/ai/tools/request-suggestions.ts
+++ b/apps/chatbot/lib/ai/tools/request-suggestions.ts
@@ -27,22 +27,28 @@ export const requestSuggestions = ({
         ),
     }),
     execute: async ({ documentId }) => {
+      // No authenticated user id means no document can belong to the caller.
+      // Bail out with the same "not found" shape rather than passing an empty
+      // string into the userId filter (a UUID-typed column), which would throw.
+      const userId = session.user?.id;
+      if (!userId) {
+        return {
+          error: "Document not found",
+        };
+      }
+
       // Scope the lookup to the calling user so this tool cannot read another
       // user's document content — mirrors the ownership check the HTTP route
       // (app/(chat)/api/document/route.ts) enforces on the same resource.
       const document = await getDocumentByIdForUser({
         id: documentId,
-        userId: session.user?.id ?? "",
+        userId,
       });
 
       // Defense in depth: re-assert ownership after the scoped lookup so a
       // future refactor cannot reopen the gap. Non-owners get the same
       // "not found" shape as a missing id.
-      if (
-        !document ||
-        document.userId !== session.user?.id ||
-        !document.content
-      ) {
+      if (!document || document.userId !== userId || !document.content) {
         return {
           error: "Document not found",
         };
@@ -105,18 +111,14 @@ export const requestSuggestions = ({
         }
       }
 
-      if (session.user?.id) {
-        const userId = session.user.id;
-
-        await saveSuggestions({
-          suggestions: suggestions.map((suggestion) => ({
-            ...suggestion,
-            userId,
-            createdAt: new Date(),
-            documentCreatedAt: document.createdAt,
-          })),
-        });
-      }
+      await saveSuggestions({
+        suggestions: suggestions.map((suggestion) => ({
+          ...suggestion,
+          userId,
+          createdAt: new Date(),
+          documentCreatedAt: document.createdAt,
+        })),
+      });
 
       return {
         id: documentId,

--- a/apps/chatbot/lib/ai/tools/update-document.ts
+++ b/apps/chatbot/lib/ai/tools/update-document.ts
@@ -2,7 +2,7 @@ import { tool, type UIMessageStreamWriter } from "ai";
 import type { Session } from "next-auth";
 import { z } from "zod";
 import { documentHandlersByArtifactKind } from "@/lib/artifacts/server";
-import { getDocumentById } from "@/lib/db/queries";
+import { getDocumentByIdForUser } from "@/lib/db/queries";
 import type { ChatMessage } from "@/lib/types";
 
 type UpdateDocumentProps = {
@@ -20,9 +20,19 @@ export const updateDocument = ({ session, dataStream }: UpdateDocumentProps) =>
         .describe("The description of changes that need to be made"),
     }),
     execute: async ({ id, description }) => {
-      const document = await getDocumentById({ id });
+      // Scope the lookup to the calling user so this tool can only ever read or
+      // update the caller's own documents — the same ownership check the HTTP
+      // route (app/(chat)/api/document/route.ts) enforces on every method.
+      const document = await getDocumentByIdForUser({
+        id,
+        userId: session.user?.id ?? "",
+      });
 
-      if (!document) {
+      // Defense in depth: even though the lookup is owner-scoped, re-assert
+      // ownership here so a future refactor of the lookup cannot silently
+      // reopen the gap. Non-owners get the same "not found" shape as a
+      // missing id, so existence is not disclosed.
+      if (!document || document.userId !== session.user?.id) {
         return {
           error: "Document not found",
         };

--- a/apps/chatbot/lib/ai/tools/update-document.ts
+++ b/apps/chatbot/lib/ai/tools/update-document.ts
@@ -20,19 +20,26 @@ export const updateDocument = ({ session, dataStream }: UpdateDocumentProps) =>
         .describe("The description of changes that need to be made"),
     }),
     execute: async ({ id, description }) => {
+      // No authenticated user id means no document can belong to the caller.
+      // Bail out with the same "not found" shape rather than passing an empty
+      // string into the userId filter (a UUID-typed column), which would throw.
+      const userId = session.user?.id;
+      if (!userId) {
+        return {
+          error: "Document not found",
+        };
+      }
+
       // Scope the lookup to the calling user so this tool can only ever read or
       // update the caller's own documents — the same ownership check the HTTP
       // route (app/(chat)/api/document/route.ts) enforces on every method.
-      const document = await getDocumentByIdForUser({
-        id,
-        userId: session.user?.id ?? "",
-      });
+      const document = await getDocumentByIdForUser({ id, userId });
 
       // Defense in depth: even though the lookup is owner-scoped, re-assert
       // ownership here so a future refactor of the lookup cannot silently
       // reopen the gap. Non-owners get the same "not found" shape as a
       // missing id, so existence is not disclosed.
-      if (!document || document.userId !== session.user?.id) {
+      if (!document || document.userId !== userId) {
         return {
           error: "Document not found",
         };

--- a/apps/chatbot/lib/db/document-query-scope.unit.test.ts
+++ b/apps/chatbot/lib/db/document-query-scope.unit.test.ts
@@ -1,0 +1,67 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression test for the *DB-layer* owner scoping of getDocumentByIdForUser.
+//
+// The ownership test suite (lib/ai/tools/document-ownership.unit.test.ts) mocks
+// the whole query module, so it proves the tools' call-site re-check but never
+// executes the real SQL. This suite closes that gap: it runs the REAL
+// getDocumentByIdForUser body against a mocked drizzle query builder, captures
+// the WHERE clause it hands to the DB, renders it to SQL, and asserts the query
+// filters on BOTH the document id AND the owner's userId.
+//
+// If someone drops the `eq(document.userId, userId)` predicate to reopen the
+// original IDOR at the DB layer, the rendered SQL loses the userId filter and
+// this test fails.
+
+const ID_VAL = "44444444-4444-4444-4444-444444444444";
+const USER_VAL = "55555555-5555-5555-5555-555555555555";
+
+// Capture the SQL object passed to .where() so we can render it below.
+let capturedWhere: unknown;
+
+const orderBy = vi.fn(async () => [] as unknown[]);
+const where = vi.fn((clause: unknown) => {
+  capturedWhere = clause;
+  return { orderBy };
+});
+const from = vi.fn(() => ({ where }));
+const select = vi.fn(() => ({ from }));
+
+// queries.ts is a server module (`import "server-only"`); stub the guard so it
+// can be imported into the vitest (node) environment.
+vi.mock("server-only", () => ({}));
+
+// Mock the postgres client + drizzle so importing queries.ts neither opens a
+// real connection nor needs POSTGRES_URL — while leaving the query BODY intact.
+vi.mock("postgres", () => ({ default: () => ({}) }));
+vi.mock("drizzle-orm/postgres-js", () => ({
+  drizzle: () => ({ select }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedWhere = undefined;
+});
+
+describe("getDocumentByIdForUser DB-layer scoping", () => {
+  it("filters on both the document id and the owner userId", async () => {
+    const { getDocumentByIdForUser } = await import("./queries");
+
+    await getDocumentByIdForUser({ id: ID_VAL, userId: USER_VAL });
+
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(capturedWhere).toBeDefined();
+
+    // Render the captured WHERE clause to concrete SQL + bound params.
+    const { sql, params } = new PgDialect().sqlToQuery(capturedWhere as never);
+
+    // The query must reference BOTH columns...
+    expect(sql).toMatch(/"id"/);
+    expect(sql).toMatch(/"userId"/);
+    // ...and bind BOTH values — losing the userId predicate (the IDOR) would
+    // drop USER_VAL from the params.
+    expect(params).toContain(ID_VAL);
+    expect(params).toContain(USER_VAL);
+  });
+});

--- a/apps/chatbot/lib/db/queries.ts
+++ b/apps/chatbot/lib/db/queries.ts
@@ -368,12 +368,26 @@ export async function getDocumentsById({ id }: { id: string }) {
   }
 }
 
-export async function getDocumentById({ id }: { id: string }) {
+// Owner-scoped lookup: filters on both the document id AND the owner, so a
+// caller can never resolve a document that belongs to another user. This is the
+// single lookup for any path that acts on the result, mirroring the ownership
+// check the HTTP route (app/(chat)/api/document/route.ts) already enforces.
+// Returns undefined when the id does not exist OR is not owned by `userId` —
+// callers cannot distinguish the two, so document existence is not disclosed.
+// (An unscoped by-id lookup was deliberately removed: it was the footgun behind
+// the document-tool IDOR — any future by-id lookup must include the owner.)
+export async function getDocumentByIdForUser({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}) {
   try {
     const [selectedDocument] = await db
       .select()
       .from(document)
-      .where(eq(document.id, id))
+      .where(and(eq(document.id, id), eq(document.userId, userId)))
       .orderBy(desc(document.createdAt));
 
     return selectedDocument;

--- a/apps/chatbot/package.json
+++ b/apps/chatbot/package.json
@@ -19,7 +19,8 @@
     "playwright:install": "playwright install --with-deps chromium",
     "test:e2e": "PLAYWRIGHT=True playwright test",
     "test:e2e:ui": "PLAYWRIGHT=True playwright test --ui",
-    "test": "pnpm test:e2e"
+    "test": "pnpm test:e2e",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.15",
@@ -125,7 +126,8 @@
     "tailwindcss": "^4.1.13",
     "tsx": "^4.19.1",
     "typescript": "^5.6.3",
-    "ultracite": "^7.0.11"
+    "ultracite": "^7.0.11",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@9.12.3"
 }

--- a/apps/chatbot/vitest.config.ts
+++ b/apps/chatbot/vitest.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+// Unit-test config for apps/chatbot. Scoped to *.unit.test.ts so it does not
+// collide with the Playwright E2E suite (tests/playwright/**, run via
+// `pnpm test:e2e`). Run with `pnpm test:unit`.
+export default defineConfig({
+  test: {
+    include: ["**/*.unit.test.ts"],
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "."),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,9 @@ importers:
       ultracite:
         specifier: ^7.0.11
         version: 7.3.0
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
   apps/noter:
     dependencies:
@@ -13033,6 +13036,11 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
+    optional: true
+
   '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.5':
@@ -13342,6 +13350,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.37
 
+  '@inquirer/confirm@5.1.21(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+    optional: true
+
   '@inquirer/confirm@5.1.21(@types/node@24.12.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.12.0)
@@ -13361,6 +13377,20 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 20.19.37
+
+  '@inquirer/core@10.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+    optional: true
 
   '@inquirer/core@10.3.2(@types/node@24.12.0)':
     dependencies:
@@ -13474,6 +13504,11 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@20.19.37)':
     optionalDependencies:
       '@types/node': 20.19.37
+
+  '@inquirer/type@3.0.10(@types/node@22.19.15)':
+    optionalDependencies:
+      '@types/node': 22.19.15
+    optional: true
 
   '@inquirer/type@3.0.10(@types/node@24.12.0)':
     optionalDependencies:
@@ -17486,6 +17521,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.10(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@22.19.15)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/mocker@4.1.10(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -18580,6 +18624,14 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  data-urls@7.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -19197,7 +19249,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -19230,7 +19282,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19244,7 +19296,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20304,6 +20356,13 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
+
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
@@ -20797,6 +20856,33 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  jsdom@29.1.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
 
   jsep@1.4.0: {}
 
@@ -21785,6 +21871,32 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+
+  msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.15)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.1
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.4.4
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
 
   msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3):
     dependencies:
@@ -24649,6 +24761,23 @@ snapshots:
       lightningcss: 1.31.1
       terser: 5.46.1
 
+  vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
@@ -24714,6 +24843,36 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
+
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.15
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.12.10(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
@@ -24782,6 +24941,15 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION

## Summary

### Why

The chatbot's AI tools `updateDocument` and `requestSuggestions` resolved a `document` row by a caller-supplied UUID with no ownership check. Any authenticated user (including guest sessions) could therefore read, overwrite, or hijack ownership of another user's document by getting that document's id into a normal chat message. The sibling HTTP route for the same table (`app/(chat)/api/document/route.ts`) already enforces `document.userId === session.user.id` on every method — the check simply existed one layer down and was missing on the AI-tool path. Reported in #516 (IDOR).

### What

- `getDocumentByIdForUser({ id, userId })` — a new owner-scoped lookup that filters on both the document id and the owner.
- The old unscoped `getDocumentById` is **deleted** (it had no remaining callers) so no future path can resolve a document by id without scoping.
- Both tools route through the scoped lookup **and** re-assert `document.userId === session.user.id` at the call site.
- A vitest unit harness + a regression suite proving both layers, and a CI step so the check can't silently regress.

### Solution

Two independent enforcement layers (defense in depth):

- **Owner-scoped query.** `getDocumentByIdForUser` returns a row only when the id and owner both match, so the tool can never resolve another user's document in the first place. Deleting the unscoped `getDocumentById` removes the footgun that caused this bug.
- **Call-site re-check.** Each tool still re-asserts ownership after the lookup, so a future refactor that weakens the query cannot silently reopen the gap. Non-owners get the tool's existing `{ error: "Document not found" }` shape — deliberately not a distinct "forbidden", so document existence is not disclosed to a non-owner.
- **No behavior change for legitimate use.** A user acting on their own document is unaffected; only cross-owner access now fails.
- Length/scope only touches the chatbot example app — no relayer, SDK, contract, or privacy-floor surface.

## Types of Changes

- [ ] Breaking change (existing functionality would change)
- [ ] New feature (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] Performance optimization
- [ ] Refactor (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Test
- [x] Security / permission-scope change

## Benchmark impact

- [x] No benchmark-affecting change (write/infra only)
- [ ] Benchmarked: LOCOMO + LongMemEval, gpt-4o judge, eval_runs=3, vs baseline
- [ ] Default-off / byte-identical when the flag is off

Chatbot example app only; does not touch recall/answer/extraction paths.

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] `cargo test` / harness tests pass — N/A (JS app); `pnpm --filter @memwal/chatbot test:unit` → **7/7 pass**

New vitest suite (`lib/ai/tools/document-ownership.unit.test.ts`) covers, for both tools:
- cross-owner rejected at the DB-scoping layer,
- cross-owner rejected at the call-site check **in isolation** — the mock is forced to return a cross-owner document so only the tool's own check can reject it (mutation-tested: deleting the check makes exactly these tests fail),
- owner allowed through,
- plus the `requestSuggestions` empty-content branch.

Wired into CI: `.github/workflows/test.yml` `chatbot-checks` runs `test:unit` (hard-fail), so a future revert of the ownership check is caught.

## Checklist

- [x] Follows the project's commit + code conventions
- [x] No ticket IDs / competitor names / local-doc paths in code comments
- [ ] Docs updated if needed — N/A
- [x] Respects the privacy floor (no server-readable plaintext index)
- [x] All new and existing tests pass

## Related

- Closes #516

## Additional Notes

- The fix returns the same `"Document not found"` shape for a non-existent id and a cross-owner id, so it does not leak document existence to non-owners.
- Out of scope (noted, not addressed here): the HTTP route's `forbidden:document` error message discloses existence, and the same route's `getSuggestionsByDocumentId` / DELETE paths use the pre-existing unscoped-then-recheck pattern. Neither is part of #516 and neither is touched by this change.
