### PR TITLE
WALM-297: Owner-scoped bearer token auth for the read API (Phase 1)

### DIFF
--- a/docs/api/owner-token-auth.md
+++ b/docs/api/owner-token-auth.md
@@ -1,0 +1,223 @@
+## Owner-Scoped Token Authentication (WALM-297, Phase 1)
+
+Lets Console call WM's owner-scoped read API (WALM-295) without ever holding
+a delegate key. Console proves control of a WM owner address `Y` entirely on
+its own side (WALM-298 — Enoki Connect or a wallet-signature challenge; WM is
+never involved in that proof). It then calls `POST /v1/owner-tokens`,
+authenticating itself as a legitimate client via a single static **service
+credential** WM issues to Console out of band, to mint a short-lived bearer
+token scoped to `Y`. Console presents that token as `Authorization: Bearer
+<token>` on subsequent read calls.
+
+This is additive: it does not replace the existing Ed25519 signed-request
+scheme (`x-public-key`/`x-signature`/...) every other protected route and
+WALM-295's read routes already use. The two schemes are separate, parallel
+auth mechanisms — mirroring how `security-delete.md`'s Bearer-token flow
+coexists with it today.
+
+**Phase 1 scope:** only the `memories.read` permission is ever granted. No
+extend/renew/write scope exists yet.
+
+## Client authentication: the service credential
+
+WM generates one static secret and shares it with Console out of band (not
+over an unauthenticated channel). Console sends it on every issuance request:
+
+```http
+POST /v1/owner-tokens
+x-service-credential: <the shared secret>
+Content-Type: application/json
+
+{"owner": "0x<64 hex chars>"}
+```
+
+Missing header, wrong value, or the secret being unconfigured on WM's side
+(`OWNER_TOKEN_SERVICE_CREDENTIAL` unset) all collapse to a bare `401` with no
+body — no detail is leaked about which of these it was.
+
+**Trust boundary, stated explicitly:** this credential is the *only* thing
+gating who can request a token, and a request's `owner` is taken as a plain
+request parameter, trusted because the caller already proved it holds the
+credential. If the credential leaks, whoever holds it can mint a
+`memories.read` token for **any** owner address — there is no secondary check
+tying a specific token request back to a specific proven identity-link event.
+This is an accepted Phase-1 trade-off (Slack thread, Henry + Harry Phan — the
+same thread that chose "service credential" over mTLS/signed-client-assertion
+for cost/complexity reasons), not an oversight. Treat the credential with the
+same handling rigor as a database password: unique per environment, rotated
+if any Console-side compromise is suspected, never logged, never in a repo.
+
+## Issuing a token
+
+```http
+POST /v1/owner-tokens
+x-service-credential: <shared secret>
+Content-Type: application/json
+
+{"owner": "0xffebf969cf2f9ec94089be20387633b3ffaf8a3c8e6caade6c47e8814852c4e7"}
+```
+
+Validation order (cheapest first): Sui address format → service credential →
+per-owner rate limit → `MemWalAccount` existence → mint. `owner` is
+canonicalized to lowercase before every downstream check and before it's
+embedded in the token's claims.
+
+Response — `200 OK`:
+
+```json
+{
+  "token": "<opaque bearer token>",
+  "expires_at": "2026-08-04T12:15:00Z",
+  "permissions": ["memories.read"]
+}
+```
+
+`token` is an opaque `base64url(claims json).base64url(HMAC-SHA256
+signature)` string — treat it as a black box, do not attempt to parse it
+client-side. Its claims (for WM's own reference, not something Console needs
+to decode): `subject` (constant `"console"`), `owner_address` (canonical
+lowercase), `audience` (constant `"memwal"`), `issued_at`/`expires_at` (Unix
+seconds), `nonce` (a UUID identifying this specific token — see "Replay and
+revocation" below), `permissions` (`["memories.read"]` in Phase 1).
+
+TTL defaults to 900s (15 minutes), configurable via `OWNER_TOKEN_TTL_SECS`.
+**Refresh path:** there is no separate refresh/rotate endpoint in Phase 1 —
+when a token is at or near expiry, call `POST /v1/owner-tokens` again with
+the same `owner` to mint a fresh one. There is no reuse or extension of an
+existing token's lifetime.
+
+### Error responses
+
+| Status | Body | Cause |
+|---|---|---|
+| `400` | `{"error": "owner must be a 0x-prefixed 32-byte Sui address (66 characters)"}` | Malformed `owner` |
+| `400` | `{"error": "owner has no MemWalAccount"}` | `owner` is a well-formed address but has never created a `MemWalAccount` — minting a token for it would be nonsensical (see WALM-298's own `GET /api/accounts/{owner}/exists`, the primitive Console should use to avoid hitting this) |
+| `401` | *(bare, no body)* | Missing/wrong `x-service-credential`, or the credential is unconfigured on this deployment |
+| `429` | See "Rate limiting" — **two different shapes**, do not assume one | Per-owner or per-credential budget exceeded |
+| `503` | See "Availability failures" — **two different shapes**, do not assume one | `OWNER_TOKEN_SECRET` unconfigured, or the rate limiter's Redis backend is unreachable |
+
+## Using a token
+
+```http
+GET /v1/owners/{owner}/memories
+Authorization: Bearer <token>
+```
+
+(This branch also exposes `GET /v1/owners/{owner}/_token_probe` as a
+development-only stand-in for WALM-295's real read routes, which do not exist
+on this branch yet — see that handler's doc comment. Wiring the same
+extractor into the real `namespaces`/`memories`/`agents` handlers is the
+follow-up once this branch merges with WALM-295.)
+
+`{owner}` in the path must exactly equal the token's `owner_address` claim
+(canonical-address comparison, not raw string equality) or the request is
+rejected `403`. The token's `permissions` must include the scope the route
+requires (`memories.read` for all three read routes) or the request is
+rejected `403`. An expired, tampered, wrongly-signed, or wrong-audience token
+is rejected `401`, with no distinction in the response between those causes.
+
+## Rate limiting
+
+Two **independent** budgets apply to `POST /v1/owner-tokens`, enforced by two
+different code paths that do **not** share a response shape:
+
+**1. Per-owner** (checked inside the handler, after the service-credential
+gate): default 5/min, 30/hour per canonical owner address
+(`OWNER_TOKEN_RATE_LIMIT_OWNER_PER_MINUTE`/`_PER_HOUR`). Exceeding it:
+
+```json
+HTTP 429
+{"error": "too many owner-token requests for this owner; retry later"}
+```
+
+No `Retry-After` header, no `layer`/`limit`/`retry_after_seconds` fields —
+this is the crate's plain `AppError` envelope, not the shared rate-limiter
+response builder.
+
+**2. Per-service-credential** (middleware, runs *before* the handler and
+before the per-owner check — a wrong credential never reaches the per-owner
+budget, confirmed by test): default 120/min, 3000/hour across all requests
+using this credential regardless of which owner they target
+(`OWNER_TOKEN_RATE_LIMIT_PER_MINUTE`/`_PER_HOUR`). Exceeding it:
+
+```json
+HTTP 429
+Retry-After: 60
+{
+  "error": "Rate limit exceeded",
+  "layer": "owner_token_credential_burst",
+  "limit": "120 weighted-requests/min",
+  "retry_after_seconds": 60
+}
+```
+
+(`layer` is `"owner_token_credential_sustained"` and `retry_after_seconds`/
+`Retry-After` are `300` for the hourly budget instead of the per-minute one.)
+This is the same response shape every other rate limiter in this crate uses
+(`rate_limit_response`) — **do not** confuse it with the per-owner shape
+above; they are genuinely different envelopes from different limiters
+guarding the same endpoint.
+
+## Availability failures
+
+Also two different shapes, both `503`, both meaning "try again later" but
+from different failure points:
+
+**Feature not configured** (`OWNER_TOKEN_SECRET` unset on this deployment —
+checked in the handler, before the per-owner rate-limit check runs):
+
+```json
+HTTP 503
+{"error": "Upstream temporarily unavailable (traceId: <uuid>)"}
+```
+
+**Per-owner rate limiter's Redis backend unreachable** (same handler-level
+check, fails closed rather than allowing the request through unmetered):
+
+```json
+HTTP 503
+{"error": "Upstream temporarily unavailable (traceId: <uuid>)"}
+```
+
+(Both of the above share one shape — the crate's generic `AppError`
+envelope.)
+
+**Per-credential rate limiter's Redis backend unreachable** (the middleware,
+a separate code path from the two above):
+
+```json
+HTTP 503
+Retry-After: 30
+{"error": "Rate limiter temporarily unavailable", "retry_after_seconds": 30}
+```
+
+This third shape is distinct from the other two `503`s — it has a
+`retry_after_seconds` field and a `Retry-After` header; they don't.
+Integrators should treat `503` generically (retry with backoff) rather than
+branching on these exact shapes, but the shapes are documented here precisely
+because they differ, so nothing downstream mis-parses one expecting the
+other.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `OWNER_TOKEN_SECRET` | *(required, empty disables the feature)* | HMAC signing key for minted tokens |
+| `OWNER_TOKEN_SERVICE_CREDENTIAL` | *(required, empty rejects everything)* | The shared WM↔Console client-auth secret |
+| `OWNER_TOKEN_TTL_SECS` | `900` | Token lifetime in seconds |
+| `OWNER_TOKEN_RATE_LIMIT_PER_MINUTE` | `120` | Per-credential issuance budget |
+| `OWNER_TOKEN_RATE_LIMIT_PER_HOUR` | `3000` | Per-credential issuance budget |
+| `OWNER_TOKEN_RATE_LIMIT_OWNER_PER_MINUTE` | `5` | Per-owner issuance budget |
+| `OWNER_TOKEN_RATE_LIMIT_OWNER_PER_HOUR` | `30` | Per-owner issuance budget |
+
+## Replay and revocation
+
+Each token's `nonce` claim is a unique UUID generated at mint time. It is
+**not** a single-use, replay-preventing nonce the way the signed-request
+scheme's `x-nonce` is — a bearer token is meant to be reused across many read
+requests during its TTL window, so per-request single-use tracking would
+break normal usage. Its purpose in Phase 1 is forward-compatibility
+(identifying a specific issued token, in case a revocation list is added
+later) and observability (logging which token served a given request). A
+stolen, unexpired token is fully usable for its entire remaining TTL — the
+short default TTL (15 minutes) is the primary mitigation, not the nonce.

--- a/docs/api/owner-token-auth.md
+++ b/docs/api/owner-token-auth.md
@@ -57,10 +57,12 @@ Content-Type: application/json
 {"owner": "0xffebf969cf2f9ec94089be20387633b3ffaf8a3c8e6caade6c47e8814852c4e7"}
 ```
 
-Validation order (cheapest first): Sui address format → service credential →
-per-owner rate limit → `MemWalAccount` existence → mint. `owner` is
-canonicalized to lowercase before every downstream check and before it's
-embedded in the token's claims.
+Validation order: per-IP rate limit (outer middleware, throttles credential
+guessing regardless of validity) → service credential (middleware) →
+per-credential rate limit (middleware) → Sui address format (handler,
+cheapest handler-level check) → per-owner rate limit → `MemWalAccount`
+existence → mint. `owner` is canonicalized to lowercase before every
+downstream check and before it's embedded in the token's claims.
 
 Response — `200 OK`:
 
@@ -118,8 +120,19 @@ is rejected `401`, with no distinction in the response between those causes.
 
 ## Rate limiting
 
-Two **independent** budgets apply to `POST /v1/owner-tokens`, enforced by two
-different code paths that do **not** share a response shape:
+Three **independent** budgets apply to `POST /v1/owner-tokens`, enforced by
+three different code paths that do **not** all share a response shape:
+
+**0. Per-IP** (outermost middleware — runs *before* the service-credential
+check, regardless of whether the credential is valid): default 30/min,
+300/hour per source IP (`OWNER_TOKEN_RATE_LIMIT_IP_PER_MINUTE`/`_PER_HOUR`).
+This is the layer that actually bounds someone guessing the shared service
+credential — the per-credential budget below is keyed by the *value* of the
+supplied credential, so a wrong guess never accumulates against it, and a
+varying guess gets a fresh bucket every time; without a per-IP layer,
+credential-guessing had no throttling anywhere. Uses the same response shape
+as the per-credential budget below (`layer: "owner_token_ip_burst"` /
+`"owner_token_ip_sustained"`).
 
 **1. Per-owner** (checked inside the handler, after the service-credential
 gate): default 5/min, 30/hour per canonical owner address
@@ -209,6 +222,8 @@ other.
 | `OWNER_TOKEN_RATE_LIMIT_PER_HOUR` | `3000` | Per-credential issuance budget |
 | `OWNER_TOKEN_RATE_LIMIT_OWNER_PER_MINUTE` | `5` | Per-owner issuance budget |
 | `OWNER_TOKEN_RATE_LIMIT_OWNER_PER_HOUR` | `30` | Per-owner issuance budget |
+| `OWNER_TOKEN_RATE_LIMIT_IP_PER_MINUTE` | `30` | Per-source-IP issuance budget (throttles credential guessing) |
+| `OWNER_TOKEN_RATE_LIMIT_IP_PER_HOUR` | `300` | Per-source-IP issuance budget (throttles credential guessing) |
 
 ## Replay and revocation
 

--- a/services/server/src/lib.rs
+++ b/services/server/src/lib.rs
@@ -16,6 +16,7 @@ mod compatibility;
 mod engine;
 mod jobs;
 mod observability;
+mod owner_token_auth;
 mod rate_limit;
 mod security_delete_auth;
 mod security_delete_error;

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -7,6 +7,7 @@ mod jobs;
 mod jobs_security_delete;
 mod mcp_proxy;
 mod observability;
+mod owner_token_auth;
 mod rate_limit;
 mod routes;
 mod security_delete_auth;
@@ -314,6 +315,29 @@ async fn main() {
         config.accounts_rate_limit.global_per_minute,
         config.accounts_rate_limit.global_per_hour,
     );
+    tracing::info!(
+        "  owner-token issuance: {} (ttl={}s); rate limit {}/min, {}/hr per credential; {}/min, {}/hr per owner",
+        if config.owner_token_secret.is_empty() {
+            "DISABLED (OWNER_TOKEN_SECRET unset)"
+        } else {
+            "enabled"
+        },
+        config.owner_token_ttl_secs,
+        config.owner_token_rate_limit.per_minute,
+        config.owner_token_rate_limit.per_hour,
+        config.owner_token_rate_limit.owner_per_minute,
+        config.owner_token_rate_limit.owner_per_hour,
+    );
+    if config.owner_token_secret.is_empty() {
+        tracing::warn!(
+            "  owner-token: OWNER_TOKEN_SECRET is unset — POST /v1/owner-tokens will 503 and the OwnerToken extractor will reject every bearer token until it's set."
+        );
+    }
+    if config.owner_token_service_credential.is_empty() {
+        tracing::warn!(
+            "  owner-token: OWNER_TOKEN_SERVICE_CREDENTIAL is unset — POST /v1/owner-tokens will 401 every caller until it's set."
+        );
+    }
     if config.rate_limit.bench_bypass_enabled {
         // Storage quota is unaffected — this only skips the request-rate
         // buckets. The warning is split across lines so each one is grep-able
@@ -1095,6 +1119,36 @@ async fn main() {
         .merge(security_delete_bearer_routes)
         .layer(security_delete_cors());
 
+    // WALM-297 — owner-scoped bearer token issuance. Its own dedicated
+    // router group (mirrors `security_delete_auth_routes`): it belongs in
+    // neither `protected_routes` (which requires an Ed25519 signed
+    // request — Console structurally can never produce one, since it
+    // never holds a delegate key) nor `public_routes` (this is the
+    // opposite of public — it demands the service credential). Router::layer
+    // runs bottom-to-top, so the credential gate (outermost / added last)
+    // rejects an uncredentialed caller before the rate limiter underneath
+    // it spends any Redis budget on the request.
+    let owner_token_routes = Router::new()
+        .route(
+            "/v1/owner-tokens",
+            post(routes::issue_token).layer(DefaultBodyLimit::max(4 * 1024)),
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            rate_limit::owner_token_credential_rate_limit_middleware,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            routes::owner_token::service_credential_gate,
+        ));
+
+    // `GET /v1/owners/{owner}/_token_probe` — no router-level middleware
+    // needed: `OwnerToken` is a pure `FromRequestParts` extractor, so axum
+    // resolves (and rejects) it per-handler before the body ever runs.
+    // See `routes::owner_token` module doc for why this route exists.
+    let owner_token_probe_routes =
+        Router::new().route("/v1/owners/{owner}/_token_probe", get(routes::token_probe));
+
     // MCP proxy routes — reverse-proxy to the Node sidecar's `/mcp/*` routes.
     // No signed-request auth here: MCP clients ship a single Bearer at SSE
     // open and the sidecar parses it as the Ed25519 delegate key. Body limit
@@ -1206,6 +1260,15 @@ async fn main() {
     let app = Router::new()
         .merge(protected_routes)
         .merge(public_routes)
+        // Owner-token routes use the same deployment-wide ALLOWED_ORIGINS
+        // CORS policy as protected/public routes (deny-all by default),
+        // NOT the security-delete API's blanket allow-any: the service
+        // credential must never reach browser JS (the mint call is
+        // server-to-server, Console backend → WM), and the probe / future
+        // WALM-295 read routes are only meant to be reachable from origins
+        // this deployment explicitly trusts.
+        .merge(owner_token_routes)
+        .merge(owner_token_probe_routes)
         .layer(cors)
         // Merge after applying the deployment-wide CORS layer so its
         // preflight handler cannot shadow the deletion API's public policy.

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1125,9 +1125,20 @@ async fn main() {
     // request — Console structurally can never produce one, since it
     // never holds a delegate key) nor `public_routes` (this is the
     // opposite of public — it demands the service credential). Router::layer
-    // runs bottom-to-top, so the credential gate (outermost / added last)
-    // rejects an uncredentialed caller before the rate limiter underneath
-    // it spends any Redis budget on the request.
+    // runs bottom-to-top (last-added = outermost = runs first), so:
+    //   1. owner_token_ip_rate_limit_middleware (outermost) — throttles by
+    //      source IP regardless of credential validity. This is the layer
+    //      that actually bounds credential-guessing: the credential gate
+    //      rejects a bad guess in-process with no I/O, so the per-credential
+    //      limiter below it is structurally unreachable for a failing guess
+    //      (and even if reached, is keyed by the guessed value itself, so a
+    //      varying guess gets a fresh bucket every time). Without this IP
+    //      layer, guessing the one shared service credential had no
+    //      throttling anywhere (found in adversarial review, fixed here).
+    //   2. service_credential_gate — rejects an uncredentialed caller before
+    //      the per-credential rate limiter spends any Redis budget on it.
+    //   3. owner_token_credential_rate_limit_middleware (innermost) — the
+    //      legitimate-traffic budget for an authenticated Console instance.
     let owner_token_routes = Router::new()
         .route(
             "/v1/owner-tokens",
@@ -1140,6 +1151,10 @@ async fn main() {
         .layer(middleware::from_fn_with_state(
             state.clone(),
             routes::owner_token::service_credential_gate,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            rate_limit::owner_token_ip_rate_limit_middleware,
         ));
 
     // `GET /v1/owners/{owner}/_token_probe` — no router-level middleware

--- a/services/server/src/owner_token_auth.rs
+++ b/services/server/src/owner_token_auth.rs
@@ -1,0 +1,335 @@
+//! WALM-297 Phase 1 — owner-scoped bearer tokens for the read API.
+//!
+//! Console proves control of a WM owner address entirely on its own side
+//! (WALM-298 — Enoki Connect or wallet-signature; WM is never involved in
+//! that proof). Once Console has done so, it calls `POST /v1/owner-tokens`
+//! (see `routes::owner_token`), authenticating itself as a legitimate
+//! client via the team-decided **service credential** (one static shared
+//! secret WM hands Console — see `routes::owner_token::SERVICE_CREDENTIAL_HEADER`),
+//! to mint a short-lived bearer token scoped to that owner. Console then
+//! presents that token as `Authorization: Bearer <token>` to WM's owner-
+//! scoped read routes (WALM-295, `GET /v1/owners/{owner}/...`).
+//!
+//! This module is deliberately modeled on `security_delete_auth.rs`'s
+//! `mint_token`/`verify_token`/`SdOwner` triad — same HMAC-SHA256
+//! construction, same base64 encoding, same `FromRequestParts` extractor
+//! pattern — rather than inventing a new token format. The two differ only
+//! in claims shape and in what they're used for: `security_delete_auth`
+//! tokens gate a destructive, wallet-signature-authenticated flow;
+//! `OwnerToken`s gate a read-only flow whose caller (Console) authenticates
+//! via the service credential instead of a wallet signature.
+
+use std::sync::Arc;
+
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::{header, request::Parts};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use uuid::Uuid;
+
+use crate::types::AppState;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Fixed audience value stamped into every minted token and checked on
+/// verify. Rejecting a mismatched audience up front means this signing
+/// secret can never be reused to forge a token for a different token
+/// family that might one day share the same HMAC key by operator mistake.
+pub const OWNER_TOKEN_AUDIENCE: &str = "memwal";
+
+/// Fixed subject value: the token's issuer/client identity (Console),
+/// **not** a user or the owner address. Every Phase 1 token has this exact
+/// subject, since Console is the only client of this endpoint.
+pub const OWNER_TOKEN_SUBJECT: &str = "console";
+
+/// Phase 1 mints exactly this one permission, always. `OwnerTokenClaims`
+/// still carries a `Vec<String>` (rather than a single fixed field) so a
+/// future phase can widen the granted scopes without a claims-shape
+/// migration.
+pub const PERMISSION_MEMORIES_READ: &str = "memories.read";
+
+/// Claims embedded in an owner-scoped bearer token, exactly as specified by
+/// WALM-297: subject · owner_address · audience · issued_at · expires_at ·
+/// nonce · permissions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OwnerTokenClaims {
+    /// The token's issuer/client identity — always `"console"` in Phase 1
+    /// (see [`OWNER_TOKEN_SUBJECT`]). This is who the token was issued
+    /// *to*, not who it's scoped *for* — that's `owner_address`.
+    pub subject: String,
+    /// The WM owner (Sui) address this token authorizes read access for,
+    /// in canonical lowercase-hex form (the route handler canonicalizes
+    /// before minting — see `routes::owner_token::issue_token`).
+    pub owner_address: String,
+    /// Fixed to [`OWNER_TOKEN_AUDIENCE`] (`"memwal"`). Checked on verify.
+    pub audience: String,
+    /// Unix timestamp (seconds) the token was minted at.
+    pub issued_at: i64,
+    /// Unix timestamp (seconds) after which the token is no longer valid.
+    pub expires_at: i64,
+    /// Unique per-token identifier (UUID v4), generated fresh at mint time.
+    ///
+    /// **Design note (deliberately NOT a single-use replay guard):** the
+    /// WALM-297 ticket text says "nonce to prevent replay," which is the
+    /// right instinct for the *signed-request* scheme this bridges from
+    /// (`auth::verify_signature`'s `x-nonce`, single-use-checked against
+    /// Redis per WALM-295's read routes) — there, a nonce stops one
+    /// specific signed HTTP request from being captured and replayed.
+    ///
+    /// But an owner-scoped token is a **bearer** token: it is minted once
+    /// and is *meant* to be reused across many `GET
+    /// /v1/owners/{owner}/...` calls for its whole TTL window. Treating
+    /// `nonce` as single-use (checked against a Redis "seen" set, rejected
+    /// on the second request) would defeat that — the token would only
+    /// ever authorize exactly one read, which is not what a "short-lived
+    /// bearer token scoped to Y" means.
+    ///
+    /// So `nonce` here is **not** checked against any single-use tracking
+    /// set in Phase 1. Its purpose is:
+    ///   1. **Forward compatibility for revocation** — a specific
+    ///      compromised/misissued token's nonce could be added to a
+    ///      future Redis blocklist without invalidating every other token
+    ///      for that owner (which revoking by `owner_address` alone would
+    ///      do).
+    ///   2. **Observability** — logging `nonce` alongside each read lets
+    ///      an operator trace which minted token served which request,
+    ///      without logging the token itself.
+    ///
+    /// This is a real ambiguity in the ticket text, resolved here rather
+    /// than silently — flagged explicitly in the WALM-297 implementation
+    /// report's design decisions.
+    pub nonce: String,
+    /// Granted scopes. Phase 1 always mints exactly `["memories.read"]`
+    /// (see [`PERMISSION_MEMORIES_READ`]); modeled as a `Vec<String>` so
+    /// additional scopes can be added later without a claims migration.
+    pub permissions: Vec<String>,
+}
+
+/// Rejection type for owner-token verification failures (bad signature,
+/// expired, malformed, wrong audience) and for the [`OwnerToken`]
+/// extractor. Deliberately carries no detail in its `IntoResponse` output:
+/// mirrors this crate's existing convention for auth failures (see
+/// `auth::verify_signature`'s bare `StatusCode::UNAUTHORIZED` rejections)
+/// of collapsing every failure mode to a bare 401 so a caller cannot
+/// distinguish "expired" from "wrong secret" from "malformed" by response
+/// content.
+#[derive(Debug)]
+pub struct OwnerTokenError;
+
+impl axum::response::IntoResponse for OwnerTokenError {
+    fn into_response(self) -> axum::response::Response {
+        axum::http::StatusCode::UNAUTHORIZED.into_response()
+    }
+}
+
+/// Serialize + HMAC-sign claims into the wire token format:
+/// `"{base64url(json claims)}.{base64url(hmac-sha256 signature)}"`.
+/// Factored out of [`mint_token`] so tests can construct a token from
+/// hand-built claims (e.g. a claims payload with a tampered audience) that
+/// [`mint_token`]'s fixed-shape signature can't express.
+fn encode_and_sign(secret: &[u8], claims: &OwnerTokenClaims) -> String {
+    let payload = serde_json::to_vec(claims).expect("owner token claims serialize");
+    let payload = URL_SAFE_NO_PAD.encode(payload);
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key size");
+    mac.update(payload.as_bytes());
+    let signature = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+    format!("{payload}.{signature}")
+}
+
+/// Mint a fresh owner-scoped bearer token. `owner` is stored verbatim into
+/// `owner_address` — callers must canonicalize (lowercase / validate) the
+/// address themselves first, exactly as `security_delete_auth::verify`
+/// canonicalizes before calling its `mint_token`. `permissions` is always
+/// exactly `["memories.read"]` in Phase 1.
+pub fn mint_token(secret: &[u8], owner: &str, ttl_secs: u64, now_unix: i64) -> String {
+    let claims = OwnerTokenClaims {
+        subject: OWNER_TOKEN_SUBJECT.to_string(),
+        owner_address: owner.to_owned(),
+        audience: OWNER_TOKEN_AUDIENCE.to_string(),
+        issued_at: now_unix,
+        expires_at: now_unix.saturating_add(ttl_secs as i64),
+        nonce: Uuid::new_v4().to_string(),
+        permissions: vec![PERMISSION_MEMORIES_READ.to_string()],
+    };
+    encode_and_sign(secret, &claims)
+}
+
+/// Verify an owner-scoped bearer token's signature, expiry, and audience,
+/// returning its claims on success. Mirrors
+/// `security_delete_auth::verify_token`'s exact HMAC verification shape
+/// (split on `.`, reject a second `.` in the signature half, base64-decode,
+/// `verify_slice`, then decode + validate the payload).
+pub fn verify_token(
+    secret: &[u8],
+    token: &str,
+    now_unix: i64,
+) -> Result<OwnerTokenClaims, OwnerTokenError> {
+    let (payload, signature) = token.split_once('.').ok_or(OwnerTokenError)?;
+    if signature.contains('.') {
+        return Err(OwnerTokenError);
+    }
+    let signature_bytes = URL_SAFE_NO_PAD
+        .decode(signature)
+        .map_err(|_| OwnerTokenError)?;
+    let mut mac = HmacSha256::new_from_slice(secret).map_err(|_| OwnerTokenError)?;
+    mac.update(payload.as_bytes());
+    mac.verify_slice(&signature_bytes)
+        .map_err(|_| OwnerTokenError)?;
+    let claims: OwnerTokenClaims = serde_json::from_slice(
+        &URL_SAFE_NO_PAD
+            .decode(payload)
+            .map_err(|_| OwnerTokenError)?,
+    )
+    .map_err(|_| OwnerTokenError)?;
+    if claims.expires_at <= now_unix {
+        return Err(OwnerTokenError);
+    }
+    if claims.audience != OWNER_TOKEN_AUDIENCE {
+        return Err(OwnerTokenError);
+    }
+    Ok(claims)
+}
+
+/// Verified claims for an owner-scoped bearer token, extracted from the
+/// `Authorization: Bearer <token>` header. Mirrors `SdOwner` in
+/// `security_delete_auth.rs`: a thin newtype `FromRequestParts` extractor
+/// that reads the header, verifies against the configured secret + current
+/// time, and yields the parsed claims (or the 401-style [`OwnerTokenError`]
+/// rejection) directly — no separate middleware layer needed since axum
+/// runs per-handler extractors before the handler body.
+pub struct OwnerToken(pub OwnerTokenClaims);
+
+impl<S> FromRequestParts<S> for OwnerToken
+where
+    S: Send + Sync,
+    Arc<AppState>: FromRef<S>,
+{
+    type Rejection = OwnerTokenError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let state = Arc::<AppState>::from_ref(state);
+        let token = parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .ok_or(OwnerTokenError)?;
+        // An empty configured secret means owner-token issuance was never
+        // configured for this deployment (`OWNER_TOKEN_SECRET` unset — see
+        // `Config::owner_token_secret`). HMAC-SHA256 accepts an empty key
+        // like any other, so without this guard a caller who *knows* the
+        // deployment is unconfigured could forge a valid signature using
+        // the well-known empty key. Fail closed instead of trusting an
+        // empty secret to behave like "no valid token can ever exist".
+        if state.config.owner_token_secret.is_empty() {
+            return Err(OwnerTokenError);
+        }
+        verify_token(
+            state.config.owner_token_secret.as_bytes(),
+            token,
+            chrono::Utc::now().timestamp(),
+        )
+        .map(Self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_token_roundtrip() {
+        let token = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        let claims = verify_token(b"test-secret", &token, 1_000_100).unwrap();
+        assert_eq!(claims.owner_address, "0xabc");
+        assert_eq!(claims.subject, OWNER_TOKEN_SUBJECT);
+        assert_eq!(claims.audience, OWNER_TOKEN_AUDIENCE);
+        assert_eq!(
+            claims.permissions,
+            vec![PERMISSION_MEMORIES_READ.to_string()]
+        );
+        assert_eq!(claims.issued_at, 1_000_000);
+        assert_eq!(claims.expires_at, 1_000_900);
+        assert!(Uuid::parse_str(&claims.nonce).is_ok());
+    }
+
+    #[test]
+    fn owner_token_expired_rejected() {
+        let token = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        assert!(verify_token(b"test-secret", &token, 1_000_901).is_err());
+    }
+
+    #[test]
+    fn owner_token_expires_at_boundary_is_exclusive() {
+        let token = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        // Exactly at expiry is rejected (`<=` in verify_token) ...
+        assert!(verify_token(b"test-secret", &token, 1_000_900).is_err());
+        // ... one second before is still accepted.
+        assert!(verify_token(b"test-secret", &token, 1_000_899).is_ok());
+    }
+
+    #[test]
+    fn owner_token_wrong_secret_rejected() {
+        let token = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        assert!(verify_token(b"other-secret", &token, 1_000_000).is_err());
+    }
+
+    #[test]
+    fn owner_token_tampered_rejected() {
+        let token = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        assert!(verify_token(b"test-secret", &(token + "x"), 1_000_000).is_err());
+    }
+
+    #[test]
+    fn owner_token_malformed_rejected() {
+        assert!(verify_token(b"test-secret", "not-a-token", 1_000_000).is_err());
+        assert!(verify_token(b"test-secret", "a.b.c", 1_000_000).is_err());
+        assert!(verify_token(b"test-secret", "", 1_000_000).is_err());
+    }
+
+    #[test]
+    fn owner_token_wrong_audience_rejected() {
+        // Hand-build claims with a tampered audience, signed with the
+        // otherwise-correct secret, to prove `verify_token` checks
+        // `audience` independently of the HMAC signature check.
+        let claims = OwnerTokenClaims {
+            subject: OWNER_TOKEN_SUBJECT.to_string(),
+            owner_address: "0xabc".to_string(),
+            audience: "not-memwal".to_string(),
+            issued_at: 1_000_000,
+            expires_at: 1_000_900,
+            nonce: Uuid::new_v4().to_string(),
+            permissions: vec![PERMISSION_MEMORIES_READ.to_string()],
+        };
+        let token = encode_and_sign(b"test-secret", &claims);
+        assert!(verify_token(b"test-secret", &token, 1_000_000).is_err());
+    }
+
+    #[test]
+    fn owner_token_owner_address_roundtrips_exactly() {
+        let owner = "0x0000000000000000000000000000000000000000000000000000000000000abc";
+        let token = mint_token(b"test-secret", owner, 900, 1_000_000);
+        let claims = verify_token(b"test-secret", &token, 1_000_000).unwrap();
+        assert_eq!(claims.owner_address, owner);
+    }
+
+    #[test]
+    fn owner_token_each_mint_gets_a_unique_nonce() {
+        let token1 = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        let token2 = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        let claims1 = verify_token(b"test-secret", &token1, 1_000_000).unwrap();
+        let claims2 = verify_token(b"test-secret", &token2, 1_000_000).unwrap();
+        assert_ne!(claims1.nonce, claims2.nonce);
+    }
+
+    #[test]
+    fn owner_token_permissions_are_memories_read_only() {
+        let token = mint_token(b"test-secret", "0xabc", 900, 1_000_000);
+        let claims = verify_token(b"test-secret", &token, 1_000_000).unwrap();
+        assert_eq!(claims.permissions.len(), 1);
+        assert_eq!(claims.permissions[0], "memories.read");
+    }
+}

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -1213,7 +1213,113 @@ pub async fn accounts_rate_limit_middleware(
 /// unauthenticated or malformed-body request is rejected by the
 /// credential gate or the handler's own `Json` extractor either way.
 ///
+/// Per-IP budget on `POST /v1/owner-tokens`, independent of whether the
+/// supplied `x-service-credential` is valid. Wired as the TRUE outermost
+/// layer on this route (outside `service_credential_gate` itself) — see
+/// `main.rs`'s `owner_token_routes` wiring for why this is load-bearing:
+/// `service_credential_gate` rejects a bad credential in-process with no
+/// I/O, so `owner_token_credential_rate_limit_middleware` below (keyed by
+/// the *value* of the supplied credential, hashed) is structurally never
+/// reached by a failing-credential request, and an attacker who varies
+/// their guess every request gets a fresh Redis bucket key each time and
+/// is never throttled by it either. Without a limiter keyed by something
+/// an attacker can't freely vary (their source IP), guessing the single
+/// shared service credential has no throttling at all — this closes that
+/// gap the same way `accounts_rate_limit_middleware`/
+/// `sponsor_rate_limit_middleware` already do for their own routes (IP
+/// budget applied unconditionally, before any auth/validity check).
 /// Fails closed to 503 on Redis error, matching every other limiter here.
+pub async fn owner_token_ip_rate_limit_middleware(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.config.rate_limit.bench_bypass_enabled {
+        return next.run(request).await;
+    }
+
+    let ip = match request
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| canonical_client_ip(request.headers(), ci.0, state.config.trusted_proxy_hops))
+    {
+        Some(ip) => ip.to_string(),
+        None => {
+            tracing::warn!("owner_token_ip_rate_limit_middleware: cannot determine client IP, denying");
+            return rate_limiter_unavailable_response();
+        }
+    };
+
+    let config = &state.config.owner_token_rate_limit;
+    let mut redis = state.redis.clone();
+    let now = chrono::Utc::now().timestamp_millis() as f64;
+
+    let min_key = format!("rate:ownertoken:ip:min:{}", ip);
+    let hr_key = format!("rate:ownertoken:ip:hr:{}", ip);
+    let min_window_start = now - 60_000.0;
+    let hr_window_start = now - 3_600_000.0;
+
+    match check_and_record_window(
+        &mut redis,
+        &min_key,
+        min_window_start,
+        now,
+        config.ip_per_minute,
+        1,
+        120,
+    )
+    .await
+    {
+        Ok(WindowCheckResult::Denied) => {
+            tracing::warn!(
+                "owner-token rate limit [IP/min]: ip={} denied (limit={})",
+                ip,
+                config.ip_per_minute
+            );
+            return rate_limit_response("owner_token_ip_burst", config.ip_per_minute, "min", 60);
+        }
+        Err(e) => {
+            tracing::error!(
+                "owner_token_ip_rate_limit_middleware: Redis error (minute bucket): {}",
+                e
+            );
+            return rate_limiter_unavailable_response();
+        }
+        Ok(WindowCheckResult::Allowed) => {}
+    }
+
+    match check_and_record_window(
+        &mut redis,
+        &hr_key,
+        hr_window_start,
+        now + 0.1,
+        config.ip_per_hour,
+        1,
+        3700,
+    )
+    .await
+    {
+        Ok(WindowCheckResult::Denied) => {
+            tracing::warn!(
+                "owner-token rate limit [IP/hr]: ip={} denied (limit={})",
+                ip,
+                config.ip_per_hour
+            );
+            return rate_limit_response("owner_token_ip_sustained", config.ip_per_hour, "hour", 300);
+        }
+        Err(e) => {
+            tracing::error!(
+                "owner_token_ip_rate_limit_middleware: Redis error (hour bucket): {}",
+                e
+            );
+            return rate_limiter_unavailable_response();
+        }
+        Ok(WindowCheckResult::Allowed) => {}
+    }
+
+    next.run(request).await
+}
+
 pub async fn owner_token_credential_rate_limit_middleware(
     State(state): State<Arc<AppState>>,
     request: Request,

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -5,6 +5,7 @@ use axum::{
     response::Response,
 };
 use percent_encoding::percent_decode_str;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -1183,6 +1184,222 @@ pub async fn accounts_rate_limit_middleware(
     }
 
     next.run(request).await
+}
+
+// ============================================================
+// Owner Token — issuance rate limiting (WALM-297)
+// ============================================================
+
+/// Pre-handler rate limiting for `POST /v1/owner-tokens`, keyed by a
+/// SHA-256 hash of the caller's `x-service-credential` header value (the
+/// raw credential itself is never used as a Redis key or logged).
+///
+/// Phase 1 has exactly one shared service credential (see
+/// `routes::owner_token` module doc), so today this is effectively one
+/// deployment-wide bucket — same mechanism as
+/// `check_global_sponsor_rate_limit`'s fixed-key global cap — but hashing
+/// the credential rather than hardcoding one key means a future
+/// multi-credential Console rollout (e.g. per-integration credentials)
+/// gets independent buckets for free, with no changes needed here.
+///
+/// This is the "per-service-credential" layer only. The additional
+/// per-owner cap (`check_owner_token_owner_rate_limit`) is applied inside
+/// the `issue_token` handler itself, after the owner address has been
+/// canonicalized — not here — because this middleware runs before the
+/// request body is parsed by the handler's `Json` extractor, and
+/// buffering + re-parsing the body a second time here (mirroring
+/// `auth::verify_signature`'s body-consumption pattern) would duplicate
+/// validation the handler already has to do, for no benefit: an
+/// unauthenticated or malformed-body request is rejected by the
+/// credential gate or the handler's own `Json` extractor either way.
+///
+/// Fails closed to 503 on Redis error, matching every other limiter here.
+pub async fn owner_token_credential_rate_limit_middleware(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    // RATE_LIMIT_DISABLED=1 — see RateLimitConfig::bench_bypass_enabled.
+    if state.config.rate_limit.bench_bypass_enabled {
+        return next.run(request).await;
+    }
+
+    // Header name duplicated from `routes::owner_token::SERVICE_CREDENTIAL_HEADER`
+    // rather than imported: `rate_limit.rs` is compiled into BOTH the
+    // `main.rs` binary crate tree and the separate `lib.rs` library crate
+    // tree (see that file's module doc — it deliberately does not declare
+    // `mod routes`, only what `sui`'s dependency closure needs), so a
+    // `crate::routes::...` reference here would fail to resolve under
+    // `cargo test --lib`. Keep this literal in sync with
+    // `SERVICE_CREDENTIAL_HEADER` if that constant's value ever changes.
+    const SERVICE_CREDENTIAL_HEADER: &str = "x-service-credential";
+    let credential = request
+        .headers()
+        .get(SERVICE_CREDENTIAL_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    let credential_hash = hex::encode(Sha256::digest(credential.as_bytes()));
+
+    let config = &state.config.owner_token_rate_limit;
+    let mut redis = state.redis.clone();
+    let now = chrono::Utc::now().timestamp_millis() as f64;
+
+    let min_key = format!("rate:ownertoken:cred:min:{credential_hash}");
+    let hr_key = format!("rate:ownertoken:cred:hr:{credential_hash}");
+    let min_window_start = now - 60_000.0;
+    let hr_window_start = now - 3_600_000.0;
+
+    match check_and_record_window(
+        &mut redis,
+        &min_key,
+        min_window_start,
+        now,
+        config.per_minute,
+        1,
+        120,
+    )
+    .await
+    {
+        Ok(WindowCheckResult::Denied) => {
+            tracing::warn!(
+                "owner-token rate limit [credential/min]: denied (limit={})",
+                config.per_minute
+            );
+            return rate_limit_response(
+                "owner_token_credential_burst",
+                config.per_minute,
+                "min",
+                60,
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                "owner_token_credential_rate_limit_middleware: Redis error (minute bucket): {}",
+                e
+            );
+            return rate_limiter_unavailable_response();
+        }
+        Ok(WindowCheckResult::Allowed) => {}
+    }
+
+    match check_and_record_window(
+        &mut redis,
+        &hr_key,
+        hr_window_start,
+        now + 0.1,
+        config.per_hour,
+        1,
+        3700,
+    )
+    .await
+    {
+        Ok(WindowCheckResult::Denied) => {
+            tracing::warn!(
+                "owner-token rate limit [credential/hr]: denied (limit={})",
+                config.per_hour
+            );
+            return rate_limit_response(
+                "owner_token_credential_sustained",
+                config.per_hour,
+                "hour",
+                300,
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                "owner_token_credential_rate_limit_middleware: Redis error (hour bucket): {}",
+                e
+            );
+            return rate_limiter_unavailable_response();
+        }
+        Ok(WindowCheckResult::Allowed) => {}
+    }
+
+    next.run(request).await
+}
+
+/// Per-owner cap on `POST /v1/owner-tokens` issuance (WALM-297). Keyed by
+/// the canonical (lowercased) owner address, independent of the
+/// per-service-credential budget enforced by
+/// `owner_token_credential_rate_limit_middleware` — a compromised or buggy
+/// Console instance that still holds a valid service credential must not
+/// be able to mint unbounded tokens for one owner. Called directly from
+/// the `issue_token` handler (see that function's doc comment for why this
+/// isn't middleware).
+///
+/// Reuses `SponsorRlResult` (`Allowed` / `MinuteLimitExceeded` /
+/// `HourLimitExceeded`) rather than defining a fourth near-identical
+/// two-tier rate-limit result enum — this crate already has
+/// `check_global_sponsor_rate_limit` and `check_global_accounts_rate_limit`
+/// returning the same shape for the same reason.
+///
+/// Returns `Err(())` on Redis failure so the caller can fail closed —
+/// consistent with every other limiter in this module.
+pub async fn check_owner_token_owner_rate_limit(
+    state: &crate::types::AppState,
+    owner: &str,
+    per_minute: i64,
+    per_hour: i64,
+) -> Result<SponsorRlResult, ()> {
+    let now = chrono::Utc::now().timestamp_millis() as f64;
+    let mut redis = state.redis.clone();
+
+    let min_key = format!("rate:ownertoken:owner:min:{owner}");
+    let hr_key = format!("rate:ownertoken:owner:hr:{owner}");
+    let min_window_start = now - 60_000.0;
+    let hr_window_start = now - 3_600_000.0;
+
+    match check_and_record_window(
+        &mut redis,
+        &min_key,
+        min_window_start,
+        now,
+        per_minute,
+        1,
+        120,
+    )
+    .await
+    {
+        Ok(WindowCheckResult::Denied) => {
+            crate::observability::record_rate_limit_denial("owner_token_owner_burst");
+            return Ok(SponsorRlResult::MinuteLimitExceeded);
+        }
+        Err(e) => {
+            tracing::error!(
+                "check_owner_token_owner_rate_limit: Redis error (minute): {}",
+                e
+            );
+            return Err(());
+        }
+        Ok(WindowCheckResult::Allowed) => {}
+    }
+
+    match check_and_record_window(
+        &mut redis,
+        &hr_key,
+        hr_window_start,
+        now + 0.1,
+        per_hour,
+        1,
+        3700,
+    )
+    .await
+    {
+        Ok(WindowCheckResult::Denied) => {
+            crate::observability::record_rate_limit_denial("owner_token_owner_sustained");
+            return Ok(SponsorRlResult::HourLimitExceeded);
+        }
+        Err(e) => {
+            tracing::error!(
+                "check_owner_token_owner_rate_limit: Redis error (hour): {}",
+                e
+            );
+            return Err(());
+        }
+        Ok(WindowCheckResult::Allowed) => {}
+    }
+
+    Ok(SponsorRlResult::Allowed)
 }
 
 // ============================================================

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -10,6 +10,10 @@
 //! - `sponsor` — `/sponsor`, `/sponsor/execute` (Enoki proxy)
 //! - `accounts` — `/api/accounts/{owner}/exists` (public MemWalAccount
 //!   existence check)
+//! - `owner_token` — WALM-297 `POST /v1/owner-tokens` (owner-scoped bearer
+//!   token issuance) + `GET /v1/owners/{owner}/_token_probe` (a minimal
+//!   token-gated route standing in for PR #537/WALM-295's real
+//!   `/v1/owners/{owner}/...` handlers, not present in this branch)
 //!
 //! Shared route-level helpers (`enqueue_wallet_job`, `truncate_str`,
 //! `collect_bounded_results`, `cleanup_expired_blob`) live here in `mod.rs`.
@@ -19,6 +23,7 @@
 mod accounts;
 mod admin;
 mod analyze;
+pub mod owner_token;
 mod recall;
 mod remember;
 pub mod security_delete;
@@ -29,6 +34,7 @@ mod sponsor;
 pub use accounts::account_exists;
 pub use admin::{ask, forget, get_config, health, restore, stats, version};
 pub use analyze::analyze;
+pub use owner_token::{issue_token, token_probe};
 pub use recall::{recall, recall_manual};
 pub use remember::{
     remember, remember_bulk, remember_bulk_status, remember_manual, remember_status,

--- a/services/server/src/routes/owner_token.rs
+++ b/services/server/src/routes/owner_token.rs
@@ -191,10 +191,24 @@ pub async fn issue_token(
     let ttl = state.config.owner_token_ttl_secs;
     let token =
         owner_token_auth::mint_token(state.config.owner_token_secret.as_bytes(), &owner, ttl, now);
-    let expires_at =
-        chrono::DateTime::<chrono::Utc>::from_timestamp(now.saturating_add(ttl as i64), 0)
-            .map(|dt| dt.to_rfc3339())
-            .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+    // `to_rfc3339_opts(_, use_z=true)`, not the plain `to_rfc3339()` used
+    // previously: chrono's `to_rfc3339()` always renders the UTC offset as
+    // `+00:00`, never as the `Z` this response's own doc comment and
+    // docs/api/owner-token-auth.md's example both promise.
+    //
+    // `OWNER_TOKEN_TTL_SECS` is clamped to `MAX_OWNER_TOKEN_TTL_SECS` at
+    // config-load time (types.rs), so `now + ttl` cannot exceed chrono's
+    // representable range in practice — but this still fails loudly with a
+    // real error rather than silently substituting "now" (which would have
+    // told the caller their brand-new token was already expired) if that
+    // invariant is ever violated.
+    let expires_at = chrono::DateTime::<chrono::Utc>::from_timestamp(now.saturating_add(ttl as i64), 0)
+        .ok_or_else(|| {
+            AppError::Internal(format!(
+                "owner-token expiry timestamp out of range (now={now}, ttl={ttl})"
+            ))
+        })?
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
     Ok(Json(IssueOwnerTokenResponse {
         token,
@@ -285,5 +299,92 @@ mod tests {
             SERVICE_CREDENTIAL_HEADER,
             SERVICE_CREDENTIAL_HEADER.to_ascii_lowercase()
         );
+    }
+
+    // `token_probe`'s two checks (owner-match, permission-scope) are the
+    // actual authorization decision this whole feature exists to make, and
+    // are explicitly documented as the copy-paste template WALM-295's real
+    // read handlers will use — so they're tested directly here even though
+    // `token_probe` is itself a dev-only stand-in route. `OwnerToken` and
+    // `Path` are both directly constructible (no AppState/DB/Redis needed),
+    // matching how `routes::accounts` unit-tests its pure logic.
+    fn claims_for(owner: &str, permissions: &[&str]) -> owner_token_auth::OwnerTokenClaims {
+        owner_token_auth::OwnerTokenClaims {
+            subject: "console".to_string(),
+            owner_address: owner.to_string(),
+            audience: owner_token_auth::OWNER_TOKEN_AUDIENCE.to_string(),
+            issued_at: 0,
+            expires_at: i64::MAX,
+            nonce: uuid::Uuid::new_v4().to_string(),
+            permissions: permissions.iter().map(|p| p.to_string()).collect(),
+        }
+    }
+
+    // Realistic 66-char Sui addresses — `same_owner`/`canonical_sui_address`
+    // reject anything shorter, so a placeholder like "0xabc" fails for the
+    // wrong reason (invalid address) rather than exercising the actual
+    // owner-comparison logic these tests target.
+    const TEST_OWNER: &str =
+        "0x0000000000000000000000000000000000000000000000000000000000000abc";
+    const OTHER_OWNER: &str =
+        "0x0000000000000000000000000000000000000000000000000000000000000def";
+
+    #[tokio::test]
+    async fn token_probe_allows_matching_owner_with_memories_read() {
+        let result = token_probe(
+            OwnerToken(claims_for(TEST_OWNER, &[PERMISSION_MEMORIES_READ])),
+            Path(TEST_OWNER.to_string()),
+        )
+        .await;
+        let Json(body) = result.expect("matching owner + correct scope must succeed");
+        assert!(body.ok);
+        assert_eq!(body.owner, TEST_OWNER);
+        assert_eq!(body.permissions, vec![PERMISSION_MEMORIES_READ.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn token_probe_rejects_owner_mismatch() {
+        let result = token_probe(
+            OwnerToken(claims_for(TEST_OWNER, &[PERMISSION_MEMORIES_READ])),
+            Path(OTHER_OWNER.to_string()),
+        )
+        .await;
+        assert_eq!(result.unwrap_err(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn token_probe_matches_owner_case_insensitively_via_same_owner() {
+        // `same_owner` canonicalizes the *path* side before comparing, so
+        // this must still succeed even though the path segment's case
+        // differs from the (already-canonical) claim — pins that
+        // token_probe reuses the real canonical comparison rather than a
+        // raw string `==`.
+        let upper_path = TEST_OWNER.to_ascii_uppercase().replacen("0X", "0x", 1);
+        let result = token_probe(
+            OwnerToken(claims_for(TEST_OWNER, &[PERMISSION_MEMORIES_READ])),
+            Path(upper_path),
+        )
+        .await;
+        assert!(result.is_ok(), "canonical-equal owners must match");
+    }
+
+    #[tokio::test]
+    async fn token_probe_rejects_missing_required_permission() {
+        let result = token_probe(
+            OwnerToken(claims_for(TEST_OWNER, &["some.other.scope"])),
+            Path(TEST_OWNER.to_string()),
+        )
+        .await;
+        assert_eq!(result.unwrap_err(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn token_probe_rejects_empty_permissions() {
+        let result = token_probe(
+            OwnerToken(claims_for(TEST_OWNER, &[])),
+            Path(TEST_OWNER.to_string()),
+        )
+        .await;
+        assert_eq!(result.unwrap_err(), StatusCode::FORBIDDEN);
     }
 }

--- a/services/server/src/routes/owner_token.rs
+++ b/services/server/src/routes/owner_token.rs
@@ -1,0 +1,289 @@
+//! WALM-297 Phase 1 — `POST /v1/owner-tokens` issuance + a minimal
+//! token-gated probe route.
+//!
+//! Console has already proven (entirely on its own side — WALM-298, PR
+//! #533; WM is never involved) that a user controls a WM owner address `Y`.
+//! It then calls `POST /v1/owner-tokens`, authenticating itself as a
+//! legitimate client via the team-decided **service credential** (a single
+//! static shared secret WM generates and hands to Console out of band —
+//! Slack thread, Henry + Harry Phan; mTLS and signed-client-assertion were
+//! explicitly considered and NOT chosen), to mint a short-lived bearer
+//! token scoped to `Y`. Console then presents that token as `Authorization:
+//! Bearer <token>` to WM's owner-scoped read routes.
+//!
+//! `token_probe` is a minimal token-gated route added SPECIFICALLY so this
+//! feature is testable end-to-end in this branch: PR #537 (WALM-295)'s real
+//! `GET /v1/owners/{owner}/{namespaces,memories,agents}` handlers do not
+//! exist here yet (this is a fresh branch off `dev`). Wiring the
+//! `OwnerToken` extractor into those real handlers is the small follow-up
+//! once this branch merges with / rebases onto PR #537's branch.
+
+use axum::extract::{Path, Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::Response;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::owner_token_auth::{self, OwnerToken, PERMISSION_MEMORIES_READ};
+use crate::rate_limit::{self, SponsorRlResult};
+use crate::routes::sponsor::validate_sui_address;
+use crate::security_delete_auth::same_owner;
+use crate::types::{AppError, AppState};
+
+/// Header Console sends the shared WM↔Console service credential on.
+/// Not specified by the ticket text; chosen to read clearly on the wire and
+/// to follow this crate's existing lowercase-`x-*` convention for
+/// auth-adjacent headers (`x-public-key`, `x-signature`, `x-account-id`,
+/// ... — see `auth.rs`), same family as the sidecar's own shared-secret
+/// header (`X-Sidecar-Secret`, `Config::sidecar_secret`).
+pub const SERVICE_CREDENTIAL_HEADER: &str = "x-service-credential";
+
+// ============================================================
+// Constant-time secret comparison
+// ============================================================
+
+/// Constant-time equality for the service-credential comparison below. This
+/// workspace has no `subtle` crate dependency (checked `Cargo.toml` — the
+/// only crypto deps are `ed25519-dalek`, `sha2`, `hmac`, `hex`), and none of
+/// the existing secret comparisons in this crate (`deletion_token_secret`
+/// verification goes through HMAC `verify_slice`, which is already
+/// constant-time; there is no existing *plain-secret* comparison to
+/// mirror) provide one either. Rather than pull in a new dependency for a
+/// single byte comparison, this hand-rolls the standard
+/// equal-length-then-XOR-accumulate technique: unlike `==`, it does not
+/// short-circuit on the first differing byte, so response timing cannot be
+/// used to learn how many leading bytes of the guess were correct.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Axum middleware gating the whole `POST /v1/owner-tokens` router group.
+/// Reads [`SERVICE_CREDENTIAL_HEADER`] and compares it against
+/// `Config::owner_token_service_credential`. Missing header, wrong value,
+/// or an unconfigured (empty) secret all collapse to a bare 401 with no
+/// body — matching this crate's existing convention for auth failures (see
+/// `auth::verify_signature`'s bare `StatusCode` rejections): no detail is
+/// leaked about *why* the request was rejected.
+pub async fn service_credential_gate(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let provided = request
+        .headers()
+        .get(SERVICE_CREDENTIAL_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    let configured = state.config.owner_token_service_credential.as_str();
+    if configured.is_empty() || !constant_time_eq(provided.as_bytes(), configured.as_bytes()) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(next.run(request).await)
+}
+
+// The per-service-credential rate-limit middleware
+// (`rate_limit::owner_token_credential_rate_limit_middleware`) lives in
+// `rate_limit.rs` alongside every other limiter in this crate
+// (`sponsor_rate_limit_middleware`, `accounts_rate_limit_middleware`) —
+// wired directly from `main.rs`, not re-exported through this module.
+
+// ============================================================
+// POST /v1/owner-tokens
+// ============================================================
+
+#[derive(Debug, Deserialize)]
+pub struct IssueOwnerTokenRequest {
+    pub owner: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IssueOwnerTokenResponse {
+    pub token: String,
+    /// RFC 3339 / ISO 8601 UTC timestamp, e.g. `"2026-08-04T12:15:00Z"`.
+    pub expires_at: String,
+    pub permissions: Vec<String>,
+}
+
+/// `POST /v1/owner-tokens` — mint a short-lived, owner-scoped bearer token.
+///
+/// Request: `{ "owner": "<sui address>" }`
+/// Response (200): `{ "token": "...", "expires_at": "<ISO8601>",
+/// "permissions": ["memories.read"] }`
+///
+/// Ordering: address format validation → configuration check → per-owner
+/// rate limit → MemWalAccount existence check → mint. Format validation
+/// runs first (cheapest, and avoids charging the rate-limit budget or
+/// touching the DB for garbage input); the existence check runs last
+/// (most expensive, a DB round trip) so it only runs for requests that
+/// already cleared every cheaper gate.
+pub async fn issue_token(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<IssueOwnerTokenRequest>,
+) -> Result<Json<IssueOwnerTokenResponse>, AppError> {
+    if !validate_sui_address(&request.owner) {
+        return Err(AppError::BadRequest(
+            "owner must be a 0x-prefixed 32-byte Sui address (66 characters)".into(),
+        ));
+    }
+    // Same case-normalization rationale as `routes::accounts::account_exists`:
+    // the indexed `accounts.owner` column is always lowercase hex (populated
+    // via `hex::encode` in the v2-indexer), and lowercasing here (rather than
+    // `LOWER(owner) = LOWER($1)` in SQL) keeps the plain btree index usable.
+    let owner = request.owner.to_ascii_lowercase();
+
+    if state.config.owner_token_secret.is_empty() {
+        // Feature not configured for this deployment (`OWNER_TOKEN_SECRET`
+        // unset). Distinct from an auth failure — this is a deployment
+        // configuration gap, not a bad caller — so it gets a 503 rather
+        // than folding into the bare-401 auth-failure convention used
+        // elsewhere in this file.
+        return Err(AppError::UpstreamUnavailable(
+            "owner-token issuance is not configured".into(),
+        ));
+    }
+
+    match rate_limit::check_owner_token_owner_rate_limit(
+        &state,
+        &owner,
+        state.config.owner_token_rate_limit.owner_per_minute,
+        state.config.owner_token_rate_limit.owner_per_hour,
+    )
+    .await
+    {
+        Ok(SponsorRlResult::Allowed) => {}
+        Ok(SponsorRlResult::MinuteLimitExceeded) | Ok(SponsorRlResult::HourLimitExceeded) => {
+            return Err(AppError::RateLimited(
+                "too many owner-token requests for this owner; retry later".into(),
+            ));
+        }
+        Err(()) => {
+            return Err(AppError::UpstreamUnavailable(
+                "rate limiter temporarily unavailable".into(),
+            ));
+        }
+    }
+
+    // Design decision (flagged for review, not explicitly demanded by the
+    // WALM-297 ticket's literal ACs): reject up front, with 400, when the
+    // owner has no MemWalAccount at all, rather than minting a token for a
+    // nonexistent account. Justification: a token scoped to an address with
+    // no account is nonsensical — every real read route it would be used
+    // against is itself scoped to an existing account's data — and this
+    // mirrors WALM-298's own `GET /api/accounts/{owner}/exists` design
+    // (an explicit existence-check primitive Console is expected to use
+    // before this call anyway). Reuses the exact same DB helper accounts.rs
+    // calls (`db.find_account_by_owner`), not a second implementation.
+    let exists = state.db.find_account_by_owner(&owner).await?.is_some();
+    if !exists {
+        return Err(AppError::BadRequest("owner has no MemWalAccount".into()));
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let ttl = state.config.owner_token_ttl_secs;
+    let token =
+        owner_token_auth::mint_token(state.config.owner_token_secret.as_bytes(), &owner, ttl, now);
+    let expires_at =
+        chrono::DateTime::<chrono::Utc>::from_timestamp(now.saturating_add(ttl as i64), 0)
+            .map(|dt| dt.to_rfc3339())
+            .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+
+    Ok(Json(IssueOwnerTokenResponse {
+        token,
+        expires_at,
+        permissions: vec![PERMISSION_MEMORIES_READ.to_string()],
+    }))
+}
+
+// ============================================================
+// GET /v1/owners/{owner}/_token_probe
+// ============================================================
+
+#[derive(Debug, Serialize)]
+pub struct TokenProbeResponse {
+    pub ok: bool,
+    pub owner: String,
+    pub permissions: Vec<String>,
+}
+
+/// `GET /v1/owners/{owner}/_token_probe` — minimal token-gated route.
+///
+/// This route exists SPECIFICALLY so owner-token auth is testable
+/// end-to-end in this branch even though PR #537 (WALM-295)'s real
+/// `GET /v1/owners/{owner}/{namespaces,memories,agents}` handlers aren't
+/// present here (this is a fresh branch off `dev`). It is not itself a
+/// WALM-295 read endpoint. Wiring the `OwnerToken` extractor into the real
+/// handlers is the small follow-up once this branch merges with / rebases
+/// onto PR #537's branch — this handler is the template for that: extract
+/// `OwnerToken`, compare the `{owner}` path segment against
+/// `claims.owner_address` via `same_owner` (403 on mismatch), and check the
+/// required permission string is present in `claims.permissions` (403
+/// "insufficient scope" if not).
+///
+/// No separate rate-limit / auth middleware needed here — `OwnerToken` is a
+/// pure `FromRequestParts` extractor, so axum resolves it (and rejects
+/// unauthenticated calls) before this handler body ever runs.
+pub async fn token_probe(
+    OwnerToken(claims): OwnerToken,
+    Path(owner): Path<String>,
+) -> Result<Json<TokenProbeResponse>, StatusCode> {
+    // Reuse `security_delete_auth::same_owner` (WALM-295's memory_read.rs
+    // does not exist in this branch to grep — see module doc — but
+    // `security_delete_auth.rs` already has the identical canonical-address
+    // comparison helper) rather than writing a second implementation.
+    if !same_owner(Some(owner.as_str()), &claims.owner_address) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    // Trivially always true in Phase 1 (only `memories.read` is ever
+    // minted — see `owner_token_auth::mint_token`), but wired as a real
+    // check against `claims.permissions` rather than hardcoded so it's not
+    // dead code once a future phase mints additional scopes.
+    if !claims
+        .permissions
+        .iter()
+        .any(|permission| permission == PERMISSION_MEMORIES_READ)
+    {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    Ok(Json(TokenProbeResponse {
+        ok: true,
+        owner: claims.owner_address.clone(),
+        permissions: claims.permissions.clone(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_matches_std_eq_semantics() {
+        assert!(constant_time_eq(b"same-secret", b"same-secret"));
+        assert!(!constant_time_eq(b"same-secret", b"different"));
+        assert!(!constant_time_eq(b"short", b"a-much-longer-value"));
+        assert!(!constant_time_eq(b"", b"nonempty"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn service_credential_header_name_is_lowercase_x_prefixed() {
+        // Header name comparisons in `HeaderMap::get` are already
+        // case-insensitive, but keep the constant itself lowercase to match
+        // every other custom header in this crate (`x-public-key`,
+        // `x-signature`, ...).
+        assert_eq!(SERVICE_CREDENTIAL_HEADER, "x-service-credential");
+        assert!(SERVICE_CREDENTIAL_HEADER.starts_with("x-"));
+        assert_eq!(
+            SERVICE_CREDENTIAL_HEADER,
+            SERVICE_CREDENTIAL_HEADER.to_ascii_lowercase()
+        );
+    }
+}

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1134,6 +1134,10 @@ mod tests {
             expiry_margin_epochs: 1,
             walrus_package_id: String::new(),
             walrus_system_object_id: String::new(),
+            owner_token_secret: "owner-token-test-secret".to_string(),
+            owner_token_service_credential: "owner-token-test-credential".to_string(),
+            owner_token_ttl_secs: 900,
+            owner_token_rate_limit: crate::types::OwnerTokenRateLimitConfig::default(),
         }
     }
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -345,6 +345,35 @@ pub struct Config {
     pub expiry_margin_epochs: u64,
     pub walrus_package_id: String,
     pub walrus_system_object_id: String,
+    /// WALM-297 — HMAC signing secret for owner-scoped bearer tokens
+    /// (`OWNER_TOKEN_SECRET`). Typed `String` rather than `Option<String>`
+    /// (unlike `deletion_token_secret`, whose env-loading idiom this
+    /// otherwise mirrors — `nonempty_env`, trimmed): owner-token issuance
+    /// isn't behind a separate feature flag the way security-delete is, so
+    /// there's no natural "component disabled" state to model with `None`.
+    /// An empty string means "not configured" — both `POST
+    /// /v1/owner-tokens` and the `OwnerToken` extractor treat that as an
+    /// unconditional rejection rather than letting an empty HMAC key
+    /// validate (see `owner_token_auth::OwnerToken`'s doc comment).
+    pub owner_token_secret: String,
+    /// WALM-297 — the team-decided **service credential**: one static
+    /// shared secret WM generates and hands to Console, which Console
+    /// includes on every `POST /v1/owner-tokens` call
+    /// (`OWNER_TOKEN_SERVICE_CREDENTIAL`, header
+    /// `routes::owner_token::SERVICE_CREDENTIAL_HEADER`). Not one of the
+    /// two fields the WALM-297 spec named explicitly for this struct
+    /// (`owner_token_secret` / `owner_token_ttl_secs`) — added because the
+    /// client-authentication requirement in the same ticket has nothing
+    /// else to compare against otherwise. Same empty-string-means-
+    /// unconfigured contract as `owner_token_secret` above.
+    pub owner_token_service_credential: String,
+    /// WALM-297 — TTL for owner-scoped bearer tokens
+    /// (`OWNER_TOKEN_TTL_SECS`). Default 900s (15 min): short-lived per the
+    /// ticket, long enough that Console doesn't need to re-mint on every
+    /// single read during one user session.
+    pub owner_token_ttl_secs: u64,
+    /// WALM-297 — rate limiting for `POST /v1/owner-tokens`.
+    pub owner_token_rate_limit: OwnerTokenRateLimitConfig,
 }
 
 impl Config {
@@ -478,6 +507,11 @@ impl Config {
             walrus_package_id: nonempty_env("WALRUS_PACKAGE_ID").unwrap_or_default(),
             walrus_system_object_id: nonempty_env("WALRUS_SYSTEM_OBJECT_ID")
                 .unwrap_or_default(),
+            owner_token_secret: nonempty_env("OWNER_TOKEN_SECRET").unwrap_or_default(),
+            owner_token_service_credential: nonempty_env("OWNER_TOKEN_SERVICE_CREDENTIAL")
+                .unwrap_or_default(),
+            owner_token_ttl_secs: env_positive_u64("OWNER_TOKEN_TTL_SECS", 900),
+            owner_token_rate_limit: OwnerTokenRateLimitConfig::from_env(),
         }
     }
 }
@@ -808,6 +842,76 @@ impl AccountsRateLimitConfig {
         if let Ok(v) = std::env::var("ACCOUNTS_GLOBAL_RATE_LIMIT_PER_HOUR") {
             if let Ok(n) = v.parse() {
                 c.global_per_hour = n;
+            }
+        }
+        c
+    }
+}
+
+// ============================================================
+// Owner Token Rate Limit Config (WALM-297)
+// ============================================================
+
+/// Rate limits for `POST /v1/owner-tokens`.
+///
+/// Two independent layers, both enforced (see
+/// `rate_limit::owner_token_credential_rate_limit_middleware` and
+/// `rate_limit::check_owner_token_owner_rate_limit`):
+///
+/// - `per_minute` / `per_hour` — keyed by the caller's service credential.
+///   Phase 1 has exactly one shared credential (Console's), so in practice
+///   this is one deployment-wide budget, same idea as
+///   `SponsorRateLimitConfig::global_per_minute`. Defaults (120/min,
+///   3000/hr) are generous relative to a 15-minute token TTL — Console
+///   minting a token per active user session, even across many concurrent
+///   sessions, stays well under this.
+/// - `owner_per_minute` / `owner_per_hour` — keyed by the (canonical)
+///   owner address, independent of which credential presented it. A
+///   compromised or buggy Console instance that still holds a valid
+///   service credential must not be able to mint unbounded tokens for one
+///   owner. Defaults (5/min, 30/hr) are tight: with a 900s default TTL, a
+///   legitimate caller has no reason to re-mint for the same owner more
+///   than a handful of times per minute.
+#[derive(Debug, Clone)]
+pub struct OwnerTokenRateLimitConfig {
+    pub per_minute: i64,
+    pub per_hour: i64,
+    pub owner_per_minute: i64,
+    pub owner_per_hour: i64,
+}
+
+impl Default for OwnerTokenRateLimitConfig {
+    fn default() -> Self {
+        Self {
+            per_minute: 120,
+            per_hour: 3000,
+            owner_per_minute: 5,
+            owner_per_hour: 30,
+        }
+    }
+}
+
+impl OwnerTokenRateLimitConfig {
+    pub fn from_env() -> Self {
+        let mut c = Self::default();
+        if let Ok(v) = std::env::var("OWNER_TOKEN_RATE_LIMIT_PER_MINUTE") {
+            if let Ok(n) = v.parse() {
+                c.per_minute = n;
+            }
+        }
+        if let Ok(v) = std::env::var("OWNER_TOKEN_RATE_LIMIT_PER_HOUR") {
+            if let Ok(n) = v.parse() {
+                c.per_hour = n;
+            }
+        }
+        if let Ok(v) = std::env::var("OWNER_TOKEN_RATE_LIMIT_OWNER_PER_MINUTE") {
+            if let Ok(n) = v.parse() {
+                c.owner_per_minute = n;
+            }
+        }
+        if let Ok(v) = std::env::var("OWNER_TOKEN_RATE_LIMIT_OWNER_PER_HOUR") {
+            if let Ok(n) = v.parse() {
+                c.owner_per_hour = n;
             }
         }
         c
@@ -1770,6 +1874,10 @@ mod tests {
             expiry_margin_epochs: 1,
             walrus_package_id: "0x3".into(),
             walrus_system_object_id: "0x4".into(),
+            owner_token_secret: "owner-token-test-secret".into(),
+            owner_token_service_credential: "owner-token-test-credential".into(),
+            owner_token_ttl_secs: 900,
+            owner_token_rate_limit: OwnerTokenRateLimitConfig::default(),
         }
     }
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -34,6 +34,14 @@ pub const DEFAULT_EMBEDDING_CACHE_TTL_SECS: u64 = 10 * 60;
 
 /// Upper bound for explicit Walrus storage purchases.
 pub const MAX_WALRUS_STORAGE_EPOCHS: u32 = 15;
+/// Hard ceiling for `OWNER_TOKEN_TTL_SECS` (WALM-297) — 24 hours. Without a
+/// bound, `env_positive_u64` accepts any positive u64, and a very large TTL
+/// both defeats the "short-lived" security property the token scheme's
+/// whole threat model rests on (see docs/api/owner-token-auth.md's
+/// trust-boundary note) and can push `now + ttl` outside chrono's
+/// representable range in `routes::owner_token::issue_token`'s `expires_at`
+/// computation.
+pub const MAX_OWNER_TOKEN_TTL_SECS: u64 = 24 * 60 * 60;
 pub const DEFAULT_TESTNET_WALRUS_STORAGE_EPOCHS: u32 = 5;
 
 pub(crate) fn default_walrus_storage_epochs_for_network(network: &str) -> u32 {
@@ -510,7 +518,8 @@ impl Config {
             owner_token_secret: nonempty_env("OWNER_TOKEN_SECRET").unwrap_or_default(),
             owner_token_service_credential: nonempty_env("OWNER_TOKEN_SERVICE_CREDENTIAL")
                 .unwrap_or_default(),
-            owner_token_ttl_secs: env_positive_u64("OWNER_TOKEN_TTL_SECS", 900),
+            owner_token_ttl_secs: env_positive_u64("OWNER_TOKEN_TTL_SECS", 900)
+                .min(MAX_OWNER_TOKEN_TTL_SECS),
             owner_token_rate_limit: OwnerTokenRateLimitConfig::from_env(),
         }
     }
@@ -878,6 +887,13 @@ pub struct OwnerTokenRateLimitConfig {
     pub per_hour: i64,
     pub owner_per_minute: i64,
     pub owner_per_hour: i64,
+    /// Per-source-IP budget, independent of `x-service-credential` validity
+    /// (see `rate_limit::owner_token_ip_rate_limit_middleware`'s doc
+    /// comment — this is what actually throttles someone guessing the
+    /// shared credential, since the per-credential budget below is keyed
+    /// by the guessed value itself and never sees repeated failed guesses).
+    pub ip_per_minute: i64,
+    pub ip_per_hour: i64,
 }
 
 impl Default for OwnerTokenRateLimitConfig {
@@ -887,6 +903,8 @@ impl Default for OwnerTokenRateLimitConfig {
             per_hour: 3000,
             owner_per_minute: 5,
             owner_per_hour: 30,
+            ip_per_minute: 30,
+            ip_per_hour: 300,
         }
     }
 }
@@ -912,6 +930,16 @@ impl OwnerTokenRateLimitConfig {
         if let Ok(v) = std::env::var("OWNER_TOKEN_RATE_LIMIT_OWNER_PER_HOUR") {
             if let Ok(n) = v.parse() {
                 c.owner_per_hour = n;
+            }
+        }
+        if let Ok(v) = std::env::var("OWNER_TOKEN_RATE_LIMIT_IP_PER_MINUTE") {
+            if let Ok(n) = v.parse() {
+                c.ip_per_minute = n;
+            }
+        }
+        if let Ok(v) = std::env::var("OWNER_TOKEN_RATE_LIMIT_IP_PER_HOUR") {
+            if let Ok(n) = v.parse() {
+                c.ip_per_hour = n;
             }
         }
         c


### PR DESCRIPTION
## Summary

Console can never call WALM-295's owner-scoped read API (`GET /v1/owners/{owner}/{namespaces,memories,agents}`) under the existing Ed25519 signed-request scheme, because it structurally never holds a delegate key — WALM-298's identity-link flow proves control of an owner address entirely on Console's own side and never grants signing capability.

This adds the missing bridge: after Console has proven control of owner `Y` itself, it authenticates as a trusted client via a single shared **service credential** (team decision — service credential over mTLS/signed-client-assertion, for lower implementation cost on both sides) and mints a short-lived, owner-scoped bearer token limited to `memories.read`.

Full contract: `docs/api/owner-token-auth.md`.

## What's here

- `owner_token_auth.rs` — HMAC-signed opaque bearer token mint/verify, mirroring the existing `security_delete_auth.rs` token scheme; a `FromRequestParts` extractor for token-gated routes.
- `routes/owner_token.rs` — `POST /v1/owner-tokens` (issuance) + `GET /v1/owners/{owner}/_token_probe`, a minimal token-gated example route standing in for WALM-295's real handlers, which don't exist on this branch yet (fresh branch off `dev`). Wiring the `OwnerToken` extractor into the real `namespaces`/`memories`/`agents` handlers is the small follow-up once this branch merges with WALM-295.
- `rate_limit.rs` — three independent budgets on issuance: per-IP (throttles credential guessing, runs before the credential check), per-service-credential, per-owner. All fail closed on Redis error.
- `types.rs` / `routes/remember.rs` — new `Config` fields + fixture updates.
- `docs/api/owner-token-auth.md` — full contract for Console: request/response shapes, all distinct 429/503 response shapes across the three limiters, the shared-secret trust-boundary note.

## Testing

Verified end-to-end against a live local build (real HTTP, not just unit tests): credential rejection, cross-owner 403, real token expiry, forged tokens with altered permissions/audience correctly rejected (proving the scope check isn't hardcoded), rate-limit trip, no secret leakage across logs/responses.

Then reviewed via an adversarial multi-dimension pass (security, correctness, API-contract-vs-code, test-coverage). Confirmed findings fixed in a follow-up commit:
- **Major**: issuance had no throttling on guessing the shared credential at all (credential-gate rejected before the rate limiter ever ran, and that limiter was keyed by the guessed value anyway) → added a true outer per-IP limiter.
- **Major**: `token_probe`'s actual authorization logic (owner-match + permission-scope check — the literal security decision this feature exists to make, and the template WALM-295 will copy) had zero test coverage → added 5 unit tests.
- 3 minor doc/format fixes (validation-order doc text, `expires_at` timestamp format matching its own documented `Z`-suffixed contract, TTL upper bound).

`cargo check --lib` / `--bin`: clean. `cargo test`: 321/321 lib + 437/437 bin, no regressions.

## Not yet done (follow-ups, non-blocking)

- Wiring `OwnerToken` into WALM-295's real read handlers (needs that branch present).
- `OWNER_TOKEN_AUDIENCE` isn't deployment-scoped — cross-environment isolation currently relies on `OWNER_TOKEN_SECRET` differing per environment (an operational convention, not code-enforced).
- A few test-coverage-only gaps noted in review (duplicate-nonce-still-verifies, per-owner-vs-per-credential rate-limiter independence, DB-error-path on the account-existence check) — none are correctness bugs, all are "should have a regression test" items.