### PR TITLE
fix(deploy): use Suiscan RPC instead of deprecated public fullnode

### DIFF
--- a/.github/workflows/deploy-app-walrus.yml
+++ b/.github/workflows/deploy-app-walrus.yml
@@ -106,7 +106,7 @@ jobs:
                 wallet_config:
                   active_env: mainnet
                 rpc_urls:
-                  - https://fullnode.mainnet.sui.io:443
+                  - https://rpc-mainnet.suiscan.xyz
             default_context: mainnet
           SITES_CONFIG: |
             contexts:


### PR DESCRIPTION
## Summary
- `fullnode.mainnet.sui.io`'s JSON-RPC is being deprecated/phased out and its coin enumeration was already returning stale results for the mainnet deploy wallet — it only saw 1 of 2 SUI coin objects, causing intermittent `could not find SUI coins with sufficient balance` failures during `site-builder`'s blob certification step (runs 30636490497, both original and re-run).
- Switches the workflow's `WALRUS_CONFIG.rpc_urls` to `https://rpc-mainnet.suiscan.xyz`, which correctly sees both coins for the same address — and matches what `relayer`/`indexer`/`app` already use in Railway production (`SUI_RPC_URL=https://rpc-mainnet.suiscan.xyz`).
- Only runs on push to `main`, so this needs to land there to actually take effect on the next mainnet deploy.

## Test plan
- [ ] Merge and confirm the next "Deploy App to Walrus Site" run on `main` no longer hits the insufficient-balance error