### PR TITLE
docs(WALM-318): make health() credential-blind behavior explicit

### DIFF
--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -183,7 +183,7 @@ RestoreResult(restored: int, skipped: int, total: int, namespace: str, owner: st
 
 ### `health() -> HealthResult`
 
-Check relayer health. No authentication. Raises `MemWalError` on non-200.
+Check relayer health. No authentication — a successful response confirms the relayer is reachable, not that your `key`/`account_id` are valid. A signed call (e.g. `remember()`, `recall()`) can still fail with `401` immediately after a passing `health()`. Raises `MemWalError` on non-200.
 
 ```python
 HealthResult(

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -172,7 +172,7 @@ Rebuild missing indexed entries for one namespace from Walrus. Incremental — o
 
 ### `health(): Promise<HealthResult>`
 
-Check relayer health. Does not require authentication.
+Check relayer health. Does not require authentication — a successful response confirms the relayer is reachable, not that your `key`/`accountId` are valid. A signed call (e.g. `remember()`, `recall()`) can still fail with `401` immediately after a passing `health()`.
 
 **Returns:** `{ status: string, version: string, relayerVersion?: string, apiVersion?: string, minSupportedSdk?: ... }`
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,5 +1,16 @@
 # memwal
 
+## 0.1.6
+
+### Added
+
+- Added flush helpers for pending middleware auto-saves.
+- Added `truncated` to restore results for incomplete recovery.
+
+### Fixed
+
+- Linked `AUTH_REJECTED` errors to troubleshooting guidance.
+
 ## 0.1.5
 
 ### Added

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -116,4 +116,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -83,7 +83,8 @@ SEAL_SESSION_SAFETY_MARGIN_MS = 30_000
 AUTH_REJECTED_MESSAGE = (
     "401 from relayer: typically wrong private key, key not registered on this "
     "account, account ID mismatch, or staging/mainnet mismatch. Check .env.local "
-    "and dashboard credentials."
+    "and dashboard credentials. Full troubleshooting: "
+    "https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors"
 )
 
 

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for Walrus Memory — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/tests/test_auth_rejected_message.py
+++ b/packages/python-sdk-memwal/tests/test_auth_rejected_message.py
@@ -1,0 +1,9 @@
+"""Tests for the AUTH_REJECTED_MESSAGE shown on a 401 from the relayer."""
+
+from __future__ import annotations
+
+from memwal.client import AUTH_REJECTED_MESSAGE
+
+
+def test_auth_rejected_message_points_to_troubleshooting_guide() -> None:
+    assert "docs.wal.app/walrus-memory/troubleshooting/overview" in AUTH_REJECTED_MESSAGE

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @mysten-incubation/memwal
 
+## 0.1.1
+
+### Added
+
+- Added `flush()` for pending `withMemWal` auto-saves.
+- Added `truncated` to restore results for incomplete recovery.
+
+### Fixed
+
+- Linked `AUTH_REJECTED` errors to troubleshooting guidance.
+
 ## 0.1.0
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -157,7 +157,8 @@ export function sanitizeServerError(
         return {
             message:
                 "401 from relayer: typically wrong private key, key not registered on this account, " +
-                "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials.",
+                "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
+                "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",
             raw: rawBody,
             serverCode: "AUTH_REJECTED",
         };

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sanitizeServerError } from "../dist/utils.js";
+
+test("401 error message points to the troubleshooting guide", () => {
+    const { message, serverCode } = sanitizeServerError(401, "");
+    assert.equal(serverCode, "AUTH_REJECTED");
+    assert.match(
+        message,
+        /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
+        "401 message should point callers at the full AUTH_REJECTED triage table"
+    );
+});

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -121,6 +121,13 @@ pub async fn stats(
 // ============================================================
 
 /// GET /health
+///
+/// Public and unauthenticated by design (registered under `public_routes`
+/// in `main.rs`) — it does not accept or validate credentials, so a `200`
+/// here means only "the server process is up," not "your delegate
+/// key/account ID are valid." A caller preflighting credentials before a
+/// signed call should not treat this as a substitute for that call
+/// succeeding (WALM-318).
 pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok".to_string(),


### PR DESCRIPTION
## Summary
WALM-318 bundled 4 small SDK/relayer DX gaps from an io.net integration report. This PR resolves what's safely fixable; the rest either doesn't reproduce or is already resolved elsewhere.

- **Item 1 (stale Python `ENV_PRESETS`):** doesn't reproduce — Python's presets already point at the correct `*.memory.walrus.xyz` hosts. No change.
- **Item 2 (unauthenticated `health()`):** confirmed, by design. Made the implication explicit in both SDK API references and the Rust handler doc comment — a passing `health()` only means the relayer is reachable, not that credentials are valid.
- **Item 3 (401 doesn't name the mismatched network):** confirmed as a real DX gap, but **deliberately not implementing the originally-suggested fix** (server detects and names the account's actual network). `verify_signature()` routes all rejections through `constant_time_reject` specifically so a caller can't distinguish "account doesn't exist here" from "wrong key" via timing — revealing the account's real network in the response body would leak that same distinction through content instead, turning the endpoint into an account-existence-per-network oracle for anyone probing account IDs. Instead, both SDKs' `AUTH_REJECTED` message (which already names "staging/mainnet mismatch" as a likely cause) now links directly to `docs/troubleshooting/overview.md`'s existing network-mismatch triage table — safe (client-side only), no new server surface.
- **Item 4 (Python middleware doesn't expose `MemWal` for `close()`):** already resolved by #534 (WALM-306), which added `client._memwal`/`llm._memwal`. No separate change needed here.

## Testing
- Items 1/2/4: docs + a doc-comment only — no behavior change. `cargo build --bin memwal-server` clean.
- Item 3: TDD — new tests written first, confirmed RED (message lacked the docs URL), then GREEN.
  - TS: `npm test` in `packages/sdk` — 17/17 pass (new: `sanitize-server-error.test.mjs`).
  - Python: `pytest tests/` in `packages/python-sdk-memwal` — 110 passed, 16 skipped (pre-existing live-infra), 0 regressions (new: `test_auth_rejected_message.py`). `ruff check` clean.

## Risks and dependencies
None. No server behavior changes, no new server code path. Depends on #534 having landed for item 4's resolution to be complete (referenced, not duplicated, here).