### PR TITLE
docs: fix community issues #547 #548 #549

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ data they can trust.
 ## For AI Agents
 
 - **Single-file guide**: Read [`SKILL.md`](SKILL.md) for a complete integration reference (install, configure, API surface, troubleshooting)
-- **LLM-friendly docs**: [`llms.txt`](https://docs.wal.app/llms.txt) — structured overview following the [llmstxt.org](https://llmstxt.org) standard
+- **LLM-friendly docs**: [`llms.txt`](https://docs.wal.app/walrus-memory/llms.txt) — structured overview following the [llmstxt.org](https://llmstxt.org) standard
 
 ## Install
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -152,7 +152,7 @@ const stored = await memwal.waitForRememberJob(accepted.job_id, {
 |---|---|---|
 | `remember(text, namespace?)` | Accept one memory job immediately | `{ job_id, status }` |
 | `rememberAndWait(text, namespace?, opts?)` | Store one memory and wait for completion | `{ id, job_id, blob_id, owner, namespace }` |
-| `recall({ query, limit?, namespace?, maxDistance? })` *(preferred)* or `recall(query, limit?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
+| `recall({ query, limit?, topK?, namespace?, maxDistance? })` *(preferred)* or `recall(query, limit?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
 | `analyze(text, namespace?)` | Extract facts and accept one memory job per fact | `{ job_ids, facts, fact_count, status, owner }` |
 | `analyzeAndWait(text, namespace?, opts?)` | Extract facts and wait for all fact jobs to complete | `{ results, facts, total, succeeded, failed, owner }` |
 | `restore(namespace, limit?)` | Rebuild missing index entries from Walrus | `{ restored, skipped, total, namespace, owner }` |
@@ -205,10 +205,12 @@ interface RecallResult {
 
 interface RecallOptions {
   limit?: number;
-  topK?: number;
+  topK?: number; // alias of limit; if both are set, topK wins
   namespace?: string;
   maxDistance?: number;
 }
+
+// `topK` and `limit` are aliases for the same value; if both are provided, `topK` takes precedence.
 
 interface RememberBulkAcceptedResult {
   job_ids: string[];

--- a/docs/contributing/run-repo-locally.md
+++ b/docs/contributing/run-repo-locally.md
@@ -54,6 +54,14 @@ cd MemWal
 pnpm install
 ```
 
+If `pnpm install` fails while downloading Chrome for Puppeteer (HTTP 403 — common in CI, sandboxes, or corporate networks), skip the browser download:
+
+```bash
+PUPPETEER_SKIP_DOWNLOAD=true pnpm install
+```
+
+You only need the Chrome download when running Puppeteer-dependent tests or packages.
+
 ## Step 2 — Build the SDK First
 
 <Warning>
@@ -151,6 +159,7 @@ MemWal/
 | `Cannot find module '@mysten-incubation/memwal'` | SDK not built | Run `pnpm build:sdk` first |
 | `ERR_MODULE_NOT_FOUND` in apps | Stale SDK build | Run `pnpm build:sdk` again |
 | `pnpm install` fails | Wrong pnpm version | Use pnpm ≥ 9.12: `corepack enable && corepack prepare pnpm@9.12.3 --activate` |
+| `pnpm install` fails on Puppeteer Chrome download (403) | Network blocks Chrome download | `PUPPETEER_SKIP_DOWNLOAD=true pnpm install` |
 | Docs site won't start | Missing Mintlify | Run `pnpm install` from the root |
 | Relayer crashes on boot | Missing pgvector | Install the `pgvector` PostgreSQL extension |
 | Sidecar timeout | Missing sidecar deps | Run `cd services/server/scripts && npm ci` |


### PR DESCRIPTION
## Summary
- **#547**: Fix README `llms.txt` link to include `/walrus-memory/` path segment
- **#548**: Document `PUPPETEER_SKIP_DOWNLOAD=true` workaround when Chrome download returns 403
- **#549**: Document that `topK` and `limit` are aliases on `RecallOptions` (`topK` wins if both set)

## Test plan
- [ ] README link opens https://docs.wal.app/walrus-memory/llms.txt
- [ ] Contributing docs mention Puppeteer skip-download env var + troubleshooting row
- [ ] SKILL.md API surface / RecallOptions note alias precedence

Closes #547
Closes #548
Closes #549