### PR TITLE
Promote staging to main

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -18,9 +18,8 @@ VITE_MEMWAL_SERVER_URL=https://relayer.dev.memwal.ai
 VITE_ENABLE_MEMORY_DELETION=false
 VITE_SECURITY_DELETE_ENABLED=false
 
-# Post-migration dashboard banner and cleanup card. Set the actual completion
-# date before the post-cutover build; the in-app fallback is only a placeholder.
-VITE_MIGRATION_COMPLETED_DATE=July XX, 2026
+# Migration date shown in the pre-migration cleanup card.
+VITE_MIGRATION_COMPLETED_DATE=July 30, 2026
 
 # Keep pre-migration account/blob lookups on the V1 contract and SEAL
 # committee while the current package points at the migrated contract.

--- a/apps/app/src/components/SecurityDeleteSection.test.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.test.tsx
@@ -9,6 +9,8 @@ vi.mock('../config', () => ({ config: {
     suiNetwork: 'testnet',
     memwalPackageId: '0x1',
     sealKeyServers: [],
+    migrationCompletedDate: 'July 30, 2026',
+    securityGuideUrl: 'https://docs.wal.app/walrus-memory/guides/delete-old-memories',
 } }))
 vi.mock('@mysten/dapp-kit', () => ({
     useCurrentAccount: () => ({ address: mocks.address }),
@@ -45,6 +47,17 @@ beforeEach(() => {
     mocks.phase = { kind: 'idle' }
     mocks.listBlobs.mockResolvedValue({ items: risk, counts, limits: { deleteBatchMax: 900 }, nextCursor: null })
     mocks.fetchPreview.mockResolvedValue('owner secret')
+})
+
+it('shows the migration notice and cleanup guide in the delete module', () => {
+    render(<SecurityDeleteSection accountObjectId="0x99" />)
+    expect(screen.getByText('Delete Pre-Migration Memories')).toBeInTheDocument()
+    expect(screen.getByText('Applies only to memories written before July 30, 2026')).toBeInTheDocument()
+    expect(screen.getByText(/On July 30, 2026 all existing memories were migrated/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'here' })).toHaveAttribute(
+        'href',
+        'https://docs.wal.app/walrus-memory/guides/delete-old-memories',
+    )
 })
 
 it('waits for explicit user intent before loading affected rows', async () => {

--- a/apps/app/src/components/SecurityDeleteSection.tsx
+++ b/apps/app/src/components/SecurityDeleteSection.tsx
@@ -232,7 +232,13 @@ export default function SecurityDeleteSection({ accountObjectId }: { accountObje
     return <Card id="cleanup" className="dashboard-cleanup-card sd-card" title="Delete Pre-Migration Memories" subtitle={`Applies only to memories written before ${config.migrationCompletedDate}`} action={
         visibleActivated && <button className="btn btn-secondary" disabled={loading || busy} onClick={refresh}><RefreshCw size={16}/> Refresh</button>
     }>
-        <div className="sd-warning"><ShieldAlert size={18}/><span>Deletion is permanent. Preview anything you need before continuing.</span></div>
+        <div className="sd-warning">
+            <ShieldAlert size={18} aria-hidden="true" />
+            <span>
+                On {config.migrationCompletedDate} all existing memories were migrated onto a new contract as part of a security upgrade. We recommend removing all pre-migration data, and reviewing any sensitive data you may have stored. A guide is available{' '}
+                <a href={config.securityGuideUrl} target="_blank" rel="noopener noreferrer">here</a>.
+            </span>
+        </div>
         {identityMatches && !activated && <div className="sd-load-prompt">
             <button className="btn dashboard-cleanup-load" disabled={loading || busy} onClick={() => setActivated(true)}>Load my memories</button>
         </div>}

--- a/apps/app/src/config.ts
+++ b/apps/app/src/config.ts
@@ -34,14 +34,13 @@ export const config = {
     // no configuration change.
     legacyMemwalPackageId: import.meta.env.VITE_LEGACY_MEMWAL_PACKAGE_ID as string || memwalPackageId,
     legacyMemwalRegistryId: import.meta.env.VITE_LEGACY_MEMWAL_REGISTRY_ID as string || memwalRegistryId,
-    // Target of the security-upgrade banner's "guide to removing data" link.
+    // Target of the pre-migration cleanup notice's guide link.
     securityGuideUrl: import.meta.env.VITE_SECURITY_GUIDE_URL as string ||
         'https://docs.wal.app/walrus-memory/guides/delete-old-memories',
     // Date the v1 → v1_new security migration completed. Shown in the
-    // security banner and the pre-migration delete card. The default is a
-    // placeholder until the migration completion date is known.
+    // pre-migration delete card.
     migrationCompletedDate: import.meta.env.VITE_MIGRATION_COMPLETED_DATE as string ||
-        'July XX, 2026',
+        'July 30, 2026',
     memwalServerUrl: import.meta.env.VITE_MEMWAL_SERVER_URL as string || 'http://localhost:8000',
     suiNetwork: (import.meta.env.VITE_SUI_NETWORK as string || 'testnet') as 'testnet' | 'mainnet',
     // The local browser suite gets a distinct dapp-kit/wallet chain identity;

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -11,7 +11,8 @@
 .dash-page .sd-warning, .dash-page .sd-counts, .dash-page .sd-actions, .dash-page .sd-tabs {
   display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap;
 }
-.dash-page .sd-warning { margin-bottom: 1rem; color: #7d5400; }
+.dash-page .sd-warning { align-items: flex-start; margin-bottom: 1rem; color: #7d5400; }
+.dash-page .sd-warning svg { flex-shrink: 0; }
 .dash-page .sd-counts, .dash-page .sd-tabs, .dash-page .sd-actions { margin-bottom: 1rem; }
 .dash-page .sd-load-prompt { display: flex; justify-content: center; margin-top: 1.5rem; }
 .dash-page .sd-tabs .btn { border: 1px solid #faf8f5; background: #000000; color: #faf8f5; }

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -783,21 +783,6 @@ const result = await generateText({
                     </div>
                 )}
 
-                <div className="dash-alert" style={{ marginBottom: 24 }}>
-                    <TriangleAlert className="dash-alert-icon" size={24} strokeWidth={2.3} aria-hidden="true" />
-                    <p>
-                        Uploads to Walrus Memory have been resumed, following completion of a security
-                        upgrade on {config.migrationCompletedDate}. This upgrade patched a bug that made
-                        it possible to bypass the encryption of stored memories. All existing memories
-                        have been migrated onto a new, secure contract. A copy of memories written
-                        before the migration remains in the previous contract, where they are exposed
-                        to the original bug. We recommend removing all pre-migration data on the
-                        previous contract, and reviewing any sensitive data you may have stored. A
-                        guide to removing pre-migration data is available{' '}
-                        <a href={config.securityGuideUrl} target="_blank" rel="noopener noreferrer">here</a>.
-                    </p>
-                </div>
-
                 {hasMaxDelegateKeys && (
                     <div className="dash-alert" style={{ marginBottom: 24 }}>
                         <TriangleAlert className="dash-alert-icon" size={24} strokeWidth={2.3} aria-hidden="true" />

--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -320,9 +320,12 @@ pub async fn recall_manual(
     Extension(auth): Extension<AuthInfo>,
     Json(body): Json<RecallManualRequest>,
 ) -> Result<Json<RecallManualResponse>, AppError> {
-    if body.vector.is_empty() {
-        return Err(AppError::BadRequest("vector cannot be empty".into()));
-    }
+    // Validate the client-supplied query vector (width + finiteness) up front.
+    // The store's embedding column is fixed-width and refuses NaN/Inf, so a
+    // malformed query vector can only fail inside pgvector and surface as an
+    // opaque 500; reject it here with an actionable 400. (No upload/gas on this
+    // read path, unlike remember_manual — this is purely a clearer-error improvement.)
+    validate_embedding_vector(&body.vector)?;
 
     // Validate scoring_weights up front (NaN / out-of-range / sub-floor
     // half-life) before the vector search, mirroring `recall`. Previously

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -913,9 +913,13 @@ pub async fn remember_manual(
             "encrypted_data cannot be empty".into(),
         ));
     }
-    if body.vector.is_empty() {
-        return Err(AppError::BadRequest("vector cannot be empty".into()));
-    }
+    // Validate the client-supplied embedding (width + finiteness) up front. The
+    // fact store's `embedding` column is a fixed-width pgvector that also refuses
+    // NaN/Inf, so a malformed vector can never be indexed — and store_blob pays
+    // for the (irreversible) Walrus upload before it reaches the insert. Rejecting
+    // here means a bad vector costs no gas and returns an actionable 400, instead
+    // of an opaque 500 after the paid upload.
+    validate_embedding_vector(&body.vector)?;
     validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;

--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -21,8 +21,10 @@ use crate::types::{AppError, Config};
 pub const EMBEDDING_MODEL: &str = "openai/text-embedding-3-small";
 
 /// Embedding vector dimensionality (text-embedding-3-small). Also the
-/// width of the deterministic mock vector.
-const EMBEDDING_DIMS: usize = 1536;
+/// width of the deterministic mock vector, and the fixed width of the
+/// `vector_entries.embedding` pgvector column — client-supplied vectors
+/// on the manual write path are validated against it.
+pub const EMBEDDING_DIMS: usize = 1536;
 
 #[async_trait]
 pub trait Embedder: Send + Sync {

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -871,6 +871,7 @@ pub fn validate_namespace(namespace: &str) -> Result<(), AppError> {
 ///   - a width other than the fixed pgvector column (`EMBEDDING_DIMS`), and
 ///   - any non-finite component (NaN / ±Inf), which pgvector refuses to index
 ///     and which is meaningless for cosine similarity.
+///
 /// Both would otherwise only fail deep in pgvector as an opaque 500.
 pub fn validate_embedding_vector(vector: &[f32]) -> Result<(), AppError> {
     use crate::services::embedder::EMBEDDING_DIMS;
@@ -1618,8 +1619,14 @@ mod tests {
             vector[7] = bad;
             match validate_embedding_vector(&vector).unwrap_err() {
                 AppError::BadRequest(msg) => {
-                    assert!(msg.contains("finite"), "message names the finiteness rule: {msg}");
-                    assert!(msg.contains("index 7"), "message names the offending index: {msg}");
+                    assert!(
+                        msg.contains("finite"),
+                        "message names the finiteness rule: {msg}"
+                    );
+                    assert!(
+                        msg.contains("index 7"),
+                        "message names the offending index: {msg}"
+                    );
                 }
                 other => panic!("expected BadRequest, got {other:?}"),
             }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -864,6 +864,30 @@ pub fn validate_namespace(namespace: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Validate a client-supplied embedding vector against what the fact store can
+/// accept. Shared by the manual write and read paths, where the vector comes
+/// from the caller rather than the server-side embedder. Rejects, with an
+/// actionable `BadRequest` (and, on the write path, before any paid upload):
+///   - a width other than the fixed pgvector column (`EMBEDDING_DIMS`), and
+///   - any non-finite component (NaN / ±Inf), which pgvector refuses to index
+///     and which is meaningless for cosine similarity.
+/// Both would otherwise only fail deep in pgvector as an opaque 500.
+pub fn validate_embedding_vector(vector: &[f32]) -> Result<(), AppError> {
+    use crate::services::embedder::EMBEDDING_DIMS;
+    if vector.len() != EMBEDDING_DIMS {
+        return Err(AppError::BadRequest(format!(
+            "vector must have exactly {EMBEDDING_DIMS} dimensions, got {}",
+            vector.len()
+        )));
+    }
+    if let Some(index) = vector.iter().position(|component| !component.is_finite()) {
+        return Err(AppError::BadRequest(format!(
+            "vector must contain only finite values; component at index {index} is not finite"
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RecallRequest {
     pub query: String,
@@ -1543,6 +1567,64 @@ mod tests {
     use std::sync::Mutex;
 
     static WALRUS_STORAGE_EPOCHS_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // ── Client-supplied embedding vector validation ──────────────
+
+    #[test]
+    fn embedding_of_correct_width_is_accepted() {
+        use crate::services::embedder::EMBEDDING_DIMS;
+        assert!(validate_embedding_vector(&vec![0.1_f32; EMBEDDING_DIMS]).is_ok());
+    }
+
+    #[test]
+    fn embedding_of_wrong_width_is_rejected_with_actionable_message() {
+        use crate::services::embedder::EMBEDDING_DIMS;
+        // A width from a different embedding model; kept distinct from the
+        // expected width so a transposed format! (expected/actual swapped) still
+        // fails the exact-string assert below.
+        let wrong = EMBEDDING_DIMS / 2 + 1;
+        match validate_embedding_vector(&vec![0.1_f32; wrong]).unwrap_err() {
+            // BadRequest maps to HTTP 400, unlike the opaque 500 a downstream
+            // pgvector failure would produce (after a paid upload on the write path).
+            AppError::BadRequest(msg) => {
+                // Build the expected message from the constant (single source of
+                // truth — survives a dimension change) while still pinning the
+                // exact wording and the expected-then-actual order.
+                assert_eq!(
+                    msg,
+                    format!("vector must have exactly {EMBEDDING_DIMS} dimensions, got {wrong}")
+                );
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn embedding_empty_vector_is_rejected() {
+        // The width check subsumes a separate non-empty guard.
+        assert!(matches!(
+            validate_embedding_vector(&[]),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn embedding_with_non_finite_component_is_rejected() {
+        use crate::services::embedder::EMBEDDING_DIMS;
+        // Correct width, but a NaN/Inf component pgvector would refuse to index —
+        // must be caught here, before any paid upload, not as an opaque 500.
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut vector = vec![0.1_f32; EMBEDDING_DIMS];
+            vector[7] = bad;
+            match validate_embedding_vector(&vector).unwrap_err() {
+                AppError::BadRequest(msg) => {
+                    assert!(msg.contains("finite"), "message names the finiteness rule: {msg}");
+                    assert!(msg.contains("index 7"), "message names the offending index: {msg}");
+                }
+                other => panic!("expected BadRequest, got {other:?}"),
+            }
+        }
+    }
 
     fn security_delete_test_config() -> Config {
         Config {


### PR DESCRIPTION
## Summary
- validate client-supplied manual embedding vectors before writes and reads (#536)
- remove the global uploads-resumed banner and move the migration notice into the cleanup card (#539)

## Promotion path
- dev to staging: https://github.com/MystenLabs/MemWal/pull/540

## Included PRs
- https://github.com/MystenLabs/MemWal/pull/536
- https://github.com/MystenLabs/MemWal/pull/539

## Testing
- covered by the CI and tests completed on the included and promotion PRs