### PR TITLE
Move migration notice to cleanup card

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -18,9 +18,8 @@ VITE_MEMWAL_SERVER_URL=https://relayer.dev.memwal.ai
 VITE_ENABLE_MEMORY_DELETION=false
 VITE_SECURITY_DELETE_ENABLED=false
 
-# Post-migration dashboard banner and cleanup card. Set the actual completion
-# date before the post-cutover build; the in-app fallback is only a placeholder.
-VITE_MIGRATION_COMPLETED_DATE=July XX, 2026
+# Migration date shown in the pre-migration cleanup card.
+VITE_MIGRATION_COMPLETED_DATE=July 30, 2026
 
 # Keep pre-migration account/blob lookups on the V1 contract and SEAL
 # committee while the current package points at the migrated contract.

--- a/apps/app/src/components/SecurityDeleteSection.test.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.test.tsx
@@ -9,6 +9,8 @@ vi.mock('../config', () => ({ config: {
     suiNetwork: 'testnet',
     memwalPackageId: '0x1',
     sealKeyServers: [],
+    migrationCompletedDate: 'July 30, 2026',
+    securityGuideUrl: 'https://docs.wal.app/walrus-memory/guides/delete-old-memories',
 } }))
 vi.mock('@mysten/dapp-kit', () => ({
     useCurrentAccount: () => ({ address: mocks.address }),
@@ -45,6 +47,17 @@ beforeEach(() => {
     mocks.phase = { kind: 'idle' }
     mocks.listBlobs.mockResolvedValue({ items: risk, counts, limits: { deleteBatchMax: 900 }, nextCursor: null })
     mocks.fetchPreview.mockResolvedValue('owner secret')
+})
+
+it('shows the migration notice and cleanup guide in the delete module', () => {
+    render(<SecurityDeleteSection accountObjectId="0x99" />)
+    expect(screen.getByText('Delete Pre-Migration Memories')).toBeInTheDocument()
+    expect(screen.getByText('Applies only to memories written before July 30, 2026')).toBeInTheDocument()
+    expect(screen.getByText(/On July 30, 2026 all existing memories were migrated/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'here' })).toHaveAttribute(
+        'href',
+        'https://docs.wal.app/walrus-memory/guides/delete-old-memories',
+    )
 })
 
 it('waits for explicit user intent before loading affected rows', async () => {

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -232,7 +232,13 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
     return <Card id="cleanup" className="dashboard-cleanup-card sd-card" title="Delete Pre-Migration Memories" subtitle={`Applies only to memories written before ${config.migrationCompletedDate}`} action={
         visibleActivated && <button className="btn btn-secondary" disabled={loading || busy} onClick={refresh}><RefreshCw size={16}/> Refresh</button>
     }>
-        <div className="sd-warning"><ShieldAlert size={18}/><span>Deletion is permanent. Preview anything you need before continuing.</span></div>
+        <div className="sd-warning">
+            <ShieldAlert size={18} aria-hidden="true" />
+            <span>
+                On {config.migrationCompletedDate} all existing memories were migrated onto a new contract as part of a security upgrade. We recommend removing all pre-migration data, and reviewing any sensitive data you may have stored. A guide is available{' '}
+                <a href={config.securityGuideUrl} target="_blank" rel="noopener noreferrer">here</a>.
+            </span>
+        </div>
         {identityMatches && !activated && <div className="sd-load-prompt">
             <button className="btn dashboard-cleanup-load" disabled={loading || busy} onClick={() => setActivated(true)}>Load my memories</button>
         </div>}

--- a/apps/app/src/config.ts
+++ b/apps/app/src/config.ts
@@ -34,14 +34,13 @@ export const config = {
     // no configuration change.
     legacyMemwalPackageId: import.meta.env.VITE_LEGACY_MEMWAL_PACKAGE_ID as string || memwalPackageId,
     legacyMemwalRegistryId: import.meta.env.VITE_LEGACY_MEMWAL_REGISTRY_ID as string || memwalRegistryId,
-    // Target of the security-upgrade banner's "guide to removing data" link.
+    // Target of the pre-migration cleanup notice's guide link.
     securityGuideUrl: import.meta.env.VITE_SECURITY_GUIDE_URL as string ||
         'https://docs.wal.app/walrus-memory/guides/delete-old-memories',
     // Date the v1 → v1_new security migration completed. Shown in the
-    // security banner and the pre-migration delete card. The default is a
-    // placeholder until the migration completion date is known.
+    // pre-migration delete card.
     migrationCompletedDate: import.meta.env.VITE_MIGRATION_COMPLETED_DATE as string ||
-        'July XX, 2026',
+        'July 30, 2026',
     memwalServerUrl: import.meta.env.VITE_MEMWAL_SERVER_URL as string || 'http://localhost:8000',
     suiNetwork: (import.meta.env.VITE_SUI_NETWORK as string || 'testnet') as 'testnet' | 'mainnet',
     // The local browser suite gets a distinct dapp-kit/wallet chain identity;

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -11,7 +11,8 @@
 .dash-page .sd-warning, .dash-page .sd-counts, .dash-page .sd-actions, .dash-page .sd-tabs {
   display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap;
 }
-.dash-page .sd-warning { margin-bottom: 1rem; color: #7d5400; }
+.dash-page .sd-warning { align-items: flex-start; margin-bottom: 1rem; color: #7d5400; }
+.dash-page .sd-warning svg { flex-shrink: 0; }
 .dash-page .sd-counts, .dash-page .sd-tabs, .dash-page .sd-actions { margin-bottom: 1rem; }
 .dash-page .sd-load-prompt { display: flex; justify-content: center; margin-top: 1.5rem; }
 .dash-page .sd-tabs .btn { border: 1px solid #faf8f5; background: #000000; color: #faf8f5; }

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -783,21 +783,6 @@ const result = await generateText({
                     </div>
                 )}
 
-                <div className="dash-alert" style={{ marginBottom: 24 }}>
-                    <TriangleAlert className="dash-alert-icon" size={24} strokeWidth={2.3} aria-hidden="true" />
-                    <p>
-                        Uploads to Walrus Memory have been resumed, following completion of a security
-                        upgrade on {config.migrationCompletedDate}. This upgrade patched a bug that made
-                        it possible to bypass the encryption of stored memories. All existing memories
-                        have been migrated onto a new, secure contract. A copy of memories written
-                        before the migration remains in the previous contract, where they are exposed
-                        to the original bug. We recommend removing all pre-migration data on the
-                        previous contract, and reviewing any sensitive data you may have stored. A
-                        guide to removing pre-migration data is available{' '}
-                        <a href={config.securityGuideUrl} target="_blank" rel="noopener noreferrer">here</a>.
-                    </p>
-                </div>
-
                 {hasMaxDelegateKeys && (
                     <div className="dash-alert" style={{ marginBottom: 24 }}>
                         <TriangleAlert className="dash-alert-icon" size={24} strokeWidth={2.3} aria-hidden="true" />


### PR DESCRIPTION
## Summary
- remove the global uploads-resumed security banner from the dashboard
- move the approved migration notice and deletion guide link into the Delete Pre-Migration Memories card
- set the migration date to July 30, 2026 and add UI coverage

## Testing
- pnpm --filter @memwal/app test -- SecurityDeleteSection.test.tsx
- pnpm --filter @memwal/app lint
- pnpm --filter @memwal/app build