### PR TITLE
docs: remove the product-status note from the What is Walrus Memory page

### DIFF
--- a/docs/getting-started/what-is-memwal.md
+++ b/docs/getting-started/what-is-memwal.md
@@ -36,10 +36,6 @@ answer: >-
   centralized trust.
 ---
 
-<Note>
-Walrus Memory is generally available, and the product keeps evolving: the developer experience and operational guidance keep improving, and builder feedback shapes each release.
-</Note>
-
 Walrus Memory enables AI agents to operate reliably across apps and sessions, without losing context. Portable, verifiable, and fully controlled by you, it's the memory layer that lets agents handle complex workflows and coordinate using data they can trust.
 
 <CardGroup cols={2}>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4,7 +4,6 @@
 
 Important notes:
 
-- MemWal is generally available and actively evolving
 - The SDK talks to a relayer service that handles embedding, SEAL encryption, Walrus upload/download, and vector search
 - All content is end-to-end encrypted — only the owner and authorized delegates can decrypt
 - Delegate keys provide scoped access — agents can read/write memory without holding the owner's private key

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,6 @@
 
 Important notes:
 
-- MemWal is generally available and actively evolving
 - The SDK talks to a relayer service that handles embedding, SEAL encryption, Walrus upload/download, and vector search
 - All content is end-to-end encrypted — only the owner and authorized delegates can decrypt
 - Delegate keys provide scoped access — agents can read/write memory without holding the owner's private key


### PR DESCRIPTION
## Description

Follow-up to #544: product-status wording comes off entirely rather than staying as generally-available callouts.

- The note at the top of the What is Walrus Memory page is removed; the page opens directly with what Walrus Memory does.
- The "MemWal is generally available and actively evolving" bullet is removed from the `llms.txt` and `llms-full.txt` Important notes; the remaining bullets describe how the product works, not its maturity.

Reaches docs.wal.app on the next publish; the page's llms.txt description then derives from the frontmatter instead of the note text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_