### PR TITLE
Fix: make remember writes idempotent — no duplicate paid Walrus blob

### DIFF
--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -30,6 +30,7 @@ import base64
 import json
 import random
 import time
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
 
@@ -223,6 +224,9 @@ class MemWal:
         self._session_build_task: Optional[asyncio.Task[str]] = None
         self._relayer_version_metadata: Optional[Dict[str, Any]] = None
         self._compatibility_lock: Optional[asyncio.Lock] = None
+        # Preserve a generated key across an ambiguous transport failure. A
+        # subsequent identical call then collapses onto the accepted paid job.
+        self._pending_remember_keys: Dict[str, str] = {}
 
     @classmethod
     def create(
@@ -281,7 +285,10 @@ class MemWal:
     # ============================================================
 
     async def remember(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> RememberAcceptedResult:
         """Submit a remember request and return as soon as the server accepts it.
 
@@ -299,12 +306,27 @@ class MemWal:
             :class:`RememberAcceptedResult` with ``job_id`` and initial
             status (``"pending"``).
         """
+        resolved_namespace = namespace or self._namespace
+        request_identity = f"{resolved_namespace}\0{text}"
+        generated_key = idempotency_key is None
+        resolved_key = idempotency_key or self._pending_remember_keys.get(request_identity)
+        if resolved_key is None:
+            resolved_key = str(uuid.uuid4())
+        if generated_key:
+            self._pending_remember_keys[request_identity] = resolved_key
+
         data = await self._signed_request(
             "POST",
             "/api/remember",
-            {"text": text, "namespace": namespace or self._namespace},
+            {
+                "text": text,
+                "namespace": resolved_namespace,
+                "idempotency_key": resolved_key,
+            },
             accepted_statuses=(200, 202),
         )
+        if generated_key:
+            self._pending_remember_keys.pop(request_identity, None)
         return RememberAcceptedResult(
             job_id=data["job_id"],
             status=data.get("status", "pending"),
@@ -312,9 +334,12 @@ class MemWal:
 
     # Alias for parity with TS SDK ``rememberAsync``.
     async def remember_async(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> RememberAcceptedResult:
-        return await self.remember(text, namespace)
+        return await self.remember(text, namespace, idempotency_key)
 
     async def wait_for_remember_job(
         self,
@@ -380,6 +405,7 @@ class MemWal:
         namespace: Optional[str] = None,
         poll_interval_ms: int = 1500,
         timeout_ms: int = 60_000,
+        idempotency_key: Optional[str] = None,
     ) -> RememberResult:
         """Submit a remember and wait for the background worker to finish.
 
@@ -388,12 +414,24 @@ class MemWal:
         ``failed``). Mirrors TS ``rememberAndWait``.
         """
 
-        accepted = await self.remember(text, namespace)
-        return await self.wait_for_remember_job(
+        resolved_namespace = namespace or self._namespace
+        request_identity = f"{resolved_namespace}\0{text}"
+        generated_key = idempotency_key is None
+        resolved_key = idempotency_key or self._pending_remember_keys.get(request_identity)
+        if resolved_key is None:
+            resolved_key = str(uuid.uuid4())
+        if generated_key:
+            self._pending_remember_keys[request_identity] = resolved_key
+
+        accepted = await self.remember(text, resolved_namespace, resolved_key)
+        result = await self.wait_for_remember_job(
             accepted.job_id,
             poll_interval_ms=poll_interval_ms,
             timeout_ms=timeout_ms,
         )
+        if generated_key:
+            self._pending_remember_keys.pop(request_identity, None)
+        return result
 
     # ============================================================
     # Bulk remember (ENG-1408)
@@ -1285,16 +1323,22 @@ class MemWalSync:
             return asyncio.run(coro)
 
     def remember(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> RememberAcceptedResult:
         """Synchronous version of :meth:`MemWal.remember` (async accept)."""
-        return self._run(self._inner.remember(text, namespace))
+        return self._run(self._inner.remember(text, namespace, idempotency_key))
 
     # Alias for parity with TS SDK ``rememberAsync``.
     def remember_async(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> RememberAcceptedResult:
-        return self._run(self._inner.remember_async(text, namespace))
+        return self._run(self._inner.remember_async(text, namespace, idempotency_key))
 
     def wait_for_remember_job(
         self,
@@ -1317,6 +1361,7 @@ class MemWalSync:
         namespace: Optional[str] = None,
         poll_interval_ms: int = 1500,
         timeout_ms: int = 60_000,
+        idempotency_key: Optional[str] = None,
     ) -> RememberResult:
         """Synchronous version of :meth:`MemWal.remember_and_wait`."""
         return self._run(
@@ -1325,6 +1370,7 @@ class MemWalSync:
                 namespace,
                 poll_interval_ms=poll_interval_ms,
                 timeout_ms=timeout_ms,
+                idempotency_key=idempotency_key,
             )
         )
 

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -189,6 +189,13 @@ export class MemWal {
     private sessionBuildPromise: Promise<string> | null = null;
     /** Single-flight guard so concurrent requests share one compatibility probe. */
     private compatibilityPromise: Promise<RelayerVersionMetadata> | null = null;
+    /**
+     * Keep a generated idempotency key while a remember request has no
+     * acknowledged response. If the transport times out after the server
+     * accepted the write, the caller's next identical attempt reuses the key
+     * and collapses onto the original paid job.
+     */
+    private pendingRememberKeys = new Map<string, string>();
 
     private constructor(config: MemWalConfig) {
         this.privateKey = typeof config.key === "string" ? hexToBytes(config.key) : config.key;
@@ -227,6 +234,7 @@ export class MemWal {
         this.serverConfig = null;
         this.relayerVersionMetadata = null;
         this.compatibilityPromise = null;
+        this.pendingRememberKeys.clear();
     }
 
     // ============================================================
@@ -236,13 +244,27 @@ export class MemWal {
     /**
      * Submit a remember request and return as soon as the server accepts the job.
      */
-    async rememberAsync(text: string, namespace?: string): Promise<RememberAcceptedResult> {
-        return this.signedRequest<RememberAcceptedResult>(
+    async rememberAsync(
+        text: string,
+        namespace?: string,
+        options: { idempotencyKey?: string } = {},
+    ): Promise<RememberAcceptedResult> {
+        const resolvedNamespace = namespace ?? this.namespace;
+        const requestIdentity = `${resolvedNamespace}\0${text}`;
+        const generatedKey = options.idempotencyKey === undefined;
+        const idempotencyKey = options.idempotencyKey
+            ?? this.pendingRememberKeys.get(requestIdentity)
+            ?? crypto.randomUUID();
+        if (generatedKey) this.pendingRememberKeys.set(requestIdentity, idempotencyKey);
+
+        const accepted = await this.signedRequest<RememberAcceptedResult>(
             "POST",
             "/api/remember",
-            { text, namespace: namespace ?? this.namespace },
+            { text, namespace: resolvedNamespace, idempotency_key: idempotencyKey },
             [200, 202],
         );
+        if (generatedKey) this.pendingRememberKeys.delete(requestIdentity);
+        return accepted;
     }
 
     /**
@@ -340,10 +362,22 @@ export class MemWal {
     async rememberAndWait(
         text: string,
         namespace?: string,
-        opts: { pollIntervalMs?: number; timeoutMs?: number } = {},
+        opts: { pollIntervalMs?: number; timeoutMs?: number; idempotencyKey?: string } = {},
     ): Promise<RememberResult> {
-        const accepted = await this.rememberAsync(text, namespace);
-        return this.waitForRememberJob(accepted.job_id, opts);
+        const resolvedNamespace = namespace ?? this.namespace;
+        const requestIdentity = `${resolvedNamespace}\0${text}`;
+        const generatedKey = opts.idempotencyKey === undefined;
+        const idempotencyKey = opts.idempotencyKey
+            ?? this.pendingRememberKeys.get(requestIdentity)
+            ?? crypto.randomUUID();
+        if (generatedKey) this.pendingRememberKeys.set(requestIdentity, idempotencyKey);
+
+        const accepted = await this.rememberAsync(text, resolvedNamespace, { idempotencyKey });
+        const completed = await this.waitForRememberJob(accepted.job_id, opts);
+        // Clear only after terminal success. A polling timeout/transport failure
+        // keeps the key so retrying the high-level operation reuses the same job.
+        if (generatedKey) this.pendingRememberKeys.delete(requestIdentity);
+        return completed;
     }
 
     /**
@@ -355,8 +389,12 @@ export class MemWal {
      * @param text - The text to remember
      * @param namespace - Optional namespace override
      */
-    async remember(text: string, namespace?: string): Promise<RememberAcceptedResult> {
-        return this.rememberAsync(text, namespace);
+    async remember(
+        text: string,
+        namespace?: string,
+        options: { idempotencyKey?: string } = {},
+    ): Promise<RememberAcceptedResult> {
+        return this.rememberAsync(text, namespace, options);
     }
 
     /**

--- a/packages/sdk/test/remember-idempotency.test.mjs
+++ b/packages/sdk/test/remember-idempotency.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWal } from "../dist/memwal.js";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test("rememberAndWait reuses its generated key and job after polling timeout", async () => {
+    const posted = [];
+    let jobPolls = 0;
+    globalThis.fetch = async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        if (path === "/version") {
+            return Response.json({
+                apiVersion: "1.0.0",
+                relayerVersion: "1.0.0",
+                minSupportedSdk: { typescript: "0.0.4" },
+            });
+        }
+        if (path === "/api/config") {
+            return Response.json({ packageId: "0x1", network: "testnet" });
+        }
+        if (path === "/api/remember" && init.method === "POST") {
+            posted.push(JSON.parse(init.body));
+            return Response.json({ job_id: "stable-job", status: "pending" }, { status: 202 });
+        }
+        if (path === "/api/remember/stable-job") {
+            jobPolls += 1;
+            if (jobPolls < 2) return Response.json({ job_id: "stable-job", status: "pending" });
+            return Response.json({
+                job_id: "stable-job",
+                status: "done",
+                blob_id: "blob-1",
+                owner: "0x1",
+                namespace: "default",
+            });
+        }
+        throw new Error(`unexpected request ${path}`);
+    };
+
+    const client = MemWal.create({
+        key: new Uint8Array(32).fill(1),
+        accountId: "0x1",
+        serverUrl: "https://relayer.example",
+    });
+    client.buildSealSession = async () => "test-session";
+
+    await assert.rejects(
+        client.rememberAndWait("same memory", undefined, { pollIntervalMs: 0, timeoutMs: 1 }),
+        /timed out/,
+    );
+    const result = await client.rememberAndWait("same memory", undefined, {
+        pollIntervalMs: 0,
+        timeoutMs: 100,
+    });
+
+    assert.equal(result.job_id, "stable-job");
+    assert.equal(posted.length, 2);
+    assert.equal(posted[0].idempotency_key, posted[1].idempotency_key);
+});

--- a/services/server/migrations/012_remember_write_idempotency.sql
+++ b/services/server/migrations/012_remember_write_idempotency.sql
@@ -1,0 +1,22 @@
+-- Durable idempotency and recovery state for paid remember writes.
+-- All columns are nullable/additive so existing rows remain readable. Legacy
+-- paid rows without an original preparation payload fail closed and require
+-- manual reconciliation rather than unsafe re-encryption.
+ALTER TABLE remember_jobs
+    ADD COLUMN IF NOT EXISTS idempotency_key TEXT,
+    ADD COLUMN IF NOT EXISTS request_fingerprint TEXT,
+    ADD COLUMN IF NOT EXISTS blob_object_id TEXT,
+    ADD COLUMN IF NOT EXISTS upload_wallet_index INTEGER,
+    ADD COLUMN IF NOT EXISTS upload_wallet_address TEXT,
+    ADD COLUMN IF NOT EXISTS upload_execution_identity JSONB,
+    ADD COLUMN IF NOT EXISTS upload_resume_step JSONB,
+    ADD COLUMN IF NOT EXISTS upload_register_transaction JSONB,
+    ADD COLUMN IF NOT EXISTS prepare_claimed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS prepare_claim_token TEXT,
+    ADD COLUMN IF NOT EXISTS recovery_claimed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS recovery_claim_token TEXT,
+    ADD COLUMN IF NOT EXISTS preparation_encrypted_b64 TEXT,
+    ADD COLUMN IF NOT EXISTS preparation_vector JSONB,
+    ADD COLUMN IF NOT EXISTS preparation_importance REAL,
+    ADD COLUMN IF NOT EXISTS preparation_account_id TEXT,
+    ADD COLUMN IF NOT EXISTS preparation_public_key TEXT;

--- a/services/server/migrations/013_remember_write_idempotency_index.sql
+++ b/services/server/migrations/013_remember_write_idempotency_index.sql
@@ -1,0 +1,4 @@
+-- Keep this standalone: CREATE INDEX CONCURRENTLY cannot run in a transaction.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_remember_jobs_owner_idempotency_key
+    ON remember_jobs (owner, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/services/server/scripts/__tests__/sidecar-find-blob-by-job.test.ts
+++ b/services/server/scripts/__tests__/sidecar-find-blob-by-job.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+
+// Minimal env for booting the default-mode sidecar app. The find-blob-by-job
+// validation path returns 400 before touching the chain, so no client mocking
+// is needed here (end-to-end reconcile behavior is covered by the live script).
+const { Ed25519Keypair } = await import("@mysten/sui/keypairs/ed25519");
+process.env.SERVER_SUI_PRIVATE_KEYS = new Ed25519Keypair().getSecretKey();
+process.env.SIDECAR_AUTH_TOKEN = "find-blob-test-token";
+process.env.SUI_NETWORK = "testnet";
+process.env.SUI_GRPC_URL = "https://find-blob.testnet.example";
+process.env.WALRUS_PACKAGE_ID = `0x${"a".repeat(64)}`;
+
+const { createSidecarApp } = await import("../sidecar/app.js");
+const { sanitizeRequestId } = await import("../sidecar/log.js");
+
+// The reconcile correctness hinges on the register-side tag value
+// (sanitizeRequestId(jobId)) equaling the query-side value (also
+// sanitizeRequestId(jobId)). For the production key space — server-minted UUIDs
+// — that must be an identity, or the tag would never match and every retry would
+// silently re-mint. Pin it.
+test("a remember-job UUID survives sanitizeRequestId unchanged (tag == query)", () => {
+    for (let i = 0; i < 50; i++) {
+        const uuid = crypto.randomUUID();
+        assert.equal(sanitizeRequestId(uuid), uuid, `UUID must round-trip: ${uuid}`);
+    }
+    // And a non-conforming id sanitizes to null on BOTH sides (no silent mismatch).
+    assert.equal(sanitizeRequestId("has spaces"), null);
+    assert.equal(sanitizeRequestId("x".repeat(129)), null);
+});
+
+async function listen(): Promise<{ server: Server; baseUrl: string }> {
+    return await new Promise((resolve) => {
+        const server = createSidecarApp().listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            if (address === null || typeof address === "string") throw new Error("no port");
+            resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
+        });
+    });
+}
+
+const headers = {
+    authorization: "Bearer find-blob-test-token",
+    "content-type": "application/json",
+};
+
+test("find-blob-by-job validates owner and jobId", async () => {
+    const { server, baseUrl } = await listen();
+    try {
+        // missing owner → 400
+        const noOwner = await fetch(`${baseUrl}/walrus/find-blob-by-job`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ jobId: "job-1" }),
+        });
+        assert.equal(noOwner.status, 400);
+
+        // missing jobId → 400
+        const noJob = await fetch(`${baseUrl}/walrus/find-blob-by-job`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ owner: `0x${"1".repeat(64)}` }),
+        });
+        assert.equal(noJob.status, 400);
+
+        // empty body → 400
+        const empty = await fetch(`${baseUrl}/walrus/find-blob-by-job`, {
+            method: "POST",
+            headers,
+            body: "{}",
+        });
+        assert.equal(empty.status, 400);
+
+        // a jobId that can't be a tag value (fails sanitizeRequestId) → 400, so
+        // the query can never silently diverge from the stored tag value.
+        const badJob = await fetch(`${baseUrl}/walrus/find-blob-by-job`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ owner: `0x${"1".repeat(64)}`, jobId: "has spaces & symbols!" }),
+        });
+        assert.equal(badJob.status, 400);
+    } finally {
+        await new Promise<void>((resolve, reject) =>
+            server.close((e) => (e ? reject(e) : resolve()))
+        );
+    }
+});

--- a/services/server/scripts/__tests__/sidecar-find-blob-matching.test.ts
+++ b/services/server/scripts/__tests__/sidecar-find-blob-matching.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// P1: the actual matching logic of findBlobObjectByJob (GH #477 reconcile). We
+// stub the module-level suiClient's listOwnedObjects + getDynamicField so we can
+// drive real fixtures through the scan/tag-match without a chain. This is the
+// funds-critical part: a wrong match (or a swallowed metadata error) → the
+// relayer either re-mints or adopts the wrong user's blob.
+
+const { Ed25519Keypair } = await import("@mysten/sui/keypairs/ed25519");
+const serverKey = new Ed25519Keypair();
+const serverAddr = serverKey.toSuiAddress();
+process.env.SERVER_SUI_PRIVATE_KEYS = serverKey.getSecretKey();
+process.env.SUI_NETWORK = "testnet";
+process.env.SUI_GRPC_URL = "https://match.testnet.example";
+process.env.WALRUS_PACKAGE_ID = `0x${"a".repeat(64)}`;
+
+const { bcs } = await import("@mysten/sui/bcs");
+const { normalizeSuiAddress } = await import("@mysten/sui/utils");
+const { suiClient } = await import("../sidecar/clients.js");
+const { findBlobObjectByJob } = await import("../sidecar/routes/walrus-query.js");
+
+const METADATA_BCS = bcs.struct("Metadata", { metadata: bcs.map(bcs.string(), bcs.string()) });
+const USER = normalizeSuiAddress(`0x${"1".repeat(64)}`);
+
+// blob_id on chain is a U256 decimal; use a value the sidecar can convert.
+function makeBlob(objectId: string, rawBlobId: string) {
+    return { objectId, json: { blob_id: rawBlobId } };
+}
+
+// tags: Map of key→value → BCS bytes the getDynamicField mock returns.
+function metadataField(tags: Record<string, string>) {
+    const map = new Map(Object.entries(tags));
+    const value = METADATA_BCS.serialize({ metadata: map }).toBytes();
+    return { dynamicField: { value: { bcs: value } } };
+}
+
+// Install stubs; each test sets these two closures.
+let ownedByAddr: (owner: string) => any[];
+let metaByObject: (objectId: string) => any;
+(suiClient as any).listOwnedObjects = async ({ owner }: { owner: string }) => ({
+    objects: ownedByAddr(owner),
+    hasNextPage: false,
+    cursor: null,
+});
+(suiClient as any).getDynamicField = async ({ parentId }: { parentId: string }) => metaByObject(parentId);
+
+const BLOB_RAW = "123456789012345678901234"; // long decimal → treated as U256
+
+test("found: a server-wallet blob tagged with this job AND owner → found", async () => {
+    ownedByAddr = (o) => (o === serverAddr ? [makeBlob("0xobjA", BLOB_RAW)] : []);
+    metaByObject = () => metadataField({ memwal_job_id: "job-1", memwal_owner: USER });
+    const r = await findBlobObjectByJob(USER, "job-1");
+    assert.equal(r.status, "found");
+    if (r.status === "found") assert.equal(r.objectId, "0xobjA");
+});
+
+test("not_found: a blob with the job tag but a DIFFERENT owner is never adopted", async () => {
+    const otherUser = normalizeSuiAddress(`0x${"2".repeat(64)}`);
+    ownedByAddr = (o) => (o === serverAddr ? [makeBlob("0xobjB", BLOB_RAW)] : []);
+    metaByObject = () => metadataField({ memwal_job_id: "job-1", memwal_owner: otherUser });
+    const r = await findBlobObjectByJob(USER, "job-1");
+    assert.equal(r.status, "not_found", "job tag alone must NOT match another user's blob");
+});
+
+test("not_found: no blob carries the job tag → not_found (caller uploads)", async () => {
+    ownedByAddr = () => [];
+    metaByObject = () => metadataField({});
+    const r = await findBlobObjectByJob(USER, "job-1");
+    assert.equal(r.status, "not_found");
+});
+
+test("a throwing per-blob metadata read PROPAGATES (fail-closed), not swallowed", async () => {
+    ownedByAddr = (o) => (o === serverAddr ? [makeBlob("0xobjC", BLOB_RAW)] : []);
+    metaByObject = () => {
+        throw new Error("gRPC getDynamicField transport error");
+    };
+    await assert.rejects(
+        findBlobObjectByJob(USER, "job-1"),
+        /getDynamicField|transport/,
+        "a metadata read failure must reject → route 500 → relayer fails closed"
+    );
+});

--- a/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
+++ b/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { Transaction, TransactionDataBuilder } from "@mysten/sui/transactions";
+import { Inputs, Transaction, TransactionDataBuilder } from "@mysten/sui/transactions";
 import {
     assertCompletionBlobObject,
     assertCompletionBlobResponse,
@@ -21,6 +21,7 @@ import {
 } from "../sidecar/routes/walrus-query.js";
 import { assertSuccessfulMetadataTransfer, extractBlobObjectId } from "../sidecar/blob-metadata.js";
 import {
+    ENOKI_FALLBACK_TO_DIRECT_SIGN,
     parseDurableWalrusEpochs,
     SUI_TYPE,
     WALRUS_PACKAGE_ID,
@@ -37,7 +38,11 @@ import { classifyDurableSideEffectError, NoSideEffectError } from "../sidecar/re
 import { uploadWalrusBlobWithEffectsRetry } from "../sidecar/routes/walrus-upload.js";
 import { metadataReceiptAlreadyApplied } from "../sidecar/routes/walrus-metadata.js";
 import { sidecarMetrics } from "../sidecar/state.js";
-import { DURABLE_WALLET_FALLBACK_POLICY } from "../sidecar/wallet.js";
+import {
+    ADDRESS_BALANCE_WALLET_FALLBACK_POLICY,
+    DURABLE_WALLET_FALLBACK_POLICY,
+} from "../sidecar/wallet.js";
+import { enforceAddressBalanceCoinIntents } from "../sidecar/address-balance.js";
 
 async function preparedRegisterFixture(funding: "addressBalance" | "coin" | "mixedLegacy" = "addressBalance"): Promise<{
     signer: Ed25519Keypair;
@@ -114,6 +119,14 @@ test("durable submissions direct-sign only when sponsorship is unconfigured", ()
     assert.deepEqual(DURABLE_WALLET_FALLBACK_POLICY, {
         directSignIfUnconfigured: true,
         directSignAfterSponsorFailure: false,
+        gasMode: "addressBalance",
+    });
+});
+
+test("legacy uploads preserve fallback behavior while using address balances", () => {
+    assert.deepEqual(ADDRESS_BALANCE_WALLET_FALLBACK_POLICY, {
+        directSignIfUnconfigured: ENOKI_FALLBACK_TO_DIRECT_SIGN,
+        directSignAfterSponsorFailure: ENOKI_FALLBACK_TO_DIRECT_SIGN,
         gasMode: "addressBalance",
     });
 });
@@ -218,6 +231,171 @@ test("the pinned Sui SDK resolves WAL payment and relay SUI tip from address bal
     assert.equal(assertAddressBalanceRegisterTransaction(resolved), 2n);
     const withdrawals = resolved.inputs.filter((input) => input.$kind === "FundsWithdrawal");
     assert.equal(withdrawals.length, 2, "WAL payment and relay SUI tip both use address balances");
+});
+
+test("address-balance uploads fail instead of falling back to owned coins", async () => {
+    const signer = new Ed25519Keypair();
+    const walType = `0x${"2".repeat(64)}::wal::WAL`;
+    const transaction = new Transaction();
+    transaction.setSender(signer.toSuiAddress());
+    transaction.coin({ type: walType, balance: 1n, useGasCoin: false });
+    enforceAddressBalanceCoinIntents(transaction);
+
+    let balanceCalls = 0;
+    const client = {
+        core: {
+            async getBalance() {
+                balanceCalls += 1;
+                return {
+                    balance: {
+                        balance: "1",
+                        addressBalance: balanceCalls === 1 ? "1" : "0",
+                        coinBalance: balanceCalls === 1 ? "0" : "1",
+                    },
+                };
+            },
+            async listCoins() {
+                return {
+                    objects: [{
+                        objectId: `0x${"1".repeat(64)}`,
+                        version: "1",
+                        digest: "11111111111111111111111111111111",
+                        balance: "1",
+                        coinType: walType,
+                    }],
+                    cursor: null,
+                    hasNextPage: false,
+                };
+            },
+            async getObjects({ objectIds }: { objectIds: string[] }) {
+                return {
+                    objects: objectIds.map((objectId) => ({
+                        objectId,
+                        type: `0x2::coin::Coin<${walType}>`,
+                    })),
+                };
+            },
+        },
+    };
+    await assert.rejects(
+        transaction.prepareForSerialization({ client: client as never }),
+        /Address-balance upload resolved owned coin objects/,
+    );
+    await assert.rejects(
+        transaction.prepareForSerialization({ client: client as never }),
+        /Address-balance upload resolved owned coin objects/,
+    );
+});
+
+test("address-balance enforcement permits newly resolved non-coin objects", async () => {
+    const signer = new Ed25519Keypair();
+    const walType = `0x${"2".repeat(64)}::wal::WAL`;
+    const objectId = `0x${"6".repeat(64)}`;
+    const transaction = new Transaction();
+    transaction.setSender(signer.toSuiAddress());
+    transaction.coin({ type: walType, balance: 1n, useGasCoin: false });
+    enforceAddressBalanceCoinIntents(transaction);
+    transaction.addSerializationPlugin(async (transactionData, _options, next) => {
+        transactionData.addInput("object", Inputs.ObjectRef({
+            objectId,
+            version: "1",
+            digest: "33333333333333333333333333333333",
+        }));
+        await next();
+    });
+
+    const client = {
+        core: {
+            async getBalance() {
+                return {
+                    balance: {
+                        balance: "1",
+                        addressBalance: "1",
+                        coinBalance: "0",
+                    },
+                };
+            },
+            async listCoins() {
+                return { objects: [], cursor: null, hasNextPage: false };
+            },
+            async getObjects() {
+                return {
+                    objects: [{
+                        objectId,
+                        type: `${WALRUS_PACKAGE_ID}::blob::Blob`,
+                    }],
+                };
+            },
+        },
+    };
+
+    await assert.doesNotReject(
+        transaction.prepareForSerialization({ client: client as never }),
+    );
+});
+
+test("address-balance uploads reject owned gas resolved during build", async () => {
+    const signer = new Ed25519Keypair();
+    const gasObjectId = `0x${"4".repeat(64)}`;
+    const transaction = new Transaction();
+    transaction.setSender(signer.toSuiAddress());
+    transaction.setGasBudget(1n);
+    transaction.setGasPrice(1n);
+    transaction.transferObjects(
+        [transaction.objectRef({
+            objectId: `0x${"5".repeat(64)}`,
+            version: "1",
+            digest: "11111111111111111111111111111111",
+        })],
+        signer.toSuiAddress(),
+    );
+    enforceAddressBalanceCoinIntents(transaction);
+
+    const client = {
+        core: {
+            resolveTransactionPlugin() {
+                return async (
+                    transactionData: TransactionDataBuilder,
+                    _options: unknown,
+                    next: () => Promise<void>,
+                ) => {
+                    transactionData.gasData.payment = [{
+                        objectId: gasObjectId,
+                        version: "1",
+                        digest: "22222222222222222222222222222222",
+                    }];
+                    await next();
+                };
+            },
+        },
+    };
+
+    await assert.rejects(
+        transaction.build({ client: client as never }),
+        /Address-balance upload resolved gas from an owned coin/,
+    );
+});
+
+test("address-balance enforcement preserves async object inputs across rebuilds", async () => {
+    const signer = new Ed25519Keypair();
+    const objectId = `0x${"3".repeat(64)}`;
+    const transaction = new Transaction();
+    transaction.setSender(signer.toSuiAddress());
+    transaction.add(async (tx) => {
+        await Promise.resolve();
+        tx.transferObjects(
+            [tx.objectRef({
+                objectId,
+                version: "1",
+                digest: "11111111111111111111111111111111",
+            })],
+            signer.toSuiAddress(),
+        );
+    });
+    enforceAddressBalanceCoinIntents(transaction);
+
+    await assert.doesNotReject(transaction.build({ onlyTransactionKind: true }));
+    await assert.doesNotReject(transaction.build({ onlyTransactionKind: true }));
 });
 
 test("migration source status trusts only verified nonexistent blobs", () => {

--- a/services/server/scripts/sidecar/address-balance.ts
+++ b/services/server/scripts/sidecar/address-balance.ts
@@ -1,0 +1,101 @@
+import type { Transaction } from "@mysten/sui/transactions";
+import { normalizeStructTag, normalizeSuiAddress, parseStructTag } from "@mysten/sui/utils";
+import { SUI_TYPE } from "./config.js";
+
+const COIN_WITH_BALANCE_INTENT = "CoinWithBalance";
+const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress("0x2");
+
+/**
+ * Prevent the SDK's CoinWithBalance resolver from falling back to owned coins
+ * when an address balance is insufficient.
+ */
+export function enforceAddressBalanceCoinIntents(transaction: Transaction): void {
+    let initialOwnedObjectIds: Set<string> | undefined;
+    let hasCoinWithBalanceIntents = false;
+    transaction.addSerializationPlugin(async (transactionData, options, next) => {
+        initialOwnedObjectIds ??= new Set(
+            transactionData.inputs
+                .map((input) => (
+                    input.Object?.ImmOrOwnedObject?.objectId ?? input.UnresolvedObject?.objectId
+                ))
+                .filter((objectId): objectId is string => typeof objectId === "string"),
+        );
+        const requiredByType = new Map<string, bigint>();
+        for (const command of transactionData.commands) {
+            if (command.$kind !== "$Intent" || command.$Intent.name !== COIN_WITH_BALANCE_INTENT) {
+                continue;
+            }
+            const type = command.$Intent.data?.type;
+            const balance = command.$Intent.data?.balance;
+            if (
+                typeof type !== "string"
+                || (typeof balance !== "bigint" && typeof balance !== "number" && typeof balance !== "string")
+            ) {
+                continue;
+            }
+            const coinType = type === "gas" ? SUI_TYPE : normalizeStructTag(type);
+            requiredByType.set(coinType, (requiredByType.get(coinType) ?? 0n) + BigInt(balance));
+        }
+
+        if (requiredByType.size > 0) {
+            hasCoinWithBalanceIntents = true;
+            const client = options.client as any;
+            if (!client?.core?.getBalance || !transactionData.sender) {
+                throw new Error("Address-balance upload requires a sender and Sui client");
+            }
+
+            await Promise.all([...requiredByType.entries()].map(async ([coinType, required]) => {
+                const response = await client.core.getBalance({
+                    owner: transactionData.sender,
+                    coinType,
+                });
+                const available = BigInt(response?.balance?.addressBalance ?? 0);
+                if (available < required) {
+                    throw new Error(
+                        `Insufficient ${coinType} address balance: required ${required}, available ${available}`,
+                    );
+                }
+            }));
+        }
+
+        await next();
+        const newlyResolvedOwnedObjects = transactionData.inputs
+            .map((input) => input.Object?.ImmOrOwnedObject?.objectId)
+            .filter((objectId): objectId is string => (
+                typeof objectId === "string" && !initialOwnedObjectIds.has(objectId)
+            ));
+        if (hasCoinWithBalanceIntents && newlyResolvedOwnedObjects.length > 0) {
+            const client = options.client as any;
+            if (!client?.core?.getObjects) {
+                throw new Error("Address-balance upload could not verify newly resolved objects");
+            }
+            const response = await client.core.getObjects({ objectIds: newlyResolvedOwnedObjects });
+            const coinObjectIds = response.objects.map((object: any) => {
+                if (object instanceof Error) {
+                    throw new Error(`Address-balance upload could not verify resolved object: ${object.message}`);
+                }
+                if (typeof object?.type !== "string") {
+                    throw new Error(`Address-balance upload could not verify resolved object ${object?.objectId ?? ""}`);
+                }
+                const type = parseStructTag(object.type);
+                return type.address === SUI_FRAMEWORK_ADDRESS
+                    && type.module === "coin"
+                    && type.name === "Coin"
+                    ? object.objectId
+                    : null;
+            }).filter((objectId: unknown): objectId is string => typeof objectId === "string");
+
+            if (coinObjectIds.length === 0) return;
+            throw new Error(
+                `Address-balance upload resolved owned coin objects: ${coinObjectIds.join(", ")}`,
+            );
+        }
+    });
+
+    transaction.addBuildPlugin(async (transactionData, _options, next) => {
+        await next();
+        if (transactionData.gasData.payment && transactionData.gasData.payment.length > 0) {
+            throw new Error("Address-balance upload resolved gas from an owned coin");
+        }
+    });
+}

--- a/services/server/scripts/sidecar/enoki.ts
+++ b/services/server/scripts/sidecar/enoki.ts
@@ -21,6 +21,7 @@ import {
     ENOKI_TRANSIENT_MAX_DELAY_MS,
 } from "./config.js";
 import { suiClient } from "./clients.js";
+import { enforceAddressBalanceCoinIntents } from "./address-balance.js";
 import { errorMessage, truncateForLog } from "./util.js";
 
 type EnokiDataWrapper<T> = { data: T };
@@ -29,12 +30,13 @@ export type EnokiExecuteResponse = { digest: string };
 export type EnokiFallbackPolicy = {
     directSignIfUnconfigured: boolean;
     directSignAfterSponsorFailure: boolean;
-    gasMode?: "auto" | "addressBalance";
+    gasMode: "auto" | "addressBalance";
 };
 
 const DEFAULT_FALLBACK_POLICY: EnokiFallbackPolicy = {
     directSignIfUnconfigured: ENOKI_FALLBACK_TO_DIRECT_SIGN,
     directSignAfterSponsorFailure: ENOKI_FALLBACK_TO_DIRECT_SIGN,
+    gasMode: "addressBalance",
 };
 
 // The migrator's controller lease reserves 60s for one Enoki call plus 10s
@@ -239,6 +241,7 @@ export async function executeWithEnokiSponsor(
     onSubmissionStarted: () => void = () => {},
 ): Promise<string> {
     if (fallbackPolicy.gasMode === "addressBalance") {
+        enforceAddressBalanceCoinIntents(tx);
         tx.setGasPayment([]);
     }
 

--- a/services/server/scripts/sidecar/routes/walrus-metadata.ts
+++ b/services/server/scripts/sidecar/routes/walrus-metadata.ts
@@ -24,7 +24,10 @@ import {
     setMetadataAndTransferBlobs,
     type MetadataTransferBlob,
 } from "../blob-metadata.js";
-import { DURABLE_WALLET_FALLBACK_POLICY } from "../wallet.js";
+import {
+    ADDRESS_BALANCE_WALLET_FALLBACK_POLICY,
+    DURABLE_WALLET_FALLBACK_POLICY,
+} from "../wallet.js";
 import { ownerMatchesRecipient, readBlobObject } from "./walrus-query.js";
 import { assertUploadExecutionIdentity, parseUploadExecutionIdentity } from "./health.js";
 
@@ -104,7 +107,15 @@ function registerWalrusMetadataBatchRoute(app: Express): void {
             releaseWalrusUploadSlots = await acquireWalrusUploadSlots(keySlot, traceId);
             const { secretKey } = decodeSuiPrivateKey(privateKey);
             const signer = Ed25519Keypair.fromSecretKey(secretKey);
-            const digest = await setMetadataAndTransferBlobs(signer, normalized, targetOwner, packageId, agentId);
+            const digest = await setMetadataAndTransferBlobs(
+                signer,
+                normalized,
+                targetOwner,
+                packageId,
+                agentId,
+                {},
+                ADDRESS_BALANCE_WALLET_FALLBACK_POLICY,
+            );
             console.log(`[walrus/set-metadata-batch] transferred ${normalized.length} blobs to owner`);
             res.json({ transferred: normalized.length, digest });
         } catch (err: any) {

--- a/services/server/scripts/sidecar/routes/walrus-query.ts
+++ b/services/server/scripts/sidecar/routes/walrus-query.ts
@@ -10,11 +10,12 @@ import { normalizeSuiAddress } from "@mysten/sui/utils";
 import {
     JSON_LIMIT_METADATA,
     JSON_LIMIT_WALRUS_VERIFY,
+    SERVER_SUI_ADDRESSES,
     SERVER_SUI_ADDRESS_SET,
     WALRUS_PACKAGE_ID,
 } from "../config.js";
 import { getWalrusClient, refreshWalrusClientIfStale, suiClient, suiGraphqlClient } from "../clients.js";
-import { requestIdFor, sidecarLog } from "../log.js";
+import { requestIdFor, sanitizeRequestId, sidecarLog } from "../log.js";
 import { withRpcRetry } from "../retry/rpc.js";
 import { errorMessage, mapConcurrent } from "../util.js";
 
@@ -418,6 +419,75 @@ export function assertCompletionBlobResponse(
     return assertCompletionBlobObject(response.object, expected, currentEpoch);
 }
 
+/**
+ * Reconciliation lookup for the write crash-window (GH #477): given a user owner
+ * and a remember job id — NOT a blob id — find the blob (if any) that a prior
+ * upload minted for that job and then lost the record of.
+ *
+ * CRITICAL ownership detail: the upload registers the blob owned by the SERVER
+ * signer wallet and only transfers it to the user in the final step. So a blob
+ * whose write crashed mid-flight is (still) owned by a server pool wallet, not
+ * the user. We therefore scan the server pool wallets AND the user, and match on
+ * BOTH `memwal_job_id == jobId` and `memwal_owner == user` — the job tag alone is
+ * not enough to prove the blob belongs to this user (guards against tag reuse /
+ * collision adopting another user's paid blob).
+ *
+ * Discriminated result so the caller never mistakes "couldn't check" for
+ * "not minted":
+ *   - { status: "found", blobId, objectId }
+ *   - { status: "not_found" } — every scanned owner fully scanned, no match
+ * The lookup paginates every scanned owner to exhaustion. A bounded prefix is
+ * not safe here: once a wallet owns more than the old cap, a matching paid blob
+ * outside that prefix would leave every retry permanently indeterminate.
+ * Per-blob metadata errors are intentionally not swallowed: a throw propagates
+ * to the relayer, which retries without uploading.
+ */
+export type FindBlobByJobResult =
+    | { status: "found"; blobId: string; objectId: string }
+    | { status: "not_found" };
+
+async function scanOwnerForJobBlob(
+    scanOwner: string,
+    userOwner: string,
+    jobId: string
+): Promise<FindBlobByJobResult> {
+    const blobType = `${WALRUS_PACKAGE_ID}::blob::Blob`;
+    const blobs = await listBlobObjectsGrpc(normalizeSuiAddress(scanOwner), blobType, Infinity);
+    for (const blob of blobs) {
+        const entries = await fetchBlobMetadataEntries(blob.objectId);
+        const jobMatches = entries.some(({ key, value }) => key === "memwal_job_id" && value === jobId);
+        // Normalize the tagged owner before comparing — the register stores the
+        // raw `owner` the relayer sent, which may be mixed-case / unpadded hex.
+        const ownerMatches = entries.some(
+            ({ key, value }) =>
+                key === "memwal_owner" &&
+                /^0x[0-9a-fA-F]{1,64}$/.test(value) &&
+                normalizeSuiAddress(value) === userOwner
+        );
+        if (jobMatches && ownerMatches) {
+            const blobId = blobIdFromRaw(blob.rawBlobId);
+            if (blobId) return { status: "found", blobId, objectId: blob.objectId };
+        }
+    }
+    return { status: "not_found" };
+}
+
+export async function findBlobObjectByJob(
+    owner: string,
+    jobId: string
+): Promise<FindBlobByJobResult> {
+    const userOwner = normalizeSuiAddress(owner);
+    // Scan the server pool wallets (where a not-yet-transferred blob lives) AND
+    // the user (where a transferred-but-unrecorded blob lives). De-dup in case a
+    // server key coincides with the user address.
+    const scanOwners = [...new Set([...SERVER_SUI_ADDRESSES.map((a) => normalizeSuiAddress(a)), userOwner])];
+    for (const scanOwner of scanOwners) {
+        const result = await scanOwnerForJobBlob(scanOwner, userOwner, jobId);
+        if (result.status === "found") return result;
+    }
+    return { status: "not_found" };
+}
+
 export async function findOwnedBlobObjects(
     owner: string,
     blobId: string,
@@ -747,6 +817,42 @@ export function registerWalrusQueryRoute(app: Express): void {
                 error: message,
             });
             res.status(500).json({ error: message, traceId });
+        }
+    });
+
+    // GH #477 reconciliation: find a blob a prior write minted for a remember
+    // job whose record was lost to a crash — by (owner, job_id), no blob id
+    // needed. The relayer calls this before re-uploading a `running` job so it
+    // can adopt an already-minted blob instead of minting a duplicate.
+    app.post("/walrus/find-blob-by-job", express.json({ limit: JSON_LIMIT_METADATA }), async (req, res) => {
+        try {
+            const { owner: rawOwner, jobId: rawJobId } = req.body;
+            if (typeof rawOwner !== "string" || !rawOwner) {
+                return res.status(400).json({ error: "Missing required field: owner" });
+            }
+            if (typeof rawJobId !== "string" || !rawJobId) {
+                return res.status(400).json({ error: "Missing required field: jobId" });
+            }
+            // Match on the SAME canonical form the register wrote the tag with
+            // (`sanitizeRequestId`), so the query value can never silently diverge
+            // from the stored value. A job id that doesn't survive sanitization was
+            // never tag-able, so it can't be reconciled — say so explicitly rather
+            // than querying with a value that could never match.
+            const jobId = sanitizeRequestId(rawJobId);
+            if (jobId === null) {
+                return res.status(400).json({ error: "jobId is not a valid tag value" });
+            }
+            const owner = /^0x[0-9a-fA-F]{1,64}$/.test(rawOwner) ? normalizeSuiAddress(rawOwner) : rawOwner;
+            const result = await findBlobObjectByJob(owner, jobId);
+            if (result.status === "found") {
+                return res.json({ blob_id: result.blobId, object_id: result.objectId });
+            }
+            // The exhaustive scan completed without a matching job tag.
+            return res.json({ blob_id: null, object_id: null });
+        } catch (error: unknown) {
+            const message = errorMessage(error);
+            sidecarLog("error", "walrus_find_blob_by_job_failed", { error: message });
+            res.status(500).json({ error: message });
         }
     });
 }

--- a/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
+++ b/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
@@ -56,8 +56,10 @@ import {
     readBlobObject,
 } from "./walrus-query.js";
 import { uploadWalrusBlobWithEffectsRetry } from "./walrus-upload.js";
+import { enforceAddressBalanceCoinIntents } from "../address-balance.js";
 import {
     assertUploadExecutionIdentity,
+    executionIdentity,
     parseUploadExecutionIdentity,
 } from "./health.js";
 
@@ -384,7 +386,7 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                     data,
                     keyIndex,
                     jobId: rawJobId,
-                    walletAddress,
+                    walletAddress: rawWalletAddress,
                     owner,
                     namespace,
                     packageId,
@@ -399,16 +401,9 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                 if (!data || keyIndex === undefined || !jobId) {
                     return res.status(400).json({ error: "Missing required fields: data, keyIndex, jobId" });
                 }
-                if (!/^0x[0-9a-fA-F]{64}$/.test(walletAddress)) {
-                    return res.status(400).json({ error: "Invalid walletAddress format" });
-                }
                 if (owner && !/^0x[0-9a-fA-F]{64}$/.test(owner)) {
                     return res.status(400).json({ error: "Invalid owner address format" });
                 }
-                // The journal may carry mixed-case hex while signers and gRPC
-                // report lowercase; canonicalize before comparisons and
-                // on-chain writes.
-                const journaledWalletAddress = normalizeSuiAddress(walletAddress);
                 const targetOwner = owner ? normalizeSuiAddress(owner) : owner;
                 if (packageId && !/^0x[0-9a-fA-F]{1,64}$/.test(packageId)) {
                     return res.status(400).json({ error: "Invalid packageId format" });
@@ -417,6 +412,17 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                 if (keySlot === null || !SERVER_SUI_PRIVATE_KEYS[keySlot]) {
                     return res.status(400).json({ error: `Invalid keyIndex: ${keyIndex}` });
                 }
+                const { secretKey } = decodeSuiPrivateKey(SERVER_SUI_PRIVATE_KEYS[keySlot]);
+                const signer = Ed25519Keypair.fromSecretKey(secretKey);
+                const signerAddress = signer.toSuiAddress();
+                const walletAddress = rawWalletAddress ?? signerAddress;
+                if (!/^0x[0-9a-fA-F]{64}$/.test(walletAddress)) {
+                    return res.status(400).json({ error: "Invalid walletAddress format" });
+                }
+                // New Rust callers can omit walletAddress on the first prepare;
+                // the sidecar derives it from the pinned key slot. Subsequent
+                // replay requests persist and send the derived address.
+                const journaledWalletAddress = normalizeSuiAddress(walletAddress);
                 const epochs = parseDurableWalrusEpochs(rawEpochs);
                 if (epochs === null) {
                     return res.status(400).json({
@@ -459,15 +465,14 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                 }
                 phaseCanSubmitSideEffect = !reconcileOnly
                     && (resume?.step === "encoded" || resume?.step === "uploaded");
-                const uploadExecutionIdentity = parseUploadExecutionIdentity(rawExecutionIdentity);
-                if (!uploadExecutionIdentity) {
-                    return res.status(400).json({ error: "Missing or invalid uploadExecutionIdentity" });
+                const uploadExecutionIdentity = rawExecutionIdentity === undefined
+                    ? null
+                    : parseUploadExecutionIdentity(rawExecutionIdentity);
+                if (rawExecutionIdentity !== undefined && !uploadExecutionIdentity) {
+                    return res.status(400).json({ error: "Invalid uploadExecutionIdentity" });
                 }
-                await assertUploadExecutionIdentity(uploadExecutionIdentity);
+                if (uploadExecutionIdentity) await assertUploadExecutionIdentity(uploadExecutionIdentity);
                 releaseWalrusUploadSlots = await acquireWalrusUploadSlots(keySlot, traceId, jobId);
-                const { secretKey } = decodeSuiPrivateKey(SERVER_SUI_PRIVATE_KEYS[keySlot]);
-                const signer = Ed25519Keypair.fromSecretKey(secretKey);
-                const signerAddress = signer.toSuiAddress();
                 if (signerAddress !== journaledWalletAddress) {
                     return res.status(409).json({
                         error: "keyIndex no longer maps to the journaled wallet",
@@ -550,6 +555,7 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                                 memwal_migration_job: jobId,
                             },
                         });
+                        enforceAddressBalanceCoinIntents(registerTx);
                         const registerTransaction = await prepareRegisterTransaction(
                             registerTx,
                             signer,
@@ -561,7 +567,12 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                             blobId: encoded.blobId,
                             digest: registerTransaction.digest,
                         })}`);
-                        return res.json({ registerTransaction });
+                        return res.json({
+                            registerTransaction,
+                            resumeStep: encoded,
+                            walletAddress: signerAddress,
+                            uploadExecutionIdentity: await executionIdentity(),
+                        });
                     }
                 } else if (resume.step === "registered") {
                     const alreadyCertified = await certifiedStep(resume.blobId, resume.blobObjectId);

--- a/services/server/scripts/sidecar/routes/walrus-upload.ts
+++ b/services/server/scripts/sidecar/routes/walrus-upload.ts
@@ -37,7 +37,12 @@ import { requestIdFor, sanitizeRequestId, sidecarLog } from "../log.js";
 import { sidecarStartedAtMs, sidecarStateSnapshot } from "../state.js";
 import { dedupeAddresses, errorMessage, parseWalrusKeySlot, shortAddress, sleep, truncateForLog } from "../util.js";
 import { isMoveAbortBalanceSplit, isMoveAbortWalDestroyZero } from "../enoki.js";
-import { patchGasCoinIntents, submitRebuildableWalletTransaction, submitWalletTransaction } from "../wallet.js";
+import {
+    ADDRESS_BALANCE_WALLET_FALLBACK_POLICY,
+    patchGasCoinIntents,
+    submitRebuildableWalletTransaction,
+    submitWalletTransaction,
+} from "../wallet.js";
 import {
     extractBlobObjectId,
     InvalidSealPersistenceFenceError,
@@ -232,6 +237,10 @@ export function registerWalrusUploadRoute(app: Express): void {
                     ...(namespace ? { memwal_namespace: namespace } : {}),
                     ...(owner ? { memwal_owner: owner } : {}),
                     ...(packageId ? { memwal_package_id: packageId } : {}),
+                    // Correlate the minted blob back to its remember job so a
+                    // crashed write (mint landed, response/DB-record lost) can be
+                    // reconciled — found and adopted — instead of re-minting.
+                    ...(jobIdForLog ? { memwal_job_id: jobIdForLog } : {}),
                 },
             });
 
@@ -255,7 +264,12 @@ export function registerWalrusUploadRoute(app: Express): void {
             );
             const registerDigest = await timedPhase(
                 "register_sponsor",
-                () => submitWalletTransaction(registerTx, signer, registerAllowedAddresses),
+                () => submitWalletTransaction(
+                    registerTx,
+                    signer,
+                    registerAllowedAddresses,
+                    ADDRESS_BALANCE_WALLET_FALLBACK_POLICY,
+                ),
                 (digest) => ({ digest })
             );
             await timedPhase(
@@ -283,11 +297,18 @@ export function registerWalrusUploadRoute(app: Express): void {
             const certifyDigest = await timedPhase(
                 "certify_sponsor",
                 () =>
-                    submitRebuildableWalletTransaction("certify_sponsor", () => flow.certify(), signer, undefined, {
-                        traceId,
-                        jobId: jobIdForLog,
-                        keyIndex: keySlot,
-                    }),
+                    submitRebuildableWalletTransaction(
+                        "certify_sponsor",
+                        () => flow.certify(),
+                        signer,
+                        undefined,
+                        {
+                            traceId,
+                            jobId: jobIdForLog,
+                            keyIndex: keySlot,
+                        },
+                        ADDRESS_BALANCE_WALLET_FALLBACK_POLICY,
+                    ),
                 (digest) => ({ digest })
             );
             await timedPhase(
@@ -311,17 +332,18 @@ export function registerWalrusUploadRoute(app: Express): void {
                         "metadata_transfer",
                         () =>
                             setMetadataAndTransferBlobs(
-                            signer,
+                                signer,
                                 [{ blobObjectId, namespace, sealFence }],
-                            owner,
-                            packageId,
-                            agentId,
+                                owner,
+                                packageId,
+                                agentId,
                                 {
                                     traceId,
                                     jobId: jobIdForLog,
                                     keyIndex: keySlot,
-                                }
-                        ),
+                                },
+                                ADDRESS_BALANCE_WALLET_FALLBACK_POLICY,
+                            ),
                         (digest) => ({ digest, blobObjectId })
                     );
                     console.log(

--- a/services/server/scripts/sidecar/wallet.ts
+++ b/services/server/scripts/sidecar/wallet.ts
@@ -13,6 +13,7 @@ import {
     isWalrusObjectLockEquivocation,
 } from "../walrus-error-detection.js";
 import {
+    ENOKI_FALLBACK_TO_DIRECT_SIGN,
     ENOKI_INVALIDATED_BASE_DELAY_MS,
     ENOKI_INVALIDATED_MAX_ATTEMPTS,
     ENOKI_INVALIDATED_MAX_DELAY_MS,
@@ -31,6 +32,14 @@ export const DURABLE_WALLET_FALLBACK_POLICY: EnokiFallbackPolicy = {
     // never submit a second transaction after an ambiguous response.
     directSignIfUnconfigured: true,
     directSignAfterSponsorFailure: false,
+    gasMode: "addressBalance",
+};
+
+// Legacy uploads are not journaled, so preserve their configured direct-sign
+// fallback while ensuring every transaction uses address balances.
+export const ADDRESS_BALANCE_WALLET_FALLBACK_POLICY: EnokiFallbackPolicy = {
+    directSignIfUnconfigured: ENOKI_FALLBACK_TO_DIRECT_SIGN,
+    directSignAfterSponsorFailure: ENOKI_FALLBACK_TO_DIRECT_SIGN,
     gasMode: "addressBalance",
 };
 

--- a/services/server/scripts/walrus-upload.ts
+++ b/services/server/scripts/walrus-upload.ts
@@ -24,6 +24,7 @@ import { WalrusClient } from "@mysten/walrus";
 import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
+import { enforceAddressBalanceCoinIntents } from "./sidecar/address-balance.js";
 
 // ============================================================
 // Parse CLI arguments
@@ -136,6 +137,10 @@ async function main() {
         owner: signerAddress,
         deletable: true,
     });
+    enforceAddressBalanceCoinIntents(registerTx);
+    // Resolve both gas and Walrus storage payment from the signer's address
+    // balance instead of selecting owned coin objects.
+    registerTx.setGasPayment([]);
 
     // Sign and execute the register transaction
     const registerResult = await suiClient.signAndExecuteTransaction({
@@ -154,6 +159,9 @@ async function main() {
 
     // Step 4: Certify blob on Sui → returns a Transaction
     const certifyTx = flow.certify();
+    certifyTx.setSenderIfNotSet(signerAddress);
+    enforceAddressBalanceCoinIntents(certifyTx);
+    certifyTx.setGasPayment([]);
 
     // Sign and execute the certify transaction
     const certifyResult = await suiClient.signAndExecuteTransaction({

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -23,7 +23,10 @@ use crate::alerts::{
     WalrusGasPoolExhaustedAlert, WalrusObjectLockedAlert, WalrusPackageUpgradeDetectedAlert,
     WalrusUploadExhaustedAlert, WalrusWalletBalanceLowAlert, SIDECAR_WALRUS_DEP_VERSION,
 };
-use crate::storage::walrus::{SetMetadataBatchEntry, UploadBlobError};
+use crate::storage::walrus::{
+    DurableUploadAdvance, PreparedRegisterTransaction, SetMetadataBatchEntry, UploadBlobError,
+    UploadExecutionIdentity, UploadJournal,
+};
 use crate::types::{configured_walrus_storage_epochs, AppState, BLOB_CACHE_KEY_PREFIX};
 
 // ============================================================
@@ -63,6 +66,9 @@ pub enum WalletOperation {
         agent_public_key: Option<String>,
         /// `remember_jobs` row ID to update with status/blob_id.
         remember_job_id: Option<String>,
+        /// Fences stale preparation workers after their lease is reclaimed.
+        #[serde(default)]
+        prepare_claim_token: Option<String>,
         /// Storage epochs for Walrus upload.
         #[serde(default = "default_epochs")]
         epochs: u32,
@@ -452,6 +458,7 @@ pub(crate) async fn execute_wallet_job(
             account_id,
             agent_public_key,
             remember_job_id,
+            prepare_claim_token,
             epochs,
         } => {
             let wallet_index = match wallet_index_for_upload_attempt(
@@ -477,6 +484,31 @@ pub(crate) async fn execute_wallet_job(
                     attempt_info.max,
                 );
             }
+            if let (Some(job_id), Some(token)) =
+                (remember_job_id.as_deref(), prepare_claim_token.as_deref())
+            {
+                let owns_claim: bool = sqlx::query_scalar(
+                    "SELECT EXISTS(SELECT 1 FROM remember_jobs WHERE id = $1 AND prepare_claim_token = $2)",
+                )
+                .bind(job_id)
+                .bind(token)
+                .fetch_one(state.db.pool())
+                .await
+                .map_err(|e| {
+                    WalletJobError::Transient(format!(
+                        "failed to verify preparation fencing token: {}",
+                        e
+                    ))
+                    .into_apalis_error()
+                })?;
+                if !owns_claim {
+                    tracing::warn!(
+                        "[wallet-job:upload] job_id={} stale preparation payload fenced before wallet execution",
+                        job_id
+                    );
+                    return Ok(());
+                }
+            }
             execute_upload_and_transfer(
                 state,
                 wallet_index,
@@ -489,6 +521,7 @@ pub(crate) async fn execute_wallet_job(
                 account_id,
                 agent_public_key,
                 remember_job_id,
+                prepare_claim_token,
                 epochs,
                 congestion_requeues,
                 attempt_info,
@@ -789,7 +822,7 @@ async fn insert_vector_and_mark_remember_done(
 
     if let Some(jid) = remember_job_id {
         let _ = sqlx::query(
-            "UPDATE remember_jobs SET status = 'done', blob_id = $1, error_msg = NULL, updated_at = NOW() WHERE id = $2",
+            "UPDATE remember_jobs SET status = 'done', blob_id = $1, prepare_claimed_at = NULL, prepare_claim_token = NULL, recovery_claimed_at = NULL, recovery_claim_token = NULL, error_msg = NULL, updated_at = NOW() WHERE id = $2",
         )
         .bind(blob_id)
         .bind(jid)
@@ -850,6 +883,491 @@ async fn enqueue_finalize_uploaded_blob(
 // ────────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
+/// What `execute_upload_and_transfer` should do given a job's already-persisted
+/// state — the idempotency decision, split out so it can be unit-tested against
+/// the real `remember_jobs` table without a live Walrus sidecar.
+#[derive(Debug, PartialEq, Eq)]
+enum UploadResume {
+    /// Job already reached its terminal `done` state — nothing to redo.
+    AlreadyDone { blob_id: String },
+    /// Paid blob already minted AND its object id is known, but metadata/transfer
+    /// (and indexing) may not have finished. Resume via the metadata/transfer
+    /// recovery path with the stored object id — never re-mint, never prematurely
+    /// finalize an un-transferred blob.
+    ResumeTransfer {
+        blob_id: String,
+        blob_object_id: String,
+    },
+    /// Paid blob already minted but no object id was recorded (a full-success
+    /// upload where the sidecar already did metadata+transfer atomically, or a
+    /// pre-`blob_object_id` legacy row). The blob exists and is transferred, only
+    /// the vector index may be missing — resume indexing, NEVER re-upload.
+    ResumeIndex { blob_id: String },
+    /// No prior attempt could have minted (pending / failed-with-NULL-blob /
+    /// missing row). Proceed with a normal upload — no reconcile needed.
+    Upload,
+    /// A `running` row with NULL blob_id: a prior attempt was in-flight and may
+    /// have minted a blob whose record was lost to a crash before it persisted.
+    /// The caller must reconcile on-chain (find a blob tagged with this job)
+    /// BEFORE uploading — adopt it if found, upload only if not.
+    ReconcileThenUpload,
+    /// The status lookup itself failed. We CANNOT tell whether a paid blob exists,
+    /// so we must not upload (fail closed) — the caller returns a retriable error
+    /// and Apalis re-reads on the next attempt.
+    Indeterminate,
+}
+
+/// Decide whether a (possibly retried) upload job should re-upload or resume.
+///
+/// A row **never re-uploads once a paid blob is recorded** (any non-NULL
+/// `blob_id`): `done` → `AlreadyDone`; `uploaded` + object_id → `ResumeTransfer`;
+/// `uploaded` without object_id → `ResumeIndex` (the blob is minted+transferred,
+/// only indexing may be pending). A `running` row with a NULL `blob_id` →
+/// `ReconcileThenUpload`: a prior attempt was in-flight and may have minted a
+/// blob whose record was lost, so the caller reconciles on-chain before
+/// uploading. Only genuinely pre-mint states — `pending`, `failed` with a NULL
+/// `blob_id`, or a missing row — `Upload`.
+///
+/// A lookup **error** returns `Indeterminate` (fail closed): after a possible
+/// mint we must not re-upload on a transient read failure, so the caller retries
+/// without uploading rather than risking a duplicate paid blob.
+async fn upload_resume_disposition(pool: &sqlx::PgPool, job_id: &str) -> UploadResume {
+    let looked_up: Result<Option<(String, Option<String>, Option<String>)>, sqlx::Error> =
+        sqlx::query_as("SELECT status, blob_id, blob_object_id FROM remember_jobs WHERE id = $1")
+            .bind(job_id)
+            .fetch_optional(pool)
+            .await;
+
+    let existing = match looked_up {
+        Ok(row) => row,
+        Err(_) => return UploadResume::Indeterminate,
+    };
+
+    match existing {
+        // Any recorded blob_id means the paid mint already happened → never upload.
+        Some((status, Some(blob_id), _)) if status == "done" => {
+            UploadResume::AlreadyDone { blob_id }
+        }
+        Some((_, Some(blob_id), Some(blob_object_id))) => UploadResume::ResumeTransfer {
+            blob_id,
+            blob_object_id,
+        },
+        Some((_, Some(blob_id), None)) => UploadResume::ResumeIndex { blob_id },
+        // A `running` row with no blob → a prior attempt was in-flight; a mint may
+        // have landed but its record was lost. Reconcile on-chain before uploading.
+        Some((status, None, _)) if status == "running" => UploadResume::ReconcileThenUpload,
+        // pending / failed with no blob, or missing row → nothing was ever minted.
+        _ => UploadResume::Upload,
+    }
+}
+
+/// Per-job upload mutex, held for the guard-read → mint → persist critical
+/// section of `execute_upload_and_transfer`. Backed by a session-level Postgres
+/// advisory lock (`pg_try_advisory_lock` — non-blocking) on a hash of the job id,
+/// taken on a dedicated connection from `wallet_lock_pool`. If another attempt of
+/// the SAME job already holds it, acquisition returns `None` and the caller must
+/// NOT upload (it re-tries later, by which point the holder has persisted
+/// `uploaded`). Different jobs hash to different keys and never contend. Unlocks
+/// on `release()`; on a panic the connection returns to the pool and its
+/// reset clears the session lock.
+struct JobUploadLock {
+    conn: sqlx::pool::PoolConnection<sqlx::Postgres>,
+}
+
+impl JobUploadLock {
+    /// Try to acquire the per-job lock. `Ok(Some(lock))` = acquired (proceed);
+    /// `Ok(None)` = another attempt of this job holds it (do not upload);
+    /// `Err` = could not reach the lock pool (fail closed — treat like held).
+    async fn try_acquire(pool: &sqlx::PgPool, job_id: &str) -> Result<Option<Self>, sqlx::Error> {
+        let mut conn = pool.acquire().await?;
+        // hashtext() → int4; advisory locks take int8. Deterministic per job id.
+        let acquired: bool =
+            sqlx::query_scalar("SELECT pg_try_advisory_lock(hashtext($1)::bigint)")
+                .bind(job_id)
+                .fetch_one(&mut *conn)
+                .await?;
+        if acquired {
+            Ok(Some(JobUploadLock { conn }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Explicitly release before drop so the unlock is awaited (Drop can't await).
+    async fn release(mut self, job_id: &str) {
+        let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
+            .bind(job_id)
+            .execute(&mut *self.conn)
+            .await;
+    }
+}
+
+/// Decision derived from a `JobUploadLock::try_acquire` result: either we hold
+/// the lock and may proceed, or we must NOT upload (deferred because another
+/// attempt holds it, or fail-closed because the lock pool was unreachable — both
+/// return a retriable error). Split out so the "never mint without the lock"
+/// rule is unit-testable without a live pool.
+enum LockOutcome {
+    Proceed(JobUploadLock),
+    Defer(WalletJobError),
+}
+
+fn lock_outcome(acquired: Result<Option<JobUploadLock>, sqlx::Error>, job_id: &str) -> LockOutcome {
+    match acquired {
+        Ok(Some(lock)) => LockOutcome::Proceed(lock),
+        Ok(None) => LockOutcome::Defer(WalletJobError::Transient(format!(
+            "another attempt of upload job {} is in progress",
+            job_id
+        ))),
+        Err(e) => LockOutcome::Defer(WalletJobError::Transient(format!(
+            "could not acquire upload lock for job {}: {}",
+            job_id, e
+        ))),
+    }
+}
+
+/// Durably persist the `uploaded` state (status + blob_id + blob_object_id) that
+/// records a completed paid mint. Unlike the surrounding best-effort status
+/// writes, a failure here is returned as a **retriable** error: the mint already
+/// happened and is irreversible, so if we can't record it we must let Apalis
+/// retry (the idempotency guard will then see the state on the next attempt)
+/// rather than press on and risk the record being lost — which would let a later
+/// retry re-mint. `blob_object_id` is stored so a retry can resume transfer.
+#[derive(sqlx::FromRow)]
+struct StoredUploadJournal {
+    upload_wallet_index: Option<i32>,
+    upload_wallet_address: Option<String>,
+    upload_execution_identity: Option<serde_json::Value>,
+    upload_resume_step: Option<serde_json::Value>,
+    upload_register_transaction: Option<serde_json::Value>,
+}
+
+fn parse_journal_value<T: serde::de::DeserializeOwned>(
+    value: Option<serde_json::Value>,
+) -> Result<Option<T>, WalletJobError> {
+    value
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| WalletJobError::Permanent(format!("invalid persisted upload journal: {}", e)))
+}
+
+async fn load_upload_journal(
+    pool: &sqlx::PgPool,
+    job_id: &str,
+    fallback_wallet_index: usize,
+) -> Result<UploadJournal, WalletJobError> {
+    let stored = sqlx::query_as::<_, StoredUploadJournal>(
+        "SELECT upload_wallet_index, upload_wallet_address, upload_execution_identity, upload_resume_step, upload_register_transaction FROM remember_jobs WHERE id = $1",
+    )
+    .bind(job_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| WalletJobError::Transient(format!("failed to load upload journal: {}", e)))?;
+
+    Ok(UploadJournal {
+        wallet_index: stored
+            .upload_wallet_index
+            .and_then(|value| usize::try_from(value).ok())
+            .unwrap_or(fallback_wallet_index),
+        wallet_address: stored.upload_wallet_address,
+        execution_identity: parse_journal_value(stored.upload_execution_identity)?,
+        resume_step: stored.upload_resume_step,
+        register_transaction: parse_journal_value(stored.upload_register_transaction)?,
+    })
+}
+
+async fn persist_upload_journal(
+    pool: &sqlx::PgPool,
+    job_id: &str,
+    journal: &UploadJournal,
+) -> Result<(), WalletJobError> {
+    let wallet_index = i32::try_from(journal.wallet_index)
+        .map_err(|_| WalletJobError::Permanent("wallet index exceeds i32".into()))?;
+    let identity = journal
+        .execution_identity
+        .as_ref()
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|e| {
+            WalletJobError::Permanent(format!("failed to encode upload identity: {}", e))
+        })?;
+    let register = journal
+        .register_transaction
+        .as_ref()
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|e| {
+            WalletJobError::Permanent(format!("failed to encode register journal: {}", e))
+        })?;
+    sqlx::query(
+        "UPDATE remember_jobs SET upload_wallet_index = $1, upload_wallet_address = $2, upload_execution_identity = $3, upload_resume_step = $4, upload_register_transaction = $5, updated_at = NOW() WHERE id = $6",
+    )
+    .bind(wallet_index)
+    .bind(&journal.wallet_address)
+    .bind(identity)
+    .bind(&journal.resume_step)
+    .bind(register)
+    .bind(job_id)
+    .execute(pool)
+    .await
+    .map_err(|e| WalletJobError::Transient(format!("failed to persist upload journal: {}", e)))?;
+    Ok(())
+}
+
+async fn consume_preparation_claim(
+    pool: &sqlx::PgPool,
+    job_id: &str,
+    token: &str,
+) -> Result<bool, WalletJobError> {
+    let consumed = sqlx::query(
+        "UPDATE remember_jobs SET status = 'running', prepare_claimed_at = NULL, updated_at = NOW() WHERE id = $1 AND prepare_claim_token = $2 AND blob_id IS NULL AND status IN ('pending', 'running')",
+    )
+    .bind(job_id)
+    .bind(token)
+    .execute(pool)
+    .await
+    .map_err(|e| WalletJobError::Transient(format!("failed to consume preparation claim: {}", e)))?;
+    Ok(consumed.rows_affected() == 1)
+}
+
+async fn persist_uploaded_state(
+    pool: &sqlx::PgPool,
+    remember_job_id: &str,
+    blob_id: &str,
+    blob_object_id: Option<&str>,
+) -> Result<(), WalletJobError> {
+    sqlx::query(
+        "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, blob_object_id = $2, prepare_claimed_at = NULL, prepare_claim_token = NULL, error_msg = NULL, updated_at = NOW() WHERE id = $3",
+    )
+    .bind(blob_id)
+    .bind(blob_object_id)
+    .bind(remember_job_id)
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        WalletJobError::Transient(format!(
+            "failed to persist uploaded state for job {} (blob minted, must retry to record): {}",
+            remember_job_id, e
+        ))
+    })?;
+    Ok(())
+}
+
+/// Resume an `uploaded`-but-not-`done` job by re-enqueuing the metadata/transfer
+/// Build the `SetMetadataAndTransfer` job that resumes an `uploaded`-but-pending
+/// write. Pure (no I/O) so a test can assert the resume routes to the transfer
+/// recovery op — carrying the stored blob object id — rather than an index/`done`
+/// finalize, which would prematurely complete an un-transferred blob.
+#[allow(clippy::too_many_arguments)]
+fn build_resume_transfer_job(
+    wallet_index: usize,
+    remember_job_id: &str,
+    blob_id: &str,
+    blob_object_id: String,
+    owner: &str,
+    namespace: &str,
+    package_id: &str,
+    account_id: &str,
+    agent_public_key: Option<&str>,
+    encrypted_b64: &str,
+    vector: &[f32],
+    blob_size_bytes: i64,
+    importance: f32,
+    seal_policy_package_id: &str,
+) -> WalletJob {
+    WalletJob {
+        wallet_index,
+        congestion_requeues: 0,
+        operation: WalletOperation::SetMetadataAndTransfer {
+            blob_object_id,
+            owner: owner.to_string(),
+            namespace: namespace.to_string(),
+            package_id: Some(package_id.to_string()),
+            agent_id: agent_public_key.map(str::to_string),
+            remember_job_id: Some(remember_job_id.to_string()),
+            blob_id: Some(blob_id.to_string()),
+            vector: Some(vector.to_vec()),
+            blob_size_bytes: Some(blob_size_bytes),
+            importance,
+            encrypted_b64: Some(encrypted_b64.to_string()),
+            account_id: Some(account_id.to_string()),
+            policy_package_id: Some(seal_policy_package_id.to_string()),
+        },
+    }
+}
+
+/// recovery job with the stored blob object id — the same handoff the
+/// upload-then-metadata-failed path uses. This never re-mints the (already paid)
+/// blob and never marks the row `done` while its transfer is still outstanding;
+/// `SetMetadataAndTransfer` finishes the transfer and only then indexes + marks
+/// `done`.
+#[allow(clippy::too_many_arguments)]
+async fn resume_metadata_and_transfer(
+    state: &AppState,
+    wallet_index: usize,
+    remember_job_id: &str,
+    blob_id: &str,
+    blob_object_id: String,
+    owner: &str,
+    namespace: &str,
+    package_id: &str,
+    account_id: &str,
+    agent_public_key: Option<&str>,
+    encrypted_b64: &str,
+    vector: &[f32],
+    blob_size_bytes: i64,
+    importance: f32,
+) -> Result<(), WalletJobError> {
+    let job = build_resume_transfer_job(
+        wallet_index,
+        remember_job_id,
+        blob_id,
+        blob_object_id,
+        owner,
+        namespace,
+        package_id,
+        account_id,
+        agent_public_key,
+        encrypted_b64,
+        vector,
+        blob_size_bytes,
+        importance,
+        &state.config.seal_policy_package_id,
+    );
+    let mut storage = state.wallet_storage.clone();
+    if let Err(e) = storage.push_request(wallet_job_request(job)).await {
+        let classified = classify_wallet_remember_handoff_failure(
+            state.db.pool(),
+            Some(remember_job_id),
+            format!("failed to enqueue metadata/transfer recovery job: {}", e),
+        )
+        .await;
+        tracing::error!(
+            "[wallet-job:upload] job_id={} {}",
+            remember_job_id,
+            classified,
+        );
+        return Err(classified);
+    }
+    tracing::info!(
+        "[wallet-job:upload] job_id={} resume enqueued metadata/transfer for blob_id={} key={}",
+        remember_job_id,
+        blob_id,
+        wallet_index,
+    );
+    Ok(())
+}
+
+fn durable_step_field(step: &serde_json::Value, field: &str) -> Result<String, WalletJobError> {
+    step.get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            WalletJobError::Permanent(format!(
+                "durable upload step is missing required field {}",
+                field
+            ))
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_durable_upload(
+    state: &AppState,
+    fallback_wallet_index: usize,
+    encrypted: &[u8],
+    encrypted_b64: &str,
+    vector: &[f32],
+    importance: f32,
+    owner: &str,
+    namespace: &str,
+    package_id: &str,
+    account_id: &str,
+    agent_public_key: Option<&str>,
+    remember_job_id: &str,
+    epochs: u32,
+) -> Result<(), WalletJobError> {
+    let mut journal =
+        load_upload_journal(state.db.pool(), remember_job_id, fallback_wallet_index).await?;
+
+    // Each sidecar call advances one checkpointable step. Persist the returned
+    // checkpoint before asking the sidecar to perform the next side effect.
+    for _ in 0..6 {
+        let advanced = crate::storage::walrus::advance_durable_upload(
+            &state.http_client,
+            &state.config.sidecar_url,
+            state.config.sidecar_secret.as_deref(),
+            encrypted,
+            epochs as u64,
+            owner,
+            namespace,
+            package_id,
+            remember_job_id,
+            journal,
+        )
+        .await
+        .map_err(|e| WalletJobError::Transient(e.to_string()))?;
+
+        match advanced {
+            DurableUploadAdvance::Prepared(next) => {
+                // This is the critical pre-submit barrier: exact signed bytes
+                // and digest are durable before the next request can submit.
+                persist_upload_journal(state.db.pool(), remember_job_id, &next).await?;
+                journal = next;
+            }
+            DurableUploadAdvance::Step {
+                journal: mut next,
+                step,
+            } => {
+                next.resume_step = Some(step.clone());
+                persist_upload_journal(state.db.pool(), remember_job_id, &next).await?;
+                let kind = step
+                    .get("step")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                if kind != "certified" {
+                    journal = next;
+                    continue;
+                }
+
+                let blob_id = durable_step_field(&step, "blobId")?;
+                let object_id = durable_step_field(&step, "blobObjectId")?;
+                persist_uploaded_state(
+                    state.db.pool(),
+                    remember_job_id,
+                    &blob_id,
+                    Some(&object_id),
+                )
+                .await?;
+                warm_blob_cache_after_upload(state, &blob_id, encrypted).await;
+                return resume_metadata_and_transfer(
+                    state,
+                    next.wallet_index,
+                    remember_job_id,
+                    &blob_id,
+                    object_id,
+                    owner,
+                    namespace,
+                    package_id,
+                    account_id,
+                    agent_public_key,
+                    encrypted_b64,
+                    vector,
+                    encrypted.len() as i64,
+                    importance,
+                )
+                .await;
+            }
+        }
+    }
+
+    Err(WalletJobError::Transient(format!(
+        "durable upload for job {} exceeded step budget",
+        remember_job_id
+    )))
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn execute_upload_and_transfer(
     state: &AppState,
     wallet_index: usize,
@@ -862,10 +1380,282 @@ async fn execute_upload_and_transfer(
     account_id: String,
     agent_public_key: Option<String>,
     remember_job_id: Option<String>,
+    prepare_claim_token: Option<String>,
     epochs: u32,
     congestion_requeues: u32,
     attempt_info: WalletJobAttemptInfo,
 ) -> Result<(), WalletJobError> {
+    // ── Per-job upload mutex ───────────────────────────────────
+    // Guard-read + mint + persist must be atomic per job: the wallet queue runs
+    // up to WALLET_JOB_CONCURRENCY workers, and Apalis's orphan-reenqueue can
+    // re-dispatch a still-Running job (stale worker heartbeat) so two attempts of
+    // the SAME job can run at once — both would read `running`/NULL and both mint.
+    // A per-job advisory lock serializes them; the loser bails without uploading.
+    let mut upload_lock = if let Some(ref jid) = remember_job_id {
+        let acquired = JobUploadLock::try_acquire(&state.wallet_lock_pool, jid).await;
+        match lock_outcome(acquired, jid) {
+            LockOutcome::Proceed(lock) => Some(lock),
+            // Deferred or fail-closed: in BOTH cases we must NOT upload — return
+            // the retriable error so Apalis re-tries later (by which point the
+            // holder will have persisted `uploaded`, or the pool is reachable).
+            LockOutcome::Defer(err) => {
+                tracing::warn!(
+                    "[wallet-job:upload] job_id={} deferring upload: {}",
+                    jid,
+                    err,
+                );
+                return Err(err);
+            }
+        }
+    } else {
+        None
+    };
+
+    // Consume the preparation claim while holding the per-job upload lock,
+    // immediately before any wallet side effect. This closes the TOCTOU window:
+    // once consumed, the row is no longer reclaimable and a stale token cannot
+    // pass even if its lease expired after an earlier queue-time check.
+    if let (Some(jid), Some(token)) = (remember_job_id.as_deref(), prepare_claim_token.as_deref()) {
+        if !consume_preparation_claim(state.db.pool(), jid, token).await? {
+            tracing::warn!(
+                "[wallet-job:upload] job_id={} stale preparation fenced inside upload lock",
+                jid
+            );
+            if let Some(lock) = upload_lock.take() {
+                lock.release(jid).await;
+            }
+            return Ok(());
+        }
+    }
+
+    let result = execute_upload_and_transfer_locked(
+        state,
+        wallet_index,
+        encrypted_b64,
+        vector,
+        importance,
+        owner,
+        namespace,
+        package_id,
+        account_id,
+        agent_public_key,
+        remember_job_id.clone(),
+        prepare_claim_token,
+        epochs,
+        congestion_requeues,
+        attempt_info,
+    )
+    .await;
+
+    if let (Some(lock), Some(jid)) = (upload_lock, remember_job_id.as_deref()) {
+        lock.release(jid).await;
+    }
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_upload_and_transfer_locked(
+    state: &AppState,
+    wallet_index: usize,
+    encrypted_b64: String,
+    vector: Vec<f32>,
+    importance: f32,
+    owner: String,
+    namespace: String,
+    package_id: String,
+    account_id: String,
+    agent_public_key: Option<String>,
+    remember_job_id: Option<String>,
+    prepare_claim_token: Option<String>,
+    epochs: u32,
+    congestion_requeues: u32,
+    attempt_info: WalletJobAttemptInfo,
+) -> Result<(), WalletJobError> {
+    // ── Idempotency guard ──────────────────────────────────────
+    // `upload_blob` mints a paid on-chain Walrus Blob. On a retry (Apalis
+    // re-run, or an ambiguous client timeout that requeued the job) the blob
+    // may already have been uploaded and its id persisted. Re-uploading would
+    // mint a *second* paid blob for the same write. Consult the job's persisted
+    // state and resume from the point after the upload instead of redoing it.
+    // (This runs under the per-job advisory lock taken by the caller.)
+    if let Some(ref jid) = remember_job_id {
+        match upload_resume_disposition(state.db.pool(), jid).await {
+            UploadResume::AlreadyDone { blob_id } => {
+                tracing::info!(
+                    "[wallet-job:upload] job_id={} already done (blob_id={}) — skipping re-upload",
+                    jid,
+                    blob_id,
+                );
+                return Ok(());
+            }
+            UploadResume::ResumeTransfer {
+                blob_id,
+                blob_object_id,
+            } => {
+                tracing::info!(
+                    "[wallet-job:upload] job_id={} already uploaded (blob_id={}) — skipping re-upload, resuming metadata/transfer",
+                    jid,
+                    blob_id,
+                );
+                // Decode only to recover the ciphertext byte length for quota
+                // accounting; the bytes themselves aren't re-uploaded. A decode
+                // failure here is a real error (the row says `uploaded`, so it
+                // decoded once) — never silently record a zero-size row.
+                let blob_size_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&encrypted_b64)
+                    .map_err(|e| {
+                        WalletJobError::Permanent(format!(
+                            "resume: encrypted_b64 no longer decodes for job {}: {}",
+                            jid, e
+                        ))
+                    })?
+                    .len() as i64;
+                return resume_metadata_and_transfer(
+                    state,
+                    wallet_index,
+                    jid,
+                    &blob_id,
+                    blob_object_id,
+                    &owner,
+                    &namespace,
+                    &package_id,
+                    &account_id,
+                    agent_public_key.as_deref(),
+                    &encrypted_b64,
+                    &vector,
+                    blob_size_bytes,
+                    importance,
+                )
+                .await;
+            }
+            UploadResume::ResumeIndex { blob_id } => {
+                // Paid blob exists and (per the full-success route) was already
+                // transferred; only indexing may be missing. Finish it — never
+                // re-upload — with the stored blob_id.
+                tracing::info!(
+                    "[wallet-job:upload] job_id={} already uploaded (blob_id={}, no object id) — skipping re-upload, resuming indexing",
+                    jid,
+                    blob_id,
+                );
+                let blob_size_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&encrypted_b64)
+                    .map_err(|e| {
+                        WalletJobError::Permanent(format!(
+                            "resume: encrypted_b64 no longer decodes for job {}: {}",
+                            jid, e
+                        ))
+                    })?
+                    .len() as i64;
+                return insert_vector_and_mark_remember_done(
+                    state,
+                    Some(jid),
+                    &owner,
+                    &namespace,
+                    &blob_id,
+                    &vector,
+                    blob_size_bytes,
+                    importance,
+                    wallet_index,
+                )
+                .await;
+            }
+            UploadResume::Indeterminate => {
+                // Couldn't read the job's state → can't tell whether a paid blob
+                // already exists. Fail closed: retry without uploading rather than
+                // risk a duplicate mint.
+                return Err(WalletJobError::Transient(format!(
+                    "could not read upload state for job {} — retrying without re-upload",
+                    jid
+                )));
+            }
+            UploadResume::ReconcileThenUpload => {
+                // A prior attempt was `running` and may have minted a blob whose
+                // record was lost to a crash. Ask the chain (by the memwal_job_id
+                // tag) before re-uploading; adopt an existing blob instead of
+                // minting a duplicate. If the reconcile READ fails, fail closed —
+                // don't risk a re-mint on a transient error.
+                match crate::storage::walrus::find_blob_by_job(
+                    &state.http_client,
+                    &state.config.sidecar_url,
+                    state.config.sidecar_secret.as_deref(),
+                    &owner,
+                    jid,
+                )
+                .await
+                {
+                    Ok(Some(found)) => {
+                        tracing::warn!(
+                            "[wallet-job:upload] job_id={} reconciled an already-minted blob (blob_id={}) — adopting, not re-uploading",
+                            jid,
+                            found.blob_id,
+                        );
+                        persist_uploaded_state(
+                            state.db.pool(),
+                            jid,
+                            &found.blob_id,
+                            found.object_id.as_deref(),
+                        )
+                        .await?;
+                        let blob_size_bytes = base64::engine::general_purpose::STANDARD
+                            .decode(&encrypted_b64)
+                            .map_err(|e| {
+                                WalletJobError::Permanent(format!(
+                                    "reconcile: encrypted_b64 no longer decodes for job {}: {}",
+                                    jid, e
+                                ))
+                            })?
+                            .len() as i64;
+                        return match found.object_id {
+                            Some(object_id) => {
+                                resume_metadata_and_transfer(
+                                    state,
+                                    wallet_index,
+                                    jid,
+                                    &found.blob_id,
+                                    object_id,
+                                    &owner,
+                                    &namespace,
+                                    &package_id,
+                                    &account_id,
+                                    agent_public_key.as_deref(),
+                                    &encrypted_b64,
+                                    &vector,
+                                    blob_size_bytes,
+                                    importance,
+                                )
+                                .await
+                            }
+                            None => {
+                                insert_vector_and_mark_remember_done(
+                                    state,
+                                    Some(jid),
+                                    &owner,
+                                    &namespace,
+                                    &found.blob_id,
+                                    &vector,
+                                    blob_size_bytes,
+                                    importance,
+                                    wallet_index,
+                                )
+                                .await
+                            }
+                        };
+                    }
+                    Ok(None) => {
+                        // No blob minted for this job yet — upload normally.
+                    }
+                    Err(e) => {
+                        return Err(WalletJobError::Transient(format!(
+                            "reconcile lookup failed for job {} — retrying without re-upload: {}",
+                            jid, e
+                        )));
+                    }
+                }
+            }
+            UploadResume::Upload => {}
+        }
+    }
+
     // ── Mark running ───────────────────────────────────────────
     if let Some(ref jid) = remember_job_id {
         let _ = sqlx::query(
@@ -907,7 +1697,26 @@ async fn execute_upload_and_transfer(
         encrypted.len(),
     );
 
-    // ── Upload to Walrus via sidecar (using pinned wallet_index) ─
+    if let Some(ref jid) = remember_job_id {
+        return execute_durable_upload(
+            state,
+            wallet_index,
+            &encrypted,
+            &encrypted_b64,
+            &vector,
+            importance,
+            &owner,
+            &namespace,
+            &package_id,
+            &account_id,
+            agent_public_key.as_deref(),
+            jid,
+            epochs,
+        )
+        .await;
+    }
+
+    // Legacy untracked jobs retain the atomic sidecar route.
     let upload_result = crate::storage::walrus::upload_blob(
         &state.http_client,
         &state.config.sidecar_url,
@@ -943,14 +1752,11 @@ async fn execute_upload_and_transfer(
 
             warm_blob_cache_after_upload(state, &blob_id, &encrypted).await;
 
+            // Durably record the paid mint + its object id before handing off to
+            // the recovery job (see persist_uploaded_state). A retry that lands
+            // here reads this to resume the transfer instead of re-minting.
             if let Some(ref jid) = remember_job_id {
-                let _ = sqlx::query(
-                    "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, error_msg = NULL, updated_at = NOW() WHERE id = $2",
-                )
-                .bind(&blob_id)
-                .bind(jid)
-                .execute(state.db.pool())
-                .await;
+                persist_uploaded_state(state.db.pool(), jid, &blob_id, Some(&object_id)).await?;
             }
 
             let job_id_for_log = remember_job_id.as_deref().unwrap_or("-").to_string();
@@ -1050,6 +1856,7 @@ async fn execute_upload_and_transfer(
                                 account_id,
                                 agent_public_key,
                                 remember_job_id,
+                                prepare_claim_token,
                                 epochs,
                             },
                         }),
@@ -1156,14 +1963,14 @@ async fn execute_upload_and_transfer(
 
     warm_blob_cache_after_upload(state, &blob_id, &encrypted).await;
 
+    // Persist the paid mint durably BEFORE indexing. This UPDATE is the record
+    // the idempotency guard reads on a retry; if it were lost, a retry would see
+    // no blob_id and re-mint. Treat a persist failure as retriable (the mint is
+    // irreversible, so we must not proceed as if it never happened) rather than
+    // the old fire-and-forget `let _ =`. Also stores blob_object_id so an
+    // uploaded-but-not-done retry can resume the transfer without re-minting.
     if let Some(ref jid) = remember_job_id {
-        let _ = sqlx::query(
-            "UPDATE remember_jobs SET status = 'uploaded', blob_id = $1, error_msg = NULL, updated_at = NOW() WHERE id = $2",
-        )
-        .bind(&blob_id)
-        .bind(jid)
-        .execute(state.db.pool())
-        .await;
+        persist_uploaded_state(state.db.pool(), jid, &blob_id, upload.object_id.as_deref()).await?;
     }
 
     // The sidecar's `/walrus/upload` endpoint already performs metadata+transfer
@@ -1924,6 +2731,7 @@ pub async fn execute_bulk_remember(
                     account_id: job.account_id.clone(),
                     agent_public_key: job.agent_public_key.clone(),
                     remember_job_id: Some(job_id.clone()),
+                    prepare_claim_token: None,
                     epochs: job.epochs,
                 },
             }))
@@ -1955,12 +2763,18 @@ mod tests {
     use sqlx::postgres::PgPoolOptions;
 
     use super::{
-        classify_wallet_remember_handoff_failure, congestion_backoff_secs,
-        escalate_if_gas_pool_exhausted, gas_pool_exhaustion_threshold,
-        is_walrus_package_version_mismatch, mark_remember_job_failed, parse_locked_object_info,
-        parse_wal_balance_alert_info, recovery_seal_persistence, wallet_index_for_upload_attempt,
-        wallet_job_request, WalletJob, WalletJobAttemptInfo, WalletJobError, WalletOperation,
-        MAX_ATTEMPTS, MAX_CONGESTION_REQUEUES,
+        build_resume_transfer_job, classify_wallet_remember_handoff_failure,
+        congestion_backoff_secs, consume_preparation_claim, escalate_if_gas_pool_exhausted,
+        gas_pool_exhaustion_threshold, is_walrus_package_version_mismatch, load_upload_journal,
+        lock_outcome, mark_remember_job_failed, parse_locked_object_info,
+        parse_wal_balance_alert_info, persist_upload_journal, persist_uploaded_state,
+        recovery_seal_persistence, upload_resume_disposition, wallet_index_for_upload_attempt,
+        wallet_job_request, JobUploadLock, LockOutcome, UploadResume, WalletJob,
+        WalletJobAttemptInfo, WalletJobError, WalletOperation, MAX_ATTEMPTS,
+        MAX_CONGESTION_REQUEUES,
+    };
+    use crate::storage::walrus::{
+        PreparedRegisterTransaction, UploadExecutionIdentity, UploadJournal,
     };
 
     /// The exact production error string from the object-lock incident
@@ -1996,6 +2810,18 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
             .execute(&pool)
             .await
             .unwrap();
+        sqlx::raw_sql(include_str!(
+            "../migrations/012_remember_write_idempotency.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::raw_sql(include_str!(
+            "../migrations/013_remember_write_idempotency_index.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
 
         pool
     }
@@ -2531,6 +3357,460 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
         });
 
         assert_eq!(req.parts.context.max_attempts(), MAX_ATTEMPTS as i32);
+    }
+
+    async fn insert_job_full(
+        pool: &sqlx::PgPool,
+        job_id: &str,
+        status: &str,
+        blob_id: Option<&str>,
+        blob_object_id: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, blob_id, blob_object_id) VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(job_id)
+        .bind("0xtest-owner")
+        .bind("test-ns")
+        .bind(status)
+        .bind(blob_id)
+        .bind(blob_object_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_job_with_status(
+        pool: &sqlx::PgPool,
+        job_id: &str,
+        status: &str,
+        blob_id: Option<&str>,
+    ) {
+        insert_job_full(pool, job_id, status, blob_id, None).await;
+    }
+
+    // GH #477: a retried upload job must not re-mint a paid Walrus blob. These
+    // pin the idempotency decision that gates the (paid) upload_blob call.
+    #[tokio::test]
+    async fn upload_resume_resumes_transfer_when_uploaded_with_object_id() {
+        let pool = test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        // uploaded WITH a stored object id → resume the transfer, never re-mint.
+        insert_job_full(
+            &pool,
+            &job_id,
+            "uploaded",
+            Some("blob-abc"),
+            Some("0xobj-abc"),
+        )
+        .await;
+
+        assert_eq!(
+            upload_resume_disposition(&pool, &job_id).await,
+            UploadResume::ResumeTransfer {
+                blob_id: "blob-abc".into(),
+                blob_object_id: "0xobj-abc".into(),
+            },
+        );
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn upload_resume_indexes_when_uploaded_without_object_id() {
+        let pool = test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        // uploaded but no object id (full-success route / legacy row): the paid
+        // blob exists and is transferred → resume INDEXING, never re-upload.
+        insert_job_full(&pool, &job_id, "uploaded", Some("blob-legacy"), None).await;
+
+        assert_eq!(
+            upload_resume_disposition(&pool, &job_id).await,
+            UploadResume::ResumeIndex {
+                blob_id: "blob-legacy".into()
+            },
+        );
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn upload_resume_fails_closed_on_lookup_error() {
+        // A closed pool makes the guard SELECT error → Indeterminate, so the
+        // caller retries WITHOUT uploading (never a fail-open re-mint).
+        let dead = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&test_database_url())
+            .await
+            .unwrap();
+        dead.close().await;
+        assert_eq!(
+            upload_resume_disposition(&dead, "any-job").await,
+            UploadResume::Indeterminate,
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_resume_is_noop_when_already_done() {
+        let pool = test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        insert_job_with_status(&pool, &job_id, "done", Some("blob-xyz")).await;
+
+        assert_eq!(
+            upload_resume_disposition(&pool, &job_id).await,
+            UploadResume::AlreadyDone {
+                blob_id: "blob-xyz".into()
+            },
+        );
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn upload_resume_uploads_only_for_pre_mint_states() {
+        let pool = test_pool().await;
+        // running with no blob_id yet → a prior attempt never landed an upload.
+        let running = format!("remember-job-{}", uuid::Uuid::new_v4());
+        insert_job_with_status(&pool, &running, "running", None).await;
+        // running + NULL blob → a prior attempt was in-flight; reconcile on-chain
+        // (find a blob tagged with this job) before re-uploading.
+        assert_eq!(
+            upload_resume_disposition(&pool, &running).await,
+            UploadResume::ReconcileThenUpload,
+        );
+
+        // pending → fresh job.
+        let pending = format!("remember-job-{}", uuid::Uuid::new_v4());
+        insert_job_with_status(&pool, &pending, "pending", None).await;
+        assert_eq!(
+            upload_resume_disposition(&pool, &pending).await,
+            UploadResume::Upload
+        );
+
+        // failed with NO blob → no paid mint recorded, so upload.
+        let failed = format!("remember-job-{}", uuid::Uuid::new_v4());
+        insert_job_with_status(&pool, &failed, "failed", None).await;
+        assert_eq!(
+            upload_resume_disposition(&pool, &failed).await,
+            UploadResume::Upload
+        );
+
+        // #3: a FAILED row that DOES carry a blob_id was marked failed after a
+        // successful mint (recovery-handoff failure / stale sweeper) → resume,
+        // NEVER re-upload and discard the paid blob.
+        let failed_with_blob = format!("remember-job-{}", uuid::Uuid::new_v4());
+        insert_job_full(
+            &pool,
+            &failed_with_blob,
+            "failed",
+            Some("blob-paid"),
+            Some("0xobj"),
+        )
+        .await;
+        assert_eq!(
+            upload_resume_disposition(&pool, &failed_with_blob).await,
+            UploadResume::ResumeTransfer {
+                blob_id: "blob-paid".into(),
+                blob_object_id: "0xobj".into()
+            },
+        );
+
+        // unknown job id → Upload (no row = no write ever happened).
+        let missing = format!("remember-job-{}", uuid::Uuid::new_v4());
+        assert_eq!(
+            upload_resume_disposition(&pool, &missing).await,
+            UploadResume::Upload
+        );
+
+        for id in [&running, &pending, &failed, &failed_with_blob] {
+            let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+                .bind(id)
+                .execute(&pool)
+                .await;
+        }
+    }
+
+    // GH #477 RC-3: two concurrent attempts of the SAME job must not both mint.
+    // The per-job advisory lock is the mutex; this proves the second acquirer is
+    // refused while the first holds it, and succeeds again after release.
+    #[tokio::test]
+    async fn upload_lock_is_mutually_exclusive_per_job() {
+        // Needs >1 connection: the holder pins one while a second attempt tries to
+        // acquire on another (the real cross-session advisory-lock behavior). The
+        // shared test_pool is max_connections(1), which would deadlock here.
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect(&test_database_url())
+            .await
+            .unwrap();
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+
+        // First attempt acquires the lock.
+        let lock = JobUploadLock::try_acquire(&pool, &job_id)
+            .await
+            .unwrap()
+            .expect("first acquire should succeed");
+
+        // A concurrent second attempt of the SAME job is refused → it must NOT
+        // upload (returns None, which the caller turns into a Transient defer).
+        assert!(
+            JobUploadLock::try_acquire(&pool, &job_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "second concurrent acquire of the same job must be refused",
+        );
+
+        // A DIFFERENT job never contends.
+        let other = format!("remember-job-{}", uuid::Uuid::new_v4());
+        assert!(
+            JobUploadLock::try_acquire(&pool, &other)
+                .await
+                .unwrap()
+                .is_some(),
+            "a different job must be able to acquire its own lock",
+        );
+
+        // After the holder releases, the job is acquirable again.
+        lock.release(&job_id).await;
+        assert!(
+            JobUploadLock::try_acquire(&pool, &job_id)
+                .await
+                .unwrap()
+                .is_some(),
+            "lock must be re-acquirable after release",
+        );
+    }
+
+    // RC-3 wiring: the caller must NOT upload when the lock is contended or the
+    // lock pool is unreachable. lock_outcome is the decision the outer fn keys on;
+    // a regression that treated either as "proceed" would double-mint.
+    #[test]
+    fn lock_outcome_defers_when_contended_and_fails_closed_on_error() {
+        // Contended (Ok(None)) → Defer with a retriable error, never Proceed.
+        match lock_outcome(Ok(None), "job-x") {
+            LockOutcome::Defer(WalletJobError::Transient(msg)) => {
+                assert!(msg.contains("in progress"), "contended message: {msg}");
+            }
+            _ => panic!("contended lock must Defer(Transient), never Proceed"),
+        }
+        // Lock-pool error → fail closed to a retriable Defer, never Proceed.
+        match lock_outcome(Err(sqlx::Error::PoolClosed), "job-y") {
+            LockOutcome::Defer(WalletJobError::Transient(msg)) => {
+                assert!(msg.contains("could not acquire"), "error message: {msg}");
+            }
+            _ => panic!("lock-pool error must fail closed to Defer(Transient)"),
+        }
+    }
+
+    #[tokio::test]
+    async fn lock_outcome_proceeds_when_acquired() {
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect(&test_database_url())
+            .await
+            .unwrap();
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        let acquired = JobUploadLock::try_acquire(&pool, &job_id).await;
+        match lock_outcome(acquired, &job_id) {
+            LockOutcome::Proceed(lock) => lock.release(&job_id).await,
+            LockOutcome::Defer(_) => panic!("a free lock must Proceed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn prepared_register_journal_round_trips_before_submission() {
+        let pool = test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        insert_job_with_status(&pool, &job_id, "running", None).await;
+        let expected = UploadJournal {
+            wallet_index: 2,
+            wallet_address: Some(format!("0x{}", "1".repeat(64))),
+            execution_identity: Some(UploadExecutionIdentity {
+                chain_identifier: "testnet-chain".into(),
+                walrus_package_id: format!("0x{}", "2".repeat(64)),
+            }),
+            resume_step: Some(serde_json::json!({
+                "step": "encoded",
+                "blobId": "blob-1",
+                "rootHash": "root",
+                "unencodedSize": 42
+            })),
+            register_transaction: Some(PreparedRegisterTransaction {
+                transaction_bytes: "dHgtYnl0ZXM=".into(),
+                signature: "signature".into(),
+                digest: "digest-1".into(),
+            }),
+        };
+
+        persist_upload_journal(&pool, &job_id, &expected)
+            .await
+            .unwrap();
+        let loaded = load_upload_journal(&pool, &job_id, 0).await.unwrap();
+        assert_eq!(loaded.wallet_index, 2);
+        assert_eq!(loaded.wallet_address, expected.wallet_address);
+        assert_eq!(
+            loaded.register_transaction.unwrap().digest,
+            "digest-1",
+            "the exact prepared digest must survive the pre-submit checkpoint"
+        );
+        assert_eq!(
+            loaded.resume_step.unwrap()["step"],
+            "encoded",
+            "encoded intent must be replayed with the prepared transaction"
+        );
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn consumed_generation_remains_valid_for_durable_retry() {
+        let pool = test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        let token = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, prepare_claim_token, prepare_claimed_at) VALUES ($1, '0xowner', 'ns', 'pending', $2, NOW())",
+        )
+        .bind(&job_id)
+        .bind(&token)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(consume_preparation_claim(&pool, &job_id, &token)
+            .await
+            .unwrap());
+        assert!(
+            consume_preparation_claim(&pool, &job_id, &token)
+                .await
+                .unwrap(),
+            "same durable generation must remain retryable after pending → running"
+        );
+        let stored: (String, Option<String>) =
+            sqlx::query_as("SELECT status, prepare_claim_token FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(stored.0, "running");
+        assert_eq!(stored.1.as_deref(), Some(token.as_str()));
+
+        assert!(
+            !consume_preparation_claim(&pool, &job_id, "superseding-token")
+                .await
+                .unwrap(),
+            "a different generation must remain fenced"
+        );
+    }
+
+    // RC-2: the durable persist must (a) actually store blob_object_id on success
+    // and (b) return a RETRIABLE error on DB failure — never swallow it, or a lost
+    // `uploaded` record lets a retry re-mint.
+    #[tokio::test]
+    async fn persist_uploaded_state_stores_object_id_and_is_retriable_on_failure() {
+        let pool = test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        insert_job_with_status(&pool, &job_id, "running", None).await;
+
+        persist_uploaded_state(&pool, &job_id, "blob-1", Some("0xobj-1"))
+            .await
+            .expect("persist should succeed");
+
+        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT status, blob_id, blob_object_id FROM remember_jobs WHERE id = $1",
+        )
+        .bind(&job_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, "uploaded");
+        assert_eq!(row.1.as_deref(), Some("blob-1"));
+        assert_eq!(
+            row.2.as_deref(),
+            Some("0xobj-1"),
+            "blob_object_id must be persisted for RC-4 resume"
+        );
+
+        // A closed pool → the mint record can't be written → must be retriable.
+        let dead = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&test_database_url())
+            .await
+            .unwrap();
+        dead.close().await;
+        match persist_uploaded_state(&dead, &job_id, "blob-1", Some("0xobj-1")).await {
+            Err(WalletJobError::Transient(msg)) => {
+                assert!(
+                    msg.contains("must retry to record"),
+                    "retriable persist failure: {msg}"
+                );
+            }
+            other => panic!("persist failure must be Transient (retriable), got {other:?}"),
+        }
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await;
+    }
+
+    // RC-4: an uploaded-but-pending resume must route to the TRANSFER recovery op
+    // (carrying the stored object id), NOT to an index/done finalize — otherwise a
+    // never-transferred blob is prematurely marked done.
+    #[test]
+    fn resume_builds_a_set_metadata_and_transfer_job_with_object_id() {
+        let job = build_resume_transfer_job(
+            3,
+            "job-abc",
+            "blob-abc",
+            "0xobj-abc".into(),
+            "0xowner",
+            "ns",
+            "0xpkg",
+            "0xacct",
+            Some("0xagent"),
+            "ciphertext-b64",
+            &[0.1, 0.2, 0.3],
+            123,
+            0.5,
+            "0xpolicy",
+        );
+        match job.operation {
+            WalletOperation::SetMetadataAndTransfer {
+                blob_object_id,
+                blob_id,
+                remember_job_id,
+                encrypted_b64,
+                ..
+            } => {
+                assert_eq!(
+                    blob_object_id, "0xobj-abc",
+                    "must carry the stored object id"
+                );
+                assert_eq!(blob_id.as_deref(), Some("blob-abc"));
+                assert_eq!(remember_job_id.as_deref(), Some("job-abc"));
+                assert_eq!(
+                    encrypted_b64.as_deref(),
+                    Some("ciphertext-b64"),
+                    "ciphertext needed for SEAL persistence"
+                );
+            }
+            other => panic!("resume must build SetMetadataAndTransfer, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -882,8 +882,25 @@ async fn main() {
     ));
 
     // Shared application state
+    // Dedicated pool for per-job upload advisory locks (see AppState docs). Sized
+    // to the wallet-job concurrency (+1 headroom) so every concurrent upload can
+    // hold its own lock connection without touching the request-serving pool. Read
+    // WALLET_JOB_CONCURRENCY here independently of the worker registration below.
+    let wallet_lock_pool_size = std::env::var("WALLET_JOB_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(8)
+        .saturating_add(1)
+        .max(2);
+    let wallet_lock_pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(wallet_lock_pool_size)
+        .connect(&config.database_url)
+        .await
+        .expect("Failed to create wallet advisory-lock pool");
+
     let state = Arc::new(AppState {
         db,
+        wallet_lock_pool,
         legacy_db,
         security_delete_nonce_store,
         security_delete_wallet_verifier,

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -533,6 +533,7 @@ pub async fn analyze(
                 account_id: account_id.clone(),
                 agent_public_key: Some(auth_pubkey_base.clone()),
                 remember_job_id: Some(job_id.clone()),
+                prepare_claim_token: None,
                 epochs: state.config.walrus_storage_epochs,
             },
         )

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -67,12 +67,18 @@ struct PendingBulkRememberItem {
 // Job-failure bookkeeping
 // ============================================================
 
-async fn mark_remember_job_failed(state: &AppState, job_id: &str, msg: &str) {
+async fn mark_remember_job_failed(
+    state: &AppState,
+    job_id: &str,
+    prepare_claim_token: Option<&str>,
+    msg: &str,
+) {
     let _ = sqlx::query(
-        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2",
+        "UPDATE remember_jobs SET status = 'failed', error_msg = $1, updated_at = NOW() WHERE id = $2 AND status NOT IN ('done', 'uploaded') AND ($3::TEXT IS NULL OR prepare_claim_token = $3)",
     )
     .bind(msg)
     .bind(job_id)
+    .bind(prepare_claim_token)
     .execute(state.db.pool())
     .await;
 }
@@ -97,6 +103,7 @@ async fn mark_remember_jobs_failed(state: &AppState, job_ids: &[String], msg: &s
 fn spawn_prepare_remember_job(
     state: Arc<AppState>,
     job_id: String,
+    prepare_claim_token: Option<String>,
     text: String,
     owner: String,
     account_id: String,
@@ -150,6 +157,33 @@ fn spawn_prepare_remember_job(
                     )
                 })?;
                 let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+                let importance = crate::services::extractor::IMPORTANCE_STANDARD;
+
+                // Persist the exact non-deterministic preparation payload before
+                // wallet handoff. Post-mint recovery must use these bytes/vector;
+                // re-encrypting plaintext would no longer match the paid blob.
+                let persisted = sqlx::query(
+                    "UPDATE remember_jobs SET preparation_encrypted_b64 = $1, preparation_vector = $2, preparation_importance = $3, preparation_account_id = $4, preparation_public_key = $5, updated_at = NOW() WHERE id = $6 AND ($7::TEXT IS NULL OR prepare_claim_token = $7)",
+                )
+                .bind(&encrypted_b64)
+                .bind(serde_json::to_value(&vector).map_err(|e| {
+                    AppError::Internal(format!("Failed to serialize preparation vector: {}", e))
+                })?)
+                .bind(importance)
+                .bind(&account_id)
+                .bind(&agent_public_key)
+                .bind(&job_id)
+                .bind(prepare_claim_token.as_deref())
+                .execute(state.db.pool())
+                .await
+                .map_err(|e| AppError::Internal(format!("Failed to persist preparation: {}", e)))?;
+                if persisted.rows_affected() != 1 {
+                    tracing::warn!(
+                        "remember preparation lost fenced claim: job_id={}",
+                        job_id
+                    );
+                    return Ok(());
+                }
 
                 enqueue_wallet_job(
                     &state,
@@ -157,17 +191,14 @@ fn spawn_prepare_remember_job(
                     WalletOperation::UploadAndTransfer {
                         encrypted_b64,
                         vector,
-                        // manual /remember has no extractor → no
-                        // bucket signal. Use neutral "standard" so user-
-                        // supplied text isn't artificially boosted or
-                        // suppressed by the ranker's importance term.
-                        importance: crate::services::extractor::IMPORTANCE_STANDARD,
+                        importance,
                         owner: owner.clone(),
                         namespace: namespace.clone(),
                         package_id: state.config.package_id.clone(),
                         account_id: account_id.clone(),
                         agent_public_key: Some(agent_public_key.clone()),
                         remember_job_id: Some(job_id.clone()),
+                        prepare_claim_token: prepare_claim_token.clone(),
                         epochs: state.config.walrus_storage_epochs,
                     },
                 )
@@ -188,7 +219,8 @@ fn spawn_prepare_remember_job(
             if let Err(e) = result {
                 let msg = e.to_string();
                 tracing::error!("remember preparation failed: job_id={} {}", job_id, msg);
-                mark_remember_job_failed(&state, &job_id, &msg).await;
+                mark_remember_job_failed(&state, &job_id, prepare_claim_token.as_deref(), &msg)
+                    .await;
             }
         };
 
@@ -636,6 +668,7 @@ pub async fn remember(
         )));
     }
     validate_namespace(&body.namespace)?;
+    validate_idempotency_key(body.idempotency_key.as_deref())?;
 
     let owner = &auth.owner;
     let namespace = &body.namespace;
@@ -643,21 +676,208 @@ pub async fn remember(
     let namespace_owned = namespace.clone();
     let text = body.text;
 
+    // Idempotent retry: if this owner already has a job under the same key,
+    // return it instead of minting a new (paid) write. Insert-then-check under
+    // the partial unique index (owner, idempotency_key) so two concurrent
+    // requests with the same key can't both create a job — the loser's insert
+    // conflicts and it reads back the winner's row.
+    let fingerprint = request_fingerprint(&text, namespace);
+    if let Some(ref key) = body.idempotency_key {
+        if let Some((existing_id, existing_status, existing_blob_id, existing_fingerprint)) =
+            find_remember_job_by_key(state.db.pool(), owner, key).await?
+        {
+            // Same key, different content → the caller reused an idempotency key
+            // for a different write. Reject rather than silently collapsing onto
+            // the original (which would drop this write). A NULL stored
+            // fingerprint (pre-migration row) is treated as "unknown" — we can't
+            // prove a mismatch, so we don't 409.
+            if let Some(ref stored) = existing_fingerprint {
+                if stored != &fingerprint {
+                    return Err(AppError::Conflict(
+                        "idempotency_key was already used for a request with different content"
+                            .into(),
+                    ));
+                }
+            }
+            // A previous attempt under this key permanently failed. Idempotency
+            // should suppress duplicate *successes*, not pin *failures* — BUT only
+            // restart a failure that never minted a paid blob. A `failed` row that
+            // still carries a `blob_id` was marked failed *after* a successful
+            // mint (a recovery-handoff failure or the stale sweeper); restarting
+            // it would clear + re-upload and DISCARD the paid blob. So: reset only
+            // when there's no blob; otherwise leave the row (preserve the mint for
+            // recovery) and return it as-is.
+            if existing_status == "failed" && existing_blob_id.is_none() {
+                let claimed = claim_remember_preparation(state.db.pool(), &existing_id).await?;
+                if let Some(token) = claimed {
+                    spawn_persisted_remember_preparation(
+                        Arc::clone(&state),
+                        existing_id.clone(),
+                        token,
+                        text,
+                        owner_owned,
+                        auth.account_id.clone(),
+                        namespace_owned,
+                        auth.public_key.clone(),
+                    );
+                }
+                return Ok((
+                    StatusCode::ACCEPTED,
+                    Json(RememberAcceptedResponse {
+                        job_id: existing_id,
+                        status: "pending".to_string(),
+                    }),
+                ));
+            }
+
+            if existing_status == "pending" && existing_blob_id.is_none() {
+                if let Some(token) =
+                    claim_remember_preparation(state.db.pool(), &existing_id).await?
+                {
+                    spawn_persisted_remember_preparation(
+                        Arc::clone(&state),
+                        existing_id.clone(),
+                        token,
+                        text,
+                        owner_owned,
+                        auth.account_id.clone(),
+                        namespace_owned,
+                        auth.public_key.clone(),
+                    );
+                }
+                return Ok((
+                    StatusCode::ACCEPTED,
+                    Json(RememberAcceptedResponse {
+                        job_id: existing_id,
+                        status: "pending".to_string(),
+                    }),
+                ));
+            }
+
+            if matches!(existing_status.as_str(), "failed" | "uploaded")
+                && existing_blob_id.is_some()
+            {
+                // Claim first, enqueue second, publish `uploaded` last. If the
+                // process dies before enqueue, the lease expires and a later
+                // retry reclaims it; no durable state falsely says recovered.
+                if let Some(token) = claim_paid_recovery(state.db.pool(), &existing_id).await? {
+                    enqueue_persisted_paid_recovery(&state, &existing_id, owner, namespace).await?;
+                    sqlx::query(
+                        "UPDATE remember_jobs SET status = 'uploaded', error_msg = NULL, updated_at = NOW() WHERE id = $1 AND recovery_claim_token = $2 AND blob_id IS NOT NULL AND status IN ('failed', 'uploaded')",
+                    )
+                    .bind(&existing_id)
+                    .bind(&token)
+                    .execute(state.db.pool())
+                    .await
+                    .map_err(|e| AppError::Internal(format!("Failed to publish paid recovery: {}", e)))?;
+                }
+                return Ok((
+                    StatusCode::ACCEPTED,
+                    Json(RememberAcceptedResponse {
+                        job_id: existing_id,
+                        status: "uploaded".to_string(),
+                    }),
+                ));
+            }
+            tracing::info!(
+                "remember idempotent hit: job_id={} owner={} ns={} status={}",
+                existing_id,
+                owner,
+                namespace,
+                existing_status,
+            );
+            return Ok((
+                StatusCode::ACCEPTED,
+                Json(RememberAcceptedResponse {
+                    job_id: existing_id,
+                    status: existing_status,
+                }),
+            ));
+        }
+    }
+
     let job_id = uuid::Uuid::new_v4().to_string();
 
-    sqlx::query(
-        "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'running')",
+    // Insert as `pending` (not `running`) so the crash-window reconcile only
+    // fires on a genuine RETRY: the wallet worker flips the row to `running`
+    // just before it uploads, so a `running`+NULL row on a later attempt means a
+    // prior attempt was actually in-flight (and may have minted). A fresh job
+    // stays `pending` → the guard takes the plain Upload path, no on-chain
+    // reconcile round-trip on the happy path. (The 202 response is still
+    // "running" for API compatibility — see below.)
+    let inserted = sqlx::query(
+        "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key, request_fingerprint) VALUES ($1, $2, $3, 'pending', $4, $5)
+         ON CONFLICT (owner, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING",
     )
     .bind(&job_id)
     .bind(owner)
     .bind(namespace)
+    .bind(body.idempotency_key.as_deref())
+    .bind(body.idempotency_key.as_ref().map(|_| fingerprint.as_str()))
     .execute(state.db.pool())
     .await
     .map_err(|e| AppError::Internal(format!("Failed to create job row: {}", e)))?;
 
+    // Lost the race against a concurrent same-key request — return the winner's
+    // job rather than spawning a duplicate write.
+    if inserted.rows_affected() == 0 {
+        if let Some(key) = body.idempotency_key.as_deref() {
+            if let Some((existing_id, existing_status, _blob_id, existing_fingerprint)) =
+                find_remember_job_by_key(state.db.pool(), owner, key).await?
+            {
+                // Lost the race to a concurrent same-key request with DIFFERENT
+                // content → reject, same as the pre-lookup path.
+                if let Some(ref stored) = existing_fingerprint {
+                    if stored != &fingerprint {
+                        return Err(AppError::Conflict(
+                            "idempotency_key was already used for a request with different content"
+                                .into(),
+                        ));
+                    }
+                }
+                tracing::info!(
+                    "remember idempotent race collapsed: job_id={} owner={} ns={}",
+                    existing_id,
+                    owner,
+                    namespace,
+                );
+                if existing_status == "pending" {
+                    if let Some(token) =
+                        claim_remember_preparation(state.db.pool(), &existing_id).await?
+                    {
+                        spawn_persisted_remember_preparation(
+                            Arc::clone(&state),
+                            existing_id.clone(),
+                            token,
+                            text,
+                            owner_owned,
+                            auth.account_id.clone(),
+                            namespace_owned,
+                            auth.public_key.clone(),
+                        );
+                    }
+                }
+                return Ok((
+                    StatusCode::ACCEPTED,
+                    Json(RememberAcceptedResponse {
+                        job_id: existing_id,
+                        status: existing_status,
+                    }),
+                ));
+            }
+        }
+        return Err(AppError::Internal(
+            "Failed to create job row: insert affected no rows".into(),
+        ));
+    }
+
+    let initial_token = claim_remember_preparation(state.db.pool(), &job_id)
+        .await?
+        .ok_or_else(|| AppError::Internal("Failed to claim new remember preparation".into()))?;
     spawn_prepare_remember_job(
         Arc::clone(&state),
         job_id.clone(),
+        Some(initial_token),
         text,
         owner_owned,
         auth.account_id.clone(),
@@ -679,6 +899,197 @@ pub async fn remember(
             status: "running".to_string(),
         }),
     ))
+}
+
+/// Whether to spawn a fresh background write after attempting to reset a failed
+/// job. Spawn only when THIS request flipped exactly one row out of `failed`
+/// (the reset UPDATE is guarded by `AND status='failed'`), so a concurrent
+/// double-reset yields exactly one spawn — the loser sees 0 rows affected and
+/// must not spawn a duplicate (paid) write. Pure so the exactly-once rule is
+/// unit-testable without the handler.
+fn should_spawn_after_reset(rows_affected: u64) -> bool {
+    rows_affected == 1
+}
+
+const PREPARE_CLAIM_TTL_SECS: i64 = 60;
+
+async fn claim_remember_preparation(
+    pool: &sqlx::PgPool,
+    job_id: &str,
+) -> Result<Option<String>, AppError> {
+    let token = uuid::Uuid::new_v4().to_string();
+    let claimed: Option<String> = sqlx::query_scalar(
+        "UPDATE remember_jobs SET prepare_claimed_at = NOW(), prepare_claim_token = $3, status = CASE WHEN status = 'failed' AND blob_id IS NULL THEN 'pending' ELSE status END, error_msg = CASE WHEN blob_id IS NULL THEN NULL ELSE error_msg END, updated_at = NOW() WHERE id = $1 AND blob_id IS NULL AND status IN ('pending', 'failed') AND (prepare_claimed_at IS NULL OR prepare_claimed_at < NOW() - make_interval(secs => $2)) RETURNING prepare_claim_token",
+    )
+    .bind(job_id)
+    .bind(PREPARE_CLAIM_TTL_SECS)
+    .bind(&token)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(format!("Failed to claim remember preparation: {}", e)))?;
+    Ok(claimed)
+}
+
+#[derive(sqlx::FromRow)]
+struct PersistedPreparation {
+    preparation_encrypted_b64: String,
+    preparation_vector: serde_json::Value,
+    preparation_importance: f32,
+    preparation_account_id: String,
+    preparation_public_key: String,
+}
+
+fn paid_recovery_operation(
+    prepared: PersistedPreparation,
+    job_id: &str,
+    owner: &str,
+    namespace: &str,
+    package_id: &str,
+    epochs: u32,
+) -> Result<WalletOperation, AppError> {
+    let vector: Vec<f32> = serde_json::from_value(prepared.preparation_vector)
+        .map_err(|e| AppError::Internal(format!("Invalid persisted preparation vector: {}", e)))?;
+    Ok(WalletOperation::UploadAndTransfer {
+        encrypted_b64: prepared.preparation_encrypted_b64,
+        vector,
+        importance: prepared.preparation_importance,
+        owner: owner.to_string(),
+        namespace: namespace.to_string(),
+        package_id: package_id.to_string(),
+        account_id: prepared.preparation_account_id,
+        agent_public_key: Some(prepared.preparation_public_key),
+        remember_job_id: Some(job_id.to_string()),
+        prepare_claim_token: None,
+        epochs,
+    })
+}
+
+async fn claim_paid_recovery(
+    pool: &sqlx::PgPool,
+    job_id: &str,
+) -> Result<Option<String>, AppError> {
+    let token = uuid::Uuid::new_v4().to_string();
+    let claimed: Option<String> = sqlx::query_scalar(
+        "UPDATE remember_jobs SET recovery_claimed_at = NOW(), recovery_claim_token = $3, updated_at = NOW() WHERE id = $1 AND status IN ('failed', 'uploaded') AND blob_id IS NOT NULL AND (recovery_claimed_at IS NULL OR recovery_claimed_at < NOW() - make_interval(secs => $2)) RETURNING recovery_claim_token",
+    )
+    .bind(job_id)
+    .bind(PREPARE_CLAIM_TTL_SECS)
+    .bind(&token)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(format!("Failed to claim paid recovery: {}", e)))?;
+    Ok(claimed)
+}
+
+async fn enqueue_persisted_paid_recovery(
+    state: &AppState,
+    job_id: &str,
+    owner: &str,
+    namespace: &str,
+) -> Result<(), AppError> {
+    let prepared = sqlx::query_as::<_, PersistedPreparation>(
+        "SELECT preparation_encrypted_b64, preparation_vector, preparation_importance, preparation_account_id, preparation_public_key FROM remember_jobs WHERE id = $1 AND blob_id IS NOT NULL",
+    )
+    .bind(job_id)
+    .fetch_optional(state.db.pool())
+    .await
+    .map_err(|e| AppError::Internal(format!("Failed to load paid preparation: {}", e)))?
+    .ok_or_else(|| {
+        AppError::Internal(
+            "Paid remember job has no original durable preparation payload; refusing to re-encrypt"
+                .into(),
+        )
+    })?;
+    let wallet_index = state.key_pool.next_index().ok_or_else(|| {
+        AppError::Internal(
+            "No Sui keys configured (set SERVER_SUI_PRIVATE_KEYS or SERVER_SUI_PRIVATE_KEY)".into(),
+        )
+    })?;
+    let operation = paid_recovery_operation(
+        prepared,
+        job_id,
+        owner,
+        namespace,
+        &state.config.package_id,
+        state.config.walrus_storage_epochs,
+    )?;
+    enqueue_wallet_job(state, wallet_index, operation)
+        .await
+        .map(|_| ())
+}
+
+fn spawn_persisted_remember_preparation(
+    state: Arc<AppState>,
+    job_id: String,
+    prepare_claim_token: String,
+    text: String,
+    owner: String,
+    account_id: String,
+    namespace: String,
+    public_key: String,
+) {
+    spawn_prepare_remember_job(
+        state,
+        job_id,
+        Some(prepare_claim_token),
+        text,
+        owner,
+        account_id,
+        namespace,
+        public_key,
+    );
+}
+
+/// Max accepted length of a client idempotency key (bytes). Generous for a
+/// UUID/hash; bounds untrusted input.
+const MAX_IDEMPOTENCY_KEY_BYTES: usize = 255;
+
+fn validate_idempotency_key(key: Option<&str>) -> Result<(), AppError> {
+    if let Some(key) = key {
+        if key.is_empty() {
+            return Err(AppError::BadRequest(
+                "idempotency_key cannot be empty (omit it instead)".into(),
+            ));
+        }
+        if key.len() > MAX_IDEMPOTENCY_KEY_BYTES {
+            return Err(AppError::BadRequest(format!(
+                "idempotency_key exceeds maximum length of {} bytes",
+                MAX_IDEMPOTENCY_KEY_BYTES
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Fingerprint the content a write is idempotent over: the text + namespace.
+/// A same idempotency key that arrives with a different fingerprint is a
+/// key-reuse mistake (409), not a retry. The NUL separator keeps
+/// (text="ab", ns="c") distinct from (text="a", ns="bc").
+fn request_fingerprint(text: &str, namespace: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(namespace.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Look up an existing remember job for `(owner, idempotency_key)`. Returns
+/// `(job_id, status, blob_id, request_fingerprint)` when one exists, so a retry
+/// can collapse onto it — or be rejected if its content fingerprint differs.
+async fn find_remember_job_by_key(
+    pool: &sqlx::PgPool,
+    owner: &str,
+    key: &str,
+) -> Result<Option<(String, String, Option<String>, Option<String>)>, AppError> {
+    sqlx::query_as::<_, (String, String, Option<String>, Option<String>)>(
+        "SELECT id, status, blob_id, request_fingerprint FROM remember_jobs WHERE owner = $1 AND idempotency_key = $2",
+    )
+    .bind(owner)
+    .bind(key)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(format!("Failed to look up idempotency key: {}", e)))
 }
 
 /// GET /api/remember/:job_id  — poll job status
@@ -786,7 +1197,10 @@ pub async fn remember_bulk(
         let job_id = uuid::Uuid::new_v4().to_string();
 
         sqlx::query(
-            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'running')",
+            // `pending` (not `running`) so a fresh job takes the plain Upload
+            // path; only a retry of an in-flight job (worker-set `running`)
+            // triggers the crash-window reconcile. See the single-remember insert.
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
         )
         .bind(&job_id)
         .bind(owner)
@@ -980,11 +1394,455 @@ pub async fn remember_manual(
 #[cfg(test)]
 mod tests {
     use super::{
-        batch_summary_inputs, build_bulk_status_results, split_text_chunks,
-        summarize_for_embedding, MAX_REMEMBER_TEXT_BYTES, SUMMARIZE_BATCH_INPUT_BYTES,
-        SUMMARIZE_CHUNK_BYTES,
+        batch_summary_inputs, build_bulk_status_results, claim_remember_preparation,
+        find_remember_job_by_key, paid_recovery_operation, request_fingerprint,
+        should_spawn_after_reset, split_text_chunks, summarize_for_embedding,
+        validate_idempotency_key, MAX_IDEMPOTENCY_KEY_BYTES, MAX_REMEMBER_TEXT_BYTES,
+        SUMMARIZE_BATCH_INPUT_BYTES, SUMMARIZE_CHUNK_BYTES,
     };
+    use crate::jobs::WalletOperation;
+    use crate::types::AppError;
+    use sqlx::postgres::PgPoolOptions;
     use std::sync::Arc;
+    use std::time::Duration;
+
+    // ── Idempotency key (GH #477) ────────────────────────────────
+
+    #[tokio::test]
+    async fn paid_recovery_publish_never_regresses_done() {
+        let pool = idem_test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, blob_id, recovery_claim_token) VALUES ($1, '0xowner', 'ns', 'done', 'blob-1', 'claim-1')",
+        )
+        .bind(&job_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let published = sqlx::query(
+            "UPDATE remember_jobs SET status = 'uploaded', error_msg = NULL, updated_at = NOW() WHERE id = $1 AND recovery_claim_token = $2 AND blob_id IS NOT NULL AND status IN ('failed', 'uploaded')",
+        )
+        .bind(&job_id)
+        .bind("claim-1")
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(published.rows_affected(), 0);
+        let status: String = sqlx::query_scalar("SELECT status FROM remember_jobs WHERE id = $1")
+            .bind(&job_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "done");
+    }
+
+    #[tokio::test]
+    async fn initial_preparation_claim_is_fenced_after_reclaim() {
+        let pool = idem_test_pool().await;
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, '0xowner', 'ns', 'pending')",
+        )
+        .bind(&job_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let old = claim_remember_preparation(&pool, &job_id)
+            .await
+            .unwrap()
+            .unwrap();
+        sqlx::query("UPDATE remember_jobs SET prepare_claimed_at = NOW() - INTERVAL '61 seconds' WHERE id = $1")
+            .bind(&job_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let current = claim_remember_preparation(&pool, &job_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_ne!(old, current);
+
+        let stale = sqlx::query(
+            "UPDATE remember_jobs SET preparation_encrypted_b64 = 'old' WHERE id = $1 AND prepare_claim_token = $2",
+        )
+        .bind(&job_id)
+        .bind(&old)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(stale.rows_affected(), 0, "expired worker must be fenced");
+        let winner = sqlx::query(
+            "UPDATE remember_jobs SET preparation_encrypted_b64 = 'new' WHERE id = $1 AND prepare_claim_token = $2",
+        )
+        .bind(&job_id)
+        .bind(&current)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(winner.rows_affected(), 1);
+    }
+
+    #[test]
+    fn paid_blob_recovery_uses_original_ciphertext_and_vector() {
+        let prepared = super::PersistedPreparation {
+            preparation_encrypted_b64: "old-ciphertext".into(),
+            preparation_vector: serde_json::json!([1.0, 2.0]),
+            preparation_importance: 0.5,
+            preparation_account_id: "account".into(),
+            preparation_public_key: "delegate".into(),
+        };
+        let operation =
+            paid_recovery_operation(prepared, "job-1", "0xowner", "ns", "0xpkg", 3).unwrap();
+        match operation {
+            WalletOperation::UploadAndTransfer {
+                encrypted_b64,
+                vector,
+                ..
+            } => {
+                assert_eq!(encrypted_b64, "old-ciphertext");
+                assert_eq!(vector, vec![1.0, 2.0]);
+                assert_ne!(encrypted_b64, "new-ciphertext");
+            }
+            _ => panic!("paid recovery must rebuild the original upload payload"),
+        }
+    }
+
+    #[test]
+    fn idempotency_key_none_is_ok() {
+        assert!(validate_idempotency_key(None).is_ok());
+    }
+
+    // Rec A: the fingerprint distinguishes different content so a same-key retry
+    // with a different write is caught (409) rather than silently collapsed.
+    #[test]
+    fn request_fingerprint_is_stable_and_content_sensitive() {
+        // Deterministic for identical content.
+        assert_eq!(
+            request_fingerprint("hello", "ns"),
+            request_fingerprint("hello", "ns")
+        );
+        // Different text → different fingerprint.
+        assert_ne!(
+            request_fingerprint("hello", "ns"),
+            request_fingerprint("world", "ns")
+        );
+        // Different namespace → different fingerprint.
+        assert_ne!(
+            request_fingerprint("hello", "ns"),
+            request_fingerprint("hello", "other")
+        );
+        // The NUL separator keeps (text="ab",ns="c") distinct from (text="a",ns="bc").
+        assert_ne!(
+            request_fingerprint("ab", "c"),
+            request_fingerprint("a", "bc")
+        );
+    }
+
+    // DB-backed: find_remember_job_by_key surfaces the stored fingerprint, which
+    // is what the handler compares to decide collapse vs 409. Pin that a
+    // different-content retry is detectable (stored != recomputed).
+    #[tokio::test]
+    async fn stored_fingerprint_detects_same_key_different_content() {
+        let pool = idem_test_pool().await;
+        let owner = format!("0xowner-{}", uuid::Uuid::new_v4());
+        let key = "fp-key";
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        let original_fp = request_fingerprint("original text", "ns");
+
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key, request_fingerprint) VALUES ($1, $2, 'ns', 'pending', $3, $4)",
+        )
+        .bind(&job_id)
+        .bind(&owner)
+        .bind(key)
+        .bind(&original_fp)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let found = find_remember_job_by_key(&pool, &owner, key)
+            .await
+            .unwrap()
+            .unwrap();
+        let stored_fp = found.3.expect("fingerprint stored");
+        assert_eq!(stored_fp, original_fp);
+        // A retry with the SAME content matches (collapse); DIFFERENT content
+        // does not (handler returns 409).
+        assert_eq!(stored_fp, request_fingerprint("original text", "ns"));
+        assert_ne!(stored_fp, request_fingerprint("DIFFERENT text", "ns"));
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE owner = $1")
+            .bind(&owner)
+            .execute(&pool)
+            .await;
+    }
+
+    // RC-5: exactly-once spawn on failed-key retry. The reset UPDATE is guarded by
+    // `AND status='failed'`, so a winner flips 1 row (spawn), and a concurrent
+    // loser flips 0 rows (must NOT spawn a duplicate paid write).
+    #[test]
+    fn spawn_only_when_reset_flipped_exactly_one_row() {
+        assert!(should_spawn_after_reset(1), "winner (1 row flipped) spawns");
+        assert!(
+            !should_spawn_after_reset(0),
+            "loser (0 rows) must not double-spawn"
+        );
+        assert!(!should_spawn_after_reset(2), "defensive: never spawn on >1");
+    }
+
+    #[test]
+    fn idempotency_key_empty_is_rejected() {
+        assert!(matches!(
+            validate_idempotency_key(Some("")),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn idempotency_key_over_max_is_rejected() {
+        let long = "a".repeat(MAX_IDEMPOTENCY_KEY_BYTES + 1);
+        assert!(matches!(
+            validate_idempotency_key(Some(&long)),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn idempotency_key_at_max_is_ok() {
+        let ok = "a".repeat(MAX_IDEMPOTENCY_KEY_BYTES);
+        assert!(validate_idempotency_key(Some(&ok)).is_ok());
+    }
+
+    async fn idem_test_pool() -> sqlx::PgPool {
+        let url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgresql://memwal:memwal_secret@localhost:5432/memwal".into());
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect(&url)
+            .await
+            .unwrap();
+        sqlx::raw_sql(include_str!("../../migrations/005_remember_jobs.sql"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::raw_sql(include_str!(
+            "../../migrations/012_remember_write_idempotency.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::raw_sql(include_str!(
+            "../../migrations/013_remember_write_idempotency_index.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn find_by_key_returns_existing_and_collapses_same_key_retry() {
+        let pool = idem_test_pool().await;
+        let owner = format!("0xowner-{}", uuid::Uuid::new_v4());
+        let key = "client-key-1";
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+
+        // No job yet for this key.
+        assert!(find_remember_job_by_key(&pool, &owner, key)
+            .await
+            .unwrap()
+            .is_none());
+
+        // First write inserts a keyed job.
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key) VALUES ($1, $2, 'ns', 'running', $3)",
+        )
+        .bind(&job_id)
+        .bind(&owner)
+        .bind(key)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Lookup now finds it (this is what a retry hits → collapse, no new write).
+        let found = find_remember_job_by_key(&pool, &owner, key).await.unwrap();
+        assert_eq!(
+            found,
+            Some((job_id.clone(), "running".to_string(), None, None))
+        );
+
+        // A concurrent same-(owner,key) insert with a fresh id must DO NOTHING.
+        let dup = sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key) VALUES ($1, $2, 'ns', 'running', $3)
+             ON CONFLICT (owner, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING",
+        )
+        .bind(format!("remember-job-{}", uuid::Uuid::new_v4()))
+        .bind(&owner)
+        .bind(key)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            dup.rows_affected(),
+            0,
+            "duplicate key insert must be a no-op"
+        );
+
+        // Original row is still the one that survives.
+        let still = find_remember_job_by_key(&pool, &owner, key).await.unwrap();
+        assert_eq!(
+            still,
+            Some((job_id.clone(), "running".to_string(), None, None))
+        );
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE owner = $1")
+            .bind(&owner)
+            .execute(&pool)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn keyless_writes_are_never_deduped() {
+        let pool = idem_test_pool().await;
+        let owner = format!("0xowner-{}", uuid::Uuid::new_v4());
+        // Two keyless (NULL) jobs for the same owner both persist — the partial
+        // unique index only constrains non-null keys.
+        for _ in 0..2 {
+            sqlx::query(
+                "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key) VALUES ($1, $2, 'ns', 'running', NULL)
+                 ON CONFLICT (owner, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING",
+            )
+            .bind(format!("remember-job-{}", uuid::Uuid::new_v4()))
+            .bind(&owner)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        let n: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM remember_jobs WHERE owner = $1")
+            .bind(&owner)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(n.0, 2, "keyless writes must not be collapsed");
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE owner = $1")
+            .bind(&owner)
+            .execute(&pool)
+            .await;
+    }
+
+    // GH #477 RC-5: a same-key retry of a FAILED job restarts it in place rather
+    // than pinning `failed` forever. This pins the reset SQL: it flips only a
+    // `failed` row (guarded by AND status='failed'), clearing blob columns/error.
+    #[tokio::test]
+    async fn failed_job_reset_flips_only_failed_no_blob_and_clears_state() {
+        let pool = idem_test_pool().await;
+        let owner = format!("0xowner-{}", uuid::Uuid::new_v4());
+        let key = "retry-key";
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+
+        // A failed job with NO blob (genuine pre-mint failure) + an error message.
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key, error_msg) VALUES ($1, $2, 'ns', 'failed', $3, 'boom')",
+        )
+        .bind(&job_id)
+        .bind(&owner)
+        .bind(key)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The handler's reset SQL: only a failed row with NO blob is restarted.
+        let reset = sqlx::query(
+            "UPDATE remember_jobs SET status = 'running', blob_object_id = NULL, error_msg = NULL, updated_at = NOW() WHERE id = $1 AND status = 'failed' AND blob_id IS NULL",
+        )
+        .bind(&job_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            reset.rows_affected(),
+            1,
+            "a failed no-blob row must be reset"
+        );
+
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT status, error_msg FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, "running");
+        assert_eq!(row.1, None, "error_msg cleared");
+
+        // Re-running on the now-`running` row is a no-op → no double-spawn.
+        let again = sqlx::query(
+            "UPDATE remember_jobs SET status = 'running' WHERE id = $1 AND status = 'failed' AND blob_id IS NULL",
+        )
+        .bind(&job_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            again.rows_affected(),
+            0,
+            "reset must not re-fire on a live row"
+        );
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE owner = $1")
+            .bind(&owner)
+            .execute(&pool)
+            .await;
+    }
+
+    // #3: a FAILED row that still carries a paid blob_id (marked failed by a
+    // recovery-handoff failure / stale sweeper) must NOT be reset+re-uploaded —
+    // doing so would discard the paid mint. The `AND blob_id IS NULL` guard makes
+    // the reset a no-op, so the blob is preserved.
+    #[tokio::test]
+    async fn failed_job_with_blob_is_not_reset() {
+        let pool = idem_test_pool().await;
+        let owner = format!("0xowner-{}", uuid::Uuid::new_v4());
+        let job_id = format!("remember-job-{}", uuid::Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key, blob_id, blob_object_id, error_msg) VALUES ($1, $2, 'ns', 'failed', 'k', 'blob-paid', '0xobj', 'handoff failed')",
+        )
+        .bind(&job_id)
+        .bind(&owner)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let reset = sqlx::query(
+            "UPDATE remember_jobs SET status = 'running', blob_object_id = NULL, error_msg = NULL, updated_at = NOW() WHERE id = $1 AND status = 'failed' AND blob_id IS NULL",
+        )
+        .bind(&job_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            reset.rows_affected(),
+            0,
+            "a failed row WITH a blob must not be reset"
+        );
+
+        // Blob state preserved for recovery.
+        let row: (Option<String>, Option<String>) =
+            sqlx::query_as("SELECT blob_id, blob_object_id FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0.as_deref(), Some("blob-paid"), "paid blob preserved");
+        assert_eq!(row.1.as_deref(), Some("0xobj"));
+
+        let _ = sqlx::query("DELETE FROM remember_jobs WHERE owner = $1")
+            .bind(&owner)
+            .execute(&pool)
+            .await;
+    }
 
     #[test]
     fn bulk_status_results_preserve_order_duplicates_and_missing_items() {

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -310,6 +310,21 @@ impl VectorDb {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 010: {}", e)))?;
 
+        // Durable idempotency, preparation, and paid-upload recovery state.
+        let migration_012 = include_str!("../../migrations/012_remember_write_idempotency.sql");
+        sqlx::raw_sql(migration_012)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 012: {}", e)))?;
+
+        // Build the owner/key uniqueness constraint without blocking writes.
+        let migration_013 =
+            include_str!("../../migrations/013_remember_write_idempotency_index.sql");
+        sqlx::raw_sql(migration_013)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 013: {}", e)))?;
+
         tracing::info!("database connected and migrations applied");
 
         Ok(Self { pool })

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 const SIDECAR_WALRUS_TIMEOUT: Duration = Duration::from_secs(300);
 const WALRUS_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
+const DURABLE_UPLOAD_PROTOCOL_VERSION: u32 = 3;
 
 /// Result of a Walrus blob upload
 pub struct UploadResult {
@@ -13,6 +14,38 @@ pub struct UploadResult {
     /// Sui object ID of the Blob object (hex, e.g. "0x...")
     #[allow(dead_code)]
     pub object_id: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparedRegisterTransaction {
+    pub transaction_bytes: String,
+    pub signature: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadExecutionIdentity {
+    pub chain_identifier: String,
+    pub walrus_package_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UploadJournal {
+    pub wallet_index: usize,
+    pub wallet_address: Option<String>,
+    pub execution_identity: Option<UploadExecutionIdentity>,
+    pub resume_step: Option<serde_json::Value>,
+    pub register_transaction: Option<PreparedRegisterTransaction>,
+}
+
+pub enum DurableUploadAdvance {
+    Prepared(UploadJournal),
+    Step {
+        journal: UploadJournal,
+        step: serde_json::Value,
+    },
 }
 
 #[derive(Debug)]
@@ -124,6 +157,42 @@ struct WalrusUploadErrorResponse {
     object_id: Option<String>,
     #[serde(default)]
     transfer_status: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DurableUploadRequest<'a> {
+    data: String,
+    key_index: usize,
+    job_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wallet_address: Option<&'a str>,
+    owner: &'a str,
+    namespace: &'a str,
+    package_id: &'a str,
+    upload_protocol_version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    upload_execution_identity: Option<&'a UploadExecutionIdentity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resume_step: Option<&'a serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    register_transaction: Option<&'a PreparedRegisterTransaction>,
+    epochs: u64,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DurableUploadResponse {
+    #[serde(default)]
+    register_transaction: Option<PreparedRegisterTransaction>,
+    #[serde(default)]
+    resume_step: Option<serde_json::Value>,
+    #[serde(default)]
+    wallet_address: Option<String>,
+    #[serde(default)]
+    upload_execution_identity: Option<UploadExecutionIdentity>,
+    #[serde(default)]
+    step: Option<serde_json::Value>,
 }
 
 #[derive(serde::Serialize)]
@@ -367,6 +436,76 @@ async fn upload_blob_inner(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub async fn advance_durable_upload(
+    client: &reqwest::Client,
+    sidecar_url: &str,
+    sidecar_secret: Option<&str>,
+    data: &[u8],
+    epochs: u64,
+    owner: &str,
+    namespace: &str,
+    package_id: &str,
+    job_id: &str,
+    journal: UploadJournal,
+) -> Result<DurableUploadAdvance, AppError> {
+    let url = format!("{}/walrus/upload-step-v3", sidecar_url);
+    let mut req = client.post(&url).json(&DurableUploadRequest {
+        data: BASE64.encode(data),
+        key_index: journal.wallet_index,
+        job_id,
+        wallet_address: journal.wallet_address.as_deref(),
+        owner,
+        namespace,
+        package_id,
+        upload_protocol_version: DURABLE_UPLOAD_PROTOCOL_VERSION,
+        upload_execution_identity: journal.execution_identity.as_ref(),
+        resume_step: journal.resume_step.as_ref(),
+        register_transaction: journal.register_transaction.as_ref(),
+        epochs,
+    });
+    if let Some(secret) = sidecar_secret {
+        req = req.header("authorization", format!("Bearer {}", secret));
+    }
+    let response = crate::observability::apply_request_id_header(req)
+        .timeout(SIDECAR_WALRUS_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("durable Walrus upload request failed: {}", e)))?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(AppError::Internal(format!(
+            "durable Walrus upload failed ({}): {}",
+            status, body
+        )));
+    }
+    let parsed: DurableUploadResponse = serde_json::from_str(&body).map_err(|e| {
+        AppError::Internal(format!("invalid durable Walrus upload response: {}", e))
+    })?;
+    let next = UploadJournal {
+        wallet_index: journal.wallet_index,
+        wallet_address: parsed.wallet_address.or(journal.wallet_address),
+        execution_identity: parsed
+            .upload_execution_identity
+            .or(journal.execution_identity),
+        resume_step: parsed.resume_step.or(journal.resume_step),
+        register_transaction: parsed.register_transaction.or(journal.register_transaction),
+    };
+    if let Some(step) = parsed.step {
+        Ok(DurableUploadAdvance::Step {
+            journal: next,
+            step,
+        })
+    } else if next.register_transaction.is_some() {
+        Ok(DurableUploadAdvance::Prepared(next))
+    } else {
+        Err(AppError::Internal(
+            "durable Walrus upload response contained neither step nor prepared transaction".into(),
+        ))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn set_metadata_batch(
     client: &reqwest::Client,
     sidecar_url: &str,
@@ -447,6 +586,89 @@ pub async fn set_metadata_batch(
         ))
     })?;
     Ok(result.transferred)
+}
+
+/// Blob a prior write minted for a remember job, discovered on-chain by the
+/// `memwal_job_id` tag (GH #477 crash-window reconciliation).
+pub struct FoundBlobByJob {
+    pub blob_id: String,
+    pub object_id: Option<String>,
+}
+
+/// Ask the sidecar whether `owner` already has a blob tagged with `job_id`.
+/// Used before re-uploading a `running` job that may have minted (and lost the
+/// record) so the relayer can adopt the blob instead of re-minting. `Ok(None)`
+/// means no such blob is visible yet (upload normally).
+pub async fn find_blob_by_job(
+    client: &reqwest::Client,
+    sidecar_url: &str,
+    sidecar_secret: Option<&str>,
+    owner: &str,
+    job_id: &str,
+) -> Result<Option<FoundBlobByJob>, AppError> {
+    let url = format!("{}/walrus/find-blob-by-job", sidecar_url);
+    let mut req = client.post(&url).json(&serde_json::json!({
+        "owner": owner,
+        "jobId": job_id,
+    }));
+    if let Some(secret) = sidecar_secret {
+        req = req.header("authorization", format!("Bearer {}", secret));
+    }
+    let req = crate::observability::apply_request_id_header(req);
+
+    let started = std::time::Instant::now();
+    // A read against the chain — bounded, not the long upload timeout.
+    let resp = req
+        .timeout(WALRUS_DOWNLOAD_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| {
+            crate::observability::observe_external(
+                "sidecar",
+                "walrus_find_blob_by_job",
+                "transport_error",
+                started.elapsed(),
+            );
+            crate::observability::record_sidecar_failure(
+                "walrus_find_blob_by_job",
+                "transport_error",
+            );
+            AppError::Internal(format!(
+                "Sidecar walrus/find-blob-by-job request failed: {}",
+                e
+            ))
+        })?;
+    let status_label = resp.status().as_u16().to_string();
+    crate::observability::observe_external(
+        "sidecar",
+        "walrus_find_blob_by_job",
+        &status_label,
+        started.elapsed(),
+    );
+    if !resp.status().is_success() {
+        crate::observability::record_sidecar_failure("walrus_find_blob_by_job", "http_error");
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Internal(format!(
+            "walrus find-blob-by-job failed: {}",
+            body
+        )));
+    }
+
+    #[derive(serde::Deserialize)]
+    struct FindBlobResp {
+        blob_id: Option<String>,
+        object_id: Option<String>,
+    }
+    let parsed: FindBlobResp = resp.json().await.map_err(|e| {
+        AppError::Internal(format!(
+            "Failed to parse walrus/find-blob-by-job response: {}",
+            e
+        ))
+    })?;
+    Ok(parsed.blob_id.map(|blob_id| FoundBlobByJob {
+        blob_id,
+        object_id: parsed.object_id,
+    }))
 }
 
 /// Query user's Walrus Blob objects from the Sui chain via sidecar.
@@ -885,5 +1107,104 @@ mod tests {
             aggregate_download_errors("blob", &errors),
             AppError::Internal(_)
         ));
+    }
+
+    // GH #477 reconcile client. The fail-closed contract is funds-critical: a
+    // sidecar error / 409-indeterminate must become Err (caller retries WITHOUT
+    // uploading), never Ok(None) (which would re-mint). Drive it against a local
+    // mock so each branch is pinned.
+    async fn mock_find_blob_server(
+        status: axum::http::StatusCode,
+        body: serde_json::Value,
+    ) -> (
+        String,
+        tokio::task::JoinHandle<()>,
+        std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+    ) {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let app = axum::Router::new().route(
+            "/walrus/find-blob-by-job",
+            axum::routing::post({
+                let seen = std::sync::Arc::clone(&seen);
+                move |axum::Json(req): axum::Json<serde_json::Value>| {
+                    let seen = std::sync::Arc::clone(&seen);
+                    let body = body.clone();
+                    async move {
+                        *seen.lock().unwrap() = Some(req);
+                        (status, axum::Json(body))
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{}", addr), handle, seen)
+    }
+
+    #[tokio::test]
+    async fn find_blob_by_job_returns_found() {
+        let (url, server, seen) = mock_find_blob_server(
+            axum::http::StatusCode::OK,
+            serde_json::json!({ "blob_id": "blob-x", "object_id": "0xobj" }),
+        )
+        .await;
+        let out = super::find_blob_by_job(&reqwest::Client::new(), &url, None, "0xowner", "job-1")
+            .await
+            .unwrap();
+        server.abort();
+        let found = out.expect("should be Some");
+        assert_eq!(found.blob_id, "blob-x");
+        assert_eq!(found.object_id.as_deref(), Some("0xobj"));
+        // request carried owner + jobId
+        let req = seen.lock().unwrap().clone().unwrap();
+        assert_eq!(req["owner"], "0xowner");
+        assert_eq!(req["jobId"], "job-1");
+    }
+
+    #[tokio::test]
+    async fn find_blob_by_job_null_is_none() {
+        let (url, server, _seen) = mock_find_blob_server(
+            axum::http::StatusCode::OK,
+            serde_json::json!({ "blob_id": null, "object_id": null }),
+        )
+        .await;
+        let out = super::find_blob_by_job(&reqwest::Client::new(), &url, None, "0xowner", "job-1")
+            .await
+            .unwrap();
+        server.abort();
+        assert!(out.is_none(), "blob_id:null → Ok(None) → upload normally");
+    }
+
+    #[tokio::test]
+    async fn find_blob_by_job_indeterminate_409_fails_closed() {
+        let (url, server, _seen) = mock_find_blob_server(
+            axum::http::StatusCode::CONFLICT,
+            serde_json::json!({ "error": "indeterminate", "indeterminate": true }),
+        )
+        .await;
+        let out =
+            super::find_blob_by_job(&reqwest::Client::new(), &url, None, "0xowner", "job-1").await;
+        server.abort();
+        assert!(
+            out.is_err(),
+            "409 indeterminate must be Err (fail closed), NEVER Ok(None)"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_blob_by_job_server_error_fails_closed() {
+        let (url, server, _seen) = mock_find_blob_server(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            serde_json::json!({ "error": "boom" }),
+        )
+        .await;
+        let out =
+            super::find_blob_by_job(&reqwest::Client::new(), &url, None, "0xowner", "job-1").await;
+        server.abort();
+        assert!(
+            out.is_err(),
+            "5xx must be Err (fail closed), never Ok(None)"
+        );
     }
 }

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -115,6 +115,12 @@ pub struct AppState {
     /// `Arc` so the `MemoryEngine` impl can share the same handle rather
     /// than duplicating the pool.
     pub db: Arc<VectorDb>,
+    /// Small dedicated pool used ONLY to hold a per-job `pg_advisory_lock`
+    /// across an upload job's guard-read → mint → persist critical section, so
+    /// two concurrent attempts of the same job can't both mint a paid blob. Kept
+    /// separate from `db` so that holding a connection for the (up to 5-minute)
+    /// upload duration never starves the request-serving pool.
+    pub wallet_lock_pool: sqlx::PgPool,
     /// Isolated old-V1 database. Present only when at least one tracked
     /// security-delete component is enabled.
     pub legacy_db: Option<Arc<crate::storage::legacy_db::LegacyDb>>,
@@ -858,6 +864,12 @@ pub struct RememberRequest {
     /// Namespace for memory isolation (default: "default")
     #[serde(default = "default_namespace")]
     pub namespace: String,
+    /// Optional client-supplied idempotency key. When set, a retry with the
+    /// same key (for the same owner) collapses onto the original job instead of
+    /// minting a new one — so an ambiguous timeout can't produce a duplicate
+    /// paid on-chain blob. Omit for the default (each request is independent).
+    #[serde(default)]
+    pub idempotency_key: Option<String>,
 }
 
 // ============================================================
@@ -1585,6 +1597,9 @@ pub enum AppError {
     RateLimited(String),
     /// Storage quota exceeded (HTTP 402)
     QuotaExceeded(String),
+    /// Request conflicts with existing state (HTTP 409) — e.g. an idempotency
+    /// key reused for a request with different content.
+    Conflict(String),
     /// upstream LLM/embedding provider returned a transient failure
     /// (gateway timeout / connection reset / "200 OK" wrapping an
     /// `{"error":{"code":504}}` envelope from OpenRouter). Maps to HTTP 503
@@ -1602,6 +1617,7 @@ impl std::fmt::Display for AppError {
             AppError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
             AppError::Internal(msg) => write!(f, "Internal Error: {}", msg),
             AppError::BlobNotFound(msg) => write!(f, "Blob Not Found: {}", msg),
+            AppError::Conflict(msg) => write!(f, "Conflict: {}", msg),
             AppError::RateLimited(msg) => write!(f, "Rate Limited: {}", msg),
             AppError::QuotaExceeded(msg) => write!(f, "Quota Exceeded: {}", msg),
             AppError::UpstreamUnavailable(msg) => write!(f, "Upstream Unavailable: {}", msg),
@@ -1632,6 +1648,7 @@ impl axum::response::IntoResponse for AppError {
                 )
             }
             AppError::BlobNotFound(msg) => (axum::http::StatusCode::NOT_FOUND, msg.clone()),
+            AppError::Conflict(msg) => (axum::http::StatusCode::CONFLICT, msg.clone()),
             AppError::RateLimited(msg) => (axum::http::StatusCode::TOO_MANY_REQUESTS, msg.clone()),
             AppError::QuotaExceeded(msg) => (axum::http::StatusCode::PAYMENT_REQUIRED, msg.clone()),
             AppError::UpstreamUnavailable(msg) => {
@@ -1666,6 +1683,7 @@ impl AppError {
             AppError::Unauthorized(_) => "unauthorized",
             AppError::Internal(_) => "internal",
             AppError::BlobNotFound(_) => "blob_not_found",
+            AppError::Conflict(_) => "conflict",
             AppError::RateLimited(_) => "rate_limited",
             AppError::QuotaExceeded(_) => "quota_exceeded",
             AppError::UpstreamUnavailable(_) => "upstream_unavailable",


### PR DESCRIPTION
---

## Summary

### Why

**The core hazard.** A `remember` write is accepted with a `202` and finished asynchronously by a
wallet job. Inside that job, `upload_blob` **mints a paid, irreversible on-chain Walrus blob** — it
spends gas and creates a unique blob object. Everything else in the job (the DB status row, the
vector index) is cheap and replayable; that one call is not. The job was written as if the whole body
were safe to re-run on retry, which is true for every step *except the mint*. So the underlying
defect is a single sentence: **a paid, irreversible external effect is treated like a replayable
step, and nothing makes "have we already minted?" and "mint" atomic.** Every finding below is a
concrete way that non-atomicity leaks into a second paid blob (or, for RC-4/RC-5, into a corrupt or
lost write).

**How a second mint is triggered — two independent doors.**

- **Client door (the reported bug, GH #477).** A write can outlive the client's ~45s confirmation
  window: the call returns failure, but the write still commits afterward. The client now can't
  distinguish a slow success from a real failure — **retry risks a duplicate paid blob; not retrying
  risks silent data loss.** There was no idempotency key, so a client retry was a *new, independent*
  job → a second mint.

- **Server door (sharpened by a commenter on the issue).** No user needs to be involved at all. The
  relayer's own Apalis retry loop re-runs the *entire* job — including `upload_blob` — on any
  retriable error, e.g. a transient DB blip on the step *after* a successful mint. With no guard
  checking the recorded `blob_id`/`status` before re-uploading, that internal retry mints again.

**Why the obvious fix ("add a guard before `upload_blob`") is not enough.** A guard that reads the
job row and skips the upload when a blob is already recorded closes the *simple serial* case — but a
guard is only as good as (a) the state it reads being *durably written*, (b) *no one else minting
concurrently*, and (c) the state it reads being *unambiguous*. Each of those turned out to be false
here, which is why the fix is five parts, not one:

| RC | The assumption that fails | Verifiable evidence | Consequence |
|----|---------------------------|---------------------|-------------|
| **RC-1** | "the job body runs once" | Apalis retries on any retriable `Err` (`MAX_ATTEMPTS=5`); the old code had no guard | retry re-mints — the reported bug |
| **RC-2** | "the status write after a mint always lands" | the `UPDATE status='uploaded'` was `let _ = …` (fire-and-forget); if it errors or the process dies, the row stays `running`/NULL | the guard on the next attempt reads no blob → **re-mints**. The record of an irreversible act was best-effort. |
| **RC-3** | "Apalis runs a job's attempts serially" | **false.** `WALLET_JOB_CONCURRENCY` = **8** workers; apalis `reenqueue_orphaned_after` = **300s** flips a `Running` job back to `Pending` on the *worker's* stale heartbeat (SQL: `WHERE status='Running' AND workers.last_seen < now-300s`) with **no check that the handler finished**; `upload_blob` can run up to **300s** | two attempts of the *same* job run at once, both read `running`/NULL, **both mint** (TOCTOU). The guard read and the mint were not mutually exclusive. |
| **RC-4** | "`uploaded` means ready to index" | `status='uploaded'` is written on **two** routes: full success, **and** the *metadata/transfer-failed* recovery path (blob minted, transfer still pending, a `SetMetadataAndTransfer` recovery enqueued) | a naive "uploaded → index and mark `done`" resume finalizes a blob **never transferred to the user** → a recallable memory the user doesn't own. (This is the regression a first-cut guard *introduced*.) |
| **RC-5** | "an idempotency key identifies a durable result" | a `(owner, key)` lookup returns any row, including `failed` | a same-key retry of a *failed* write collapses onto the dead row forever → the memory is **never written**. A failed attempt isn't a durable result. |

**Why the sidecar doesn't save us.** The Walrus sidecar journals its own multi-step write for
*resume* and dedups an *identical prepared transaction by digest* — but a server retry rebuilds
`upload_blob` from scratch (fresh encrypt/prepare → a **different** transaction digest), so the
sidecar treats it as a new write and mints again. Idempotency has to be enforced on our side.

**The deeper "why it was unhandled."** The `remember_jobs` row was a *reporting* artifact
(best-effort `let _ =` writes) rather than the *authoritative gate* for a paid action; and the
queue's at-least-once + orphan-reaper semantics were never reconciled with the need for an
at-most-once *mint*. The fix turns the row into the authoritative gate (durable, lock-guarded reads)
and adds the missing mutual exclusion.

*(Full trace with file:line and the empirical apalis/PG reproduction is in the methodology trail;
the runtime constants above — 8 / 300s / 300s / 10-conn pool / unpruned table — were read from source
and apalis-sql 0.7.4, not assumed.)*

### What

The client-facing capability (idempotency key, incl. RC-5) + the four internal safety fixes
(RC-1..RC-4), plus the pre-existing poll endpoint stated honestly.

**Client idempotency key (the reporter's ask #1):** optional `idempotency_key` on `RememberRequest`;
a `(owner, idempotency_key)` partial-unique index; lookup-before-insert + `ON CONFLICT DO NOTHING` +
lost-race re-read so a retry (or concurrent race) collapses onto **one** job and spawns exactly one
background write. A same-key retry of a *failed* job restarts it in place (RC-5) instead of pinning
`failed`.

**Definite-state poll (ask #2):** **already exists** — `GET /api/remember/:job_id` returns terminal
`done`(+blob_id) / `failed`(+error), and the SDK carries `job_id` on a 504. No code change; this PR
does not touch it. (The close-out reply should point the reporter at it.)

**Internal double-mint safety (RC-1..RC-4):**
- **Guard** `upload_resume_disposition` before the mint: `done` → no-op; `uploaded` + stored
  `blob_object_id` → resume transfer; else → upload.
- **Durable persist** `persist_uploaded_state`: the uploaded-state write is no longer fire-and-forget
  — a failure returns retriable so the guard always reads accurate state; also records
  `blob_object_id`.
- **Per-job advisory lock** `JobUploadLock` (`pg_try_advisory_lock` on a **dedicated small pool**):
  serializes concurrent attempts of the same job across guard→mint→persist; a contender **defers
  (retriable) without minting**. `lock_outcome` centralizes the "never mint without the lock" rule.
- **Transfer-aware resume** `build_resume_transfer_job`: an `uploaded`-but-pending retry re-enqueues
  the existing `SetMetadataAndTransfer` recovery (finish transfer, never re-mint, never premature
  `done`).

### Solution notes / design decisions

- **Advisory lock, not `SELECT … FOR UPDATE` / txn lock.** `upload_blob` can run up to 300s; holding
  a request-pool connection (or an open txn) across it would starve recall/status under a sidecar
  backlog. So the lock is `pg_try_advisory_lock` on a **dedicated** `wallet_lock_pool` (sized to
  `WALLET_JOB_CONCURRENCY`), reusing the existing `security_delete_background_sui` isolation pattern.
  A contender that can't get the lock returns retriable — it never blocks-and-holds.
- **`blob_object_id` column (migration 011).** Required so an `uploaded`-but-transfer-pending job can
  resume via `SetMetadataAndTransfer` (which needs the object id) without re-minting. It's an
  additive **metadata-only** column (nullable, no default) — cheaper/safer than the Part-2 index.
- **Privacy floor unaffected.** The key and `blob_object_id` are client-/system-owned identifiers on
  the job row (same trust tier as `owner`/`job_id`/`blob_id`) — no new server-readable plaintext
  *content* index.
- **Byte-identical for keyless clients.** `idempotency_key` is serde-default `None`; the whole
  idempotency block is skipped when absent, and the keyless INSERT is unconstrained.

---

## The failure sequences, step by step

The RC table above says *which* assumption fails; these timelines show *exactly how* each turns into
a second paid blob (or the RC-4 corruption). They're the concrete version of the same three cases.

**Sequence 1 — internal retry after a DB blip (RC-1 + RC-2).** Single worker, no client involved:

```
worker attempt #1:
  upload_blob() ─────────────► ✅ PAID BLOB MINTED (on-chain, irreversible)
  UPDATE status='uploaded'  ── (was `let _ =` — fire-and-forget)
        │
        ├─ if this UPDATE errors, OR the process dies here, the row stays
        │  status='running', blob_id=NULL
        ▼
  insert_vector_and_mark_remember_done() ── transient DB error → Err
  → Apalis retries the whole job (MAX_ATTEMPTS=5)

worker attempt #2 (old behavior):
  no guard → upload_blob() ──► ✅ SECOND PAID BLOB   ← the bug
```
Fix: RC-1 guard reads the row first; RC-2 makes the `uploaded` write durable (retriable on failure)
so attempt #2 reliably sees `uploaded`+`blob_id` and resumes instead of re-minting.

**Sequence 2 — concurrent re-dispatch (RC-3, the TOCTOU).** Two of the 8 workers, same job:

```
t0  worker A picks job J → guard SELECT → status='running', blob_id=NULL → proceed
t1  A enters upload_blob() … (slow: sidecar backlog, up to 300s)
t2  A's worker heartbeat goes stale (>300s); apalis reenqueue_orphaned flips J → Pending
t3  worker B picks J → guard SELECT → STILL status='running', blob_id=NULL → proceed
t4  A's upload_blob() ─► ✅ PAID BLOB #1
t5  B's upload_blob() ─► ✅ PAID BLOB #2       ← both mint; guard read was stale
```
Fix: RC-3 per-job `pg_try_advisory_lock` — B can't get the lock A holds, so B **defers (retriable)
without minting**. (Guard-read + mint + persist are all inside the lock.)

**Sequence 3 — the regression the naive fix introduced (RC-4).** An `uploaded` row is ambiguous:
Route A (full success, about to index) and Route B (mint OK, **transfer failed**, recovery pending)
both write `status='uploaded'`. A naive "uploaded → index and mark done" resume finalizes a Route-B
row → a recallable memory pointing at a blob **never transferred to the user**. Fix: RC-4 resumes an
`uploaded` row via `SetMetadataAndTransfer` (needs the new `blob_object_id`), never a bare finalize.

## `remember_jobs` state machine (after the fix)

```
 pending ─► running ─► uploaded ─► done
                │          │
                └► failed ◄┘         (failed carries error_msg; may retain blob_id/object_id)

guard (upload_resume_disposition) on entry to the upload job:
   done                       → no-op (Ok)                        [never re-mint]
   uploaded + blob_object_id  → resume SetMetadataAndTransfer      [never re-mint]
   uploaded + NULL object_id  → Upload (legacy row, under lock)
   running / pending / failed → Upload
   missing / lookup error     → Upload (fail-open, lock-guarded)

failed + same idempotency_key retry → reset row to running (clear blob cols/error), re-spawn once
```

## Per-commit walkthrough (dependency-ordered; each compiles)

1. **`88b808aa` feat(server): schema + wallet lock pool** — migrations `010`/`011`, `db.rs` wiring
   (`db.rs::new`), `RememberRequest.idempotency_key` (`types.rs`), `AppState.wallet_lock_pool`
   (`types.rs:120`) constructed in `main.rs:726-736` (sized to `WALLET_JOB_CONCURRENCY+1`). No
   behavior change yet.
2. **`f66f80ad` fix(server): idempotent upload** (`jobs.rs`) — the internals:
   - `upload_resume_disposition` (`jobs.rs:888`) — the guard (RC-1/RC-4 classification).
   - `JobUploadLock` (`:921`) + `lock_outcome` (`:963`) — RC-3 mutex + the never-mint-without-lock rule.
   - `persist_uploaded_state` (`:987`) — RC-2 durable persist (now `&PgPool`, returns retriable).
   - `build_resume_transfer_job` (`:1016`) / `resume_metadata_and_transfer` (`:1059`) — RC-4 resume.
   - `execute_upload_and_transfer` (`:1116`, outer: takes lock → calls inner → releases on all paths)
     wrapping `execute_upload_and_transfer_locked` (`:1183`, the guard+mint+persist body).
3. **`60d94b64` feat(remember): idempotency-key dedup** (`remember.rs`) — the `remember` handler
   (`:623`) idempotency block: pre-lookup (`find_remember_job_by_key` `:815`), failed-restart via
   `should_spawn_after_reset` (`:788`), `ON CONFLICT DO NOTHING` + lost-race re-read,
   `validate_idempotency_key` (`:796`).
4. **`906da1cf` test(server): live e2e script** — `tests/live_write_idempotency_check.py`.

## Types of Changes

- [ ] Breaking change (existing functionality would change)
- [x] New feature (non-breaking) — opt-in idempotency key
- [x] Bug fix (non-breaking) — the double-mint
- [ ] Performance optimization
- [ ] Refactor (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Test
- [ ] Security / permission-scope change

## Benchmark impact

- [x] No benchmark-affecting change (write/infra only)
- [ ] Benchmarked: LOCOMO + LongMemEval, gpt-4o judge, eval_runs=3, vs baseline
- Result: N/A
- [ ] Default-off / byte-identical when the flag is off

Write-path only. Recall/answer/extraction paths untouched. (The added advisory-lock acquire is a
per-upload-attempt DB op on a dedicated pool — not on the read path.)

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] `cargo test` / harness tests pass

**Two-layer strategy** (deliberate — the mint is an external on-chain effect that can't be asserted
in-process without a live chain, and we did not want a mock seam in the production upload path):

- **Layer 1 — decision unit tests (CI, Postgres-backed).** Each funds-critical decision is a small
  testable unit: `lock_outcome` (contended / pool-error → defer-retriable, free → proceed);
  `persist_uploaded_state` (stores object id; failure → retriable); `build_resume_transfer_job`
  (routes to `SetMetadataAndTransfer`, not an index/finalize); `should_spawn_after_reset`
  (exactly-once); `upload_resume_disposition` per state; `JobUploadLock` mutual-exclusion; the
  idempotency-collapse / keyless / failed-reset / validation tests.
- **Layer 2 — live e2e script** `tests/live_write_idempotency_check.py` (manual/staging, not CI):
  same-key → same job/blob, concurrent → one job, keyless → distinct, optional failed-key restart.

Run: `cargo test --bin memwal-server` against a live Postgres (`DATABASE_URL`, default
`postgresql://memwal:memwal_secret@localhost:5432/memwal`) — the DB-backed tests silently no-op
without one, so CI must provide it. Local run: **full suite 441 passed, 0 failed** (jobs 51, remember
16), build + clippy clean (no new lints vs the pre-existing lib/bin baseline).

**Layer-1 test → the regression it catches** (each would fail if the fix regressed — not a trivial
pass):

| Test (`jobs::tests` / `routes::remember::tests`) | Catches |
|---|---|
| `upload_resume_resumes_transfer_when_uploaded_with_object_id` | guard sending an `uploaded`+object_id job to re-upload (re-mint) or to a bare finalize |
| `upload_resume_reuploads_when_uploaded_without_object_id` | guard trying to resume a legacy NULL-object_id row it can't complete |
| `upload_resume_is_noop_when_already_done` / `..._uploads_for_pending_running_or_missing_blob` | guard skipping a real write, or re-minting a done job |
| `upload_lock_is_mutually_exclusive_per_job` | the advisory-lock primitive failing to serialize same-job attempts |
| `lock_outcome_defers_when_contended_and_fails_closed_on_error` | a contended/pool-error attempt being allowed to **mint** instead of deferring |
| `lock_outcome_proceeds_when_acquired` | a free lock wrongly blocking the legitimate attempt |
| `persist_uploaded_state_stores_object_id_and_is_retriable_on_failure` | reverting to fire-and-forget persist (RC-2 re-mint) or dropping the object_id write (breaks RC-4) |
| `resume_builds_a_set_metadata_and_transfer_job_with_object_id` | resume routing to an index/finalize instead of the transfer recovery (RC-4 premature-done) |
| `find_by_key_returns_existing_and_collapses_same_key_retry` | ON CONFLICT not deduping → a duplicate keyed job |
| `keyless_writes_are_never_deduped` | the partial index wrongly constraining keyless writes |
| `failed_job_reset_flips_only_failed_and_clears_state` | reset firing on a non-failed row, or not clearing stale blob/error |
| `spawn_only_when_reset_flipped_exactly_one_row` | a concurrent double-reset double-spawning (two paid writes) |
| `idempotency_key_{none,empty,over_max,at_max}` | unbounded / malformed key input |

**Honest coverage boundary:** the funds-critical *decision logic* is unit-tested (above); the *full
`execute_upload_and_transfer` / handler thread* is not exercised in-process (no test builds a full
`AppState`, and `upload_blob` is a hard-coded call — we deliberately avoided adding a mock seam to the
prod upload path), so the wiring between the tested decisions is verified by code review + Layer 2.
The *end-to-end* "no second paid blob" under a real crash / forced orphan-reenqueue is only observable
live — Layer 2 covers the client-visible half; injected-crash chaos is a follow-up, not in this PR.

## Checklist

- [x] Follows the project's commit + code conventions
- [x] No ticket IDs / competitor names / local-doc paths in code comments
- [x] Docs updated if needed (n/a in-repo; design/root-cause docs live in the methodology trail)
- [x] Respects the privacy floor (no new server-readable plaintext index)
- [x] All new and existing tests pass

## Related

- Closes #477
- Linear: WALM-320

## Additional Notes

**Migrations (2, both additive) — per-statement lock analysis:**

| Statement | Lock / cost | Notes |
|---|---|---|
| `010`: `ADD COLUMN idempotency_key TEXT` (nullable, no default) | metadata-only (PG 11+) | no table rewrite/scan |
| `010`: `CREATE UNIQUE INDEX … (owner, idempotency_key) WHERE … IS NOT NULL` | **`SHARE` lock — blocks INSERT/UPDATE/DELETE on `remember_jobs` for the build duration** | plain (non-`CONCURRENTLY`) build scans the table; `remember_jobs` is **unpruned/large** → a deploy-time **write stall on the whole remember path**. This is the one operational item to decide. |
| `011`: `ADD COLUMN blob_object_id TEXT` (nullable, no default) | metadata-only (PG 11+) | safe regardless of table size; no new index |

Both files are `IF NOT EXISTS`, re-runnable, and wired into `db.rs::new` (applied in order after
`009`). The `010` ON CONFLICT partial-index semantics were verified end-to-end with a live `psql`
probe (null-key coexist / same-`(owner,key)` no-op / cross-owner allowed). **Recommend `pg_dump`
before running against any shared/prod DB** (project rule).

Options for the `010` index on prod: (a) accept the brief write-stall if `remember_jobs` is small
enough; (b) build the index out-of-band with `CREATE UNIQUE INDEX CONCURRENTLY` **before** shipping
the app that assumes it (note `CONCURRENTLY` can't run inside a txn block). Needs a prod row count to
decide.

**Open decisions for reviewers / the team:**
1. **Deploy plan for the 010 index** — accept the brief write-lock, or pre-build `CONCURRENTLY`
   out-of-band? (Depends on prod `remember_jobs` size.)
2. **`remember_bulk` is intentionally NOT covered** — it inserts `remember_jobs` rows but takes no
   idempotency key. Out of scope for #477 (single-write ambiguous-timeout case); flag as a possible
   follow-up. Do not read this PR as protecting bulk.
3. **SDK** — the server accepts `idempotency_key` but the SDK doesn't send one yet; an SDK change to
   auto-generate/pass a key is a follow-up.

**Rollback:** additive schema + default-off request field → rollback = revert the app; the two
nullable columns can stay harmlessly.

**Commits (4, dependency-ordered, each compiles):** schema+pool plumbing → internal double-mint
safety (RC-1..4) → client idempotency key (+RC-5) → live e2e script.
