### PR TITLE
docs: remove beta labels; Walrus Memory is generally available

### DIFF
--- a/docs/contributing/docs-workflow.md
+++ b/docs/contributing/docs-workflow.md
@@ -1,5 +1,5 @@
 ---
-title: "Docs Workflow"
+title: Docs Workflow
 description: >-
   Guidelines for contributing to Walrus Memory documentation, including source of truth,
   working rules for URL changes, and pre-ship verification steps.
@@ -10,7 +10,7 @@ keywords:
   - contributing
   - docs workflow
 goal:
-  description: Follow the docs contribution workflow — branch, edit, verify frontmatter, and open a PR — without breaking build or frontmatter validation rules.
+  description: Follow the docs contribution workflow (branch, edit, verify frontmatter, and open a PR) without breaking build or frontmatter validation rules.
   requires:
     - has_frontmatter:
         - title
@@ -33,7 +33,7 @@ answer: >-
   nav and sidebar links to verify correctness.
 ---
 
-Walrus Memory is still in beta, so documentation is an active part of product hardening.
+Walrus Memory evolves quickly, so documentation is an active part of product hardening.
 If you see unclear guidance, outdated flows, or missing examples, contributions are welcome.
 
 ## Source of Truth

--- a/docs/fundamentals/architecture/data-flow-security-model.md
+++ b/docs/fundamentals/architecture/data-flow-security-model.md
@@ -124,4 +124,4 @@ Every protected API call goes through Ed25519 signature verification:
 
 ## Current status
 
-This describes the production beta model. The trust boundaries continue to evolve: future versions might introduce client-side encryption by default or additional verifiability layers. Self-hosting remains the strongest option for teams that need full control today.
+This describes the current production model. The trust boundaries continue to evolve: future versions might introduce client-side encryption by default or additional verifiability layers. Self-hosting remains the strongest option for teams that need full control today.

--- a/docs/getting-started/what-is-memwal.md
+++ b/docs/getting-started/what-is-memwal.md
@@ -37,7 +37,7 @@ answer: >-
 ---
 
 <Note>
-Walrus Memory is in beta and actively evolving. It is fully usable today, and the developer experience and operational guidance keep improving. Feedback from early builders helps shape the product.
+Walrus Memory is generally available, and the product keeps evolving: the developer experience and operational guidance keep improving, and builder feedback shapes each release.
 </Note>
 
 Walrus Memory enables AI agents to operate reliably across apps and sessions, without losing context. Portable, verifiable, and fully controlled by you, it's the memory layer that lets agents handle complex workflows and coordinate using data they can trust.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4,7 +4,7 @@
 
 Important notes:
 
-- MemWal is currently in beta
+- MemWal is generally available and actively evolving
 - The SDK talks to a relayer service that handles embedding, SEAL encryption, Walrus upload/download, and vector search
 - All content is end-to-end encrypted — only the owner and authorized delegates can decrypt
 - Delegate keys provide scoped access — agents can read/write memory without holding the owner's private key

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Important notes:
 
-- MemWal is currently in beta
+- MemWal is generally available and actively evolving
 - The SDK talks to a relayer service that handles embedding, SEAL encryption, Walrus upload/download, and vector search
 - All content is end-to-end encrypted — only the owner and authorized delegates can decrypt
 - Delegate keys provide scoped access — agents can read/write memory without holding the owner's private key

--- a/docs/relayer/public-relayer.md
+++ b/docs/relayer/public-relayer.md
@@ -1,5 +1,5 @@
 ---
-title: "Managed Relayer"
+title: Managed Relayer
 description: >-
   Use the Walrus Foundation-hosted managed relayer to get started with Walrus Memory without running infrastructure. Covers available endpoints, minimal SDK configuration, and the trust and availability trade-offs of the shared deployment.
 keywords:
@@ -28,14 +28,14 @@ questions:
   - "How do I connect to the public MemWal relayer?"
   - "What are the trade-offs of using the managed Walrus Memory relayer?"
 answer: >-
-  The Walrus Foundation hosts managed relayer endpoints for production (mainnet) at relayer.memory.walrus.xyz and staging (testnet) at relayer-staging.memory.walrus.xyz. The managed relayer provides the fastest integration path but involves trusting the hosted instance with plaintext during encryption, sharing the deployment with other users, and accepting beta availability without SLA guarantees.
+  The Walrus Foundation hosts managed relayer endpoints for production (mainnet) at relayer.memory.walrus.xyz and staging (testnet) at relayer-staging.memory.walrus.xyz. The managed relayer provides the fastest integration path but involves trusting the hosted instance with plaintext during encryption, sharing the deployment with other users, and accepting that the service carries no SLA guarantees.
 ---
 
 A managed relayer is a simpler experience for teams that want to get started without running infrastructure. If a managed relayer endpoint is available for your environment, it gives you the fastest path to integration.
 
 ## Walrus Foundation hosted endpoints
 
-| Network | Relayer URL |
+| **Network** | **Relayer URL** |
 |---|---|
 | **Production** (mainnet) | `https://relayer.memory.walrus.xyz` |
 | **Staging** (testnet) | `https://relayer-staging.memory.walrus.xyz` |
@@ -55,9 +55,9 @@ const memwal = MemWal.create({
 
 ## What to Know
 
-- **Shared App ID** - all users of the managed relayer share the same Walrus Memory package ID. Your data is isolated by your own `owner + namespace` (Memory Space), but the underlying deployment is shared.
-- **Trust assumption** - the relayer sees plaintext during encryption and embedding. By using the managed relayer, you're trusting the Walrus Foundation-hosted instance with that data. See [Trust & Security Model](/fundamentals/architecture/data-flow-security-model) for details.
-- **Availability** - the managed relayer is a managed beta service. There are no SLA guarantees.
-- **Storage costs** - the server wallet covers Walrus storage fees. Usage limits may apply during beta.
+- **Shared App ID** - all users of the managed relayer share the same Walrus Memory package ID. Your own `owner + namespace` (Memory Space) isolates your data, but the underlying deployment is shared.
+- **Trust assumption** - the relayer sees plaintext during encryption and embedding. By using the managed relayer, you're trusting the Walrus Foundation-hosted instance with that data. See [Trust and Security Model](/fundamentals/architecture/data-flow-security-model) for details.
+- **Availability** - the Walrus Foundation provides the managed relayer as a public good without SLA guarantees.
+- **Storage costs** - the server wallet covers Walrus storage fees. The service can apply usage limits.
 
 If you need full control over the trust boundary or your own dedicated instance, see [Self-Hosting](/relayer/self-hosting).

--- a/docs/relayer/self-hosting.md
+++ b/docs/relayer/self-hosting.md
@@ -49,7 +49,7 @@ The most common reasons to self-host include:
 - **Control the trust boundary:** Keep plaintext, encryption, and embedding under your own control rather than trusting a third party.
 - **Run your own Walrus Memory instance:** Deploy your own contract with a separate package ID, Seal encryption keys, and hard data isolation.
 - **Choose your own embedding provider:** Use your own OpenAI-compatible API and credentials.
-- **Guarantee availability:** The managed relayer is a beta service with no SLA.
+- **Guarantee availability:** The managed relayer carries no SLA.
 
 ## Data isolation with namespaces
 


### PR DESCRIPTION
## Description

Product declared Walrus Memory out of beta. An external audit also flagged that AI search tools keep reporting "beta" from our own pages and machine-readable indexes. This removes every beta reference across the docs — seven files, all verified as the complete set (`grep -ri beta docs`, changelogs excluded):

- `getting-started/what-is-memwal.md` — the note now reads generally available, with the evolving-product framing kept.
- `contributing/docs-workflow.md` — the exact line AI tools kept citing drops the beta claim.
- `fundamentals/architecture/data-flow-security-model.md` — "production beta model" becomes "current production model".
- `relayer/public-relayer.md` + `relayer/self-hosting.md` — the managed relayer loses the beta label while **keeping the no-SLA and usage-limit disclaimers**: those describe service guarantees, not product maturity, and stay until ops says otherwise.
- `llms.txt` + `llms-full.txt` — the machine-readable summaries stop telling AI tools the product is in beta.

Also carries small style fixes on the touched pages (unquoted titles, bold table headers, an em dash, an ampersand, and two passive constructions).

Companion change on the docs.wal.app side: walrus #3616 stops the unpublished contributing pages (with their stale beta line) from leaking into the site's llms.txt. After this PR merges, the wording reaches docs.wal.app on the next publish.

## Verification

- `grep -ri beta docs` returns no product-status references (changelog history untouched).
- Style audit clean on all five touched pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_