### PR TITLE
Fix: validate manual embedding vector on write and read paths

### DIFF
--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -320,9 +320,12 @@ pub async fn recall_manual(
     Extension(auth): Extension<AuthInfo>,
     Json(body): Json<RecallManualRequest>,
 ) -> Result<Json<RecallManualResponse>, AppError> {
-    if body.vector.is_empty() {
-        return Err(AppError::BadRequest("vector cannot be empty".into()));
-    }
+    // Validate the client-supplied query vector (width + finiteness) up front.
+    // The store's embedding column is fixed-width and refuses NaN/Inf, so a
+    // malformed query vector can only fail inside pgvector and surface as an
+    // opaque 500; reject it here with an actionable 400. (No upload/gas on this
+    // read path, unlike remember_manual — this is purely a clearer-error improvement.)
+    validate_embedding_vector(&body.vector)?;
 
     // Validate scoring_weights up front (NaN / out-of-range / sub-floor
     // half-life) before the vector search, mirroring `recall`. Previously

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -913,9 +913,13 @@ pub async fn remember_manual(
             "encrypted_data cannot be empty".into(),
         ));
     }
-    if body.vector.is_empty() {
-        return Err(AppError::BadRequest("vector cannot be empty".into()));
-    }
+    // Validate the client-supplied embedding (width + finiteness) up front. The
+    // fact store's `embedding` column is a fixed-width pgvector that also refuses
+    // NaN/Inf, so a malformed vector can never be indexed — and store_blob pays
+    // for the (irreversible) Walrus upload before it reaches the insert. Rejecting
+    // here means a bad vector costs no gas and returns an actionable 400, instead
+    // of an opaque 500 after the paid upload.
+    validate_embedding_vector(&body.vector)?;
     validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;

--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -21,8 +21,10 @@ use crate::types::{AppError, Config};
 pub const EMBEDDING_MODEL: &str = "openai/text-embedding-3-small";
 
 /// Embedding vector dimensionality (text-embedding-3-small). Also the
-/// width of the deterministic mock vector.
-const EMBEDDING_DIMS: usize = 1536;
+/// width of the deterministic mock vector, and the fixed width of the
+/// `vector_entries.embedding` pgvector column — client-supplied vectors
+/// on the manual write path are validated against it.
+pub const EMBEDDING_DIMS: usize = 1536;
 
 #[async_trait]
 pub trait Embedder: Send + Sync {

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -871,6 +871,7 @@ pub fn validate_namespace(namespace: &str) -> Result<(), AppError> {
 ///   - a width other than the fixed pgvector column (`EMBEDDING_DIMS`), and
 ///   - any non-finite component (NaN / ±Inf), which pgvector refuses to index
 ///     and which is meaningless for cosine similarity.
+///
 /// Both would otherwise only fail deep in pgvector as an opaque 500.
 pub fn validate_embedding_vector(vector: &[f32]) -> Result<(), AppError> {
     use crate::services::embedder::EMBEDDING_DIMS;
@@ -1618,8 +1619,14 @@ mod tests {
             vector[7] = bad;
             match validate_embedding_vector(&vector).unwrap_err() {
                 AppError::BadRequest(msg) => {
-                    assert!(msg.contains("finite"), "message names the finiteness rule: {msg}");
-                    assert!(msg.contains("index 7"), "message names the offending index: {msg}");
+                    assert!(
+                        msg.contains("finite"),
+                        "message names the finiteness rule: {msg}"
+                    );
+                    assert!(
+                        msg.contains("index 7"),
+                        "message names the offending index: {msg}"
+                    );
                 }
                 other => panic!("expected BadRequest, got {other:?}"),
             }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -864,6 +864,30 @@ pub fn validate_namespace(namespace: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Validate a client-supplied embedding vector against what the fact store can
+/// accept. Shared by the manual write and read paths, where the vector comes
+/// from the caller rather than the server-side embedder. Rejects, with an
+/// actionable `BadRequest` (and, on the write path, before any paid upload):
+///   - a width other than the fixed pgvector column (`EMBEDDING_DIMS`), and
+///   - any non-finite component (NaN / ±Inf), which pgvector refuses to index
+///     and which is meaningless for cosine similarity.
+/// Both would otherwise only fail deep in pgvector as an opaque 500.
+pub fn validate_embedding_vector(vector: &[f32]) -> Result<(), AppError> {
+    use crate::services::embedder::EMBEDDING_DIMS;
+    if vector.len() != EMBEDDING_DIMS {
+        return Err(AppError::BadRequest(format!(
+            "vector must have exactly {EMBEDDING_DIMS} dimensions, got {}",
+            vector.len()
+        )));
+    }
+    if let Some(index) = vector.iter().position(|component| !component.is_finite()) {
+        return Err(AppError::BadRequest(format!(
+            "vector must contain only finite values; component at index {index} is not finite"
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RecallRequest {
     pub query: String,
@@ -1543,6 +1567,64 @@ mod tests {
     use std::sync::Mutex;
 
     static WALRUS_STORAGE_EPOCHS_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // ── Client-supplied embedding vector validation ──────────────
+
+    #[test]
+    fn embedding_of_correct_width_is_accepted() {
+        use crate::services::embedder::EMBEDDING_DIMS;
+        assert!(validate_embedding_vector(&vec![0.1_f32; EMBEDDING_DIMS]).is_ok());
+    }
+
+    #[test]
+    fn embedding_of_wrong_width_is_rejected_with_actionable_message() {
+        use crate::services::embedder::EMBEDDING_DIMS;
+        // A width from a different embedding model; kept distinct from the
+        // expected width so a transposed format! (expected/actual swapped) still
+        // fails the exact-string assert below.
+        let wrong = EMBEDDING_DIMS / 2 + 1;
+        match validate_embedding_vector(&vec![0.1_f32; wrong]).unwrap_err() {
+            // BadRequest maps to HTTP 400, unlike the opaque 500 a downstream
+            // pgvector failure would produce (after a paid upload on the write path).
+            AppError::BadRequest(msg) => {
+                // Build the expected message from the constant (single source of
+                // truth — survives a dimension change) while still pinning the
+                // exact wording and the expected-then-actual order.
+                assert_eq!(
+                    msg,
+                    format!("vector must have exactly {EMBEDDING_DIMS} dimensions, got {wrong}")
+                );
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn embedding_empty_vector_is_rejected() {
+        // The width check subsumes a separate non-empty guard.
+        assert!(matches!(
+            validate_embedding_vector(&[]),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn embedding_with_non_finite_component_is_rejected() {
+        use crate::services::embedder::EMBEDDING_DIMS;
+        // Correct width, but a NaN/Inf component pgvector would refuse to index —
+        // must be caught here, before any paid upload, not as an opaque 500.
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut vector = vec![0.1_f32; EMBEDDING_DIMS];
+            vector[7] = bad;
+            match validate_embedding_vector(&vector).unwrap_err() {
+                AppError::BadRequest(msg) => {
+                    assert!(msg.contains("finite"), "message names the finiteness rule: {msg}");
+                    assert!(msg.contains("index 7"), "message names the offending index: {msg}");
+                }
+                other => panic!("expected BadRequest, got {other:?}"),
+            }
+        }
+    }
 
     fn security_delete_test_config() -> Config {
         Config {


### PR DESCRIPTION
## Summary

### Why

The manual write path `POST /api/remember/manual` (`remember_manual`) accepted a client-supplied
embedding vector without validating it. The fact store's pgvector column is fixed at `vector(1536)`
**and** refuses non-finite values, so a malformed vector — a wrong width, or one containing NaN/Inf —
can never be indexed. But `store_blob` pays for the (irreversible) Walrus upload **before** the
failing insert. The result:

1. **Real gas wasted** on a write that can never land — the paid upload happens, then `insert_vector`
   fails on the dimension/finiteness mismatch.
2. **Opaque 500**, not an actionable error — the pgvector error maps to `AppError::Internal`, so the
   client gets a scrubbed `Internal server error (traceId: …)` and the real message is hidden. A
   caller (e.g. one embedding with a 768-dim model, or emitting a NaN) has no signal and can retry
   indefinitely, burning gas each time.

Reported in GH #394; independently reproduced and re-confirmed unfixed against current `dev`.

The sibling read path `POST /api/recall/manual` (`recall_manual`) has the same class of hole: it
also takes a client-supplied vector and only checked `is_empty()`, so a wrong-width **query** vector
also fell through to an opaque pgvector 500. No gas is spent there (it's a read), but the confusing
error is the same, so this PR closes both the write and read manual paths in one change.

### What

- `remember_manual` now validates the client vector **up front, before any upload** — rejecting a
  wrong width (with a `400` naming expected vs actual) **and** any non-finite (NaN/±Inf) component
  (naming the offending index).
- `recall_manual` (the sibling read path, also client-vector) gets the same guard before the pgvector
  search. It's a read — no upload, no gas — but a malformed query vector previously also produced an
  opaque 500; now it's an actionable 400.
- The embedder's dimension constant `EMBEDDING_DIMS` (1536) is promoted to `pub` and reused as the
  single source of truth for the width check, so the validator and the server-side embedder can never
  drift apart.
- Adds unit coverage for correct / wrong-width / empty / non-finite vectors.

### Solution

- New shared helper `validate_embedding_vector(&[f32]) -> Result<(), AppError>` in `types.rs`, beside
  `validate_namespace` (the established validation-helper location); both manual paths call it. It
  checks width (against `EMBEDDING_DIMS`) then finiteness. `remember_manual` calls it before
  `store_blob` (before the first gas spend); `recall_manual` before `search_similar`. It replaces and
  subsumes the old `vector.is_empty()` guards (empty still 400s, with a clearer message).
- Standard `/api/remember`, bulk remember, `analyze`, and `restore` are unaffected — they embed
  server-side (always 1536-dim) or don't accept a client vector. The two manual paths are the only
  ones that accept a client-supplied vector, and both are now guarded.
- No DB schema change, no new architectural surface, no privacy-floor impact (the manual paths
  already trust a client-supplied plaintext vector by design; this only tightens their validation).

## Types of Changes

- [ ] Breaking change (existing functionality would change)
- [ ] New feature (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] Performance optimization
- [ ] Refactor (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Test
- [ ] Security / permission-scope change

## Benchmark impact

- [x] No benchmark-affecting change (write/infra only)
- [ ] Benchmarked: LOCOMO + LongMemEval, gpt-4o judge, eval_runs=3, vs baseline
- Result: N/A
- [ ] Default-off / byte-identical when the flag is off

The write-path guard is infra-only. The `recall_manual` read-path guard only **rejects an
already-invalid query vector (wrong width or non-finite) before the search** — it cannot change
results for any valid 1536-dim query, so recall/answer quality is unaffected. No benchmark rerun
needed.

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] `cargo test` / harness tests pass

Unit tests (co-located with the helper in `types.rs`): correct-width accepted; 768-dim rejected with
the exact message; empty rejected; NaN/+Inf/-Inf rejected, naming the offending index. `cargo test`
— validation tests 4/4, `routes::remember` + `routes::recall` green; `cargo build` clean.

## Checklist

- [x] Follows the project's commit + code conventions
- [x] No ticket IDs / competitor names / local-doc paths in code comments
- [x] Docs updated if needed (n/a — behavior is a stricter 400 on an already-invalid input)
- [x] Respects the privacy floor (no server-readable plaintext index; no change to storage surface)
- [x] All new and existing tests pass

## Related

- Closes #394
- Linear: WALM-314

## Additional Notes

Adversarially reviewed (completeness + bug/logic). Confirmed `remember_manual` is the only path that
takes a client vector and does upload-then-insert (the gas-waste bug), with `recall_manual` the only
other client-vector path — both now guarded via the shared helper. The guard covers both malformed
classes that pgvector would otherwise reject after a paid upload: wrong width and non-finite
components. No known remaining client-vector input that reaches a paid upload or fixed-width insert
unvalidated.
