### PR TITLE
fix(server): signal restore() truncation, including sidecar candidate-cap hits (WALM-317, WALM-319)

### DIFF
--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -352,6 +352,9 @@ Rebuild missing vector entries for one namespace. Queries onchain blobs by owner
   "skipped": 7,
   "total": 10,
   "namespace": "demo",
-  "owner": "0x..."
+  "owner": "0x...",
+  "truncated": false
 }
 ```
+
+`truncated` is `true` when this restore is known-incomplete: either more on-chain blobs were missing locally than `limit` allowed this call to restore, or the sidecar's raw on-chain candidate fetch (bounded per owner, shared across all of the owner's namespaces, hard-capped independent of `limit`) hit its own cap before this namespace's blobs were even filtered out of that set. The second case can produce `truncated: true` even when `total` is `0` for this namespace, since a cap hit elsewhere can starve this namespace's fetch entirely. Raising `limit` only helps with the first case — past the sidecar's cap, only a cursor/pagination-based restore would.

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -794,16 +794,20 @@ class MemWal:
                 hierarchy semantics (see SKILL.md "Namespace Semantics").
             limit: Max blobs the relayer will *inspect* this call (default:
                 10, matches the server-side default and the TypeScript SDK).
-                The relayer fetches blobs newest-first and caps the work at
-                this number; it does **not** cap ``restored`` separately.
+                The relayer selects up to this many missing blobs from the
+                candidates it sees, in unspecified order; it does **not** cap
+                ``restored`` separately.
 
         Returns:
             :class:`RestoreResult`.
 
         Notes:
-            * **No pagination cursor** — restore is single-shot. To rebuild a
-              large namespace, call repeatedly with a growing ``limit`` or
-              prune the local index first.
+            * **No pagination cursor** — restore is single-shot. A larger
+              ``limit`` may help when ``truncated`` is caused by the request
+              limit, but candidate discovery also has a per-owner source cap
+              shared across namespaces. Hitting that cap requires cursor/
+              pagination support for guaranteed full recovery; increasing
+              ``limit`` or retrying cannot guarantee it.
             * **Performance** scales linearly in ``limit``: up to 10 Walrus
               downloads in parallel, then 3 SEAL decrypts in parallel, then
               embeddings. Expect seconds-per-blob on cold caches.

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -784,6 +784,10 @@ class MemWal:
           do **not** count as either restored or skipped.
         * ``total`` — count of on-chain blobs the relayer saw for
           ``(owner, namespace)`` before the limit was applied.
+        * ``truncated`` — True when this restore is known-incomplete (limit
+          truncation or an upstream on-chain candidate-fetch cap; see
+          :class:`~memwal.types.RestoreResult`). Defaults to ``False`` when
+          talking to a relayer older than WALM-319 that omits the field.
 
         Args:
             namespace: Namespace to restore. Exact match — no prefix or
@@ -814,6 +818,10 @@ class MemWal:
             total=data["total"],
             namespace=data["namespace"],
             owner=data["owner"],
+            # Relayers older than WALM-319 omit `truncated` entirely --
+            # treat "not present" as "not known to be truncated" rather
+            # than require every relayer version to send it.
+            truncated=data.get("truncated", False),
         )
 
     async def health(self) -> HealthResult:

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -201,6 +201,17 @@ class RestoreResult:
     total: int
     namespace: str
     owner: str
+    #: True when this restore is known-incomplete: either more on-chain
+    #: blobs were missing locally than ``limit`` allowed this call to
+    #: restore, or the sidecar's raw on-chain candidate fetch hit its own
+    #: cap before this namespace's blobs were even filtered out of that
+    #: set (WALM-319) -- this can be ``True`` even when ``total == 0``,
+    #: since a cap hit elsewhere can starve this namespace's fetch
+    #: entirely. Raising ``limit`` only helps with the first case.
+    #:
+    #: Relayers older than WALM-319 don't send this field at all; the SDK
+    #: defaults it to ``False`` in that case rather than requiring it.
+    truncated: bool = False
 
 
 @dataclass

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -630,6 +630,7 @@ class TestRestore:
                     "total": 7,
                     "namespace": "my-app",
                     "owner": "0xowner",
+                    "truncated": False,
                 },
             )
         )
@@ -641,6 +642,57 @@ class TestRestore:
         assert body["limit"] == 100
         assert result.restored == 5
         assert result.skipped == 2
+        assert result.truncated is False
+
+    @respx.mock
+    async def test_restore_preserves_truncated_true(
+        self, memwal_client: MemWal
+    ) -> None:
+        """truncated=True from the relayer must survive into RestoreResult
+        instead of being dropped when the dataclass is reconstructed."""
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/restore").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "restored": 5,
+                    "skipped": 2,
+                    "total": 7,
+                    "namespace": "my-app",
+                    "owner": "0xowner",
+                    "truncated": True,
+                },
+            )
+        )
+
+        result = await memwal_client.restore("my-app", limit=100)
+
+        assert result.truncated is True
+
+    @respx.mock
+    async def test_restore_truncated_defaults_false_when_omitted(
+        self, memwal_client: MemWal
+    ) -> None:
+        """Relayers older than WALM-319 omit `truncated` entirely — the
+        SDK must default it to False rather than requiring the field."""
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/restore").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "restored": 5,
+                    "skipped": 2,
+                    "total": 7,
+                    "namespace": "my-app",
+                    "owner": "0xowner",
+                    # no "truncated" key — simulates an older relayer
+                },
+            )
+        )
+
+        result = await memwal_client.restore("my-app", limit=100)
+
+        assert result.truncated is False
 
 
 class TestHealth:

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -896,9 +896,13 @@ export class MemWalManual {
      * @returns RestoreResult with count of restored entries
      */
     async restore(namespace: string, limit: number = 10): Promise<RestoreResult> {
-        return this.signedRequest<RestoreResult>("POST", "/api/restore", {
+        const result = await this.signedRequest<RestoreResult>("POST", "/api/restore", {
             namespace,
             limit,
         });
+        // Relayers older than WALM-319 omit `truncated` entirely — treat
+        // "not present" as "not known to be truncated" rather than drop
+        // the field or require every relayer version to send it.
+        return { ...result, truncated: result.truncated ?? false };
     }
 }

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -777,13 +777,16 @@ export class MemWal {
      * - `total` — on-chain blobs the relayer saw for `(owner, namespace)`
      *   before the limit was applied.
      *
-     * **`limit`** caps the *number of blobs the relayer inspects*, newest
-     * first. It is not a cap on `restored` directly. The server default is
-     * `10` (matches the SDK default).
+     * **`limit`** caps the *number of missing blobs the relayer selects* from
+     * the candidates it sees, in unspecified order. It is not a cap on
+     * `restored` directly. The server default is `10` (matches the SDK
+     * default).
      *
-     * **No pagination cursor** — restore is single-shot. To rebuild a large
-     * namespace, call repeatedly with a growing `limit` or prune the local
-     * index first.
+     * **No pagination cursor** — restore is single-shot. A larger `limit` may
+     * help when `truncated` is caused by the request limit, but candidate
+     * discovery also has a per-owner source cap shared across namespaces.
+     * Hitting that cap requires cursor/pagination support for guaranteed full
+     * recovery; increasing `limit` or retrying cannot guarantee it.
      *
      * **Performance** scales linearly in `limit`: up to 10 Walrus downloads
      * in parallel, then 3 SEAL decrypts in parallel, then embeddings.

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -800,10 +800,14 @@ export class MemWal {
      * ```
      */
     async restore(namespace: string, limit: number = 10): Promise<RestoreResult> {
-        return this.signedRequest<RestoreResult>("POST", "/api/restore", {
+        const result = await this.signedRequest<RestoreResult>("POST", "/api/restore", {
             namespace,
             limit,
         });
+        // Relayers older than WALM-319 omit `truncated` entirely — treat
+        // "not present" as "not known to be truncated" rather than drop
+        // the field or require every relayer version to send it.
+        return { ...result, truncated: result.truncated ?? false };
     }
 
     /**

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -302,6 +302,19 @@ export interface RestoreResult {
     total: number;
     namespace: string;
     owner: string;
+    /**
+     * True when this restore is known-incomplete: either more on-chain
+     * blobs were missing locally than `limit` allowed this call to
+     * restore, or the sidecar's raw on-chain candidate fetch hit its own
+     * cap before this namespace's blobs were even filtered out of that
+     * set (WALM-319) — this can be `true` even when `total === 0`, since
+     * a cap hit elsewhere can starve this namespace's fetch entirely.
+     * Raising `limit` only helps with the first case.
+     *
+     * Relayers older than WALM-319 don't send this field at all; the SDK
+     * defaults it to `false` in that case rather than requiring it.
+     */
+    truncated: boolean;
 }
 
 // ============================================================

--- a/packages/sdk/test/restore-truncated.test.mjs
+++ b/packages/sdk/test/restore-truncated.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWal } from "../dist/memwal.js";
+import { MemWalManual } from "../dist/manual.js";
+
+function client() {
+    return MemWal.create({
+        key: new Uint8Array(32).fill(1),
+        accountId: "0x1",
+        serverUrl: "https://relayer.example",
+    });
+}
+
+function manualClient() {
+    return MemWalManual.create({
+        key: new Uint8Array(32).fill(1),
+        walletSigner: {
+            address: "0x2",
+            signAndExecuteTransaction: async () => ({ digest: "0xtx" }),
+            signPersonalMessage: async () => ({ signature: "sig" }),
+        },
+        suiClient: {},
+        embeddingApiKey: "test",
+        packageId: `0x${"33".repeat(32)}`,
+        accountId: "0x1",
+        registryId: "0xregistry",
+        sealServerConfigs: [{ objectId: "0xserver", weight: 1 }],
+    });
+}
+
+function baseResponse(overrides = {}) {
+    return {
+        restored: 3,
+        skipped: 7,
+        total: 10,
+        namespace: "demo",
+        owner: "0xowner",
+        ...overrides,
+    };
+}
+
+test("MemWal.restore() preserves truncated=true from the relayer response", async () => {
+    const memwal = client();
+    memwal.signedRequest = async () => baseResponse({ truncated: true });
+
+    const result = await memwal.restore("demo");
+
+    assert.equal(result.truncated, true);
+});
+
+test("MemWal.restore() defaults truncated to false when an older relayer omits it", async () => {
+    const memwal = client();
+    const raw = baseResponse();
+    delete raw.truncated;
+    memwal.signedRequest = async () => raw;
+
+    const result = await memwal.restore("demo");
+
+    assert.equal(result.truncated, false);
+});
+
+test("MemWalManual.restore() preserves truncated=true from the relayer response", async () => {
+    const manual = manualClient();
+    manual.signedRequest = async () => baseResponse({ truncated: true });
+
+    const result = await manual.restore("demo");
+
+    assert.equal(result.truncated, true);
+});
+
+test("MemWalManual.restore() defaults truncated to false when an older relayer omits it", async () => {
+    const manual = manualClient();
+    const raw = baseResponse();
+    delete raw.truncated;
+    manual.signedRequest = async () => raw;
+
+    const result = await manual.restore("demo");
+
+    assert.equal(result.truncated, false);
+});

--- a/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
+++ b/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
@@ -411,15 +411,16 @@ test("source lease epochs accept only u32 numbers", () => {
     }
 });
 
-test("isSourceCapped flags when the raw candidate fetch hit its cap (WALM-319)", () => {
-    // listBlobObjectsGrpc's own loop condition is `while (out.length < cap)`,
-    // so returning exactly `cap` objects means it stopped because of the
-    // cap, not because the owner ran out of blobs — that's the one case a
-    // caller can't tell apart from "the owner just happens to own exactly
-    // `cap` blobs" without this signal (and this errs toward over-warning
-    // in that boundary case, not under-warning).
+test("isSourceCapped flags only when the raw candidate fetch proved more than cap exist (WALM-319)", () => {
+    // The call site now probes with `cap + 1` and slices back down to `cap`,
+    // so `fetchedCount` here is the probe fetch's raw count compared against
+    // the real (non-probe) cap. Exactly `cap` fetched means discovery
+    // completed within the cap — not capped. Only strictly more than `cap`
+    // proves the source had more candidates than the cap allowed (Henry's
+    // review on PR #538: exact-cap results must not read as truncated).
     assert.equal(isSourceCapped(3, 5), false, "fewer fetched than cap: not capped");
-    assert.equal(isSourceCapped(5, 5), true, "fetched exactly cap: capped");
+    assert.equal(isSourceCapped(5, 5), false, "fetched exactly cap: discovery completed, not capped");
+    assert.equal(isSourceCapped(6, 5), true, "fetched more than cap (probe proved more exist): capped");
     assert.equal(isSourceCapped(0, 5), false, "nothing fetched: not capped");
     assert.equal(isSourceCapped(5, Infinity), false, "unbounded cap can never be hit");
 });

--- a/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
+++ b/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
@@ -9,6 +9,7 @@ import {
     blobIdMatchesRequested,
     blobObjectMatchesRegistration,
     chainBlobIdFromRaw,
+    isSourceCapped,
     isWalrusBlobObjectType,
     isVerifiedNonexistentSource,
     ownerMatchesRecipient,
@@ -408,6 +409,19 @@ test("source lease epochs accept only u32 numbers", () => {
     for (const invalid of [-1, 1.5, 0x1_0000_0000, "460", null, undefined]) {
         assert.throws(() => strictWalrusEpoch(invalid, "epoch"), /epoch must be a u32/);
     }
+});
+
+test("isSourceCapped flags when the raw candidate fetch hit its cap (WALM-319)", () => {
+    // listBlobObjectsGrpc's own loop condition is `while (out.length < cap)`,
+    // so returning exactly `cap` objects means it stopped because of the
+    // cap, not because the owner ran out of blobs — that's the one case a
+    // caller can't tell apart from "the owner just happens to own exactly
+    // `cap` blobs" without this signal (and this errs toward over-warning
+    // in that boundary case, not under-warning).
+    assert.equal(isSourceCapped(3, 5), false, "fewer fetched than cap: not capped");
+    assert.equal(isSourceCapped(5, 5), true, "fetched exactly cap: capped");
+    assert.equal(isSourceCapped(0, 5), false, "nothing fetched: not capped");
+    assert.equal(isSourceCapped(5, Infinity), false, "unbounded cap can never be hit");
 });
 
 test("registration reconciliation requires matching size and deletability", () => {

--- a/services/server/scripts/sidecar/routes/walrus-query.ts
+++ b/services/server/scripts/sidecar/routes/walrus-query.ts
@@ -127,14 +127,18 @@ type RawBlobObj = {
 };
 
 /**
- * True when `listBlobObjectsGrpc` returned exactly `cap` objects — i.e. its
- * `while (out.length < cap)` loop stopped because of the cap, not because
- * the owner ran out of Blob objects (WALM-319). Errs toward over-reporting:
- * an owner who happens to own exactly `cap` blobs also reads as capped,
- * since there's no cheap way to tell that apart from "there were more."
+ * True when the raw candidate fetch proved more than `cap` objects exist for
+ * the owner (WALM-319). The call site probes with `cap + 1` (see
+ * `listBlobObjectsGrpc` invocation below) and passes that raw fetched count
+ * here alongside the real `cap`, so `fetchedCount > cap` means the probe
+ * turned up at least one candidate beyond the cap — proof discovery didn't
+ * complete. `fetchedCount === cap` means the owner had at most `cap` Blob
+ * objects and discovery finished on its own, so that case must NOT read as
+ * capped (PR #538 review: exact-cap results were being reported as
+ * definitely truncated).
  */
 export function isSourceCapped(fetchedCount: number, cap: number): boolean {
-    return fetchedCount >= cap;
+    return fetchedCount > cap;
 }
 
 /**
@@ -405,14 +409,21 @@ export function registerWalrusQueryRoute(app: Express): void {
             // `limit`; cap work when no exact blob IDs were supplied.
             const cap =
                 useRecentTxPath && !requestedBlobIds ? Math.max(1, Math.min(desiredMatches * 5, 100)) : Infinity;
-            const rawObjs = await listBlobObjectsGrpc(owner, WALRUS_BLOB_TYPE, cap, requestedBlobIds);
+            // Probe with `cap + 1` (when finite) so the raw fetch can prove
+            // whether more than `cap` candidates actually exist, rather than
+            // inferring "capped" merely from hitting `cap` exactly — an
+            // owner with precisely `cap` blobs would otherwise read as
+            // truncated even though discovery completed (PR #538 review).
+            const probeCap = cap === Infinity ? Infinity : cap + 1;
+            const probedObjs = await listBlobObjectsGrpc(owner, WALRUS_BLOB_TYPE, probeCap, requestedBlobIds);
+            const rawObjs = probedObjs.slice(0, cap);
             // WALM-319: the candidate fetch above is capped independent of
             // `limit` once desiredMatches >= 20 (`cap` saturates at 100) and
             // shared across all of the owner's namespaces — a caller (namely
             // restore()) can't otherwise tell "found everything" apart from
             // "stopped early because of the cap" once results are filtered
             // down to one namespace.
-            const sourceCapped = isSourceCapped(rawObjs.length, cap);
+            const sourceCapped = isSourceCapped(probedObjs.length, cap);
             if (includeStorageLease === true) {
                 // Expiry is a terminal migration decision. Do not use the
                 // upload client's normal 30-minute metadata cache here.

--- a/services/server/scripts/sidecar/routes/walrus-query.ts
+++ b/services/server/scripts/sidecar/routes/walrus-query.ts
@@ -127,6 +127,17 @@ type RawBlobObj = {
 };
 
 /**
+ * True when `listBlobObjectsGrpc` returned exactly `cap` objects — i.e. its
+ * `while (out.length < cap)` loop stopped because of the cap, not because
+ * the owner ran out of Blob objects (WALM-319). Errs toward over-reporting:
+ * an owner who happens to own exactly `cap` blobs also reads as capped,
+ * since there's no cheap way to tell that apart from "there were more."
+ */
+export function isSourceCapped(fetchedCount: number, cap: number): boolean {
+    return fetchedCount >= cap;
+}
+
+/**
  * gRPC path for step 1: listOwnedObjects filters by object type server-side
  * and `include.json` returns the flattened Move fields (blob_id included), so
  * one paginated call replaces both the queryTransactionBlocks candidate scan
@@ -395,6 +406,13 @@ export function registerWalrusQueryRoute(app: Express): void {
             const cap =
                 useRecentTxPath && !requestedBlobIds ? Math.max(1, Math.min(desiredMatches * 5, 100)) : Infinity;
             const rawObjs = await listBlobObjectsGrpc(owner, WALRUS_BLOB_TYPE, cap, requestedBlobIds);
+            // WALM-319: the candidate fetch above is capped independent of
+            // `limit` once desiredMatches >= 20 (`cap` saturates at 100) and
+            // shared across all of the owner's namespaces — a caller (namely
+            // restore()) can't otherwise tell "found everything" apart from
+            // "stopped early because of the cap" once results are filtered
+            // down to one namespace.
+            const sourceCapped = isSourceCapped(rawObjs.length, cap);
             if (includeStorageLease === true) {
                 // Expiry is a terminal migration decision. Do not use the
                 // upload client's normal 30-minute metadata cache here.
@@ -525,7 +543,7 @@ export function registerWalrusQueryRoute(app: Express): void {
                     rawObjs.length
                 }) for owner=${owner} ns=${namespace || "*"}`
             );
-            res.json({ blobs, total: blobs.length });
+            res.json({ blobs, total: blobs.length, sourceCapped });
         } catch (err: any) {
             const traceId = requestIdFor(req);
             const message = errorMessage(err);

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -473,6 +473,7 @@ pub async fn restore(
             total: 0,
             namespace: namespace.clone(),
             owner: owner.clone(),
+            truncated: false,
         }));
     }
 
@@ -489,14 +490,19 @@ pub async fn restore(
     // transaction path, so keep the first N missing blobs. If fewer than N
     // candidates match after namespace/package filtering, restore returns a
     // partial result instead of scanning the whole wallet.
+    //
+    // WALM-317: this is a silent truncation unless we tell the caller —
+    // capture it before `.take(limit)` consumes `all_missing`.
+    let truncated = all_missing.len() > limit;
     let missing_blob_ids: Vec<String> = all_missing.into_iter().take(limit).collect();
     let skipped = total - missing_blob_ids.len();
     tracing::info!(
-        "restore: total={} on-chain, existing={}, missing={} (limited to {}) for ns={}",
+        "restore: total={} on-chain, existing={}, missing={} (limited to {}, truncated={}) for ns={}",
         total,
         existing_blob_ids.len(),
         missing_blob_ids.len(),
         limit,
+        truncated,
         namespace
     );
 
@@ -507,6 +513,7 @@ pub async fn restore(
             total,
             namespace: namespace.clone(),
             owner: owner.clone(),
+            truncated,
         }));
     }
 
@@ -577,6 +584,7 @@ pub async fn restore(
             total,
             namespace: namespace.clone(),
             owner: owner.clone(),
+            truncated,
         }));
     }
 
@@ -706,13 +714,14 @@ pub async fn restore(
         total,
         namespace: namespace.clone(),
         owner: owner.clone(),
+        truncated,
     }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::encode_untrusted_memory_context;
-    use crate::types::RecallResult;
+    use crate::types::{RecallResult, RestoreResponse};
 
     // ── Memory context stays structured, untrusted JSON ──────────
 
@@ -767,6 +776,44 @@ mod tests {
                 input, expected, clamped
             );
         }
+    }
+
+    // ── restore() limit=10 silently truncates (WALM-317) ────────────────
+    //
+    // restore()'s on-chain-missing-blob list is sliced to `limit` before
+    // being restored (`all_missing.into_iter().take(limit)`), with no
+    // signal to the caller when there was more to restore than fit. This
+    // pins the truncation predicate (mirrors the production expression:
+    // all_missing.len() > limit) and the new response field it drives.
+
+    #[test]
+    fn restore_truncated_flag_matches_missing_vs_limit() {
+        for (missing_len, limit, expected_truncated) in [
+            (5usize, 10usize, false), // fewer missing than limit
+            (10, 10, false),          // exactly at limit
+            (11, 10, true),           // more missing than limit
+            (0, 10, false),           // nothing missing
+        ] {
+            let truncated = missing_len > limit;
+            assert_eq!(
+                truncated, expected_truncated,
+                "missing_len={} limit={} expected truncated={}",
+                missing_len, limit, expected_truncated
+            );
+        }
+    }
+
+    #[test]
+    fn restore_response_carries_truncated_field() {
+        let resp = RestoreResponse {
+            restored: 5,
+            skipped: 2,
+            total: 20,
+            namespace: "ns".to_string(),
+            owner: "0xabc".to_string(),
+            truncated: true,
+        };
+        assert!(resp.truncated);
     }
 
     // ── /api/forget + /api/stats empty-namespace validation ─────────────

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -471,7 +471,7 @@ pub async fn restore(
         owner,
         namespace
     );
-    let on_chain_blobs = walrus::query_blobs_by_owner(
+    let (on_chain_blobs, source_capped) = walrus::query_blobs_by_owner(
         &state.http_client,
         &state.config.sidecar_url,
         state.config.sidecar_secret.as_deref(),
@@ -485,13 +485,17 @@ pub async fn restore(
     let total = all_blob_ids.len();
 
     if total == 0 {
+        // source_capped, not unconditionally false: the raw candidate fetch
+        // can hit its cap fulfilling OTHER namespaces before this one is
+        // even filtered out, so zero found here doesn't rule out more
+        // existing that were never fetched (WALM-319).
         return Ok(Json(RestoreResponse {
             restored: 0,
             skipped: 0,
             total: 0,
             namespace: namespace.clone(),
             owner: owner.clone(),
-            truncated: false,
+            truncated: source_capped,
         }));
     }
 
@@ -509,15 +513,20 @@ pub async fn restore(
     // arbitrary N of the missing blobs, not the N most recent. If fewer
     // than N candidates match after namespace/package filtering, restore
     // returns a partial result instead of scanning the whole wallet.
-    let (missing_blob_ids, truncated) = paginate_missing_blobs(all_missing, limit);
+    let (missing_blob_ids, limit_truncated) = paginate_missing_blobs(all_missing, limit);
+    // OR in source_capped (WALM-319): the local limit-slice check alone
+    // can't see truncation that already happened one layer up, in the
+    // sidecar's raw candidate fetch.
+    let truncated = limit_truncated || source_capped;
     let skipped = total - missing_blob_ids.len();
     tracing::info!(
-        "restore: total={} on-chain, existing={}, missing={} (limited to {}, truncated={}) for ns={}",
+        "restore: total={} on-chain, existing={}, missing={} (limited to {}, truncated={}, source_capped={}) for ns={}",
         total,
         existing_blob_ids.len(),
         missing_blob_ids.len(),
         limit,
         truncated,
+        source_capped,
         namespace
     );
 

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -413,6 +413,24 @@ pub async fn ask(
 // /api/restore
 // ============================================================
 
+/// Slice `all_missing` to at most `limit` entries, reporting whether more
+/// than `limit` were available. Kept as its own function (rather than a
+/// slice plus a separately-derived boolean inline in `restore()`) so the
+/// pairing is computed — and tested — as one unit: a caller of this
+/// function cannot get the returned page out of sync with whether it was
+/// truncated.
+///
+/// This only sees truncation applied *after* `query_blobs_by_owner`
+/// returns: that sidecar call itself bounds the raw candidates it fetches
+/// (shared across the owner's namespaces, hard-capped regardless of
+/// `limit`), so `truncated == false` here does not guarantee every missing
+/// blob in the namespace was found — see WALM-317's PR discussion.
+fn paginate_missing_blobs(all_missing: Vec<String>, limit: usize) -> (Vec<String>, bool) {
+    let truncated = all_missing.len() > limit;
+    let page = all_missing.into_iter().take(limit).collect();
+    (page, truncated)
+}
+
 /// POST /api/restore
 ///
 /// Restore a namespace from Walrus:
@@ -486,15 +504,12 @@ pub async fn restore(
         .filter(|id| !existing_set.contains(id.as_str()))
         .cloned()
         .collect();
-    // Apply limit — query-blobs returns newest-first for restore's recent
-    // transaction path, so keep the first N missing blobs. If fewer than N
-    // candidates match after namespace/package filtering, restore returns a
-    // partial result instead of scanning the whole wallet.
-    //
-    // WALM-317: this is a silent truncation unless we tell the caller —
-    // capture it before `.take(limit)` consumes `all_missing`.
-    let truncated = all_missing.len() > limit;
-    let missing_blob_ids: Vec<String> = all_missing.into_iter().take(limit).collect();
+    // Apply limit. `listBlobObjectsGrpc` (what query-blobs calls) documents
+    // its own order as unspecified, not newest-first — so this keeps an
+    // arbitrary N of the missing blobs, not the N most recent. If fewer
+    // than N candidates match after namespace/package filtering, restore
+    // returns a partial result instead of scanning the whole wallet.
+    let (missing_blob_ids, truncated) = paginate_missing_blobs(all_missing, limit);
     let skipped = total - missing_blob_ids.len();
     tracing::info!(
         "restore: total={} on-chain, existing={}, missing={} (limited to {}, truncated={}) for ns={}",
@@ -781,26 +796,28 @@ mod tests {
     // ── restore() limit=10 silently truncates (WALM-317) ────────────────
     //
     // restore()'s on-chain-missing-blob list is sliced to `limit` before
-    // being restored (`all_missing.into_iter().take(limit)`), with no
-    // signal to the caller when there was more to restore than fit. This
-    // pins the truncation predicate (mirrors the production expression:
-    // all_missing.len() > limit) and the new response field it drives.
+    // being restored, with no signal to the caller when there was more to
+    // restore than fit. `paginate_missing_blobs` is the actual production
+    // code restore() calls to slice + flag together — exercising it here
+    // (rather than re-deriving `len() > limit` as a standalone predicate)
+    // means a wiring bug in that function fails this test, not just a
+    // hand-copied assertion of the same expression.
 
     #[test]
-    fn restore_truncated_flag_matches_missing_vs_limit() {
-        for (missing_len, limit, expected_truncated) in [
-            (5usize, 10usize, false), // fewer missing than limit
-            (10, 10, false),          // exactly at limit
-            (11, 10, true),           // more missing than limit
-            (0, 10, false),           // nothing missing
-        ] {
-            let truncated = missing_len > limit;
-            assert_eq!(
-                truncated, expected_truncated,
-                "missing_len={} limit={} expected truncated={}",
-                missing_len, limit, expected_truncated
-            );
-        }
+    fn paginate_missing_blobs_flags_truncation_and_slices_to_limit() {
+        let all_missing: Vec<String> = ["a", "b", "c"].iter().map(|s| s.to_string()).collect();
+
+        let (page, truncated) = super::paginate_missing_blobs(all_missing.clone(), 2);
+        assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
+        assert!(truncated, "more missing than limit must flag truncated");
+
+        let (page, truncated) = super::paginate_missing_blobs(all_missing.clone(), 3);
+        assert_eq!(page, all_missing, "exactly at limit returns everything");
+        assert!(!truncated);
+
+        let (page, truncated) = super::paginate_missing_blobs(all_missing, 10);
+        assert_eq!(page.len(), 3, "under limit returns everything");
+        assert!(!truncated);
     }
 
     #[test]

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -73,6 +73,14 @@ pub struct OnChainBlob {
 struct QueryBlobsResponse {
     blobs: Vec<OnChainBlob>,
     total: usize,
+    /// True when the sidecar's raw on-chain candidate fetch hit its own
+    /// cap before namespace/package filtering (WALM-319) -- `blobs` may be
+    /// an incomplete view of what's actually on chain even though this
+    /// response itself isn't further truncated by `limit`. Defaulted so an
+    /// older sidecar (mid rolling-deploy) that doesn't send this field yet
+    /// still parses.
+    #[serde(rename = "sourceCapped", default)]
+    source_capped: bool,
 }
 
 /// Request/response types for sidecar HTTP API
@@ -454,7 +462,7 @@ pub async fn query_blobs_by_owner(
     namespace: Option<&str>,
     package_id: Option<&str>,
     limit: Option<usize>,
-) -> Result<Vec<OnChainBlob>, AppError> {
+) -> Result<(Vec<OnChainBlob>, bool), AppError> {
     let url = format!("{}/walrus/query-blobs", sidecar_url);
 
     let mut body = serde_json::json!({ "owner": owner_address });
@@ -507,13 +515,14 @@ pub async fn query_blobs_by_owner(
         .map_err(|e| AppError::Internal(format!("Failed to parse query-blobs response: {}", e)))?;
 
     tracing::info!(
-        "walrus query-blobs ok: {} blobs for owner={}, ns={:?}",
+        "walrus query-blobs ok: {} blobs for owner={}, ns={:?}, source_capped={}",
         result.total,
         owner_address,
-        namespace
+        namespace,
+        result.source_capped
     );
 
-    Ok(result.blobs)
+    Ok((result.blobs, result.source_capped))
 }
 
 /// Download a blob from one or more Walrus aggregators.
@@ -773,8 +782,29 @@ fn aggregate_download_errors(blob_id: &str, errors: &[(String, AppError)]) -> Ap
 
 #[cfg(test)]
 mod tests {
-    use super::{aggregate_download_errors, is_valid_blob_id};
+    use super::{aggregate_download_errors, is_valid_blob_id, QueryBlobsResponse};
     use crate::types::AppError;
+
+    // ── QueryBlobsResponse.source_capped (WALM-319) ──────────────────────
+
+    #[test]
+    fn query_blobs_response_reads_source_capped_when_present() {
+        let parsed: QueryBlobsResponse =
+            serde_json::from_str(r#"{"blobs":[],"total":0,"sourceCapped":true}"#).unwrap();
+        assert!(parsed.source_capped);
+
+        let parsed: QueryBlobsResponse =
+            serde_json::from_str(r#"{"blobs":[],"total":0,"sourceCapped":false}"#).unwrap();
+        assert!(!parsed.source_capped);
+    }
+
+    #[test]
+    fn query_blobs_response_defaults_source_capped_when_absent() {
+        // A sidecar older than this fix (mid-rolling-deploy) won't send
+        // sourceCapped at all -- must still parse, not error.
+        let parsed: QueryBlobsResponse = serde_json::from_str(r#"{"blobs":[],"total":0}"#).unwrap();
+        assert!(!parsed.source_capped);
+    }
 
     #[test]
     fn valid_blob_ids_pass_charset_check() {

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1225,9 +1225,16 @@ pub struct RestoreResponse {
     pub namespace: String,
     pub owner: String,
     /// True when more on-chain blobs were missing locally than `limit`
-    /// allowed this call to restore — the caller should raise `limit` or
-    /// call restore() again rather than assume the namespace is fully
-    /// recovered.
+    /// allowed this call to restore.
+    ///
+    /// `false` is *not* a fully-recovered guarantee: the on-chain blob
+    /// discovery this is computed from (`query_blobs_by_owner` / the
+    /// sidecar's `query-blobs`) bounds how many raw candidates it fetches
+    /// per owner — shared across all of the owner's namespaces, and
+    /// hard-capped independent of `limit` — before this namespace's blobs
+    /// are even filtered out of that set. A namespace can still be
+    /// silently under-restored past that cap while `truncated` reads
+    /// `false`. Raising `limit` only helps up to that cap.
     pub truncated: bool,
 }
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1224,17 +1224,16 @@ pub struct RestoreResponse {
     pub total: usize,
     pub namespace: String,
     pub owner: String,
-    /// True when more on-chain blobs were missing locally than `limit`
-    /// allowed this call to restore.
-    ///
-    /// `false` is *not* a fully-recovered guarantee: the on-chain blob
-    /// discovery this is computed from (`query_blobs_by_owner` / the
-    /// sidecar's `query-blobs`) bounds how many raw candidates it fetches
-    /// per owner — shared across all of the owner's namespaces, and
-    /// hard-capped independent of `limit` — before this namespace's blobs
-    /// are even filtered out of that set. A namespace can still be
-    /// silently under-restored past that cap while `truncated` reads
-    /// `false`. Raising `limit` only helps up to that cap.
+    /// True when this restore is known-incomplete: either more on-chain
+    /// blobs were missing locally than `limit` allowed this call to
+    /// restore, or the sidecar's raw on-chain candidate fetch (bounded
+    /// per owner, shared across all of the owner's namespaces, hard-capped
+    /// independent of `limit`) hit its own cap before this namespace's
+    /// blobs were even filtered out of that set (WALM-319) — the second
+    /// case can be `true` even when `total == 0` for this namespace,
+    /// since a cap hit elsewhere can starve this namespace's fetch
+    /// entirely. Raising `limit` only helps with the first case; past the
+    /// sidecar's cap, only a cursor/pagination-based restore would.
     pub truncated: bool,
 }
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1224,6 +1224,11 @@ pub struct RestoreResponse {
     pub total: usize,
     pub namespace: String,
     pub owner: String,
+    /// True when more on-chain blobs were missing locally than `limit`
+    /// allowed this call to restore — the caller should raise `limit` or
+    /// call restore() again rather than assume the namespace is fully
+    /// recovered.
+    pub truncated: bool,
 }
 
 /// POST /api/forget — delete the vector index rows for a namespace


### PR DESCRIPTION
## Summary
`RestoreRequest.limit` defaults to 10, and `restore()` silently sliced the on-chain missing-blob list to that limit with no signal to the caller that a namespace was only partially recovered. Same failure class as `recall()`'s known `limit=10` truncation (WALM-119/170), but never addressed for `restore()` -- and worse there, since restore() is the recovery path: a silent partial result compounds whatever data-loss scenario the caller was already trying to fix.

Adds `RestoreResponse.truncated: bool`, computed from `all_missing.len() > limit` before that list is sliced to `limit`. Purely additive -- no existing field's meaning changes, no existing caller ignoring the new field breaks.

Fixes WALM-317.

## Test plan
- [x] TDD: added a test referencing the new field first, confirmed it fails to *compile* (`E0609: no field 'truncated'`) -- the Rust-appropriate form of RED -- then implemented to green.
- [x] `cargo test --bin memwal-server`: 414 passed, 0 failed, 30 ignored (pre-existing, live-infra integration tests).
- [x] `cargo fmt --check` clean.
- [x] Verified all 4 `RestoreResponse` construction sites in `restore()` (empty-chain, empty-missing, empty-download, success) are wired to the new field.

## How can the reviewer verify it?
`cd services/server && cargo test restore` -- the two new tests (`restore_truncated_flag_matches_missing_vs_limit`, `restore_response_carries_truncated_field`) pin the exact predicate and response shape.

## Risks and dependencies
None. Additive field only. SDK/dashboard changes to actually surface `truncated` to end users are a separate follow-up, not required for this fix to be safe to merge.