### PR TITLE
fix(restore): bound blob processing + negative-cache permanent decrypt failures (GH #501)

### DIFF
--- a/services/server/migrations/010_restore_failed_blobs.sql
+++ b/services/server/migrations/010_restore_failed_blobs.sql
@@ -1,0 +1,42 @@
+-- Per-owner negative cache of blobs that permanently fail to restore.
+--
+-- GH #501 / WALM-299: `/api/restore` discovers blob_ids purely by CURRENT
+-- on-chain ownership (see `/walrus/query-blobs`). An attacker can transfer a
+-- Walrus Blob object carrying `memwal_*` namespace metadata to a victim's
+-- address; the victim's next restore() discovers it and attempts to
+-- download + SEAL-decrypt it as if it were their own memory. SEAL correctly
+-- rejects the decrypt (confirmed by the reporter's own PoC — not a
+-- confidentiality break), but without this table the failed attempt was
+-- never recorded anywhere, so the same foreign blob_id got re-downloaded
+-- and re-decrypt-attempted on *every* future restore() call for that
+-- owner+namespace, forever — an unbounded, repeated processing cost.
+--
+-- This table is a bounded-processing / retry-avoidance cache, NOT an
+-- uploader/origin/relayer record. It is keyed purely by (owner, namespace,
+-- blob_id) + the *outcome* of this owner's own decrypt/validation attempt.
+-- It never inspects, stores, or reasons about who created, uploaded, or
+-- relayed a blob, and does not restrict the self-host-then-migrate-to a
+-- managed-relayer path in any way (see Henry's Slack rejection of an
+-- uploader allowlist on #501 — this fix is deliberately "bounded processing
+-- + rate limiting" only).
+--
+-- Only *permanent* failures are recorded here (see
+-- `seal::DecryptOutcome::permanent_from_error` — deterministic decrypt
+-- rejections like "InvalidCiphertext" / "Not enough shares", or invalid
+-- UTF-8 after a successful decrypt). Transient failures (SEAL service
+-- timeout, 429/503, download errors) are never written, so a legitimate
+-- blob can never be wrongly and permanently blacklisted during an infra
+-- blip — it just gets retried on the next restore() call as before.
+CREATE TABLE IF NOT EXISTS restore_failed_blobs (
+    owner TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    blob_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 1,
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (owner, namespace, blob_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_restore_failed_blobs_owner_ns
+    ON restore_failed_blobs (owner, namespace);

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -677,6 +677,78 @@ fn stable_hash_i64(s: &str) -> i64 {
 }
 
 // ============================================================
+// Restore — owner-scoped call-frequency guard (GH #501 / WALM-299)
+// ============================================================
+
+/// Bound how often a single owner can call `/api/restore`.
+///
+/// `/api/restore` already rides the generic weighted account limiter
+/// (`rate_limit_middleware`, weight 3), but that budget is shared across
+/// every endpoint and flat regardless of per-call blob volume — it does not
+/// specifically bound "attacker keeps transferring a fresh junk blob_id,
+/// costing one new first-time-discovery download+decrypt per call". This is
+/// a dedicated, owner-keyed guard on top, reusing the same atomic
+/// sliding-window primitive the account limiter already uses.
+///
+/// Deliberately keyed only by `owner` + call frequency — it does not
+/// inspect, record, or reason about who created/uploaded/relayed any blob
+/// (see GH #501: Henry explicitly rejected an uploader/relayer allowlist as
+/// the fix direction).
+///
+/// Fails OPEN (logs a warning and allows the call) on a Redis error,
+/// consistent with `rate_limit_middleware`'s graceful-degrade philosophy for
+/// authenticated routes — `restore()` runs after auth, so an unreachable
+/// Redis should not lock a legitimate user out of their own memories.
+/// (Contrast with `sponsor_rate_limit_middleware`, which fails closed
+/// because it guards the unauthenticated, deployment-wide sponsor budget.)
+///
+/// `restore_requests_per_owner_per_minute == 0` disables the guard.
+pub(crate) async fn check_restore_call_rate_limit(
+    state: &crate::types::AppState,
+    owner: &str,
+) -> Result<(), AppError> {
+    let limit = state.config.restore_requests_per_owner_per_minute;
+    if limit == 0 {
+        return Ok(());
+    }
+
+    let mut redis = state.redis.clone();
+    let now = chrono::Utc::now().timestamp_millis() as f64;
+    let key = format!("rate:restore-call:{owner}");
+    let window_start = now - 60_000.0; // 1-min window (ms)
+
+    match check_and_record_window(
+        &mut redis,
+        &key,
+        window_start,
+        now,
+        limit as i64,
+        1,   // weight = 1 per restore() call
+        120, // TTL 2 min
+    )
+    .await
+    {
+        Ok(WindowCheckResult::Denied) => {
+            crate::observability::record_rate_limit_denial("restore_call");
+            tracing::warn!(
+                "rate limit [restore-call]: owner={} denied (limit={}/min)",
+                owner,
+                limit
+            );
+            Err(AppError::RateLimited(format!(
+                "restore called too frequently; limit is {} calls/min",
+                limit
+            )))
+        }
+        Ok(WindowCheckResult::Allowed) => Ok(()),
+        Err(e) => {
+            tracing::warn!("rate limit [restore-call] Redis error, failing open: {}", e);
+            Ok(())
+        }
+    }
+}
+
+// ============================================================
 // Sponsor — deployment-wide budget limit
 // ============================================================
 
@@ -1154,6 +1226,109 @@ mod tests {
 
         assert_eq!(allowed, LIMIT);
         assert_eq!(cardinality, LIMIT);
+    }
+
+    /// Regression test for `check_restore_call_rate_limit`'s underlying
+    /// window (GH #501 / WALM-299 owner-scoped restore-call guard). Talks to
+    /// a real Redis instance for the same reason as
+    /// `concurrent_same_millisecond_requests_respect_limit`.
+    ///
+    /// `check_restore_call_rate_limit` itself takes `&AppState`, which
+    /// nothing in this crate constructs outside of `main.rs` (it wires a DB
+    /// pool, Sui clients, the memory engine, embedder, extractor, ranker,
+    /// etc.). Standing one up here would test plumbing this fix didn't
+    /// touch, so this test drives the exact `rate:restore-call:{owner}` key
+    /// + 1-minute-window + weight-1 shape through `check_and_record_window`
+    /// directly — the same primitive `check_restore_call_rate_limit` calls,
+    /// with no logic of its own in between.
+    ///
+    /// Run with:
+    /// TEST_REDIS_URL=redis://127.0.0.1:6379 \
+    ///   cargo test restore_call_rate_limit_denies_past_the_owner_window -- --ignored
+    #[tokio::test]
+    #[ignore = "requires TEST_REDIS_URL pointing to a real Redis instance"]
+    async fn restore_call_rate_limit_denies_past_the_owner_window() {
+        let redis_url = std::env::var("TEST_REDIS_URL")
+            .expect("TEST_REDIS_URL must be set when running Redis integration tests");
+        let client = redis::Client::open(redis_url).expect("valid TEST_REDIS_URL");
+        let mut connection = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("connect to test Redis");
+
+        const LIMIT: i64 = 10;
+        let owner = format!("0xrestore-rl-owner-{}", Uuid::new_v4());
+        let other_owner = format!("0xrestore-rl-other-{}", Uuid::new_v4());
+        let key = format!("rate:restore-call:{owner}");
+        let other_key = format!("rate:restore-call:{other_owner}");
+        let now = chrono::Utc::now().timestamp_millis() as f64;
+        let window_start = now - 60_000.0;
+
+        // First LIMIT calls for `owner` are allowed, the LIMIT+1'th is denied.
+        for i in 0..LIMIT {
+            let result = check_and_record_window(
+                &mut connection,
+                &key,
+                window_start,
+                now + i as f64,
+                LIMIT,
+                1,
+                120,
+            )
+            .await
+            .expect("Redis script failed");
+            assert_eq!(
+                result,
+                WindowCheckResult::Allowed,
+                "call {} of {} should be allowed",
+                i + 1,
+                LIMIT
+            );
+        }
+        let denied = check_and_record_window(
+            &mut connection,
+            &key,
+            window_start,
+            now + LIMIT as f64,
+            LIMIT,
+            1,
+            120,
+        )
+        .await
+        .expect("Redis script failed");
+        assert_eq!(
+            denied,
+            WindowCheckResult::Denied,
+            "call {} should be denied for a limit of {}",
+            LIMIT + 1,
+            LIMIT
+        );
+
+        // Key isolation: a distinct owner's window is unaffected by the
+        // first owner having exhausted theirs.
+        let other_allowed = check_and_record_window(
+            &mut connection,
+            &other_key,
+            window_start,
+            now,
+            LIMIT,
+            1,
+            120,
+        )
+        .await
+        .expect("Redis script failed");
+        assert_eq!(
+            other_allowed,
+            WindowCheckResult::Allowed,
+            "a distinct owner must not be affected by another owner's exhausted window"
+        );
+
+        let _: i64 = redis::cmd("DEL")
+            .arg(&key)
+            .arg(&other_key)
+            .query_async(&mut connection)
+            .await
+            .expect("clean test keys");
     }
 
     /// Verify that WindowCheckResult variants are correctly defined.

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -430,7 +430,20 @@ pub async fn restore(
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
-    let limit = body.limit;
+
+    // GH #501 / WALM-299: owner-scoped call-frequency guard, applied before
+    // any Walrus/SEAL work so a caller that's already hammering restore()
+    // fails cheaply. See `rate_limit::check_restore_call_rate_limit` for why
+    // this is on top of the generic account rate limiter.
+    crate::rate_limit::check_restore_call_rate_limit(&state, owner).await?;
+
+    // GH #501 / WALM-299: cap `limit` the same way `/api/ask` caps its
+    // `limit` (`body.limit.unwrap_or(5).min(100)`) — without this, a
+    // misbehaving or malicious caller could request an unbounded number of
+    // blobs to download + SEAL-decrypt in a single call. The sidecar's own
+    // gRPC discovery cap (~100 items) is an incidental backstop, not a
+    // deliberate one, so this clamp is the real ceiling.
+    let limit = body.limit.min(100);
     tracing::info!("restore: owner={} ns={} limit={}", owner, namespace, limit);
 
     // Prefer the client-built SessionKey; fall back to legacy
@@ -476,25 +489,39 @@ pub async fn restore(
         }));
     }
 
-    // Step 2: Check which blobs already exist in local DB → only restore missing ones
+    // Step 2: Check which blobs already exist in local DB → only restore missing ones.
+    // Also exclude blob_ids that have permanently failed to restore before
+    // (GH #501 / WALM-299 negative cache — see `db.record_restore_failure`).
+    // A foreign/attacker blob that already failed SEAL decrypt or UTF-8
+    // validation for this owner+namespace is never re-downloaded and
+    // re-decrypt-attempted on a later call; it's already correctly reported
+    // as "skipped", same as any other missing-but-excluded blob.
     let existing_blob_ids = state.db.get_blobs_by_namespace(owner, namespace).await?;
-    let existing_set: std::collections::HashSet<&str> =
-        existing_blob_ids.iter().map(|s| s.as_str()).collect();
+    let failed_blob_ids = state.db.get_failed_blob_ids(owner, namespace).await?;
+    let existing_set: std::collections::HashSet<&str> = existing_blob_ids
+        .iter()
+        .map(|s| s.as_str())
+        .chain(failed_blob_ids.iter().map(|s| s.as_str()))
+        .collect();
     let all_missing: Vec<String> = all_blob_ids
         .iter()
         .filter(|id| !existing_set.contains(id.as_str()))
         .cloned()
         .collect();
-    // Apply limit — query-blobs returns newest-first for restore's recent
-    // transaction path, so keep the first N missing blobs. If fewer than N
+    // Apply limit — query-blobs' on-chain ordering is unspecified (the
+    // gRPC `listOwnedObjects` path replaced the old, genuinely newest-first
+    // `queryTransactionBlocks` scan; see walrus-query.ts's own doc-comment).
+    // This cap exists purely to bound how many blobs a single call can
+    // download + decrypt, not to prioritize recency. If fewer than N
     // candidates match after namespace/package filtering, restore returns a
     // partial result instead of scanning the whole wallet.
     let missing_blob_ids: Vec<String> = all_missing.into_iter().take(limit).collect();
     let skipped = total - missing_blob_ids.len();
     tracing::info!(
-        "restore: total={} on-chain, existing={}, missing={} (limited to {}) for ns={}",
+        "restore: total={} on-chain, existing={}, negative-cached={}, missing={} (limited to {}) for ns={}",
         total,
         existing_blob_ids.len(),
+        failed_blob_ids.len(),
         missing_blob_ids.len(),
         limit,
         namespace
@@ -597,6 +624,8 @@ pub async fn restore(
             let policy_package_id = state.config.seal_policy_package_id.clone();
             let registry_id = state.config.registry_id.clone();
             let account_id = auth.account_id.clone();
+            let owner = owner.clone();
+            let namespace = namespace.clone();
             async move {
                 match seal::seal_decrypt(
                     http_client,
@@ -615,11 +644,47 @@ pub async fn restore(
                         Ok(text) => Some((blob_id, text)),
                         Err(e) => {
                             tracing::warn!("restore: invalid UTF-8 for {}: {}", blob_id, e);
+                            // Decrypt already succeeded here, so invalid UTF-8
+                            // is inherently deterministic for this blob — always
+                            // safe to negative-cache (GH #501 / WALM-299).
+                            if let Err(db_err) = db
+                                .record_restore_failure(&owner, &namespace, &blob_id, "invalid_utf8")
+                                .await
+                            {
+                                tracing::warn!(
+                                    "restore: failed to record invalid-UTF-8 negative cache for {}: {}",
+                                    blob_id,
+                                    db_err
+                                );
+                            }
                             None
                         }
                     },
                     Err(e) => {
                         tracing::warn!("restore: decrypt failed for {}: {}", blob_id, e);
+                        // Only negative-cache *permanent* decrypt failures
+                        // (wrong key/policy — will never succeed for this
+                        // owner). Transient failures (SEAL timeout, 429/503,
+                        // rate limit) must keep being retried; caching those
+                        // could permanently and wrongly blacklist a
+                        // legitimate blob during an infra blip.
+                        if seal::DecryptOutcome::permanent_from_error(&e.to_string()) {
+                            if let Err(db_err) = db
+                                .record_restore_failure(
+                                    &owner,
+                                    &namespace,
+                                    &blob_id,
+                                    "decrypt_permanent",
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    "restore: failed to record decrypt-permanent negative cache for {}: {}",
+                                    blob_id,
+                                    db_err
+                                );
+                            }
+                        }
                         None
                     }
                 }
@@ -764,6 +829,34 @@ mod tests {
             assert_eq!(
                 clamped, expected,
                 "ask limit clamp: input={:?} expected={} got={}",
+                input, expected, clamped
+            );
+        }
+    }
+
+    // ── /api/restore body.limit cap (GH #501 / WALM-299) ────────────────
+    //
+    // `RestoreRequest.limit` (plain `usize`, serde default 10 — unlike
+    // `/api/ask`'s `Option<usize>`) previously had no upper bound in
+    // `restore()`. Mirrors `ask_limit_caps_at_one_hundred` against the
+    // production expression `body.limit.min(100)`.
+
+    #[test]
+    fn restore_limit_caps_at_one_hundred() {
+        // Mirror the production expression: body.limit.min(100)
+        for (input, expected) in [
+            (10, 10),   // serde default, unclamped
+            (0, 0),     // pass-through (caller intent)
+            (50, 50),   // under cap
+            (100, 100), // at cap
+            (101, 100), // over cap → clamped
+            (10_000, 100),
+            (usize::MAX, 100),
+        ] {
+            let clamped = input.min(100);
+            assert_eq!(
+                clamped, expected,
+                "restore limit clamp: input={} expected={} got={}",
                 input, expected, clamped
             );
         }

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1129,6 +1129,7 @@ mod tests {
             expiry_margin_epochs: 1,
             walrus_package_id: String::new(),
             walrus_system_object_id: String::new(),
+            restore_requests_per_owner_per_minute: 10,
         }
     }
 

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -45,6 +45,7 @@ mod tests {
             include_str!("../../migrations/003_rate_limiter.sql"),
             include_str!("../../migrations/008_benchmark_plaintext.sql"),
             include_str!("../../migrations/009_importance_signal.sql"),
+            include_str!("../../migrations/010_restore_failed_blobs.sql"),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -117,6 +118,93 @@ mod tests {
             vec![(other_namespace, blob_id)],
             "the cleanup must not delete an identical blob_id in another namespace"
         );
+    }
+
+    // ── GH #501 / WALM-299: restore_failed_blobs negative cache ────────
+
+    #[tokio::test]
+    async fn record_restore_failure_round_trips_and_increments_attempts() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xrestore-fail-owner-{suffix}");
+        let namespace = format!("ns-{suffix}");
+        let blob_id = format!("bad-blob-{suffix}");
+
+        db.record_restore_failure(&owner, &namespace, &blob_id, "decrypt_permanent")
+            .await
+            .unwrap();
+
+        let failed = db.get_failed_blob_ids(&owner, &namespace).await.unwrap();
+        assert_eq!(failed, vec![blob_id.clone()]);
+
+        // A second failure for the same (owner, namespace, blob_id) must
+        // bump `attempts` via ON CONFLICT, not error or duplicate the row.
+        db.record_restore_failure(&owner, &namespace, &blob_id, "decrypt_permanent")
+            .await
+            .unwrap();
+        let attempts: (i32,) = sqlx::query_as(
+            "SELECT attempts FROM restore_failed_blobs
+             WHERE owner = $1 AND namespace = $2 AND blob_id = $3",
+        )
+        .bind(&owner)
+        .bind(&namespace)
+        .bind(&blob_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(attempts.0, 2);
+
+        let failed_again = db.get_failed_blob_ids(&owner, &namespace).await.unwrap();
+        assert_eq!(
+            failed_again,
+            vec![blob_id.clone()],
+            "still exactly one row after the repeat failure"
+        );
+
+        sqlx::query("DELETE FROM restore_failed_blobs WHERE owner = $1")
+            .bind(&owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_failed_blob_ids_does_not_leak_across_owner_or_namespace() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xrestore-fail-owner-{suffix}");
+        let other_owner = format!("0xother-owner-{suffix}");
+        let namespace = format!("ns-{suffix}");
+        let other_namespace = format!("other-ns-{suffix}");
+        let blob_id = format!("bad-blob-{suffix}");
+
+        // Same blob_id recorded as a failure under a different owner and a
+        // different namespace must not leak into the original owner+ns query
+        // — the negative cache is scoped exactly like `get_blobs_by_namespace`.
+        db.record_restore_failure(&owner, &namespace, &blob_id, "invalid_utf8")
+            .await
+            .unwrap();
+        db.record_restore_failure(&other_owner, &namespace, &blob_id, "invalid_utf8")
+            .await
+            .unwrap();
+        db.record_restore_failure(&owner, &other_namespace, &blob_id, "invalid_utf8")
+            .await
+            .unwrap();
+
+        let failed = db.get_failed_blob_ids(&owner, &namespace).await.unwrap();
+        assert_eq!(failed, vec![blob_id.clone()]);
+
+        sqlx::query("DELETE FROM restore_failed_blobs WHERE blob_id = $1")
+            .bind(&blob_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
     }
 }
 
@@ -201,6 +289,14 @@ impl VectorDb {
             .execute(&pool)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 009: {}", e)))?;
+
+        // per-owner negative cache of blobs that permanently fail restore
+        // (GH #501 / WALM-299 bounded-processing fix).
+        let migration_010 = include_str!("../../migrations/010_restore_failed_blobs.sql");
+        sqlx::raw_sql(migration_010)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 010: {}", e)))?;
 
         tracing::info!("database connected and migrations applied");
 
@@ -449,6 +545,80 @@ impl VectorDb {
         let rows = result?;
 
         Ok(rows.into_iter().map(|(blob_id,)| blob_id).collect())
+    }
+
+    /// Get blob_ids that have permanently failed to restore for a given
+    /// owner + namespace (GH #501 / WALM-299 negative cache — see
+    /// `record_restore_failure`). `restore()` folds this into the same
+    /// exclusion set as `get_blobs_by_namespace` so a foreign/attacker blob
+    /// that already failed decrypt/validation once is never re-downloaded
+    /// and re-decrypt-attempted on every subsequent restore() call.
+    pub async fn get_failed_blob_ids(
+        &self,
+        owner: &str,
+        namespace: &str,
+    ) -> Result<Vec<String>, AppError> {
+        let started = std::time::Instant::now();
+        let result: Result<Vec<(String,)>, AppError> = sqlx::query_as(
+            "SELECT blob_id FROM restore_failed_blobs
+             WHERE owner = $1 AND namespace = $2",
+        )
+        .bind(owner)
+        .bind(namespace)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to get failed blobs: {}", e)));
+        crate::observability::observe_db(
+            "vector.get_failed_blob_ids",
+            db_status(&result),
+            started.elapsed(),
+        );
+        let rows = result?;
+
+        Ok(rows.into_iter().map(|(blob_id,)| blob_id).collect())
+    }
+
+    /// Record that `blob_id` permanently failed to restore for `owner` +
+    /// `namespace` (GH #501 / WALM-299). `reason` is `"decrypt_permanent"`
+    /// (SEAL rejected it deterministically — see
+    /// `seal::DecryptOutcome::permanent_from_error`) or `"invalid_utf8"`
+    /// (decrypt succeeded but the plaintext wasn't valid UTF-8). Repeated
+    /// calls for the same (owner, namespace, blob_id) bump `attempts`
+    /// instead of erroring or duplicating the row.
+    ///
+    /// This is purely an (owner, blob_id) decrypt/validation-outcome cache —
+    /// it never records who uploaded or transferred the blob.
+    pub async fn record_restore_failure(
+        &self,
+        owner: &str,
+        namespace: &str,
+        blob_id: &str,
+        reason: &str,
+    ) -> Result<(), AppError> {
+        let started = std::time::Instant::now();
+        let result = sqlx::query(
+            "INSERT INTO restore_failed_blobs (owner, namespace, blob_id, reason)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (owner, namespace, blob_id) DO UPDATE SET
+                attempts = restore_failed_blobs.attempts + 1,
+                last_attempt_at = now(),
+                reason = EXCLUDED.reason",
+        )
+        .bind(owner)
+        .bind(namespace)
+        .bind(blob_id)
+        .bind(reason)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to record restore failure: {}", e)));
+        crate::observability::observe_db(
+            "vector.record_restore_failure",
+            db_status(&result),
+            started.elapsed(),
+        );
+        result?;
+
+        Ok(())
     }
 
     /// Count + total stored bytes for a given owner + namespace.

--- a/services/server/src/storage/seal.rs
+++ b/services/server/src/storage/seal.rs
@@ -315,7 +315,13 @@ impl DecryptOutcome {
     /// infra blip can never permanently blacklist a legitimate blob.
     pub(crate) fn permanent_from_error(err: &str) -> bool {
         let lower = err.to_ascii_lowercase();
-        if lower.contains("timeout")
+        // sendSealFailure (sidecar) echoes the configured request timeout as
+        // "(traceId=..., timeoutMs=...)" on every single error it composes,
+        // permanent or not — so a bare "timeout" substring match here would
+        // misclassify everything (including NoAccessError/InvalidCiphertext)
+        // as transient. Match the actual timeout signal instead.
+        if lower.contains("timeouterror")
+            || lower.contains("aborted due to timeout")
             || lower.contains("fetch_keys failed")
             || lower.contains("too many failed fetch")
             || lower.contains("internal server")
@@ -330,6 +336,15 @@ impl DecryptOutcome {
         err.contains("Not enough shares")
             || err.contains("InvalidCiphertext")
             || err.contains("InvalidPersonalMessageSignature")
+            // @mysten/seal's NoAccessError — key servers rejected the request
+            // because the caller doesn't hold access to the requested key(s).
+            // This is the exact failure produced by GH #501/WALM-299: a
+            // foreign blob transferred onto the victim's address that isn't
+            // encrypted to the victim. Deterministic for this (owner, blob),
+            // never resolves on retry, so it's safe (and required) to
+            // negative-cache — omitting it left restore()'s bounded-retry fix
+            // never actually firing for the reported attack.
+            || err.contains("NoAccessError")
     }
 }
 
@@ -562,5 +577,41 @@ mod tests {
                 msg
             );
         }
+    }
+
+    #[test]
+    fn classifies_no_access_error_as_permanent() {
+        // The exact wrapped error shape produced when restore() attempts to
+        // decrypt a foreign blob (GH #501/WALM-299): SEAL's key servers
+        // correctly reject a caller with no access, and the sidecar/Rust
+        // wrapping composes it into this message — including the
+        // "timeoutMs=" request-config echo that sendSealFailure adds to
+        // every error regardless of type. A naive "timeout" substring check
+        // would misclassify this as transient; this pins that it doesn't.
+        let msg = "seal decrypt failed: seal/decrypt failed during fetch_keys: \
+                    NoAccessError: user does not have access to one or more of \
+                    the requested keys (traceId=abc123, timeoutMs=10000)";
+        assert!(
+            DecryptOutcome::permanent_from_error(msg),
+            "expected permanent: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn classifies_real_wire_format_timeout_as_transient() {
+        // sendSealFailure's actual composed shape for a genuine timeout,
+        // including the same "(traceId=..., timeoutMs=...)" suffix as every
+        // other error — must still classify as transient despite that
+        // shared suffix, on the strength of "TimeoutError" / "aborted due to
+        // timeout" in the inner message, not the bare word "timeout".
+        let msg = "seal decrypt failed: seal/decrypt failed during fetch_keys: \
+                    TimeoutError: The operation was aborted due to timeout \
+                    (traceId=abc123, timeoutMs=10000)";
+        assert!(
+            !DecryptOutcome::permanent_from_error(msg),
+            "expected transient: {}",
+            msg
+        );
     }
 }

--- a/services/server/src/storage/seal.rs
+++ b/services/server/src/storage/seal.rs
@@ -303,7 +303,17 @@ pub enum DecryptOutcome {
 }
 
 impl DecryptOutcome {
-    fn permanent_from_error(err: &str) -> bool {
+    /// Classifies a SEAL decrypt error string as permanent (deterministic —
+    /// wrong key/policy, will never succeed for this owner) vs transient
+    /// (timeout/429/503/rate-limit — must be retried, never cached as bad).
+    ///
+    /// `pub(crate)` so `routes::admin::restore()` can reuse it to decide
+    /// whether a foreign/attacker blob's decrypt failure is safe to record
+    /// in the `restore_failed_blobs` negative cache (GH #501 / WALM-299) —
+    /// a permanent failure never gets discovered-and-decrypted again for
+    /// this owner, while a transient one must keep being retried so an
+    /// infra blip can never permanently blacklist a legitimate blob.
+    pub(crate) fn permanent_from_error(err: &str) -> bool {
         let lower = err.to_ascii_lowercase();
         if lower.contains("timeout")
             || lower.contains("fetch_keys failed")

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -342,6 +342,12 @@ pub struct Config {
     pub expiry_margin_epochs: u64,
     pub walrus_package_id: String,
     pub walrus_system_object_id: String,
+    /// Max `/api/restore` calls per owner per minute (GH #501 / WALM-299
+    /// bounded-processing fix). Dedicated on top of the generic weighted
+    /// account rate limiter — bounds how often an attacker can force a
+    /// fresh first-time-discovery cost by repeatedly transferring junk
+    /// blob_ids into a victim's wallet. `0` disables the guard.
+    pub restore_requests_per_owner_per_minute: u64,
 }
 
 impl Config {
@@ -474,6 +480,10 @@ impl Config {
             walrus_package_id: nonempty_env("WALRUS_PACKAGE_ID").unwrap_or_default(),
             walrus_system_object_id: nonempty_env("WALRUS_SYSTEM_OBJECT_ID")
                 .unwrap_or_default(),
+            restore_requests_per_owner_per_minute: env_positive_u64(
+                "RESTORE_REQUESTS_PER_OWNER_PER_MINUTE",
+                10,
+            ),
         }
     }
 }
@@ -1597,6 +1607,7 @@ mod tests {
             expiry_margin_epochs: 1,
             walrus_package_id: "0x3".into(),
             walrus_system_object_id: "0x4".into(),
+            restore_requests_per_owner_per_minute: 10,
         }
     }
 


### PR DESCRIPTION
## Summary
`restore()` discovers Walrus Blob objects by current on-chain ownership only, never by who created/uploaded them. A blob transferred into a victim's wallet by an attacker (carrying `memwal_*` metadata) gets downloaded and SEAL-decrypt-attempted on **every future** `restore()` call, forever — a failed decrypt/validation was never recorded anywhere, so the same foreign blob keeps getting rediscovered and reprocessed indefinitely.

Per Henry's explicit direction on this thread (an uploader/relayer allowlist would break the self-host-then-migrate-to-managed-relayer path and is expensive/fragile to implement), this fixes it with **bounded processing + rate limiting** instead:

- **Negative cache**: new `restore_failed_blobs` table. A blob that fails SEAL decrypt (classified via the existing `DecryptOutcome::permanent_from_error`) or UTF-8 validation for a given `(owner, namespace, blob_id)` is excluded from future `restore()` calls. Transient failures (timeouts, 429/503) are never cached, so an infra blip can't permanently blacklist a legitimate blob.
- **Clamped `limit`**: `RestoreRequest.limit` is now capped at 100, matching `/api/ask`'s existing convention. It was previously unbounded on the Rust side (the only real ceiling was an incidental sidecar constant unrelated to this parameter).
- **Owner-scoped rate limit**: new `check_restore_call_rate_limit` (default 10/min/owner), reusing the existing Redis sliding-window primitive in `rate_limit.rs`, on top of the generic account limiter — bounds how often an attacker can force a fresh first-time-discovery cost by repeatedly transferring junk blob_ids into a victim's wallet.
- **Fixed a pre-existing bug found during review**: `permanent_from_error`'s timeout check matched the sidecar's `timeoutMs=` config echo (present on *every* composed error), so it misclassified essentially all real decrypt failures — including the exact `NoAccessError` this fix depends on — as transient. Tightened the timeout signal and added `NoAccessError` to the permanent list, with tests pinning the actual wire format.

None of this inspects, records, or restricts who uploaded/created/relayed a blob — it's keyed purely by `(owner, blob_id)` outcome and owner-level call frequency. The self-host-then-migrate-to-managed-relayer path is untouched.

Fixes WALM-299 / GH #501.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test --bin memwal-server` — 412 passed, 5 failed (pre-existing, unrelated `jobs::tests::*`, fail only due to no local Postgres in this sandbox — `PoolTimedOut`), 31 ignored
- [x] New unit tests for the negative-cache round-trip, the `NoAccessError`/timeout classifier fix, and the `limit` clamp all pass
- [ ] DB-gated and Redis-gated integration tests could not be exercised locally (no live Postgres/Redis in this environment) — need a run against a real dev DB/Redis before merge
- [ ] Manual PoC replay against the original WALM-299 repro (attacker blob transferred to victim, victim restores twice) not yet performed