### PR TITLE
Gate security-delete wallet auth behind explicit user action

### DIFF
--- a/apps/app/e2e/securityDelete.spec.ts
+++ b/apps/app/e2e/securityDelete.spec.ts
@@ -114,8 +114,11 @@ test('security delete: connect, table, Seal preview, delete selected, progress, 
 	await page.getByRole('button', { name: 'MemWal E2E Dev Wallet' }).click()
 	await expect(page).toHaveURL(/\/dashboard/, { timeout: 20_000 })
 
-	// 2. "Stored" tab (default) lists all 3 seeded rows with blobId/objectId/createdAt.
+	// 2. Loading the list requires explicit user intent before the wallet auth
+	// challenge. The "Stored" tab then lists all 3 seeded rows.
 	await page.locator('#cleanup').scrollIntoViewIfNeeded()
+	await expect(await walletCalls(page)).toHaveLength(0)
+	await page.getByRole('button', { name: 'Load my memories' }).click()
 	const atRiskTab = page.getByRole('tab', { name: 'Stored' })
 	await expect(atRiskTab).toHaveAttribute('aria-selected', 'true')
 
@@ -193,8 +196,8 @@ test('security delete: connect, table, Seal preview, delete selected, progress, 
 		{ timeout: 30_000 },
 	)
 
-	// 6. Popup-count contract (spec §10): exactly 1 personal-message
-	// signature (security-delete auth challenge — the same cached token
+	// 6. Popup-count contract (spec §10): exactly 1 explicitly initiated
+	// personal-message signature (security-delete auth challenge — the same cached token
 	// covers list/prepare/submit) + 1 Seal-session personal-message
 	// signature (cached across preview clicks, only 1 preview click here) +
 	// 1 tx signature (both selected rows delete in a single batch, well

--- a/apps/app/src/components/SecurityDeleteSection.test.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.test.tsx
@@ -35,6 +35,8 @@ const risk = [
     { blobId: 'blob-two-long-identifier', objectId: null, createdAt: '2026-01-02T00:00:00Z', state: 'deletable' },
 ]
 
+const loadMemories = (user: ReturnType<typeof userEvent.setup>) => user.click(screen.getByRole('button', { name: 'Load my memories' }))
+
 beforeEach(() => {
     vi.clearAllMocks()
     mocks.address = '0x1'
@@ -44,9 +46,13 @@ beforeEach(() => {
     mocks.fetchPreview.mockResolvedValue('owner secret')
 })
 
-it('renders affected rows and authoritative counts', async () => {
+it('waits for explicit user intent before loading affected rows', async () => {
+    const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
-    expect(await screen.findByText('Stored')).toBeInTheDocument()
+    expect(mocks.listBlobs).not.toHaveBeenCalled()
+    expect(screen.getByText(/wallet will ask you to sign/i)).toBeInTheDocument()
+    await loadMemories(user)
+    expect(await screen.findByRole('tab', { name: 'Stored' })).toBeInTheDocument()
     await waitFor(() => expect(mocks.listBlobs).toHaveBeenCalledWith('token', expect.objectContaining({ state: 'deletable' })))
     expect(screen.getByTitle('blob-one-long-identifier')).toBeInTheDocument()
     expect(screen.getByText('resolving…')).toBeInTheDocument()
@@ -55,6 +61,7 @@ it('renders affected rows and authoritative counts', async () => {
 it('loads the read-only progress state set after tab switch', async () => {
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await screen.findByTitle('blob-one-long-identifier')
     const storedTab = screen.getByRole('tab', { name: 'Stored' })
     const deletedTab = screen.getByRole('tab', { name: 'Deleted' })
@@ -69,6 +76,7 @@ it('loads the read-only progress state set after tab switch', async () => {
 it('passes the exact selected IDs after confirmation', async () => {
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await user.click(await screen.findByLabelText('Select blob-one-long-identifier'))
     await user.click(screen.getByRole('button', { name: /Delete selected/ }))
     await user.click(screen.getByRole('button', { name: 'Delete forever' }))
@@ -89,10 +97,15 @@ it('ignores an old owner response that resolves after address switch', async () 
         counts: { ...counts, total: 1, deletable: 1 }, limits: { deleteBatchMax: 900 }, nextCursor: null,
     }
     mocks.listBlobs.mockReset().mockReturnValueOnce(oldResponse).mockResolvedValue(nextResponse)
+    const user = userEvent.setup()
     const { rerender } = render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await waitFor(() => expect(mocks.listBlobs).toHaveBeenCalledTimes(1))
     mocks.address = '0x2'
     rerender(<SecurityDeleteSection accountObjectId="0x99" />)
+    expect(screen.getByRole('button', { name: 'Load my memories' })).toBeInTheDocument()
+    expect(mocks.listBlobs).toHaveBeenCalledTimes(1)
+    await loadMemories(user)
     expect(await screen.findByTitle('new-owner-blob')).toBeInTheDocument()
     releaseOld({ items: risk, counts, limits: { deleteBatchMax: 900 }, nextCursor: null })
     await Promise.resolve()
@@ -109,6 +122,7 @@ it('clears rows and ignores an old tab response during a tab switch', async () =
     mocks.listBlobs.mockReset().mockReturnValueOnce(oldRiskResponse).mockResolvedValue(progressResponse)
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await waitFor(() => expect(mocks.listBlobs).toHaveBeenCalledOnce())
     await user.click(screen.getByRole('tab', { name: 'Deleted' }))
     expect(await screen.findByTitle('progress-blob')).toBeInTheDocument()
@@ -120,6 +134,7 @@ it('clears rows and ignores an old tab response during a tab switch', async () =
 it('removes owner-scoped plaintext immediately on an address switch', async () => {
     const user = userEvent.setup()
     const { rerender } = render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await user.click(await screen.findByRole('button', { name: 'Preview blob-one-long-identifier' }))
     expect(await screen.findByText('owner secret')).toBeInTheDocument()
     expect(mocks.fetchPreview).toHaveBeenCalledOnce()
@@ -151,6 +166,7 @@ it('shows a dismissible toast when a deletion operation completes', async () => 
 it('keeps the loaded rows when the active tab is clicked again', async () => {
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await screen.findByTitle('blob-one-long-identifier')
     await user.click(screen.getByRole('tab', { name: 'Stored' }))
     expect(screen.getByTitle('blob-one-long-identifier')).toBeInTheDocument()
@@ -167,6 +183,7 @@ it('jumps to an unvisited page by walking cursors and shows pager state', async 
         return { items: pageRows('p3'), counts: bigCounts, limits: { deleteBatchMax: 900 }, nextCursor: null }
     })
     render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await screen.findByTitle('p1-row')
     expect(screen.getByText('Page 1 of 3')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '‹ Prev' })).toBeDisabled()
@@ -191,6 +208,7 @@ it('steps back when the current page empties out after deletions', async () => {
         return { items: [{ blobId: 'p2-row', objectId: '0x2', createdAt: '2026-01-02T00:00:00Z', state: 'deletable' }], counts: liveCounts, limits: { deleteBatchMax: 900 }, nextCursor: null }
     })
     render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await screen.findByTitle('p1-row')
     await user.click(screen.getByRole('button', { name: 'Next ›' }))
     await screen.findByTitle('p2-row')
@@ -204,6 +222,7 @@ it('steps back when the current page empties out after deletions', async () => {
 it('select page toggles to unselect page and clears the page selection', async () => {
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
     await screen.findByTitle('blob-one-long-identifier')
     await user.click(screen.getByRole('button', { name: 'Select page' }))
     expect(screen.getByLabelText('Select blob-one-long-identifier')).toBeChecked()

--- a/apps/app/src/components/SecurityDeleteSection.test.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({ address: '0x1', securityDeleteEnabled: true, phase: { kind: 'idle' } as { kind: string; batch?: number; totalBatches?: number | null }, listBlobs: vi.fn(), deleteSelection: vi.fn(), deleteAll: vi.fn(), cancelActive: vi.fn(), fetchPreview: vi.fn(), clearSealSession: vi.fn() }))
+const mocks = vi.hoisted(() => ({ address: '0x1', securityDeleteEnabled: true, phase: { kind: 'idle' } as { kind: string; batch?: number; totalBatches?: number | null }, onStateChanged: () => {}, listBlobs: vi.fn(), deleteSelection: vi.fn(), deleteAll: vi.fn(), cancelActive: vi.fn(), fetchPreview: vi.fn(), clearSealSession: vi.fn() }))
 vi.mock('../config', () => ({ config: {
     get securityDeleteEnabled() { return mocks.securityDeleteEnabled },
     memwalServerUrl: 'http://test',
@@ -15,9 +15,10 @@ vi.mock('@mysten/dapp-kit', () => ({
     useSuiClient: () => ({}),
     useSignPersonalMessage: () => ({ mutateAsync: vi.fn() }),
 }))
-vi.mock('../hooks/useSecurityDeletion', () => ({ useSecurityDeletion: () => ({
-    phase: mocks.phase, deleteSelection: mocks.deleteSelection, deleteAll: mocks.deleteAll, cancelActive: mocks.cancelActive,
-}) }))
+vi.mock('../hooks/useSecurityDeletion', () => ({ useSecurityDeletion: ({ onStateChanged }: { onStateChanged: () => void }) => {
+    mocks.onStateChanged = onStateChanged
+    return { phase: mocks.phase, deleteSelection: mocks.deleteSelection, deleteAll: mocks.deleteAll, cancelActive: mocks.cancelActive }
+} }))
 vi.mock('../utils/securityDeleteAuth', () => ({
     withAuth: (_address: string, _sign: unknown, call: (token: string) => unknown) => call('token'),
     clearToken: vi.fn(),
@@ -71,6 +72,61 @@ it('loads the read-only progress state set after tab switch', async () => {
     expect(storedTab).toHaveAttribute('aria-selected', 'false')
     expect(deletedTab).toHaveAttribute('aria-selected', 'true')
     await waitFor(() => expect(mocks.listBlobs).toHaveBeenLastCalledWith('token', expect.objectContaining({ state: 'deleting,deleted,deleted_external,not_owner,expired' })))
+})
+
+it('keeps the activated list when the account object resolves for the same owner', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<SecurityDeleteSection accountObjectId={null} />)
+    await loadMemories(user)
+    await screen.findByTitle('blob-one-long-identifier')
+
+    rerender(<SecurityDeleteSection accountObjectId="0x99" />)
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument()
+    expect(screen.getByTitle('blob-one-long-identifier')).toBeInTheDocument()
+    expect(mocks.listBlobs).toHaveBeenCalledOnce()
+})
+
+it('ignores a stale deletion refresh after the wallet changes', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
+    await screen.findByTitle('blob-one-long-identifier')
+    const staleRefresh = mocks.onStateChanged
+
+    mocks.address = '0x2'
+    rerender(<SecurityDeleteSection accountObjectId="0x99" />)
+    staleRefresh()
+
+    expect(screen.getByRole('button', { name: 'Load my memories' })).toBeInTheDocument()
+    expect(mocks.listBlobs).toHaveBeenCalledOnce()
+})
+
+it('ignores a stale deletion refresh after switching tabs', async () => {
+    const user = userEvent.setup()
+    render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
+    await screen.findByTitle('blob-one-long-identifier')
+    const staleRefresh = mocks.onStateChanged
+
+    await user.click(screen.getByRole('tab', { name: 'Deleted' }))
+    await waitFor(() => expect(mocks.listBlobs).toHaveBeenCalledTimes(2))
+    staleRefresh()
+
+    expect(mocks.listBlobs).toHaveBeenCalledTimes(2)
+    expect(screen.getByRole('tab', { name: 'Deleted' })).toHaveAttribute('aria-selected', 'true')
+})
+
+it('prevents tab changes while deletion is in progress', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<SecurityDeleteSection accountObjectId="0x99" />)
+    await loadMemories(user)
+    await screen.findByTitle('blob-one-long-identifier')
+
+    mocks.phase = { kind: 'executing', batch: 1 }
+    rerender(<SecurityDeleteSection accountObjectId="0x99" />)
+
+    expect(screen.getByRole('tab', { name: 'Stored' })).toBeDisabled()
+    expect(screen.getByRole('tab', { name: 'Deleted' })).toBeDisabled()
 })
 
 it('passes the exact selected IDs after confirmation', async () => {

--- a/apps/app/src/components/SecurityDeleteSection.test.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.test.tsx
@@ -50,7 +50,6 @@ it('waits for explicit user intent before loading affected rows', async () => {
     const user = userEvent.setup()
     render(<SecurityDeleteSection accountObjectId="0x99" />)
     expect(mocks.listBlobs).not.toHaveBeenCalled()
-    expect(screen.getByText(/wallet will ask you to sign/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Load my memories' }).closest('.card-header')).toBeNull()
     await loadMemories(user)
     expect(await screen.findByRole('tab', { name: 'Stored' })).toBeInTheDocument()

--- a/apps/app/src/components/SecurityDeleteSection.test.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.test.tsx
@@ -51,6 +51,7 @@ it('waits for explicit user intent before loading affected rows', async () => {
     render(<SecurityDeleteSection accountObjectId="0x99" />)
     expect(mocks.listBlobs).not.toHaveBeenCalled()
     expect(screen.getByText(/wallet will ask you to sign/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Load my memories' }).closest('.card-header')).toBeNull()
     await loadMemories(user)
     expect(await screen.findByRole('tab', { name: 'Stored' })).toBeInTheDocument()
     await waitFor(() => expect(mocks.listBlobs).toHaveBeenCalledWith('token', expect.objectContaining({ state: 'deletable' })))

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -218,10 +218,13 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
 
     if (!config.securityDeleteEnabled || !address) return null
     return <Card id="cleanup" className="dashboard-cleanup-card sd-card" title="Delete Pre-Migration Memories" subtitle={`Applies only to memories written before ${config.migrationCompletedDate}`} action={
-        <button className="btn btn-secondary" disabled={loading || busy} onClick={activated ? refresh : () => setActivated(true)}>{activated && <RefreshCw size={16}/>} {activated ? 'Refresh' : 'Load my memories'}</button>
+        activated && <button className="btn btn-secondary" disabled={loading || busy} onClick={refresh}><RefreshCw size={16}/> Refresh</button>
     }>
         <div className="sd-warning"><ShieldAlert size={18}/><span>Deletion is permanent. Preview anything you need before continuing.</span></div>
-        {!activated && <p>Load your pre-migration memories to review them. Your wallet will ask you to sign a message to verify ownership.</p>}
+        {!activated && <div className="sd-load-prompt">
+            <p>Load your pre-migration memories to review them. Your wallet will ask you to sign a message to verify ownership.</p>
+            <button className="btn btn-secondary" disabled={loading || busy} onClick={() => setActivated(true)}>Load my memories</button>
+        </div>}
         {activated && <>
             <div className="sd-counts"><strong>{visibleCounts.deletable}</strong> Stored / <strong>{visibleCounts.deleting}</strong> in Progress / <strong>{visibleCounts.deleted + visibleCounts.deletedExternal}</strong> Deleted</div>
             <div className="sd-tabs" role="tablist">

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -223,7 +223,7 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
         <div className="sd-warning"><ShieldAlert size={18}/><span>Deletion is permanent. Preview anything you need before continuing.</span></div>
         {!activated && <div className="sd-load-prompt">
             <p>Load your pre-migration memories to review them. Your wallet will ask you to sign a message to verify ownership.</p>
-            <button className="btn btn-secondary" disabled={loading || busy} onClick={() => setActivated(true)}>Load my memories</button>
+            <button className="btn dashboard-cleanup-load" disabled={loading || busy} onClick={() => setActivated(true)}>Load my memories</button>
         </div>}
         {activated && <>
             <div className="sd-counts"><strong>{visibleCounts.deletable}</strong> Stored / <strong>{visibleCounts.deleting}</strong> in Progress / <strong>{visibleCounts.deleted + visibleCounts.deletedExternal}</strong> Deleted</div>

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -222,7 +222,6 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
     }>
         <div className="sd-warning"><ShieldAlert size={18}/><span>Deletion is permanent. Preview anything you need before continuing.</span></div>
         {!activated && <div className="sd-load-prompt">
-            <p>Load your pre-migration memories to review them. Your wallet will ask you to sign a message to verify ownership.</p>
             <button className="btn dashboard-cleanup-load" disabled={loading || busy} onClick={() => setActivated(true)}>Load my memories</button>
         </div>}
         {activated && <>

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -60,7 +60,9 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
     const nextToastId = useRef(0)
     const requestGeneration = useRef(0)
     const previousAddress = useRef(address)
-    const previousIdentity = useRef(`${address}:${accountObjectId ?? ''}`)
+    const previousAccountObjectId = useRef(accountObjectId)
+    const refreshContext = useRef({ address, tab, activated })
+    refreshContext.current = { address, tab, activated }
     const previewTrigger = useRef<HTMLElement | null>(null)
     const confirmTrigger = useRef<HTMLElement | null>(null)
 
@@ -122,21 +124,29 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
         }
     }, [address, signer, tab])
 
-    const refresh = useCallback(() => { void load(pageRef.current) }, [load])
+    const refresh = useCallback(() => {
+        const current = refreshContext.current
+        // Deletion callbacks can outlive the wallet or tab that started them.
+        // Never let a stale callback trigger auth or overwrite another view.
+        if (!current.activated || current.address !== address || current.tab !== tab) return
+        void load(pageRef.current)
+    }, [address, load, tab])
     const deletion = useSecurityDeletion({ onStateChanged: refresh })
 
     useEffect(() => {
-        const identity = `${address}:${accountObjectId ?? ''}`
-        if (previousIdentity.current === identity) return
         const addressChanged = previousAddress.current !== address
-        previousIdentity.current = identity
+        const accountObjectChanged = previousAccountObjectId.current !== accountObjectId
+        if (!addressChanged && !accountObjectChanged) return
         if (previousAddress.current && addressChanged) clearToken(previousAddress.current)
         previousAddress.current = address
+        previousAccountObjectId.current = accountObjectId
+        setPreview(null)
+        clearSealSession()
+        if (!addressChanged) return
         requestGeneration.current++
         setActivated(false)
-        setItems([]); setSelected(new Set()); setConfirm(null); setPreview(null); setError(''); setLoading(false)
+        setItems([]); setSelected(new Set()); setConfirm(null); setError(''); setLoading(false)
         pageCursors.current = [null]; pageRef.current = 1; setPage(1)
-        clearSealSession()
     }, [address, accountObjectId])
     useEffect(() => {
         if (activated) void load(1)
@@ -166,13 +176,14 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
     // Effects clear owner-scoped state after a wallet/account transition, but
     // effects run after paint. Suppress it synchronously during that transition
     // so rows, selections, dialogs, and plaintext never flash for the new owner.
-    const identityMatches = previousIdentity.current === `${address}:${accountObjectId ?? ''}`
+    const identityMatches = previousAddress.current === address
+    const previewIdentityMatches = identityMatches && previousAccountObjectId.current === accountObjectId
     const visibleItems = identityMatches ? items : []
     const visibleCounts = identityMatches ? counts : EMPTY_COUNTS
     const visibleSelected = identityMatches ? selected : new Set<string>()
     const visiblePage = identityMatches ? page : 1
     const visibleConfirm = identityMatches ? confirm : null
-    const visiblePreview = identityMatches ? preview : null
+    const visiblePreview = previewIdentityMatches ? preview : null
     const riskPageIds = visibleItems.filter(item => item.state === 'deletable').map(item => item.blobId)
     const allPageSelected = riskPageIds.length > 0 && riskPageIds.every(id => visibleSelected.has(id))
     const busy = ['preparing', 'signing', 'executing'].includes(deletion.phase.kind)
@@ -227,8 +238,8 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
         {activated && <>
             <div className="sd-counts"><strong>{visibleCounts.deletable}</strong> Stored / <strong>{visibleCounts.deleting}</strong> in Progress / <strong>{visibleCounts.deleted + visibleCounts.deletedExternal}</strong> Deleted</div>
             <div className="sd-tabs" role="tablist">
-                <button role="tab" aria-selected={tab === 'risk'} aria-controls="sd-tab-panel" className={`btn ${tab === 'risk' ? 'btn-secondary' : ''}`} onClick={() => selectTab('risk')}>Stored</button>
-                <button role="tab" aria-selected={tab === 'progress'} aria-controls="sd-tab-panel" className={`btn ${tab === 'progress' ? 'btn-secondary' : ''}`} onClick={() => selectTab('progress')}>Deleted</button>
+                <button role="tab" aria-selected={tab === 'risk'} aria-controls="sd-tab-panel" className={`btn ${tab === 'risk' ? 'btn-secondary' : ''}`} disabled={busy} onClick={() => selectTab('risk')}>Stored</button>
+                <button role="tab" aria-selected={tab === 'progress'} aria-controls="sd-tab-panel" className={`btn ${tab === 'progress' ? 'btn-secondary' : ''}`} disabled={busy} onClick={() => selectTab('progress')}>Deleted</button>
             </div>
         </>}
         {error && <div className="dashboard-cleanup-error" role="alert">{error}</div>}

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -51,6 +51,7 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
     const pageCursors = useRef<(string | null)[]>([null])
     const pageRef = useRef(1)
     const [selected, setSelected] = useState<Set<string>>(new Set())
+    const [activated, setActivated] = useState(false)
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState('')
     const [confirm, setConfirm] = useState<'all' | 'selection' | null>(null)
@@ -132,15 +133,14 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
         if (previousAddress.current && addressChanged) clearToken(previousAddress.current)
         previousAddress.current = address
         requestGeneration.current++
-        setItems([]); setSelected(new Set()); setConfirm(null); setPreview(null); setError('')
+        setActivated(false)
+        setItems([]); setSelected(new Set()); setConfirm(null); setPreview(null); setError(''); setLoading(false)
         pageCursors.current = [null]; pageRef.current = 1; setPage(1)
         clearSealSession()
-        // Address changes are loaded by the address/tab effect below. Account
-        // object changes still need an explicit reload because that dependency
-        // intentionally is not part of the list request.
-        if (address && !addressChanged) void load(1)
-    }, [address, accountObjectId, load])
-    useEffect(() => { void load(1) }, [address, tab]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [address, accountObjectId])
+    useEffect(() => {
+        if (activated) void load(1)
+    }, [activated, tab]) // eslint-disable-line react-hooks/exhaustive-deps
     const dismissToast = useCallback((id: number) => {
         setToasts(previous => previous.filter(toast => toast.id !== id))
     }, [])
@@ -218,14 +218,17 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
 
     if (!config.securityDeleteEnabled || !address) return null
     return <Card id="cleanup" className="dashboard-cleanup-card sd-card" title="Delete Pre-Migration Memories" subtitle={`Applies only to memories written before ${config.migrationCompletedDate}`} action={
-        <button className="btn btn-secondary" disabled={loading || busy} onClick={refresh}><RefreshCw size={16}/> Refresh</button>
+        <button className="btn btn-secondary" disabled={loading || busy} onClick={activated ? refresh : () => setActivated(true)}>{activated && <RefreshCw size={16}/>} {activated ? 'Refresh' : 'Load my memories'}</button>
     }>
         <div className="sd-warning"><ShieldAlert size={18}/><span>Deletion is permanent. Preview anything you need before continuing.</span></div>
-        <div className="sd-counts"><strong>{visibleCounts.deletable}</strong> Stored / <strong>{visibleCounts.deleting}</strong> in Progress / <strong>{visibleCounts.deleted + visibleCounts.deletedExternal}</strong> Deleted</div>
-        <div className="sd-tabs" role="tablist">
-            <button role="tab" aria-selected={tab === 'risk'} aria-controls="sd-tab-panel" className={`btn ${tab === 'risk' ? 'btn-secondary' : ''}`} onClick={() => selectTab('risk')}>Stored</button>
-            <button role="tab" aria-selected={tab === 'progress'} aria-controls="sd-tab-panel" className={`btn ${tab === 'progress' ? 'btn-secondary' : ''}`} onClick={() => selectTab('progress')}>Deleted</button>
-        </div>
+        {!activated && <p>Load your pre-migration memories to review them. Your wallet will ask you to sign a message to verify ownership.</p>}
+        {activated && <>
+            <div className="sd-counts"><strong>{visibleCounts.deletable}</strong> Stored / <strong>{visibleCounts.deleting}</strong> in Progress / <strong>{visibleCounts.deleted + visibleCounts.deletedExternal}</strong> Deleted</div>
+            <div className="sd-tabs" role="tablist">
+                <button role="tab" aria-selected={tab === 'risk'} aria-controls="sd-tab-panel" className={`btn ${tab === 'risk' ? 'btn-secondary' : ''}`} onClick={() => selectTab('risk')}>Stored</button>
+                <button role="tab" aria-selected={tab === 'progress'} aria-controls="sd-tab-panel" className={`btn ${tab === 'progress' ? 'btn-secondary' : ''}`} onClick={() => selectTab('progress')}>Deleted</button>
+            </div>
+        </>}
         {error && <div className="dashboard-cleanup-error" role="alert">{error}</div>}
         {deletion.phase.kind === 'error' && <div className="dashboard-cleanup-error" role="alert">{deletion.phase.message} <code>{deletion.phase.code}</code></div>}
         {busy && <div className="dashboard-cleanup-status" aria-live="polite"><span>{deletion.phase.kind === 'signing' ? 'Check your wallet to sign this batch…' : `Deleting batch ${'batch' in deletion.phase ? deletion.phase.batch : ''}…`}</span>{deletion.phase.kind === 'signing' && <button type="button" className="btn btn-secondary" onClick={() => void deletion.cancelActive()}>Cancel batch</button>}</div>}
@@ -235,7 +238,7 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
                 <button type="button" className="sd-toast-dismiss" aria-label="Dismiss notification" onClick={() => dismissToast(toast.id)}>×</button>
             </div>)}
         </div>}
-        {tab === 'risk' && <div className="sd-actions">
+        {activated && tab === 'risk' && <div className="sd-actions">
             <button className="btn btn-secondary" disabled={!riskPageIds.length || busy} onClick={() => setSelected(previous => {
                 if (allPageSelected) return new Set([...previous].filter(id => !riskPageIds.includes(id)))
                 return new Set([...previous, ...riskPageIds])
@@ -243,8 +246,8 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
             <button className="btn btn-danger" disabled={!visibleSelected.size || busy} onClick={() => openConfirm('selection')}><Trash2 size={16}/> Delete selected ({visibleSelected.size})</button>
             <button className="btn btn-danger" disabled={!visibleCounts.deletable || busy} onClick={() => openConfirm('all')}><Trash2 size={16}/> Delete all ({visibleCounts.deletable})</button>
         </div>}
-        <div id="sd-tab-panel" role="tabpanel">{loading && visibleItems.length === 0 ? <p role="status">Loading affected memories…</p> : <SecurityDeleteTable items={visibleItems} selectable={tab === 'risk'} selected={visibleSelected} onToggle={toggle} onPreview={openPreview} previewEnabled={Boolean(accountObjectId)}/>}</div>
-        {totalPages > 1 && <nav className="sd-pager" aria-label="Memory pages">
+        {activated && <div id="sd-tab-panel" role="tabpanel">{loading && visibleItems.length === 0 ? <p role="status">Loading affected memories…</p> : <SecurityDeleteTable items={visibleItems} selectable={tab === 'risk'} selected={visibleSelected} onToggle={toggle} onPreview={openPreview} previewEnabled={Boolean(accountObjectId)}/>}</div>}
+        {activated && totalPages > 1 && <nav className="sd-pager" aria-label="Memory pages">
             <button className="btn btn-secondary" disabled={visiblePage <= 1 || loading} onClick={() => void load(visiblePage - 1)}>‹ Prev</button>
             {pageStrip(visiblePage, totalPages).map((entry, index) => entry === 'gap'
                 ? <span key={`gap-${index}`} className="sd-pager-gap" aria-hidden="true">…</span>

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -128,7 +128,7 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
         const current = refreshContext.current
         // Deletion callbacks can outlive the wallet or tab that started them.
         // Never let a stale callback trigger auth or overwrite another view.
-        if (!current.activated || current.address !== address || current.tab !== tab) return
+        if (previousAddress.current !== address || !current.activated || current.address !== address || current.tab !== tab) return
         void load(pageRef.current)
     }, [address, load, tab])
     const deletion = useSecurityDeletion({ onStateChanged: refresh })
@@ -178,6 +178,7 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
     // so rows, selections, dialogs, and plaintext never flash for the new owner.
     const identityMatches = previousAddress.current === address
     const previewIdentityMatches = identityMatches && previousAccountObjectId.current === accountObjectId
+    const visibleActivated = identityMatches && activated
     const visibleItems = identityMatches ? items : []
     const visibleCounts = identityMatches ? counts : EMPTY_COUNTS
     const visibleSelected = identityMatches ? selected : new Set<string>()
@@ -229,13 +230,13 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
 
     if (!config.securityDeleteEnabled || !address) return null
     return <Card id="cleanup" className="dashboard-cleanup-card sd-card" title="Delete Pre-Migration Memories" subtitle={`Applies only to memories written before ${config.migrationCompletedDate}`} action={
-        activated && <button className="btn btn-secondary" disabled={loading || busy} onClick={refresh}><RefreshCw size={16}/> Refresh</button>
+        visibleActivated && <button className="btn btn-secondary" disabled={loading || busy} onClick={refresh}><RefreshCw size={16}/> Refresh</button>
     }>
         <div className="sd-warning"><ShieldAlert size={18}/><span>Deletion is permanent. Preview anything you need before continuing.</span></div>
-        {!activated && <div className="sd-load-prompt">
+        {identityMatches && !activated && <div className="sd-load-prompt">
             <button className="btn dashboard-cleanup-load" disabled={loading || busy} onClick={() => setActivated(true)}>Load my memories</button>
         </div>}
-        {activated && <>
+        {visibleActivated && <>
             <div className="sd-counts"><strong>{visibleCounts.deletable}</strong> Stored / <strong>{visibleCounts.deleting}</strong> in Progress / <strong>{visibleCounts.deleted + visibleCounts.deletedExternal}</strong> Deleted</div>
             <div className="sd-tabs" role="tablist">
                 <button role="tab" aria-selected={tab === 'risk'} aria-controls="sd-tab-panel" className={`btn ${tab === 'risk' ? 'btn-secondary' : ''}`} disabled={busy} onClick={() => selectTab('risk')}>Stored</button>
@@ -251,7 +252,7 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
                 <button type="button" className="sd-toast-dismiss" aria-label="Dismiss notification" onClick={() => dismissToast(toast.id)}>×</button>
             </div>)}
         </div>}
-        {activated && tab === 'risk' && <div className="sd-actions">
+        {visibleActivated && tab === 'risk' && <div className="sd-actions">
             <button className="btn btn-secondary" disabled={!riskPageIds.length || busy} onClick={() => setSelected(previous => {
                 if (allPageSelected) return new Set([...previous].filter(id => !riskPageIds.includes(id)))
                 return new Set([...previous, ...riskPageIds])
@@ -259,8 +260,8 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
             <button className="btn btn-danger" disabled={!visibleSelected.size || busy} onClick={() => openConfirm('selection')}><Trash2 size={16}/> Delete selected ({visibleSelected.size})</button>
             <button className="btn btn-danger" disabled={!visibleCounts.deletable || busy} onClick={() => openConfirm('all')}><Trash2 size={16}/> Delete all ({visibleCounts.deletable})</button>
         </div>}
-        {activated && <div id="sd-tab-panel" role="tabpanel">{loading && visibleItems.length === 0 ? <p role="status">Loading affected memories…</p> : <SecurityDeleteTable items={visibleItems} selectable={tab === 'risk'} selected={visibleSelected} onToggle={toggle} onPreview={openPreview} previewEnabled={Boolean(accountObjectId)}/>}</div>}
-        {activated && totalPages > 1 && <nav className="sd-pager" aria-label="Memory pages">
+        {visibleActivated && <div id="sd-tab-panel" role="tabpanel">{loading && visibleItems.length === 0 ? <p role="status">Loading affected memories…</p> : <SecurityDeleteTable items={visibleItems} selectable={tab === 'risk'} selected={visibleSelected} onToggle={toggle} onPreview={openPreview} previewEnabled={Boolean(accountObjectId)}/>}</div>}
+        {visibleActivated && totalPages > 1 && <nav className="sd-pager" aria-label="Memory pages">
             <button className="btn btn-secondary" disabled={visiblePage <= 1 || loading} onClick={() => void load(visiblePage - 1)}>‹ Prev</button>
             {pageStrip(visiblePage, totalPages).map((entry, index) => entry === 'gap'
                 ? <span key={`gap-${index}`} className="sd-pager-gap" aria-hidden="true">…</span>

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -13,8 +13,7 @@
 }
 .dash-page .sd-warning { margin-bottom: 1rem; color: #7d5400; }
 .dash-page .sd-counts, .dash-page .sd-tabs, .dash-page .sd-actions { margin-bottom: 1rem; }
-.dash-page .sd-load-prompt { display: flex; flex-direction: column; align-items: center; gap: 1.25rem; }
-.dash-page .sd-load-prompt p { width: 100%; margin: 0; text-align: left; }
+.dash-page .sd-load-prompt { display: flex; justify-content: center; margin-top: 1.5rem; }
 .dash-page .sd-tabs .btn { border: 1px solid #faf8f5; background: #000000; color: #faf8f5; }
 .dash-page .sd-tabs .btn[aria-selected='true'] { border-color: #faf8f5; background: #faf8f5; color: #000000; }
 .dash-page .sd-table-wrap { overflow-x: auto; }

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -13,6 +13,8 @@
 }
 .dash-page .sd-warning { margin-bottom: 1rem; color: #7d5400; }
 .dash-page .sd-counts, .dash-page .sd-tabs, .dash-page .sd-actions { margin-bottom: 1rem; }
+.dash-page .sd-load-prompt { display: flex; flex-direction: column; align-items: center; gap: 1.25rem; text-align: center; }
+.dash-page .sd-load-prompt p { margin: 0; }
 .dash-page .sd-tabs .btn { border: 1px solid #faf8f5; background: #000000; color: #faf8f5; }
 .dash-page .sd-tabs .btn[aria-selected='true'] { border-color: #faf8f5; background: #faf8f5; color: #000000; }
 .dash-page .sd-table-wrap { overflow-x: auto; }

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -13,8 +13,8 @@
 }
 .dash-page .sd-warning { margin-bottom: 1rem; color: #7d5400; }
 .dash-page .sd-counts, .dash-page .sd-tabs, .dash-page .sd-actions { margin-bottom: 1rem; }
-.dash-page .sd-load-prompt { display: flex; flex-direction: column; align-items: center; gap: 1.25rem; text-align: center; }
-.dash-page .sd-load-prompt p { margin: 0; }
+.dash-page .sd-load-prompt { display: flex; flex-direction: column; align-items: center; gap: 1.25rem; }
+.dash-page .sd-load-prompt p { width: 100%; margin: 0; text-align: left; }
 .dash-page .sd-tabs .btn { border: 1px solid #faf8f5; background: #000000; color: #faf8f5; }
 .dash-page .sd-tabs .btn[aria-selected='true'] { border-color: #faf8f5; background: #faf8f5; color: #000000; }
 .dash-page .sd-table-wrap { overflow-x: auto; }
@@ -11345,6 +11345,27 @@ h1, h2, h3 {
   gap: 20px;
 }
 
+.dash-page .dashboard-cleanup-load {
+  min-height: 52px;
+  height: 52px;
+  padding: 10px 30px;
+  border: 1px solid #faf8f5;
+  border-radius: 26px;
+  background: transparent;
+  color: #faf8f5;
+  font-family: var(--font-sans);
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.72px;
+}
+
+.dash-page .dashboard-cleanup-load:hover:not(:disabled) {
+  background: rgba(250, 248, 245, 0.16);
+  border-color: #faf8f5;
+  color: #faf8f5;
+}
+
 /* Old-memories banner — first thing in the shell: below the navbar,
    above the "Welcome" header (all other dash-shell orders start at 0). */
 .dash-page .dash-alert--cleanup {
@@ -11401,9 +11422,17 @@ h1, h2, h3 {
   line-height: 1.3;
 }
 
-/* The generic 860px rules shrink header pills to 44px but only match
-   .btn-secondary — keep the danger pill in step with Refresh. */
+/* Keep cleanup actions in step with the 44px mobile header pills. */
 @media (max-width: 860px) {
+  .dash-page .dashboard-cleanup-load {
+    min-height: 44px;
+    height: 44px;
+    padding: 0 16px;
+    border-radius: 22px;
+    font-size: 15px;
+    letter-spacing: 0.25px;
+  }
+
   .dash-page .dashboard-cleanup-delete {
     min-height: 44px;
     height: 44px;


### PR DESCRIPTION
## Summary
- Prevent the security-delete list from triggering a wallet signature on dashboard mount
- Require an explicit `Load my memories` action before loading pre-migration memories
- Preserve activation when the account object resolves and guard stale wallet/tab refresh callbacks
- Keep the CTA centered with the existing dashboard action styling

## Verification
- `pnpm --filter @memwal/app test` (70 tests)
- `pnpm --filter @memwal/app lint`
- `pnpm --filter @memwal/app build`
- Live devstack E2E not run locally

Fixes WALM-315.