### PR TITLE
Fix: answer MCP initialize locally, connect relayer in background (#415)

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Answer the MCP `initialize` handshake locally and connect the relayer in the background, so a slow cold start no longer trips the client's 30s connection timeout and leaves the session with no memory tools. Tool discovery is served immediately and refreshed once the relayer is up; a hung relayer now degrades to a tool-call error instead of a failed startup. (#415)
 - Reload credentials after browser login without restarting the MCP client.
 - Reject stale handshakes and prevent request replay across account changes.
 - Report truncated restores and enforce the relayer's bounded restore limit.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,11 +6,14 @@
 
 - Human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login tool discovery, matching the remote relayer metadata used by Claude connectors.
 
+### Fixed
+
+- Answer the MCP `initialize` handshake locally and connect the relayer in the background, so a slow cold start no longer trips the client's 30s connection timeout and leaves the session with no memory tools. Tool discovery is served immediately and refreshed once the relayer is up; a hung relayer now degrades to a tool-call error instead of a failed startup. (#415)
+
 ## 0.0.7
 
 ### Fixed
 
-- Answer the MCP `initialize` handshake locally and connect the relayer in the background, so a slow cold start no longer trips the client's 30s connection timeout and leaves the session with no memory tools. Tool discovery is served immediately and refreshed once the relayer is up; a hung relayer now degrades to a tool-call error instead of a failed startup. (#415)
 - Reload credentials after browser login without restarting the MCP client.
 - Reject stale handshakes and prevent request replay across account changes.
 - Report truncated restores and enforce the relayer's bounded restore limit.

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -34,7 +34,15 @@ interface RpcMessage {
     error?: unknown;
 }
 
-const TOOL_DEFINITIONS = [
+/** The static memory-tool definitions served before a live relayer session
+ * exists. Exported so the bridge can serve the same list instantly at cold
+ * start (refreshed from the real upstream list once connected).
+ *
+ * MUST mirror the tools the relayer sidecar registers
+ * (services/server/scripts/mcp/tools/index.ts) so the cold-start list and the
+ * post-connect list advertise the same set — order and names matched to that
+ * registration (remember, remember_bulk, recall, analyze, restore, health). */
+export const TOOL_DEFINITIONS = [
     {
         name: "memwal_remember",
         title: "Remember a Fact",
@@ -48,6 +56,25 @@ const TOOL_DEFINITIONS = [
                 namespace: { type: "string" },
             },
             required: ["text"],
+            additionalProperties: false,
+        },
+    },
+    {
+        name: "memwal_remember_bulk",
+        description:
+            "Save multiple durable facts in one call. Use when you learned several distinct facts at once (onboarding details, a list of preferences, decisions from a discussion). Pass an array of complete fact statements (max 20) — do not summarize. Prefer this over repeated memwal_remember calls.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                facts: {
+                    type: "array",
+                    items: { type: "string", minLength: 1 },
+                    minItems: 1,
+                    maxItems: 20,
+                },
+                namespace: { type: "string" },
+            },
+            required: ["facts"],
             additionalProperties: false,
         },
     },
@@ -97,6 +124,16 @@ const TOOL_DEFINITIONS = [
                 limit: { type: "integer", minimum: 1, maximum: 100, default: 10 },
             },
             required: ["namespace"],
+            additionalProperties: false,
+        },
+    },
+    {
+        name: "memwal_health",
+        description:
+            "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
+        inputSchema: {
+            type: "object",
+            properties: {},
             additionalProperties: false,
         },
     },
@@ -339,7 +376,13 @@ function handleAuthLine(
             id,
             result: {
                 protocolVersion: "2024-11-05",
-                capabilities: { tools: { listChanged: false } },
+                // listChanged:true because the tool set DOES change after a
+                // mid-session login: the hot-handoff to the bridge emits
+                // `notifications/tools/list_changed`, and a client told
+                // `false` here would be entitled to ignore it and never pick up
+                // the real upstream tools (or `memwal_logout`). Advertise the
+                // capability the handoff depends on.
+                capabilities: { tools: { listChanged: true } },
                 serverInfo: { name: "memwal", version: "0.0.1" },
             },
         });

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -61,6 +61,8 @@ export const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_remember_bulk",
+        title: "Remember Several Facts",
+        annotations: { readOnlyHint: false, destructiveHint: false },
         description:
             "Save multiple durable facts in one call. Use when you learned several distinct facts at once (onboarding details, a list of preferences, decisions from a discussion). Pass an array of complete fact statements (max 20) — do not summarize. Prefer this over repeated memwal_remember calls.",
         inputSchema: {
@@ -129,6 +131,8 @@ export const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_health",
+        title: "Check Relayer Health",
+        annotations: { readOnlyHint: true, destructiveHint: false },
         description:
             "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
         inputSchema: {

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -42,6 +42,7 @@ export interface BridgeConfig {
  * agent calls it without). */
 const NAMESPACE_TOOLS = new Set([
     "memwal_remember",
+    "memwal_remember_bulk",
     "memwal_recall",
     "memwal_analyze",
     "memwal_restore",
@@ -146,7 +147,9 @@ const LOCAL_TOOL_NAMES = new Set(LOCAL_TOOL_DEFINITIONS.map((t) => t.name));
  * `LOCAL_TOOL_DEFINITIONS` blindly would advertise `memwal_login` twice. This
  * yields the SAME shape as the post-connect spliced list (upstream memory tools
  * + login + logout, each once), so the static→refreshed transition doesn't
- * change the tool set out from under the client. Refreshed via
+ * change the tool set out from under the client. OAuth-scoped sessions may
+ * over-advertise write tools until `tools/list_changed` refreshes from the
+ * relayer. Refreshed via
  * `tools/list_changed` once the relayer session is up. */
 const LOCAL_TOOLS_LIST = {
     tools: [
@@ -905,8 +908,14 @@ export async function runBridge(
             const purge = (msg: RpcMessage): void => {
                 if (msg.id == null) return; // notification — nothing to reply to
                 pendingListIds.delete(msg.id);
+                if (msg.method === "initialize") {
+                    // Already answered locally. Keep any suppress arm so a
+                    // queued upstream initialize reply is consumed, and record
+                    // closedOutIds so the pump drops it even if the arm is gone.
+                    closedOutIds.add(msg.id);
+                    return;
+                }
                 suppressUpstreamReplies.delete(msg.id);
-                if (msg.method === "initialize") return; // already answered locally
                 // A request can be in BOTH inFlight and pendingForward (cold-start
                 // dual-tracking), so guard against answering the same id twice.
                 if (closedOutIds.has(msg.id)) return;
@@ -1249,9 +1258,6 @@ export async function runBridge(
         });
     }
 
-    /** Fail whatever is still buffered when we give up connecting for good
-     * (stdin closed) — reply to open tool calls with an error envelope instead
-     * of leaving them to hang until the client's own timeout. Skips:
     /** Write the "relayer unavailable" reply for one open request, stop tracking
      * it, and never double-answer a locally-answered request. Shared by the
      * buffered (`failPendingForward`) and in-flight (`failInFlightRequests`)
@@ -1265,10 +1271,11 @@ export async function runBridge(
     function failRequest(msg: RpcMessage, reason: string): void {
         if (msg.id == null) return; // notification — nothing to answer
         if (msg.method === "initialize") {
-            // Locally answered already. Never write a second reply for this id;
-            // just stop tracking it (and clear any pending suppression).
+            // Locally answered already. Never write a second reply for this id.
+            // Keep any suppress arm and record closedOutIds so a late upstream
+            // initialize result is dropped by the pump.
             inFlight.delete(msg.id);
-            suppressUpstreamReplies.delete(msg.id);
+            closedOutIds.add(msg.id);
             return;
         }
         inFlight.delete(msg.id);
@@ -1329,11 +1336,37 @@ export async function runBridge(
     // connect, the client's own per-tool timeout fires (graceful) — and on
     // shutdown `failPendingForward` closes out anything still open. `initialize`
     // is answered locally, so it never blocks and is only forwarded, not failed.
+    // First connect stays on `openSseStream` + `flushPendingForward` so a
+    // flush-time 404 still goes through the existing reconnect/replay path.
+    // It must NOT publish if login already owns `sse`, or if the handshake
+    // finished after `credentialGeneration` moved — that was the double-flush.
     const connectInBackground = (async () => {
         let attempt = 0;
         while (!stdinClosed) {
+            if (reconnectPromise) {
+                await reconnectPromise;
+                continue;
+            }
+            if (sse) {
+                signalFirstConnect();
+                const notifications = pendingForward.filter((m) => m.id == null);
+                pendingForward.length = 0;
+                pendingForward.push(...notifications);
+                await flushPendingForward();
+                return;
+            }
+            const openingGeneration = credentialGeneration;
             try {
-                sse = await openSseStream(creds.relayerUrl, creds);
+                const candidate = await openSseStream(creds.relayerUrl, creds);
+                if (stdinClosed) {
+                    candidate.abort();
+                    break;
+                }
+                if (openingGeneration !== credentialGeneration || sse) {
+                    candidate.abort();
+                    continue;
+                }
+                sse = candidate;
                 note(`Connected. Bridging stdio MCP ↔ ${creds.relayerUrl}`);
                 log.info("bridge.connected", { relayer: creds.relayerUrl });
                 signalFirstConnect();
@@ -1345,10 +1378,6 @@ export async function runBridge(
                 log.error("bridge.initial_connect_failed", { err: reason, attempt });
                 if (stdinClosed) break;
                 const backoff = Math.min(15_000, 500 * Math.pow(2, attempt - 1));
-                // Sleep, but wake immediately if stdin closes mid-backoff so we
-                // don't hold the process open for up to 15s after shutdown. The
-                // timer is unref'd for the same reason (cf. the connect timer /
-                // idle watchdog).
                 await new Promise<void>((resolve) => {
                     const timer = setTimeout(() => {
                         unregister();
@@ -1362,9 +1391,6 @@ export async function runBridge(
                 });
             }
         }
-        // stdin closed before we ever connected — unblock serverPump so the race
-        // can settle, and close out anything still buffered (open tool calls get
-        // an error envelope instead of hanging; initialize/notifications skipped).
         signalFirstConnect();
         failPendingForward("connection not established before shutdown");
     })();

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -16,7 +16,8 @@
  */
 import type { MemWalCredentials } from "./auth.js";
 import { clearCreds, credsPath } from "./auth.js";
-import { ensureCompatibleRelayer } from "./compatibility.js";
+import { TOOL_DEFINITIONS } from "./auth-required.js";
+import { ensureCompatibleRelayer, resolveConnectTimeoutMs } from "./compatibility.js";
 import { loginFlow } from "./login.js";
 import { log, note } from "./logger.js";
 
@@ -101,6 +102,59 @@ const LOCAL_TOOL_DEFINITIONS = [
     },
 ];
 
+/** Protocol versions this local `initialize` responder can speak. We echo the
+ * client's requested version when it's one of these, else fall back to our
+ * baseline — the same negotiation shape a real MCP server does. */
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(["2024-11-05", "2025-03-26", "2025-06-18"]);
+const FALLBACK_PROTOCOL_VERSION = "2024-11-05";
+
+/** Build the `initialize` result we answer LOCALLY and instantly, before the
+ * relayer session is up. Echoes the client's requested protocolVersion when we
+ * support it (otherwise the baseline) instead of hard-coding one and ignoring
+ * the request. `tools.listChanged: true` is a deliberate difference from
+ * auth-required mode: the bridge serves a static `tools/list` at cold start and
+ * then emits `notifications/tools/list_changed` once the background relayer
+ * connect completes, so the client re-lists and picks up the real upstream tool
+ * set. Advertising `listChanged: false` (as auth-required does, since it never
+ * refreshes) would let a client ignore that notification. */
+function buildLocalInitializeResult(params: unknown): {
+    protocolVersion: string;
+    capabilities: { tools: { listChanged: boolean } };
+    serverInfo: { name: string; version: string };
+} {
+    const requested = (params as { protocolVersion?: unknown } | undefined)?.protocolVersion;
+    const protocolVersion =
+        typeof requested === "string" && SUPPORTED_PROTOCOL_VERSIONS.has(requested)
+            ? requested
+            : FALLBACK_PROTOCOL_VERSION;
+    return {
+        protocolVersion,
+        capabilities: { tools: { listChanged: true } },
+        serverInfo: { name: "memwal", version: "0.0.1" },
+    };
+}
+
+/** Names of the tools we serve locally, so we can de-dup them out of the
+ * imported memory-tool list (which already carries its own `memwal_login`
+ * entry) before appending our canonical definitions. */
+const LOCAL_TOOL_NAMES = new Set(LOCAL_TOOL_DEFINITIONS.map((t) => t.name));
+
+/** The `tools/list` we serve LOCALLY at cold start: the memory tools (from the
+ * same source as auth-required mode) plus the locally-handled login/logout
+ * tools. We strip any locally-served name from the imported list first —
+ * `TOOL_DEFINITIONS` bundles its own `memwal_login`, and concatenating
+ * `LOCAL_TOOL_DEFINITIONS` blindly would advertise `memwal_login` twice. This
+ * yields the SAME shape as the post-connect spliced list (upstream memory tools
+ * + login + logout, each once), so the static→refreshed transition doesn't
+ * change the tool set out from under the client. Refreshed via
+ * `tools/list_changed` once the relayer session is up. */
+const LOCAL_TOOLS_LIST = {
+    tools: [
+        ...TOOL_DEFINITIONS.filter((t) => !LOCAL_TOOL_NAMES.has(t.name)),
+        ...LOCAL_TOOL_DEFINITIONS,
+    ],
+};
+
 const LOGIN_BG_TIMEOUT_MS = 5 * 60_000;
 const URL_READY_TIMEOUT_MS = 5_000;
 
@@ -149,22 +203,65 @@ async function openSseStream(
     relayerUrl: string,
     creds: MemWalCredentials,
 ): Promise<SseHandshakeResult> {
-    await ensureCompatibleRelayer(relayerUrl);
+    const connectTimeoutMs = resolveConnectTimeoutMs();
+    // One shared budget for the WHOLE attempt: the compatibility check (GET
+    // /version + /health fallback) and the SSE connect below both honour this
+    // single deadline, so an attempt is bounded by connectTimeoutMs in total
+    // rather than each step getting its own (which could sum to 2–3×).
+    const budgetSignal = AbortSignal.timeout(connectTimeoutMs);
+    await ensureCompatibleRelayer(relayerUrl, budgetSignal);
 
     const url = `${relayerUrl.replace(/\/+$/, "")}/api/mcp/sse`;
     const controller = new AbortController();
 
-    const resp = await fetch(url, {
-        method: "GET",
-        headers: {
-            ...mcpAuthHeaders(creds),
-            accept: "text/event-stream",
-            "cache-control": "no-cache",
-        },
-        signal: controller.signal,
-    });
+    // Bound the INITIAL connect (headers + the wait-for-`endpoint`-event loop
+    // below) on the SAME shared budget as the compat check above, so a hung
+    // relayer aborts well before the MCP client's ~30s timeout and one attempt
+    // never exceeds connectTimeoutMs total. This is distinct from the idle
+    // watchdog, which only bounds silence AFTER the stream is up. When the
+    // budget fires we abort `controller` (so the in-flight fetch/read unwinds);
+    // we detach the listener the instant the endpoint resolves — past that
+    // point the idle watchdog owns liveness and this must never fire, or it
+    // would tear down a healthy stream.
+    let connectTimedOut = false;
+    const onBudgetExpired = (): void => {
+        if (!controller.signal.aborted) {
+            connectTimedOut = true;
+            log.warn("bridge.connect_timeout", { url, timeoutMs: connectTimeoutMs });
+            controller.abort();
+        }
+    };
+    // If the compat check already burned the whole budget, `budgetSignal` is
+    // already aborted — fire synchronously so we don't even attempt the SSE GET.
+    if (budgetSignal.aborted) onBudgetExpired();
+    else budgetSignal.addEventListener("abort", onBudgetExpired, { once: true });
+    const clearConnectTimer = (): void =>
+        budgetSignal.removeEventListener("abort", onBudgetExpired);
+
+    let resp: Response;
+    try {
+        resp = await fetch(url, {
+            method: "GET",
+            headers: {
+                ...mcpAuthHeaders(creds),
+                accept: "text/event-stream",
+                "cache-control": "no-cache",
+            },
+            signal: controller.signal,
+        });
+    } catch (err) {
+        clearConnectTimer();
+        if (connectTimedOut) {
+            throw new Error(
+                `Walrus Memory relayer SSE connect timed out after ${connectTimeoutMs}ms ` +
+                    `(${url}). The relayer may be slow, cold-starting, or unreachable.`
+            );
+        }
+        throw err;
+    }
 
     if (resp.status === 401) {
+        clearConnectTimer();
         controller.abort();
         log.warn("bridge.unauthorized", { url });
         // DO NOT wipe creds here. A 401 from the relayer is *evidence* of
@@ -184,6 +281,7 @@ async function openSseStream(
         );
     }
     if (!resp.ok || !resp.body) {
+        clearConnectTimer();
         const body = resp.body ? await resp.text() : "";
         controller.abort();
         throw new Error(
@@ -193,6 +291,7 @@ async function openSseStream(
 
     const ct = resp.headers.get("content-type") ?? "";
     if (!ct.includes("event-stream")) {
+        clearConnectTimer();
         controller.abort();
         throw new Error(
             `Walrus Memory relayer returned unexpected content-type "${ct}" for SSE endpoint`
@@ -306,13 +405,26 @@ async function openSseStream(
     // Wait for the `endpoint` event (or first message) before returning.
     while (!endpointResolved) {
         if (streamEnded) {
+            clearConnectTimer();
             controller.abort();
+            if (connectTimedOut) {
+                throw new Error(
+                    `Walrus Memory relayer SSE connect timed out after ${connectTimeoutMs}ms ` +
+                        `(${url}) waiting for the endpoint event. The relayer may be slow, ` +
+                        `cold-starting, or unreachable.`
+                );
+            }
             throw new Error(
                 `Walrus Memory relayer SSE handshake ended before endpoint event${streamError ? `: ${streamError}` : ""}`
             );
         }
         await new Promise<void>((r) => (queueResolver = r));
     }
+
+    // Endpoint resolved — the stream is up. Hand liveness over to the idle
+    // watchdog and disarm the connect timer so it can never abort a healthy
+    // stream.
+    clearConnectTimer();
 
     const iter: AsyncIterator<RpcMessage> = {
         async next(): Promise<IteratorResult<RpcMessage>> {
@@ -513,15 +625,112 @@ export async function runBridge(
     });
 
     // Live handle to the current SSE stream — replaced whenever we reconnect.
-    let sse = await openSseStream(creds.relayerUrl, creds);
-    note(`Connected. Bridging stdio MCP ↔ ${creds.relayerUrl}`);
-    log.info("bridge.connected", { relayer: creds.relayerUrl });
+    // Starts null: we answer `initialize` / `tools/list` LOCALLY and wire stdin
+    // BEFORE the relayer session exists, so the MCP client's handshake never
+    // waits on a (possibly slow / cold) relayer round-trip. The connect runs in
+    // the background; anything that must reach the relayer (`tools/call`) is
+    // buffered in `pendingForward` until `sse` is live, then flushed.
+    let sse: SseHandshakeResult | null = null;
 
     let stdinClosed = false;
     let reconnectAttempt = 0;
     let reconnectPromise: Promise<void> | null = null;
     let credentialGeneration = 0;
     let activeCredentialGeneration = 0;
+
+    /** Callbacks to run once, the moment stdin closes — used to wake anything
+     * parked on a timer (e.g. the connect-retry backoff) so shutdown is prompt
+     * instead of waiting out the timer. `markStdinClosed` is the single writer
+     * of `stdinClosed`; call it instead of assigning the flag directly. */
+    const stdinCloseListeners = new Set<() => void>();
+    /** Register a shutdown callback. Returns an unregister fn so a caller that
+     * only cares about shutdown *while it's parked* (e.g. one backoff sleep) can
+     * detach when it wakes normally — otherwise the set would grow one stale
+     * closure per retry for the whole session. Fires immediately if already
+     * closed (unregister is then a no-op). */
+    function onStdinClose(fn: () => void): () => void {
+        if (stdinClosed) {
+            fn();
+            return () => {};
+        }
+        stdinCloseListeners.add(fn);
+        return () => stdinCloseListeners.delete(fn);
+    }
+    function markStdinClosed(): void {
+        if (stdinClosed) return;
+        stdinClosed = true;
+        for (const fn of stdinCloseListeners) {
+            try {
+                fn();
+            } catch {
+                /* listener failure must not block shutdown */
+            }
+        }
+        stdinCloseListeners.clear();
+    }
+
+    /** Requests that arrived before the relayer session came up. Held here and
+     * flushed in order once `sse` is live. `tools/call` (and any other request
+     * that must reach the relayer) lands here; `tools/list` and
+     * `memwal_login|logout` are answered locally and never buffered. `initialize`
+     * IS buffered (to forward upstream for capability negotiation) but is never
+     * failed back — `failRequest` skips `method === "initialize"`. */
+    const pendingForward: RpcMessage[] = [];
+
+    /** True while `flushPendingForward` is draining the buffer after the first
+     * connect. New stdin requests that arrive mid-drain must keep buffering
+     * rather than posting directly, or they'd overtake still-queued items and
+     * break arrival order. */
+    let flushing = false;
+
+    /** Resolves the first time the SSE stream is up (or when stdin closes before
+     * that ever happens). `serverPump` waits on this before reading from
+     * `sse.iter`; after it resolves, `sse` is either a live handle or null
+     * (stdin closed) — the pump loop guards on both. Idempotent. */
+    let signalFirstConnect: () => void = () => {};
+    let firstConnectSignaled = false;
+    const firstConnect = new Promise<void>((r) => {
+        signalFirstConnect = () => {
+            if (firstConnectSignaled) return;
+            firstConnectSignaled = true;
+            r();
+        };
+    });
+
+    /** Expected-suppression COUNT per id, for requests we answered locally but
+     * still forwarded upstream (currently just `initialize`, so the relayer
+     * session negotiates capabilities). The upstream reply must be dropped in
+     * the pump — the client already has our local reply, and a second response
+     * for the same id corrupts its JSON-RPC state.
+     *
+     * A count (not a bare Set) so suppression is EXACT and self-limiting: we
+     * expect exactly one upstream reply per forward, so we increment on each
+     * forward (initial + every reconnect replay) and decrement on each dropped
+     * reply, removing the id at zero. Once the initialize replies are all
+     * consumed, the id stops suppressing — so a client that later REUSES the
+     * initialize id for a real request gets that request's genuine reply
+     * (result OR error) through, instead of it being swallowed forever. */
+    const suppressUpstreamReplies = new Map<string | number, number>();
+
+    /** IDs we've already answered with a shutdown "unavailable" envelope
+     * (`failRequest`). If a late upstream reply for one of these still arrives —
+     * e.g. a flush-404 reconnect re-posted the request onto a live session that
+     * answers just as we were closing out at shutdown — the pump must DROP it,
+     * or the client would get two responses for one id. */
+    const closedOutIds = new Set<string | number>();
+
+    const expectSuppressedReply = (id: string | number): void => {
+        suppressUpstreamReplies.set(id, (suppressUpstreamReplies.get(id) ?? 0) + 1);
+    };
+    /** Consume one expected suppression for `id`. Returns true if the reply
+     * should be dropped (an outstanding local-answer suppression existed). */
+    const consumeSuppressedReply = (id: string | number): boolean => {
+        const n = suppressUpstreamReplies.get(id);
+        if (!n) return false;
+        if (n <= 1) suppressUpstreamReplies.delete(id);
+        else suppressUpstreamReplies.set(id, n - 1);
+        return true;
+    };
 
     // In-flight requests pending a response. We replay them after a forced
     // reconnect so a server-side session swap doesn't strand a tool call
@@ -535,16 +744,22 @@ export async function runBridge(
      * client surfaces them in its tool palette. */
     const pendingListIds = new Set<string | number>();
 
+    /** Reopen the SSE stream and replay outstanding `inFlight` requests against
+     * the fresh session. All callers await the SAME reconnect via
+     * `reconnectPromise` — returning immediately while one is active would let
+     * the server pump spin on the aborted stream and let client messages race
+     * the stale POST URL. Any reconnect replays the WHOLE `inFlight` map, so
+     * callers must treat every id-bearing request as reconnect-owned and never
+     * re-post it themselves. `immediate` skips the backoff (used right after a
+     * login credential swap). Credential-generation checks discard a session
+     * whose key rotated mid-handshake. */
     async function reconnect(reason: string, immediate = false): Promise<void> {
         if (stdinClosed) return;
-        // All callers await the same reconnect. Returning immediately while a
-        // reconnect is active lets the server pump spin on the aborted stream
-        // and lets client messages race the stale POST URL.
         if (reconnectPromise) return reconnectPromise;
 
         reconnectPromise = (async () => {
             try {
-                sse.abort();
+                sse?.abort();
             } catch {
                 /* already dead */
             }
@@ -557,7 +772,22 @@ export async function runBridge(
                 backoffMs: backoff,
                 attempt: reconnectAttempt,
             });
-            if (backoff > 0) await new Promise((r) => setTimeout(r, backoff));
+            // Sleep, but wake immediately on stdin close so shutdown isn't held
+            // up for the whole backoff; unref'd so the timer never keeps the
+            // event loop alive on its own (mirrors the connect-retry backoff).
+            if (backoff > 0) {
+                await new Promise<void>((resolve) => {
+                    const timer = setTimeout(() => {
+                        unregister();
+                        resolve();
+                    }, backoff);
+                    timer.unref?.();
+                    const unregister = onStdinClose(() => {
+                        clearTimeout(timer);
+                        resolve();
+                    });
+                });
+            }
             try {
                 while (!stdinClosed) {
                     const openingGeneration = credentialGeneration;
@@ -593,6 +823,19 @@ export async function runBridge(
                     // start arriving on the new session.
                     for (const [id, msg] of Array.from(inFlight.entries())) {
                         try {
+                            // A replayed `initialize` produces a fresh upstream
+                            // reply on the NEW session that must also be dropped.
+                            // REPLACE (not stack) any pending suppression for this
+                            // id: the old session was aborted, so its initialize
+                            // reply will never arrive to consume its own arm.
+                            // Re-arming without clearing would leave that orphaned
+                            // arm forever, and a later reused id would have its
+                            // real reply wrongly dropped. Reset to exactly one —
+                            // the single reply the new session will send.
+                            if (msg.method === "initialize" && msg.id != null) {
+                                suppressUpstreamReplies.delete(msg.id);
+                                expectSuppressedReply(msg.id);
+                            }
                             const status = await postMessage(sse.postUrl, msg, openingCreds);
                             log.info("bridge.replayed", { id, status });
                         } catch (err) {
@@ -607,6 +850,17 @@ export async function runBridge(
                     // it passed the first generation check.
                     if (openingGeneration !== credentialGeneration) {
                         candidate.abort();
+                        // The replay above armed one initialize suppression for
+                        // THIS (now-discarded) candidate; its reply will never
+                        // arrive to consume it. Clear those arms so the count
+                        // doesn't leak if the loop exits before another replay
+                        // re-arms (a leaked arm would swallow a later reused-id
+                        // reply). A surviving candidate re-arms fresh next pass.
+                        for (const [, msg] of inFlight) {
+                            if (msg.method === "initialize" && msg.id != null) {
+                                suppressUpstreamReplies.delete(msg.id);
+                            }
+                        }
                         continue;
                     }
                     break;
@@ -635,23 +889,44 @@ export async function runBridge(
         // operations belong in the newly-selected account.
         if (accountChanged) {
             try {
-                sse.abort();
+                sse?.abort();
             } catch {
                 /* already dead */
             }
-            for (const [id] of Array.from(inFlight.entries())) {
+            // Purge EVERY structure that holds an account-A request. `inFlight`
+            // (tracked requests) AND `pendingForward` (cold-start / mid-flush
+            // buffered requests) — the latter is unique to the cold-start path
+            // and would otherwise be flushed to account B's session (a
+            // cross-account replay) since the flush posts with the current
+            // `creds`. For each, reply once with a retryable error and stop
+            // tracking; never write a second reply for a locally-answered
+            // `initialize`, and clear its suppression arm so a reused id later
+            // isn't silently swallowed.
+            const purge = (msg: RpcMessage): void => {
+                if (msg.id == null) return; // notification — nothing to reply to
+                pendingListIds.delete(msg.id);
+                suppressUpstreamReplies.delete(msg.id);
+                if (msg.method === "initialize") return; // already answered locally
+                // A request can be in BOTH inFlight and pendingForward (cold-start
+                // dual-tracking), so guard against answering the same id twice.
+                if (closedOutIds.has(msg.id)) return;
+                // Record the id so a late reply for it (e.g. one already
+                // in-flight on the aborted session, or a racing replay) is
+                // dropped by the pump rather than becoming a second response.
+                closedOutIds.add(msg.id);
                 writeStdoutMessage({
                     jsonrpc: "2.0",
-                    id,
+                    id: msg.id,
                     error: {
                         code: -32001,
                         message:
                             "Walrus Memory account changed during login; retry this request for the new account",
                     },
                 });
-                pendingListIds.delete(id);
-            }
+            };
+            for (const [, msg] of Array.from(inFlight.entries())) purge(msg);
             inFlight.clear();
+            for (const msg of pendingForward.splice(0, pendingForward.length)) purge(msg);
         }
 
         creds = nextCreds;
@@ -673,11 +948,57 @@ export async function runBridge(
     // Server → client: stream SSE messages to stdout. Loop forever, restart
     // pump on stream end (which means SSE got cut → we already reconnected).
     const serverPump = (async () => {
+        // Nothing to pump until the first relayer session is up. `firstConnect`
+        // resolves only on a SUCCESSFUL connect (the background connector
+        // retries failures with backoff), unless stdin closed first — in which
+        // case `sse` stays null and we exit the loop immediately.
+        await firstConnect;
         while (!stdinClosed) {
             try {
+                // Snapshot the current stream. `sse` is non-null here: set before
+                // signalFirstConnect(), and reconnect() only ever replaces it with
+                // another live handle. Reading through a local keeps us on one
+                // stream for the duration of this drain; a reconnect swaps `sse`
+                // and we pick up the new handle on the next outer iteration.
+                // Cast: TS control-flow narrows `sse` to `null` in the outer
+                // scope because every non-null assignment happens inside a
+                // sibling closure (connectInBackground / reconnect) that TS
+                // analyzes independently. At runtime `sse` is a live handle here.
+                const stream = sse as SseHandshakeResult | null;
+                if (!stream) break; // stdin closed before we ever connected
                 while (true) {
-                    const { value, done } = await sse.iter.next();
+                    const { value, done } = await stream.iter.next();
                     if (done) break;
+                    // Drop the upstream reply to a request we already answered
+                    // locally (e.g. `initialize`). Writing it would be a second
+                    // response for the same id. We consume exactly ONE expected
+                    // suppression per id (see suppressUpstreamReplies), so once
+                    // the initialize reply(s) are drained the id stops
+                    // suppressing — a client that later reuses that id for a real
+                    // request still gets THAT request's reply (result or error).
+                    if (
+                        value &&
+                        value.id !== undefined &&
+                        value.id !== null &&
+                        (value.result !== undefined || value.error !== undefined) &&
+                        consumeSuppressedReply(value.id)
+                    ) {
+                        inFlight.delete(value.id);
+                        continue;
+                    }
+                    // Drop a late reply for an id we already closed out at
+                    // shutdown — writing it would be a second response for that
+                    // id (see closedOutIds / failRequest).
+                    if (
+                        value &&
+                        value.id !== undefined &&
+                        value.id !== null &&
+                        (value.result !== undefined || value.error !== undefined) &&
+                        closedOutIds.has(value.id)
+                    ) {
+                        inFlight.delete(value.id);
+                        continue;
+                    }
                     // Clear in-flight tracking once the response lands.
                     if (
                         value &&
@@ -701,7 +1022,14 @@ export async function runBridge(
                         pendingListIds.delete(value.id);
                         const result = value.result as { tools?: unknown };
                         if (Array.isArray(result.tools)) {
-                            result.tools = [...result.tools, ...LOCAL_TOOL_DEFINITIONS];
+                            // Strip any locally-served name from the upstream set
+                            // before appending ours, so a relayer that ever
+                            // advertises login/logout itself can't produce a
+                            // duplicate tool name. Mirrors LOCAL_TOOLS_LIST.
+                            const upstream = (result.tools as { name?: string }[]).filter(
+                                (t) => !LOCAL_TOOL_NAMES.has(t.name ?? ""),
+                            );
+                            result.tools = [...upstream, ...LOCAL_TOOL_DEFINITIONS];
                         }
                     }
                     writeStdoutMessage(value);
@@ -712,7 +1040,13 @@ export async function runBridge(
                 });
             }
             if (stdinClosed) break;
-            // Stream ended unexpectedly — reconnect and resume.
+            // Stream ended. If a reconnect is ALREADY in progress (e.g. the
+            // flush hit a 404), await THAT one rather than hammering reconnect()
+            // — otherwise this loop would spin on the dead stream's immediate
+            // `done`. reconnect() itself returns the shared reconnectPromise when
+            // one is active, so awaiting it here is enough; on the next
+            // iteration `sse` has been swapped to the fresh session and we
+            // resume reading. If no reconnect is in progress, this starts one.
             await reconnect("server-pump-eof");
         }
     })();
@@ -724,6 +1058,36 @@ export async function runBridge(
         void (async () => {
             try {
                 const msg = JSON.parse(line) as RpcMessage;
+
+                // Answer `initialize` LOCALLY and instantly so the MCP client's
+                // handshake never waits on the relayer connect (the cold-start
+                // bug). We STILL forward it upstream (below) so the relayer
+                // session negotiates capabilities — but suppress that upstream
+                // reply, since the client already has this one.
+                if (msg.method === "initialize" && msg.id != null) {
+                    writeStdoutMessage({
+                        jsonrpc: "2.0",
+                        id: msg.id,
+                        result: buildLocalInitializeResult(msg.params),
+                    });
+                    // Expect exactly one upstream reply to drop for this forward.
+                    expectSuppressedReply(msg.id);
+                    // Fall through: forward/buffer the initialize upstream too.
+                }
+
+                // Answer `tools/list` LOCALLY at cold start (before the relayer
+                // session exists) so tool discovery unblocks immediately. Once
+                // connected we emit `notifications/tools/list_changed` and the
+                // client re-lists — that re-list is forwarded upstream and gets
+                // the real tool set spliced (handled further down + in the pump).
+                if (msg.method === "tools/list" && msg.id != null && sse === null) {
+                    writeStdoutMessage({
+                        jsonrpc: "2.0",
+                        id: msg.id,
+                        result: LOCAL_TOOLS_LIST,
+                    });
+                    return;
+                }
 
                 // Local interception: `memwal_login` and `memwal_logout`
                 // are handled here, never sent to the relayer. The user
@@ -778,6 +1142,20 @@ export async function runBridge(
                 ) {
                     inFlight.set(msg.id, msg);
                 }
+                // Relayer session not up yet, OR the post-connect flush is still
+                // draining — buffer so this request stays behind everything that
+                // arrived before it (posting directly here would let it overtake
+                // a still-queued buffered item). The flush (or the next connect)
+                // forwards it in order. Dropping it would strand the request.
+                if (sse === null || flushing) {
+                    pendingForward.push(msg);
+                    log.info("bridge.buffered_pre_connect", {
+                        method: msg.method,
+                        id: msg.id ?? null,
+                    });
+                    return;
+                }
+
                 // A successful background login swaps credentials and SSE
                 // sessions asynchronously. Wait for that swap before sending a
                 // new request so it cannot race the stale session URL/key.
@@ -798,21 +1176,218 @@ export async function runBridge(
         })();
     };
 
+    /** Flush everything buffered before the session came up, in arrival order,
+     * then announce the real tool set. Called once, right after the first
+     * successful connect. `flushing` keeps concurrently-arriving stdin requests
+     * buffering (rather than posting directly and overtaking the queue); we
+     * drain until the buffer is empty so those late arrivals are forwarded too. */
+    async function flushPendingForward(): Promise<void> {
+        flushing = true;
+        try {
+            if (pendingForward.length > 0) {
+                log.info("bridge.flushing_pre_connect", { count: pendingForward.length });
+            }
+            while (pendingForward.length > 0) {
+                if (stdinClosed) {
+                    // Shutting down mid-flush: don't post to a torn-down session.
+                    // Everything still buffered (plus what we've already shifted
+                    // into inFlight but not delivered) is closed out below.
+                    break;
+                }
+                if (!sse) break; // lost the session; reconnect replays inFlight
+                const msg = pendingForward.shift()!;
+                try {
+                    const status = await postMessage(sse.postUrl, msg, creds);
+                    if (status === 404) {
+                        // Stale session right after connect. EVERY id-bearing
+                        // request is in `inFlight`, and ANY reconnect — this
+                        // flush's own, or a concurrent `server-pump-eof` one that
+                        // shares the same `reconnectPromise` — replays the whole
+                        // `inFlight` map against the fresh session. So id-bearing
+                        // items are owned by reconnect, period; re-posting them
+                        // from the flush would duplicate them (double write +
+                        // two replies for one id). We therefore drop ALL
+                        // id-bearing items from the queue after reconnect and
+                        // keep only id-less notifications (never in `inFlight`,
+                        // so no reconnect carries them) to re-drain. `await
+                        // reconnect()` resolves the shared reconnectPromise, so
+                        // `inFlight` has been fully replayed by the time we
+                        // decide what's left to send — no matter which caller
+                        // owns the reconnect.
+                        log.warn("bridge.session_stale", { sessionUrl: sse.postUrl });
+                        if (msg.id == null) pendingForward.unshift(msg);
+                        await reconnect("post-404");
+                        const notifications = pendingForward.filter((m) => m.id == null);
+                        pendingForward.length = 0;
+                        pendingForward.push(...notifications);
+                        continue;
+                    }
+                } catch (err) {
+                    log.error("bridge.flush_failed", {
+                        id: msg.id ?? null,
+                        err: err instanceof Error ? err.message : String(err),
+                    });
+                }
+            }
+        } finally {
+            flushing = false;
+        }
+        // If stdin closed while we were draining, close out anything still open
+        // (buffered + already-in-inFlight-but-undelivered) so those calls get an
+        // error envelope instead of hanging until the client's own timeout.
+        if (stdinClosed) {
+            failPendingForward("connection lost during shutdown");
+            failInFlightRequests("connection lost during shutdown");
+            return;
+        }
+        // The client discovered tools from our static `tools/list`. Now that the
+        // real relayer session is up, tell it to re-list so it picks up the
+        // authoritative upstream set (spliced with login/logout in the pump).
+        writeStdoutMessage({
+            jsonrpc: "2.0",
+            method: "notifications/tools/list_changed",
+        });
+    }
+
+    /** Fail whatever is still buffered when we give up connecting for good
+     * (stdin closed) — reply to open tool calls with an error envelope instead
+     * of leaving them to hang until the client's own timeout. Skips:
+    /** Write the "relayer unavailable" reply for one open request, stop tracking
+     * it, and never double-answer a locally-answered request. Shared by the
+     * buffered (`failPendingForward`) and in-flight (`failInFlightRequests`)
+     * close-outs. Skips:
+     *   - notifications (no id → nothing to reply to; also unforwardable now).
+     *   - `initialize` (we already answered it locally; a second response for
+     *     that id would corrupt the client's JSON-RPC state — just untrack).
+     * Only `tools/call` shaped requests get the tool-result error envelope; any
+     * other id-bearing request gets a JSON-RPC error object (the correct shape
+     * for a non-tool request). */
+    function failRequest(msg: RpcMessage, reason: string): void {
+        if (msg.id == null) return; // notification — nothing to answer
+        if (msg.method === "initialize") {
+            // Locally answered already. Never write a second reply for this id;
+            // just stop tracking it (and clear any pending suppression).
+            inFlight.delete(msg.id);
+            suppressUpstreamReplies.delete(msg.id);
+            return;
+        }
+        inFlight.delete(msg.id);
+        // Remember we answered this id, so a late genuine reply (e.g. from a
+        // flush-404 reconnect that re-posted onto a live session) is dropped by
+        // the pump instead of becoming a second response for the same id.
+        closedOutIds.add(msg.id);
+        if (msg.method === "tools/call") {
+            writeStdoutMessage({
+                jsonrpc: "2.0",
+                id: msg.id,
+                result: {
+                    content: [
+                        {
+                            type: "text",
+                            text: `❌ Walrus Memory relayer unavailable: ${reason}. The memory tool could not run. Please retry shortly.`,
+                        },
+                    ],
+                    isError: true,
+                },
+            });
+        } else {
+            writeStdoutMessage({
+                jsonrpc: "2.0",
+                id: msg.id,
+                error: {
+                    code: -32000,
+                    message: `Walrus Memory relayer unavailable: ${reason}`,
+                },
+            });
+        }
+    }
+
+    function failPendingForward(reason: string): void {
+        const queued = pendingForward.splice(0, pendingForward.length);
+        for (const msg of queued) failRequest(msg, reason);
+    }
+
+    /** Close out requests that reached `inFlight` but were never delivered a
+     * reply — the shutdown counterpart of `failPendingForward`. Used when stdin
+     * closes mid-flush: items already shifted out of `pendingForward` and posted
+     * to a torn-down session would otherwise hang, since no upstream reply is
+     * coming. Idempotent w.r.t. ids already closed out (delete-then-skip). */
+    function failInFlightRequests(reason: string): void {
+        for (const msg of Array.from(inFlight.values())) failRequest(msg, reason);
+    }
+
+    // Kick off the relayer connect in the BACKGROUND — do NOT await it before
+    // wiring stdin below. This is the whole fix: `initialize` / `tools/list` are
+    // answered locally the moment they arrive, while the (possibly slow / cold)
+    // relayer round-trip proceeds off the handshake's critical path.
+    //
+    // Retry with backoff so a cold-starting relayer eventually connects. We do
+    // NOT fail buffered requests between attempts: a request that the next
+    // attempt would serve must not get a spurious "unavailable" error (that
+    // would also drop the auth-required hot-handoff request). Buffered tool
+    // calls stay queued and are flushed on the first SUCCESS; if they never
+    // connect, the client's own per-tool timeout fires (graceful) — and on
+    // shutdown `failPendingForward` closes out anything still open. `initialize`
+    // is answered locally, so it never blocks and is only forwarded, not failed.
+    const connectInBackground = (async () => {
+        let attempt = 0;
+        while (!stdinClosed) {
+            try {
+                sse = await openSseStream(creds.relayerUrl, creds);
+                note(`Connected. Bridging stdio MCP ↔ ${creds.relayerUrl}`);
+                log.info("bridge.connected", { relayer: creds.relayerUrl });
+                signalFirstConnect();
+                await flushPendingForward();
+                return;
+            } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                attempt += 1;
+                log.error("bridge.initial_connect_failed", { err: reason, attempt });
+                if (stdinClosed) break;
+                const backoff = Math.min(15_000, 500 * Math.pow(2, attempt - 1));
+                // Sleep, but wake immediately if stdin closes mid-backoff so we
+                // don't hold the process open for up to 15s after shutdown. The
+                // timer is unref'd for the same reason (cf. the connect timer /
+                // idle watchdog).
+                await new Promise<void>((resolve) => {
+                    const timer = setTimeout(() => {
+                        unregister();
+                        resolve();
+                    }, backoff);
+                    timer.unref?.();
+                    const unregister = onStdinClose(() => {
+                        clearTimeout(timer);
+                        resolve();
+                    });
+                });
+            }
+        }
+        // stdin closed before we ever connected — unblock serverPump so the race
+        // can settle, and close out anything still buffered (open tool calls get
+        // an error envelope instead of hanging; initialize/notifications skipped).
+        signalFirstConnect();
+        failPendingForward("connection not established before shutdown");
+    })();
+
     // Replay anything the auth-required server handed off (the tool call that
-    // triggered the hot-handoff, plus anything buffered behind it) now that the
-    // SSE stream is connected. Without this the triggering request is dropped in
-    // the mode switch and the user has to retry / restart.
+    // triggered the hot-handoff, plus anything buffered behind it). These run
+    // through handleClientLine, which buffers them into pendingForward until the
+    // background connect lands — so the triggering request is served for real
+    // instead of being dropped in the mode switch.
     if (pendingLines.length > 0) {
         log.info("bridge.replaying_handoff", { count: pendingLines.length });
         for (const line of pendingLines) handleClientLine(line);
     }
 
     const clientPump = readStdinLines(handleClientLine).then(() => {
-        stdinClosed = true;
-        sse.abort();
+        markStdinClosed();
+        sse?.abort();
     });
 
     await Promise.race([serverPump, clientPump]);
-    sse.abort();
+    markStdinClosed();
+    const finalStream = sse as SseHandshakeResult | null;
+    finalStream?.abort();
+    await connectInBackground.catch(() => {});
     log.info("bridge.closed", {});
 }

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -903,16 +903,13 @@ export async function runBridge(
             // cross-account replay) since the flush posts with the current
             // `creds`. For each, reply once with a retryable error and stop
             // tracking; never write a second reply for a locally-answered
-            // `initialize`, and clear its suppression arm so a reused id later
-            // isn't silently swallowed.
+            // `initialize`. Keep its one-shot suppress arm so a queued
+            // upstream initialize reply is consumed. Do not put initialize in
+            // closedOutIds — a later reused id must still get a real reply.
             const purge = (msg: RpcMessage): void => {
                 if (msg.id == null) return; // notification — nothing to reply to
                 pendingListIds.delete(msg.id);
                 if (msg.method === "initialize") {
-                    // Already answered locally. Keep any suppress arm so a
-                    // queued upstream initialize reply is consumed, and record
-                    // closedOutIds so the pump drops it even if the arm is gone.
-                    closedOutIds.add(msg.id);
                     return;
                 }
                 suppressUpstreamReplies.delete(msg.id);
@@ -936,6 +933,13 @@ export async function runBridge(
             for (const [, msg] of Array.from(inFlight.entries())) purge(msg);
             inFlight.clear();
             for (const msg of pendingForward.splice(0, pendingForward.length)) purge(msg);
+        } else {
+            // Same account: reconnect() owns inFlight. Drop id-bearing
+            // pendingForward so a login mid-flush cannot POST the same
+            // remember/recall again after replay.
+            const leftover = pendingForward.filter((m) => m.id == null);
+            pendingForward.length = 0;
+            pendingForward.push(...leftover);
         }
 
         creds = nextCreds;
@@ -1272,10 +1276,9 @@ export async function runBridge(
         if (msg.id == null) return; // notification — nothing to answer
         if (msg.method === "initialize") {
             // Locally answered already. Never write a second reply for this id.
-            // Keep any suppress arm and record closedOutIds so a late upstream
-            // initialize result is dropped by the pump.
+            // Keep any suppress arm so a late upstream initialize result is
+            // consumed; do not closedOut the id (clients may reuse it later).
             inFlight.delete(msg.id);
-            closedOutIds.add(msg.id);
             return;
         }
         inFlight.delete(msg.id);

--- a/packages/mcp/src/compatibility.ts
+++ b/packages/mcp/src/compatibility.ts
@@ -1,6 +1,31 @@
 export const MEMWAL_MCP_COMPATIBILITY_VERSION = "0.0.1";
 export const SUPPORTED_RELAYER_API_MAJOR = 1;
 
+/** Default budget for ONE relayer connect attempt — the compatibility check
+ * (`GET /version`, and a `/health` fallback) PLUS the initial SSE `GET` share
+ * this deadline (the caller threads a single `AbortSignal` through both). Kept
+ * well under the MCP client's ~30s connection timeout so a slow-but-alive
+ * relayer still succeeds, while a hung one aborts long before the client would
+ * SIGTERM us. Since `initialize` is now answered locally, exceeding this only
+ * defers when `tools/call` becomes available — it surfaces as a tool-call
+ * error, never a failed handshake. */
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * Resolve the per-step relayer connect timeout. Overridable via
+ * `MEMWAL_MCP_CONNECT_TIMEOUT_MS` (same pattern as `MEMWAL_MCP_SSE_IDLE_MS`).
+ * Non-numeric / non-positive values fall back to the default. A value of `0`
+ * is treated as "use the default" rather than "no timeout" — an unbounded
+ * connect is the bug we're fixing, so we never expose a way back to it.
+ */
+export function resolveConnectTimeoutMs(): number {
+    const raw = process.env.MEMWAL_MCP_CONNECT_TIMEOUT_MS;
+    if (!raw) return DEFAULT_CONNECT_TIMEOUT_MS;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) return DEFAULT_CONNECT_TIMEOUT_MS;
+    return n;
+}
+
 interface RelayerVersionMetadata {
     relayerVersion?: string;
     apiVersion?: string;
@@ -13,26 +38,45 @@ let compatibilityCache: RelayerVersionMetadata | null = null;
 let compatibilityCacheUrl: string | null = null;
 let compatibilityPromise: Promise<void> | null = null;
 
-export async function ensureCompatibleRelayer(relayerUrl: string): Promise<void> {
+/**
+ * @param signal Optional abort signal bounding the whole check. The caller
+ *   passes ONE signal shared with the subsequent SSE connect so a single
+ *   connect attempt is bounded in total, not per-step. When omitted, each fetch
+ *   gets its own `AbortSignal.timeout(resolveConnectTimeoutMs())`.
+ */
+export async function ensureCompatibleRelayer(
+    relayerUrl: string,
+    signal?: AbortSignal,
+): Promise<void> {
     const base = relayerUrl.replace(/\/+$/, "");
     if (compatibilityCache && compatibilityCacheUrl === base) return;
     if (compatibilityPromise) return compatibilityPromise;
 
-    compatibilityPromise = fetchAndValidate(base).finally(() => {
+    compatibilityPromise = fetchAndValidate(base, signal).finally(() => {
         compatibilityPromise = null;
     });
     return compatibilityPromise;
 }
 
-async function fetchAndValidate(relayerUrl: string): Promise<void> {
+async function fetchAndValidate(relayerUrl: string, signal?: AbortSignal): Promise<void> {
     const base = relayerUrl;
-    const versionResp = await fetch(`${base}/version`, { method: "GET" });
+    // Bound the request(s) so a hung relayer aborts well before the MCP client's
+    // ~30s connection timeout. Prefer the caller's shared signal (so the compat
+    // check + SSE connect share one budget); else fall back to a per-check one.
+    const abort = signal ?? AbortSignal.timeout(resolveConnectTimeoutMs());
+    const versionResp = await fetch(`${base}/version`, {
+        method: "GET",
+        signal: abort,
+    });
     let metadata: RelayerVersionMetadata;
 
     if (versionResp.ok) {
         metadata = (await versionResp.json()) as RelayerVersionMetadata;
     } else if (versionResp.status === 404 || versionResp.status === 405) {
-        const healthResp = await fetch(`${base}/health`, { method: "GET" });
+        const healthResp = await fetch(`${base}/health`, {
+            method: "GET",
+            signal: abort,
+        });
         if (!healthResp.ok) {
             throw new Error(
                 `Walrus Memory MCP compatibility check failed: GET /version returned ` +

--- a/packages/mcp/test/coldstart-flush-404.test.mjs
+++ b/packages/mcp/test/coldstart-flush-404.test.mjs
@@ -1,0 +1,426 @@
+/**
+ * Regression test for GH #415 round-2 finding N1 — a 404 during the post-connect
+ * flush must NOT cause buffered requests to be delivered twice.
+ *
+ * Bug being guarded against: buffered tool calls live in BOTH pendingForward and
+ * inFlight. If a POST during flushPendingForward returns 404, reconnect() replays
+ * the ENTIRE inFlight map (all still-queued items) against the fresh session — and
+ * if the flush loop then keeps draining pendingForward, those items get POSTed a
+ * SECOND time (duplicate memory writes + two JSON-RPC replies for one id).
+ *
+ * Repro:
+ *   - Client sends initialize + three tools/call BEFORE the relayer connects (all
+ *     buffered). The mock delays the endpoint event so they queue up.
+ *   - First SSE session: the first POST it receives returns 404 (stale-session
+ *     race), forcing reconnect. The second session answers normally.
+ *   - Assert: each of the three tool-call ids is answered EXACTLY once, and the
+ *     relayer received each distinct fact EXACTLY once (no duplicate write).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const EXPECTED_BEARER = "a".repeat(64);
+const EXPECTED_ACCOUNT_ID = "0x" + "3".repeat(64);
+const SSE_DELAY_MS = 700;
+
+function hasBridgeAuth(req) {
+    return (
+        req.headers.authorization === `Bearer ${EXPECTED_BEARER}` &&
+        req.headers["x-memwal-account-id"] === EXPECTED_ACCOUNT_ID
+    );
+}
+
+/** Mock relayer: two SSE sessions. The FIRST POST to session-1 returns 404
+ * (forcing a reconnect mid-flush); session-2 answers normally. Counts how many
+ * times each distinct fact text is received, to detect duplicate delivery. */
+function startFlaky404Relayer() {
+    const sessions = new Map();
+    let sseGetCount = 0;
+    let firstPostRejected = false;
+    const factDeliveries = new Map(); // fact text -> count
+
+    const server = http.createServer((req, res) => {
+        const u = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && u.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ apiVersion: "1.0.0", relayerVersion: "1.0.0", minSupportedSdk: { mcp: "0.0.1" } }));
+            return;
+        }
+        if (req.method === "GET" && u.pathname === "/api/mcp/sse") {
+            if (!hasBridgeAuth(req)) { res.writeHead(401); res.end(); return; }
+            sseGetCount += 1;
+            const sessionId = `session-${sseGetCount}`;
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+            // Delay the endpoint event on the FIRST session so the client buffers
+            // initialize + all three tool calls before the stream is up.
+            const delay = sseGetCount === 1 ? SSE_DELAY_MS : 0;
+            const t = setTimeout(() => {
+                if (res.writableEnded) return;
+                res.write(`event: endpoint\ndata: /api/mcp/messages?sessionId=${sessionId}\n\n`);
+                sessions.set(sessionId, { res });
+                const hb = setInterval(() => { if (!res.writableEnded) res.write(":\n\n"); else clearInterval(hb); }, 200);
+                hb.unref?.();
+                res.on("close", () => clearInterval(hb));
+            }, delay);
+            t.unref?.();
+            return;
+        }
+        if (req.method === "POST" && u.pathname === "/api/mcp/messages") {
+            if (!hasBridgeAuth(req)) { res.writeHead(401); res.end(); return; }
+            const sessionId = u.searchParams.get("sessionId");
+            const session = sessions.get(sessionId);
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                let msg;
+                try { msg = JSON.parse(body); } catch { res.writeHead(202); res.end(); return; }
+                // Reject the very first tool-call POST once, to force a reconnect
+                // during the flush. initialize is allowed through so the handshake
+                // forward isn't what trips it.
+                if (!firstPostRejected && msg.method === "tools/call") {
+                    firstPostRejected = true;
+                    res.writeHead(404);
+                    res.end();
+                    return;
+                }
+                if (!session) { res.writeHead(404); res.end(); return; }
+                res.writeHead(202);
+                res.end();
+                if (msg.method === "initialize") return; // suppressed by the bridge
+                if (msg.method === "tools/call" && msg.params?.name === "memwal_remember") {
+                    const fact = msg.params?.arguments?.text ?? "";
+                    factDeliveries.set(fact, (factDeliveries.get(fact) ?? 0) + 1);
+                    session.res.write(
+                        `event: message\ndata: ${JSON.stringify({
+                            jsonrpc: "2.0",
+                            id: msg.id,
+                            result: { content: [{ type: "text", text: `SAVED:${fact}` }], isError: false },
+                        })}\n\n`,
+                    );
+                    return;
+                }
+            });
+            return;
+        }
+        res.writeHead(404); res.end();
+    });
+    return new Promise((res) => {
+        server.listen(0, "127.0.0.1", () => {
+            res({
+                server,
+                base: `http://127.0.0.1:${server.address().port}`,
+                factDeliveries,
+                getSseGetCount: () => sseGetCount,
+            });
+        });
+    });
+}
+
+function makeCreds(relayerUrl) {
+    return {
+        delegatePrivateKey: EXPECTED_BEARER, delegatePublicKeyHex: "b".repeat(64),
+        delegateAddress: "0x" + "1".repeat(64), walletAddress: "0x" + "2".repeat(64),
+        accountId: EXPECTED_ACCOUNT_ID, packageId: "0x" + "4".repeat(64),
+        relayerUrl, label: "Flush404 Test", createdAt: new Date(0).toISOString(), version: 1,
+    };
+}
+
+test("a 404 during the post-connect flush does not double-deliver buffered requests", async (t) => {
+    const mock = await startFlaky404Relayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-flush404-test-"));
+    const credsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credsPath), { recursive: true });
+    writeFileSync(credsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl); buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg; try { msg = JSON.parse(line); } catch { continue; }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+    let stderrBuf = "";
+    child.stderr.on("data", (d) => (stderrBuf += d.toString()));
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => { listeners.delete(l); rej(new Error(`timeout\n${stderrBuf}\n${received.map((m) => JSON.stringify(m)).join("\n")}`)); }, ms);
+            const l = (m) => { if (pred(m)) { clearTimeout(timer); listeners.delete(l); res(m); } };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => { child.kill("SIGKILL"); mock.server.close(); rmSync(home, { recursive: true, force: true }); });
+
+    // Handshake + three remembers, all sent before the (delayed) connect → buffered.
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await waitFor((m) => m.id === 1 && m.result, 3_000);
+    for (const [id, fact] of [[2, "fact-A"], [3, "fact-B"], [4, "fact-C"]]) {
+        send({ jsonrpc: "2.0", id, method: "tools/call", params: { name: "memwal_remember", arguments: { text: fact } } });
+    }
+
+    // All three must be answered (after the 404 → reconnect → replay recovers them).
+    await waitFor((m) => m.id === 2, 10_000);
+    await waitFor((m) => m.id === 3, 10_000);
+    await waitFor((m) => m.id === 4, 10_000);
+
+    // Give any erroneous duplicate delivery a chance to land before asserting.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Each id answered EXACTLY once (no duplicate JSON-RPC response for an id).
+    for (const id of [2, 3, 4]) {
+        const replies = received.filter((m) => m.id === id && (m.result || m.error));
+        assert.equal(replies.length, 1, `id=${id} must be answered exactly once, saw ${replies.length}: ${JSON.stringify(replies)}`);
+    }
+
+    // Each distinct fact delivered to the relayer EXACTLY once (no duplicate write).
+    for (const fact of ["fact-A", "fact-B", "fact-C"]) {
+        assert.equal(
+            mock.factDeliveries.get(fact),
+            1,
+            `fact "${fact}" must be written exactly once, was written ${mock.factDeliveries.get(fact)} time(s)`,
+        );
+    }
+
+    // Sanity: the 404 actually forced a reconnect (>=2 SSE handshakes).
+    assert.ok(mock.getSseGetCount() >= 2, `expected a reconnect (>=2 SSE handshakes), saw ${mock.getSseGetCount()}`);
+});
+
+test("a request arriving DURING the flush-404 reconnect backoff is delivered exactly once (not double-posted)", async (t) => {
+    // Round-4 finding C2: a tools/call that arrives while reconnect is in its
+    // backoff lands in BOTH inFlight (reconnect replays it) AND pendingForward
+    // (the flush would re-post it) → double delivery. This times a second
+    // request into that ~500ms backoff window and asserts single delivery.
+    const mock = await startFlaky404Relayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-flush404b-test-"));
+    const credsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credsPath), { recursive: true });
+    writeFileSync(credsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl); buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg; try { msg = JSON.parse(line); } catch { continue; }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+    let stderrBuf = "";
+    child.stderr.on("data", (d) => (stderrBuf += d.toString()));
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => { listeners.delete(l); rej(new Error(`timeout\n${stderrBuf}\n${received.map((m) => JSON.stringify(m)).join("\n")}`)); }, ms);
+            const l = (m) => { if (pred(m)) { clearTimeout(timer); listeners.delete(l); res(m); } };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => { child.kill("SIGKILL"); mock.server.close(); rmSync(home, { recursive: true, force: true }); });
+
+    // initialize + one remember up front. The remember's flush POST 404s →
+    // reconnect() enters a ~500ms backoff.
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await waitFor((m) => m.id === 1 && m.result, 5_000);
+    send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "memwal_remember", arguments: { text: "fact-A" } } });
+
+    // Send a SECOND remember ~150ms later — inside the reconnect backoff window,
+    // so it arrives while flushing===true and reconnect is sleeping.
+    await new Promise((r) => setTimeout(r, 150));
+    send({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "memwal_remember", arguments: { text: "fact-B" } } });
+
+    await waitFor((m) => m.id === 2, 10_000);
+    await waitFor((m) => m.id === 3, 10_000);
+    await new Promise((r) => setTimeout(r, 500)); // let any duplicate land
+
+    for (const id of [2, 3]) {
+        const replies = received.filter((m) => m.id === id && (m.result || m.error));
+        assert.equal(replies.length, 1, `id=${id} must be answered exactly once, saw ${replies.length}`);
+    }
+    for (const fact of ["fact-A", "fact-B"]) {
+        assert.equal(
+            mock.factDeliveries.get(fact),
+            1,
+            `fact "${fact}" must be written exactly once, was written ${mock.factDeliveries.get(fact)} time(s)`,
+        );
+    }
+});
+
+/** Like startFlaky404Relayer, but on the first tool-call POST it BOTH returns 404
+ * AND closes session-1's SSE stream. Closing the stream makes the bridge's
+ * serverPump see EOF and trigger its OWN reconnect('server-pump-eof'), which can
+ * win the `reconnecting` flag before the flush's reconnect('post-404') — the
+ * round-5 finding D1 double-post scenario. */
+function startConcurrentReconnectRelayer() {
+    const sessions = new Map();
+    let sseGetCount = 0;
+    let firstPostRejected = false;
+    const factDeliveries = new Map();
+    const server = http.createServer((req, res) => {
+        const u = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && u.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ apiVersion: "1.0.0", relayerVersion: "1.0.0", minSupportedSdk: { mcp: "0.0.1" } }));
+            return;
+        }
+        if (req.method === "GET" && u.pathname === "/api/mcp/sse") {
+            if (!hasBridgeAuth(req)) { res.writeHead(401); res.end(); return; }
+            sseGetCount += 1;
+            const sessionId = `session-${sseGetCount}`;
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+            const delay = sseGetCount === 1 ? SSE_DELAY_MS : 0;
+            const t = setTimeout(() => {
+                if (res.writableEnded) return;
+                res.write(`event: endpoint\ndata: /api/mcp/messages?sessionId=${sessionId}\n\n`);
+                sessions.set(sessionId, { res });
+                const hb = setInterval(() => { if (!res.writableEnded) res.write(":\n\n"); else clearInterval(hb); }, 200);
+                hb.unref?.();
+                res.on("close", () => clearInterval(hb));
+            }, delay);
+            t.unref?.();
+            return;
+        }
+        if (req.method === "POST" && u.pathname === "/api/mcp/messages") {
+            if (!hasBridgeAuth(req)) { res.writeHead(401); res.end(); return; }
+            const sessionId = u.searchParams.get("sessionId");
+            const session = sessions.get(sessionId);
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                let msg;
+                try { msg = JSON.parse(body); } catch { res.writeHead(202); res.end(); return; }
+                if (!firstPostRejected && msg.method === "tools/call") {
+                    firstPostRejected = true;
+                    // Close session-1's SSE stream so serverPump also reconnects.
+                    const s1 = sessions.get(sessionId);
+                    if (s1 && !s1.res.writableEnded) s1.res.end();
+                    sessions.delete(sessionId);
+                    res.writeHead(404); res.end();
+                    return;
+                }
+                if (!session) { res.writeHead(404); res.end(); return; }
+                res.writeHead(202); res.end();
+                if (msg.method === "initialize") return;
+                if (msg.method === "tools/call" && msg.params?.name === "memwal_remember") {
+                    const fact = msg.params?.arguments?.text ?? "";
+                    factDeliveries.set(fact, (factDeliveries.get(fact) ?? 0) + 1);
+                    session.res.write(`event: message\ndata: ${JSON.stringify({
+                        jsonrpc: "2.0", id: msg.id,
+                        result: { content: [{ type: "text", text: `SAVED:${fact}` }], isError: false },
+                    })}\n\n`);
+                    return;
+                }
+            });
+            return;
+        }
+        res.writeHead(404); res.end();
+    });
+    return new Promise((res) => {
+        server.listen(0, "127.0.0.1", () => {
+            res({ server, base: `http://127.0.0.1:${server.address().port}`, factDeliveries, getSseGetCount: () => sseGetCount });
+        });
+    });
+}
+
+test("a concurrent serverPump reconnect during the flush-404 does not double-deliver buffered requests", async (t) => {
+    const mock = await startConcurrentReconnectRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-flush404c-test-"));
+    const credsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credsPath), { recursive: true });
+    writeFileSync(credsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home }, stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl); buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg; try { msg = JSON.parse(line); } catch { continue; }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+    let stderrBuf = "";
+    child.stderr.on("data", (d) => (stderrBuf += d.toString()));
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => { listeners.delete(l); rej(new Error(`timeout\n${stderrBuf}\n${received.map((m) => JSON.stringify(m)).join("\n")}`)); }, ms);
+            const l = (m) => { if (pred(m)) { clearTimeout(timer); listeners.delete(l); res(m); } };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => { child.kill("SIGKILL"); mock.server.close(); rmSync(home, { recursive: true, force: true }); });
+
+    // initialize + three remembers, all buffered before the delayed connect.
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await waitFor((m) => m.id === 1 && m.result, 5_000);
+    for (const [id, fact] of [[2, "fact-A"], [3, "fact-B"], [4, "fact-C"]]) {
+        send({ jsonrpc: "2.0", id, method: "tools/call", params: { name: "memwal_remember", arguments: { text: fact } } });
+    }
+
+    await waitFor((m) => m.id === 2, 12_000);
+    await waitFor((m) => m.id === 3, 12_000);
+    await waitFor((m) => m.id === 4, 12_000);
+    await new Promise((r) => setTimeout(r, 600)); // let any duplicate land
+
+    for (const id of [2, 3, 4]) {
+        const replies = received.filter((m) => m.id === id && (m.result || m.error));
+        assert.equal(replies.length, 1, `id=${id} answered exactly once, saw ${replies.length}: ${JSON.stringify(replies)}`);
+    }
+    for (const fact of ["fact-A", "fact-B", "fact-C"]) {
+        assert.equal(
+            mock.factDeliveries.get(fact),
+            1,
+            `fact "${fact}" written exactly once, was written ${mock.factDeliveries.get(fact)} time(s)`,
+        );
+    }
+});

--- a/packages/mcp/test/coldstart-init.test.mjs
+++ b/packages/mcp/test/coldstart-init.test.mjs
@@ -1,0 +1,380 @@
+/**
+ * Regression test for GH #415 — the bridge must NOT block the MCP `initialize`
+ * handshake on the relayer connect during a slow cold start.
+ *
+ * Bug being guarded against: on a credentialed cold start, `runBridge` awaited a
+ * full relayer round-trip (TLS + GET /version + SSE handshake + endpoint event)
+ * BEFORE it read stdin or answered `initialize`. `initialize` was forwarded to
+ * the relayer, not answered locally, so a slow relayer tripped the MCP client's
+ * ~30s connection timeout → the client SIGTERM'd the process → no tools loaded.
+ *
+ * Repro here:
+ *   - Mock relayer answers GET /version immediately but DELAYS the SSE endpoint
+ *     event by SSE_DELAY_MS, simulating a slow/cold relayer.
+ *   - The bridge must answer `initialize` and a cold-start `tools/list` LOCALLY
+ *     and near-instantly — well before the SSE stream is up.
+ *   - A `tools/call` sent before the stream is up must be BUFFERED and served
+ *     once the relayer connect completes (not dropped, not hung).
+ *   - Once connected, the bridge emits notifications/tools/list_changed so the
+ *     client re-lists and gets the real upstream tool set.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const EXPECTED_BEARER = "a".repeat(64);
+const EXPECTED_ACCOUNT_ID = "0x" + "3".repeat(64);
+
+/** How long the mock relayer withholds the SSE endpoint event. Large enough
+ * that a bridge which (wrongly) waited on the relayer before answering
+ * `initialize` would blow the assertion deadlines below. */
+const SSE_DELAY_MS = 3_000;
+
+/** The tools the real relayer sidecar registers
+ * (services/server/scripts/mcp/tools/index.ts). The cold-start static list must
+ * cover exactly these (plus the locally-served login/logout), so the
+ * static→refreshed transition doesn't change the tool set under the client. */
+const UPSTREAM_TOOL_NAMES = [
+    "memwal_remember",
+    "memwal_remember_bulk",
+    "memwal_recall",
+    "memwal_analyze",
+    "memwal_restore",
+    "memwal_health",
+];
+
+function hasBridgeAuth(req) {
+    return (
+        req.headers.authorization === `Bearer ${EXPECTED_BEARER}` &&
+        req.headers["x-memwal-account-id"] === EXPECTED_ACCOUNT_ID
+    );
+}
+
+/** Mock relayer that cold-starts slowly: /version is instant, but the SSE
+ * endpoint event is delayed by SSE_DELAY_MS. After that, the session behaves
+ * normally (answers initialize + tools/call over the stream). */
+function startSlowRelayer() {
+    const sessions = new Map();
+    let sseGetCount = 0;
+    let versionHits = 0;
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/version") {
+            versionHits += 1;
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    apiVersion: "1.0.0",
+                    relayerVersion: "1.0.0",
+                    minSupportedSdk: { mcp: "0.0.1" },
+                }),
+            );
+            return;
+        }
+        if (req.method === "GET" && url.pathname === "/api/mcp/sse") {
+            if (!hasBridgeAuth(req)) {
+                res.writeHead(401);
+                res.end();
+                return;
+            }
+            sseGetCount += 1;
+            const sessionId = `session-${sseGetCount}`;
+            res.writeHead(200, {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+            });
+            // The slow part: withhold the endpoint event. A correct bridge has
+            // already answered initialize locally by now.
+            const t = setTimeout(() => {
+                if (res.writableEnded) return;
+                res.write(
+                    `event: endpoint\ndata: /api/mcp/messages?sessionId=${sessionId}\n\n`,
+                );
+                sessions.set(sessionId, { res });
+                const hb = setInterval(() => {
+                    if (res.writableEnded) {
+                        clearInterval(hb);
+                        return;
+                    }
+                    res.write(":\n\n");
+                }, 200);
+                hb.unref?.();
+                res.on("close", () => clearInterval(hb));
+            }, SSE_DELAY_MS);
+            t.unref?.();
+            return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/mcp/messages") {
+            if (!hasBridgeAuth(req)) {
+                res.writeHead(401);
+                res.end();
+                return;
+            }
+            const sessionId = url.searchParams.get("sessionId");
+            const session = sessions.get(sessionId);
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                if (!session) {
+                    res.writeHead(404);
+                    res.end();
+                    return;
+                }
+                res.writeHead(202);
+                res.end();
+                let msg;
+                try {
+                    msg = JSON.parse(body);
+                } catch {
+                    return;
+                }
+                if (msg.method === "initialize") {
+                    // The upstream initialize reply — the bridge must SUPPRESS
+                    // this (client already got the local one). If it leaked, the
+                    // client would see two responses for the same id.
+                    session.res.write(
+                        `event: message\ndata: ${JSON.stringify({
+                            jsonrpc: "2.0",
+                            id: msg.id,
+                            result: {
+                                protocolVersion: "2024-11-05",
+                                capabilities: { tools: { listChanged: true } },
+                                serverInfo: { name: "memwal-upstream", version: "9.9.9" },
+                            },
+                        })}\n\n`,
+                    );
+                    return;
+                }
+                if (msg.method === "tools/call" && msg.params?.name === "memwal_recall") {
+                    session.res.write(
+                        `event: message\ndata: ${JSON.stringify({
+                            jsonrpc: "2.0",
+                            id: msg.id,
+                            result: {
+                                content: [{ type: "text", text: "RECALL_OK: served after background connect" }],
+                                isError: false,
+                            },
+                        })}\n\n`,
+                    );
+                    return;
+                }
+                if (msg.method === "tools/list") {
+                    // The real upstream tool set (the 6 tools the sidecar
+                    // registers). The bridge splices login/logout onto this.
+                    session.res.write(
+                        `event: message\ndata: ${JSON.stringify({
+                            jsonrpc: "2.0",
+                            id: msg.id,
+                            result: {
+                                tools: UPSTREAM_TOOL_NAMES.map((name) => ({
+                                    name,
+                                    description: `upstream ${name}`,
+                                    inputSchema: { type: "object" },
+                                })),
+                            },
+                        })}\n\n`,
+                    );
+                    return;
+                }
+            });
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+    return new Promise((res) => {
+        server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address();
+            res({
+                server,
+                base: `http://127.0.0.1:${port}`,
+                getSseGetCount: () => sseGetCount,
+                getVersionHits: () => versionHits,
+            });
+        });
+    });
+}
+
+function makeCreds(relayerUrl) {
+    return {
+        delegatePrivateKey: EXPECTED_BEARER,
+        delegatePublicKeyHex: "b".repeat(64),
+        delegateAddress: "0x" + "1".repeat(64),
+        walletAddress: "0x" + "2".repeat(64),
+        accountId: EXPECTED_ACCOUNT_ID,
+        packageId: "0x" + "4".repeat(64),
+        relayerUrl,
+        label: "Coldstart Test",
+        createdAt: new Date(0).toISOString(),
+        version: 1,
+    };
+}
+
+test("initialize is answered locally during a slow relayer cold start; tools/call is buffered then served", async (t) => {
+    const mock = await startSlowRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-coldstart-test-"));
+    const credsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credsPath), { recursive: true });
+    writeFileSync(credsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            received.push({ msg, at: Date.now() });
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+    let stderrBuf = "";
+    child.stderr.on("data", (d) => (stderrBuf += d.toString()));
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find((r) => pred(r.msg));
+        if (hit) return Promise.resolve(hit.msg);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => {
+                listeners.delete(l);
+                rej(
+                    new Error(
+                        `timed out waiting for message\n--- stderr ---\n${stderrBuf}\n--- received ---\n${received.map((r) => JSON.stringify(r.msg)).join("\n")}`,
+                    ),
+                );
+            }, ms);
+            const l = (m) => {
+                if (pred(m)) {
+                    clearTimeout(timer);
+                    listeners.delete(l);
+                    res(m);
+                }
+            };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => {
+        child.kill("SIGKILL");
+        mock.server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    const startedAt = Date.now();
+
+    // 1) initialize must come back near-instantly — well before the relayer's
+    //    SSE endpoint event (SSE_DELAY_MS). This is the core fix. We request a
+    //    specific protocolVersion to confirm the local responder ECHOES it
+    //    (rather than hard-coding one and ignoring the client's request).
+    send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {} },
+    });
+    const init = await waitFor((m) => m.id === 1 && m.result, SSE_DELAY_MS);
+    const initElapsed = Date.now() - startedAt;
+    assert.equal(init.result.serverInfo.name, "memwal");
+    assert.equal(init.result.capabilities.tools.listChanged, true);
+    assert.equal(
+        init.result.protocolVersion,
+        "2025-06-18",
+        `expected the local initialize to echo the requested protocolVersion, got ${init.result.protocolVersion}`,
+    );
+    assert.ok(
+        initElapsed < SSE_DELAY_MS - 500,
+        `initialize took ${initElapsed}ms — expected it answered locally, well before the ${SSE_DELAY_MS}ms relayer connect`,
+    );
+
+    // 2) tools/list at cold start is served locally and instantly with the
+    //    static list, which must be EXACTLY the upstream tool set plus the
+    //    locally-served login/logout — each name once.
+    send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+    const list = await waitFor((m) => m.id === 2 && m.result, SSE_DELAY_MS);
+    const coldNames = list.result.tools.map((t) => t.name);
+    const expectedNames = new Set([...UPSTREAM_TOOL_NAMES, "memwal_login", "memwal_logout"]);
+    // Unique names (TOOL_DEFINITIONS bundles its own memwal_login; a blind concat
+    // with the local login/logout defs would list it twice).
+    assert.equal(
+        new Set(coldNames).size,
+        coldNames.length,
+        `cold tools/list has duplicate tool names: ${coldNames}`,
+    );
+    // Exact set match — guards against the cold list drifting from the real
+    // upstream registration (e.g. missing memwal_remember_bulk / memwal_health).
+    assert.deepEqual(
+        new Set(coldNames),
+        expectedNames,
+        `cold tools/list set mismatch. got ${[...coldNames].sort()}, expected ${[...expectedNames].sort()}`,
+    );
+
+    // 3) tools/call sent BEFORE the stream is up must be buffered and served
+    //    once the background connect completes (not dropped, not hung).
+    send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "memwal_recall", arguments: { query: "anything" } },
+    });
+    const recall = await waitFor((m) => m.id === 3, 15_000);
+    assert.notEqual(recall.result?.isError, true);
+    assert.match(JSON.stringify(recall.result), /RECALL_OK/);
+
+    // 4) Once connected, the bridge announces the real tool set so the client
+    //    re-lists (notifications/tools/list_changed).
+    const changed = await waitFor((m) => m.method === "notifications/tools/list_changed", 5_000);
+    assert.ok(changed);
+
+    // 5) The upstream initialize reply (serverInfo "memwal-upstream") must have
+    //    been SUPPRESSED — the client only ever saw our local reply for id 1.
+    const initReplies = received.filter((r) => r.msg.id === 1 && r.msg.result);
+    assert.equal(
+        initReplies.length,
+        1,
+        `expected exactly one initialize reply, saw ${initReplies.length}: ${JSON.stringify(initReplies.map((r) => r.msg))}`,
+    );
+    assert.equal(initReplies[0].msg.result.serverInfo.name, "memwal");
+
+    // 6) After connect, a re-list is forwarded upstream and spliced with
+    //    login/logout. That authoritative set must EQUAL the cold static set —
+    //    the static→refreshed transition must not change the tool set (each
+    //    name once, no dup even if upstream ever served login).
+    send({ jsonrpc: "2.0", id: 4, method: "tools/list", params: {} });
+    const relist = await waitFor((m) => m.id === 4 && m.result, 10_000);
+    const splicedNames = relist.result.tools.map((t) => t.name);
+    assert.equal(
+        new Set(splicedNames).size,
+        splicedNames.length,
+        `post-connect tools/list has duplicate tool names: ${splicedNames}`,
+    );
+    assert.deepEqual(
+        new Set(splicedNames),
+        new Set(coldNames),
+        `cold and post-connect tool sets differ. cold=${[...coldNames].sort()} spliced=${[...splicedNames].sort()}`,
+    );
+
+    assert.ok(mock.getSseGetCount() >= 1, "expected at least one SSE handshake");
+});

--- a/packages/mcp/test/coldstart-timeout.test.mjs
+++ b/packages/mcp/test/coldstart-timeout.test.mjs
@@ -1,0 +1,226 @@
+/**
+ * Regression test for GH #415 (graceful-degradation gate) — a hung relayer must
+ * NOT be fatal (no SIGTERM), and must not corrupt the handshake.
+ *
+ * Repro:
+ *   - Mock relayer answers GET /version, accepts the SSE GET, then goes SILENT
+ *     forever (never sends the endpoint event) — a relayer that's up enough to
+ *     accept the socket but never completes the MCP handshake.
+ *   - With MEMWAL_MCP_CONNECT_TIMEOUT_MS small, each connect attempt aborts at
+ *     the bound and retries with backoff.
+ *
+ * Asserts the corrected degraded-path behaviour (post adversarial review):
+ *   - `initialize` is answered locally EXACTLY ONCE (guards the double-reply bug
+ *     where the connect-failure path wrote a second envelope for the same id).
+ *   - a buffered `tools/call` is NOT eager-failed between retries (a call the
+ *     next attempt could serve must not get a spurious error; this also protects
+ *     the auth-required hot-handoff request).
+ *   - the process stays alive throughout (no SIGTERM / startup failure).
+ *   - on shutdown (stdin close) the still-open call is closed out with an error
+ *     envelope rather than left hanging.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const EXPECTED_BEARER = "a".repeat(64);
+const EXPECTED_ACCOUNT_ID = "0x" + "3".repeat(64);
+
+function hasBridgeAuth(req) {
+    return (
+        req.headers.authorization === `Bearer ${EXPECTED_BEARER}` &&
+        req.headers["x-memwal-account-id"] === EXPECTED_ACCOUNT_ID
+    );
+}
+
+/** Mock relayer that accepts the SSE GET but NEVER sends the endpoint event —
+ * the initial connect hangs until the bridge's bounded timeout aborts it. */
+function startHungRelayer() {
+    let sseGetCount = 0;
+    const openStreams = [];
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    apiVersion: "1.0.0",
+                    relayerVersion: "1.0.0",
+                    minSupportedSdk: { mcp: "0.0.1" },
+                }),
+            );
+            return;
+        }
+        if (req.method === "GET" && url.pathname === "/api/mcp/sse") {
+            if (!hasBridgeAuth(req)) {
+                res.writeHead(401);
+                res.end();
+                return;
+            }
+            sseGetCount += 1;
+            res.writeHead(200, {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+            });
+            // Deliberately send nothing else — the handshake never completes.
+            openStreams.push(res);
+            return;
+        }
+        // No messages endpoint is ever reached (no session established).
+        res.writeHead(404);
+        res.end();
+    });
+    return new Promise((res) => {
+        server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address();
+            res({
+                server,
+                base: `http://127.0.0.1:${port}`,
+                getSseGetCount: () => sseGetCount,
+                closeStreams: () => openStreams.forEach((r) => r.end()),
+            });
+        });
+    });
+}
+
+function makeCreds(relayerUrl) {
+    return {
+        delegatePrivateKey: EXPECTED_BEARER,
+        delegatePublicKeyHex: "b".repeat(64),
+        delegateAddress: "0x" + "1".repeat(64),
+        walletAddress: "0x" + "2".repeat(64),
+        accountId: EXPECTED_ACCOUNT_ID,
+        packageId: "0x" + "4".repeat(64),
+        relayerUrl,
+        label: "Coldstart Timeout Test",
+        createdAt: new Date(0).toISOString(),
+        version: 1,
+    };
+}
+
+test("a hung relayer bounds the connect and returns a tool-call error instead of hanging", async (t) => {
+    const mock = await startHungRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-coldstart-timeout-test-"));
+    const credsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credsPath), { recursive: true });
+    writeFileSync(credsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: {
+            ...process.env,
+            HOME: home,
+            USERPROFILE: home,
+            MEMWAL_MCP_CONNECT_TIMEOUT_MS: "1000",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+    let stderrBuf = "";
+    child.stderr.on("data", (d) => (stderrBuf += d.toString()));
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => {
+                listeners.delete(l);
+                rej(
+                    new Error(
+                        `timed out waiting for message\n--- stderr ---\n${stderrBuf}\n--- received ---\n${received.map((m) => JSON.stringify(m)).join("\n")}`,
+                    ),
+                );
+            }, ms);
+            const l = (m) => {
+                if (pred(m)) {
+                    clearTimeout(timer);
+                    listeners.delete(l);
+                    res(m);
+                }
+            };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => {
+        child.kill("SIGKILL");
+        mock.closeStreams();
+        mock.server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    // initialize is still answered locally even though the relayer never
+    // completes its handshake.
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const init = await waitFor((m) => m.id === 1 && m.result, 5_000);
+    assert.equal(init.result.serverInfo.name, "memwal");
+
+    // A tool call buffered before connect. The relayer never comes up, so the
+    // connect retries with backoff. The call must NOT be eager-failed between
+    // attempts (a call the next attempt could serve must not get a spurious
+    // error — that also protects the auth-required hot-handoff request). It
+    // stays pending; the client's own per-tool timeout would handle it.
+    send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "memwal_recall", arguments: { query: "anything" } },
+    });
+
+    // Wait out several connect-retry cycles (timeout 1s + backoff). During this
+    // window the buffered call must NOT have been answered with an error.
+    await new Promise((r) => setTimeout(r, 4_500));
+    assert.ok(
+        !received.some((m) => m.id === 2),
+        `id=2 must stay buffered during retries, but got a reply: ${JSON.stringify(received.find((m) => m.id === 2))}`,
+    );
+
+    // Regression guard for the double-`initialize` bug: id=1 must have been
+    // answered EXACTLY once (the local reply) — never a second envelope from the
+    // connect-failure path.
+    const initReplies = received.filter((m) => m.id === 1 && (m.result || m.error));
+    assert.equal(
+        initReplies.length,
+        1,
+        `initialize (id=1) must be answered exactly once; saw ${initReplies.length}: ${JSON.stringify(initReplies)}`,
+    );
+
+    // Process is still alive despite the hung relayer — the whole point is no
+    // SIGTERM / startup failure.
+    assert.equal(child.exitCode, null, "bridge should still be running, not exited");
+
+    // On shutdown (stdin closes) the still-buffered tool call is closed out with
+    // an error envelope instead of being left hanging.
+    child.stdin.end();
+    const recall = await waitFor((m) => m.id === 2, 5_000);
+    assert.equal(recall.result?.isError, true, `expected isError envelope on shutdown, got ${JSON.stringify(recall)}`);
+    assert.match(JSON.stringify(recall.result), /relayer unavailable/i);
+});

--- a/packages/mcp/test/initialize-id-reuse.test.mjs
+++ b/packages/mcp/test/initialize-id-reuse.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * Regression test for GH #415 round-3 finding T2 — suppression of the upstream
+ * `initialize` reply must be EXACTLY ONE reply, not a permanent id filter.
+ *
+ * Bug being guarded against: the bridge answers `initialize` locally and forwards
+ * it upstream, suppressing the upstream reply. An earlier fix kept the initialize
+ * id in a suppress set for the whole session AND dropped ANY error on that id — so
+ * a client that (out of spec, but defensively supported) reuses the initialize id
+ * for a later real request had that request's reply (result OR error) silently
+ * swallowed, hanging the call. The fix makes suppression a one-shot count.
+ *
+ * This test reuses id=1 for a real tools/call after initialize and asserts the
+ * real reply comes through — for both a success and an error response.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const EXPECTED_BEARER = "a".repeat(64);
+const EXPECTED_ACCOUNT_ID = "0x" + "3".repeat(64);
+
+function hasBridgeAuth(req) {
+    return (
+        req.headers.authorization === `Bearer ${EXPECTED_BEARER}` &&
+        req.headers["x-memwal-account-id"] === EXPECTED_ACCOUNT_ID
+    );
+}
+
+/** Mock relayer that answers immediately. It replies to initialize with an
+ * upstream initialize result (to be suppressed), a memwal_recall call with a
+ * success, and a memwal_restore call with a JSON-RPC error. */
+function startRelayer() {
+    const sessions = new Map();
+    let sseGetCount = 0;
+    const server = http.createServer((req, res) => {
+        const u = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && u.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ apiVersion: "1.0.0", relayerVersion: "1.0.0", minSupportedSdk: { mcp: "0.0.1" } }));
+            return;
+        }
+        if (req.method === "GET" && u.pathname === "/api/mcp/sse") {
+            if (!hasBridgeAuth(req)) { res.writeHead(401); res.end(); return; }
+            sseGetCount += 1;
+            const sessionId = `session-${sseGetCount}`;
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+            res.write(`event: endpoint\ndata: /api/mcp/messages?sessionId=${sessionId}\n\n`);
+            sessions.set(sessionId, { res });
+            const hb = setInterval(() => { if (!res.writableEnded) res.write(":\n\n"); else clearInterval(hb); }, 200);
+            hb.unref?.();
+            res.on("close", () => clearInterval(hb));
+            return;
+        }
+        if (req.method === "POST" && u.pathname === "/api/mcp/messages") {
+            if (!hasBridgeAuth(req)) { res.writeHead(401); res.end(); return; }
+            const session = sessions.get(u.searchParams.get("sessionId"));
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                let msg;
+                try { msg = JSON.parse(body); } catch { res.writeHead(202); res.end(); return; }
+                if (!session) { res.writeHead(404); res.end(); return; }
+                res.writeHead(202); res.end();
+                const name = msg.params?.name;
+                if (msg.method === "initialize") {
+                    // Upstream initialize reply — must be suppressed by the bridge.
+                    session.res.write(`event: message\ndata: ${JSON.stringify({
+                        jsonrpc: "2.0", id: msg.id,
+                        result: { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "memwal-upstream", version: "9.9.9" } },
+                    })}\n\n`);
+                    return;
+                }
+                if (msg.method === "tools/call" && name === "memwal_recall") {
+                    session.res.write(`event: message\ndata: ${JSON.stringify({
+                        jsonrpc: "2.0", id: msg.id,
+                        result: { content: [{ type: "text", text: "REUSED_ID_RESULT" }], isError: false },
+                    })}\n\n`);
+                    return;
+                }
+                if (msg.method === "tools/call" && name === "memwal_restore") {
+                    // A genuine JSON-RPC ERROR on a (reused) id — must reach the client.
+                    session.res.write(`event: message\ndata: ${JSON.stringify({
+                        jsonrpc: "2.0", id: msg.id,
+                        error: { code: -32000, message: "REUSED_ID_ERROR" },
+                    })}\n\n`);
+                    return;
+                }
+            });
+            return;
+        }
+        res.writeHead(404); res.end();
+    });
+    return new Promise((res) => {
+        server.listen(0, "127.0.0.1", () => res({ server, base: `http://127.0.0.1:${server.address().port}` }));
+    });
+}
+
+function makeCreds(relayerUrl) {
+    return {
+        delegatePrivateKey: EXPECTED_BEARER, delegatePublicKeyHex: "b".repeat(64),
+        delegateAddress: "0x" + "1".repeat(64), walletAddress: "0x" + "2".repeat(64),
+        accountId: EXPECTED_ACCOUNT_ID, packageId: "0x" + "4".repeat(64),
+        relayerUrl, label: "IdReuse Test", createdAt: new Date(0).toISOString(), version: 1,
+    };
+}
+
+test("reusing the initialize id for a real request still gets that request's reply (result and error)", async (t) => {
+    const mock = await startRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-idreuse-test-"));
+    const credsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credsPath), { recursive: true });
+    writeFileSync(credsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home }, stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl); buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg; try { msg = JSON.parse(line); } catch { continue; }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+    let stderrBuf = "";
+    child.stderr.on("data", (d) => (stderrBuf += d.toString()));
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => { listeners.delete(l); rej(new Error(`timeout\n${stderrBuf}\n${received.map((m) => JSON.stringify(m)).join("\n")}`)); }, ms);
+            const l = (m) => { if (pred(m)) { clearTimeout(timer); listeners.delete(l); res(m); } };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => { child.kill("SIGKILL"); mock.server.close(); rmSync(home, { recursive: true, force: true }); });
+
+    // initialize (id=1) → local reply; upstream reply suppressed (one-shot).
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const init = await waitFor((m) => m.id === 1 && m.result, 5_000);
+    assert.equal(init.result.serverInfo.name, "memwal"); // local, not "memwal-upstream"
+
+    // Let the connect settle so the request goes to the live session.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // REUSE id=1 for a real tools/call with a SUCCESS reply — must come through.
+    send({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memwal_recall", arguments: { query: "x" } } });
+    const okReply = await waitFor((m) => m.id === 1 && m.result && JSON.stringify(m.result).includes("REUSED_ID_RESULT"), 8_000);
+    assert.ok(okReply, "reused-id success reply was suppressed (should pass through)");
+
+    // REUSE id=1 again for a request whose upstream reply is an ERROR — must come through.
+    send({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memwal_restore", arguments: { namespace: "n" } } });
+    const errReply = await waitFor((m) => m.id === 1 && m.error && m.error.message === "REUSED_ID_ERROR", 8_000);
+    assert.ok(errReply, "reused-id error reply was suppressed (should pass through)");
+});

--- a/packages/mcp/test/live-login-credentials.test.mjs
+++ b/packages/mcp/test/live-login-credentials.test.mjs
@@ -375,7 +375,9 @@ test("a request buffered during cold start is NOT flushed to a new account after
 
     // No account-B session may have received the account-A recall (id=5), and
     // id=5 must have been answered exactly once (no double response).
+    const id1Replies = bridge.received.filter((m) => m.id === 1);
     const id5Replies = bridge.received.filter((m) => m.id === 5);
+    assert.equal(id1Replies.length, 1, `initialize answered exactly once, saw ${id1Replies.length}`);
     assert.equal(id5Replies.length, 1, `id=5 answered exactly once, saw ${id5Replies.length}: ${JSON.stringify(id5Replies)}`);
     const bAccountRecall = bridge.received.find(
         (m) => m.id === 5 && m.result && /account A secret/.test(JSON.stringify(m)),

--- a/packages/mcp/test/live-login-credentials.test.mjs
+++ b/packages/mcp/test/live-login-credentials.test.mjs
@@ -171,6 +171,7 @@ function collectMessages(child) {
     });
 
     return {
+        received,
         send: (message) => child.stdin.write(`${JSON.stringify(message)}\n`),
         waitFor(predicate, timeoutMs = 10_000) {
             const existing = received.find(predicate);
@@ -249,6 +250,10 @@ test("in-session memwal_login reconnects the bridge with the new credentials", a
 
     bridge.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
     await bridge.waitFor((message) => message.id === 1 && message.result);
+    // `initialize` is answered locally and the relayer connect runs in the
+    // background, so the SSE handshake lands shortly AFTER the init reply rather
+    // than synchronously with it — wait for it before asserting.
+    await waitUntil(() => mock.handshakes.length >= 1);
     assert.equal(mock.handshakes[0].bearer, `Bearer ${INITIAL_BEARER}`);
     assert.equal(mock.handshakes[0].accountId, ACCOUNT_A);
 
@@ -291,4 +296,79 @@ test("in-session memwal_login reconnects the bridge with the new credentials", a
     assert.notEqual(recall.result?.isError, true);
     assert.match(recall.result.content[0].text, new RegExp(`account=${ACCOUNT_B}`));
     assert.match(recall.result.content[0].text, new RegExp(`bearer=${updatedHandshake.bearer}`));
+});
+
+test("a request buffered during cold start is NOT flushed to a new account after an in-session login", async (t) => {
+    // Merge-composition regression (#415 × #597): a request buffered while the
+    // relayer is still cold-starting (sse not yet up) must not survive an
+    // account-change login and be flushed to the NEW account's session. It must
+    // be failed with the -32001 account-change error, and the new account must
+    // never receive it.
+    const mock = await startMockRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-coldstart-login-test-"));
+    const credentialsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credentialsPath), { recursive: true });
+    writeFileSync(credentialsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    // Delay the FIRST handshake so the initial connect never completes before
+    // the login — the bridge stays in cold start, buffering into pendingForward.
+    mock.delayNextHandshake();
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    const bridge = collectMessages(child);
+    t.after(() => {
+        child.kill("SIGKILL");
+        mock.server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    // initialize is answered locally; the connect is delayed (handshake held).
+    bridge.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await bridge.waitFor((message) => message.id === 1 && message.result);
+    await waitUntil(() => mock.handshakes.length >= 1); // the (delayed) GET arrived
+    assert.equal(mock.handshakes[0].accountId, ACCOUNT_A);
+
+    // A recall for account A — buffered into pendingForward (connect not up).
+    bridge.send({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "memwal_recall", arguments: { query: "account A secret" } },
+    });
+
+    // Log into a DIFFERENT account (B) while id=5 sits buffered.
+    bridge.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "memwal_login", arguments: {} },
+    });
+    const login = await bridge.waitFor((message) => message.id === 2);
+    const connectUrl = login.result.content[0].text.match(/\*\*URL:\*\* (http[^\n]+)/)?.[1];
+    assert.ok(connectUrl, "memwal_login should return the browser URL");
+    await completeLogin(connectUrl, ACCOUNT_B);
+
+    // Now release the held handshake so the connect can proceed / reconnect.
+    mock.releaseDelayedHandshake();
+
+    // The buffered account-A recall must come back as the -32001 account-change
+    // error — NOT an account-B recall result.
+    const recallReply = await bridge.waitFor((message) => message.id === 5);
+    assert.equal(recallReply.error?.code, -32001, `id=5 must be the account-change error, got ${JSON.stringify(recallReply)}`);
+    assert.equal(recallReply.result, undefined, "id=5 must not carry a recall result");
+
+    // Give the bridge time to (wrongly) flush id=5 if the bug were present.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // No account-B session may have received the account-A recall (id=5), and
+    // id=5 must have been answered exactly once (no double response).
+    const id5Replies = bridge.received.filter((m) => m.id === 5);
+    assert.equal(id5Replies.length, 1, `id=5 answered exactly once, saw ${id5Replies.length}: ${JSON.stringify(id5Replies)}`);
+    const bAccountRecall = bridge.received.find(
+        (m) => m.id === 5 && m.result && /account A secret/.test(JSON.stringify(m)),
+    );
+    assert.ok(!bAccountRecall, "the account-A recall must never be served by account B");
 });

--- a/packages/mcp/test/live-login-credentials.test.mjs
+++ b/packages/mcp/test/live-login-credentials.test.mjs
@@ -33,6 +33,7 @@ function makeCreds(relayerUrl) {
 function startMockRelayer() {
     const sessions = new Map();
     const handshakes = [];
+    const posts = [];
     let nextSession = 1;
     let delayNextHandshake = false;
     let delayedHandshake = null;
@@ -98,6 +99,14 @@ function startMockRelayer() {
                 res.writeHead(202);
                 res.end();
                 const msg = JSON.parse(body);
+                posts.push({
+                    sessionId: url.searchParams.get("sessionId"),
+                    bearer: req.headers.authorization,
+                    accountId: req.headers["x-memwal-account-id"],
+                    method: msg.method,
+                    id: msg.id ?? null,
+                    name: msg.params?.name ?? null,
+                });
                 const result =
                     msg.method === "initialize"
                         ? {
@@ -131,6 +140,7 @@ function startMockRelayer() {
                 server,
                 base: `http://127.0.0.1:${port}`,
                 handshakes,
+                posts,
                 delayNextHandshake() {
                     delayNextHandshake = true;
                 },
@@ -371,4 +381,92 @@ test("a request buffered during cold start is NOT flushed to a new account after
         (m) => m.id === 5 && m.result && /account A secret/.test(JSON.stringify(m)),
     );
     assert.ok(!bAccountRecall, "the account-A recall must never be served by account B");
+});
+
+test("same-account login during cold start delivers each buffered call once on the new bearer", async (t) => {
+    // Same-account memwal_login must not let connectInBackground flush
+    // pendingForward after reconnect() already replayed inFlight.
+    const mock = await startMockRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-same-account-coldstart-"));
+    const credentialsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credentialsPath), { recursive: true });
+    writeFileSync(credentialsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    mock.delayNextHandshake();
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    const bridge = collectMessages(child);
+    t.after(() => {
+        child.kill("SIGKILL");
+        mock.server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    bridge.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await bridge.waitFor((message) => message.id === 1 && message.result);
+    await waitUntil(() => mock.handshakes.length >= 1);
+
+    bridge.send({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "memwal_recall", arguments: { query: "same account" } },
+    });
+
+    bridge.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "memwal_login", arguments: {} },
+    });
+    const login = await bridge.waitFor((message) => message.id === 2);
+    const connectUrl = login.result.content[0].text.match(/\*\*URL:\*\* (http[^\n]+)/)?.[1];
+    assert.ok(connectUrl, "memwal_login should return the browser URL");
+    await completeLogin(connectUrl, ACCOUNT_A);
+
+    mock.releaseDelayedHandshake();
+
+    const recall = await bridge.waitFor((message) => message.id === 5);
+    assert.notEqual(recall.result?.isError, true);
+    const saved = JSON.parse(readFileSync(credentialsPath, "utf8"));
+    assert.match(recall.result.content[0].text, new RegExp(`account=${ACCOUNT_A}`));
+    assert.match(
+        recall.result.content[0].text,
+        new RegExp(`bearer=Bearer ${saved.delegatePrivateKey}`),
+    );
+
+    await new Promise((r) => setTimeout(r, 400));
+    const id1 = bridge.received.filter((m) => m.id === 1);
+    const id5 = bridge.received.filter((m) => m.id === 5);
+    assert.equal(id1.length, 1, `initialize answered once, saw ${id1.length}`);
+    assert.equal(id5.length, 1, `recall answered once, saw ${id5.length}`);
+
+    const recallPosts = mock.posts.filter((p) => p.name === "memwal_recall" && p.id === 5);
+    assert.equal(
+        recallPosts.length,
+        1,
+        `recall POSTed once, saw ${recallPosts.length}: ${JSON.stringify(recallPosts)}`,
+    );
+    assert.equal(recallPosts[0].bearer, `Bearer ${saved.delegatePrivateKey}`);
+    assert.equal(recallPosts[0].accountId, ACCOUNT_A);
+
+    const initPosts = mock.posts.filter((p) => p.method === "initialize");
+    assert.equal(initPosts.length, 1, `initialize POSTed once, saw ${JSON.stringify(initPosts)}`);
+    assert.equal(initPosts[0].bearer, `Bearer ${saved.delegatePrivateKey}`);
+
+    bridge.send({
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/call",
+        params: { name: "memwal_recall", arguments: { query: "after login" } },
+    });
+    const followUp = await bridge.waitFor((message) => message.id === 6);
+    assert.notEqual(followUp.result?.isError, true);
+    assert.match(
+        followUp.result.content[0].text,
+        new RegExp(`bearer=Bearer ${saved.delegatePrivateKey}`),
+    );
 });

--- a/packages/mcp/test/login-handoff.test.mjs
+++ b/packages/mcp/test/login-handoff.test.mjs
@@ -179,6 +179,10 @@ test("auth-required mode picks up credentials mid-session without a restart", as
             title: "Remember a Fact",
             annotations: { readOnlyHint: false, destructiveHint: false },
         },
+        memwal_remember_bulk: {
+            title: "Remember Several Facts",
+            annotations: { readOnlyHint: false, destructiveHint: false },
+        },
         memwal_recall: {
             title: "Recall Memories",
             annotations: { readOnlyHint: false, destructiveHint: true },
@@ -190,6 +194,10 @@ test("auth-required mode picks up credentials mid-session without a restart", as
         memwal_restore: {
             title: "Restore Memory Index",
             annotations: { readOnlyHint: false, destructiveHint: false },
+        },
+        memwal_health: {
+            title: "Check Relayer Health",
+            annotations: { readOnlyHint: true, destructiveHint: false },
         },
         memwal_login: {
             title: "Sign In to Walrus Memory",


### PR DESCRIPTION
## Summary

### Why
On a credentialed cold start (the common returning-user case), `memwal-mcp`
awaited a full relayer round-trip — TLS + `GET /version` + SSE handshake + the
`endpoint` event — **before** answering the MCP `initialize` handshake, because
the stdio↔SSE bridge forwarded `initialize` to the relayer rather than answering
it locally. When the cold-start path was slow (npx fetch + relayer TLS), this
exceeded the MCP client's 30s connection timeout, so the client SIGTERM'd the
process and **no memory tools loaded for that session**. Reported in #415
(WALM-321) with three timeout occurrences on the mainnet relayer.

### What
- Answer `initialize` **locally and instantly**, and serve a static cold-start
  `tools/list`, before the relayer session exists — wiring stdin **before** the
  connect.
- Run the relayer connect in a **background retry loop**; buffer `tools/call`
  until connected, then flush in arrival order and emit
  `notifications/tools/list_changed` so the client re-lists the authoritative
  upstream tool set (spliced with the locally-served `memwal_login`/`memwal_logout`).
- Bound the connect with a new `MEMWAL_MCP_CONNECT_TIMEOUT_MS` (default 10s),
  shared across the compatibility check and the SSE connect, so a hung relayer
  **degrades to a tool-call error** instead of a failed startup.
- `initialize` is still forwarded upstream for capability negotiation, with its
  reply suppressed (one-shot, so a reused id still gets its real reply).

### Solution
Mirrors the existing "auth-required" mode, which already answers `initialize`
locally when credentials are missing — this applies the same pattern to the
credentialed bridge path. The connect is decoupled from the handshake; the
existing reconnect + in-flight replay machinery owns delivery of any buffered
request after a stale-session 404 (so nothing is double-posted, even when a
concurrent reconnect races the flush). No new architectural surface; behaviour
is unchanged once the stream is up.

Preserved invariants: reconnect + in-flight replay, the login/logout `tools/list`
splice, default-namespace injection, the no-creds-wipe-on-401 semantics, and the
auth-required → bridge hot-handoff.

## Types of Changes

- [x] Bug fix (non-breaking)
- [x] Test

## Benchmark impact

- [x] No benchmark-affecting change (MCP client DX; no recall / answer / extraction path touched)

## Testing

- [x] Tested locally
- [x] Added/updated integration tests
- [x] All new and existing tests pass (`packages/mcp`: 15/15, `tsc` clean)

New end-to-end tests (spawn the built binary against a mock relayer):
- `initialize` answered locally well before a slow relayer's SSE endpoint; static
  `tools/list` served instantly; buffered `tools/call` served after connect;
  upstream `initialize` reply suppressed; cold list == post-connect spliced set.
- Hung relayer → bounded connect → tool-call error envelope; process stays alive
  (no SIGTERM); buffered call closed out on shutdown.
- Flush-time 404 → reconnect de-duplicates (no double memory write / double
  reply), including a request arriving during the reconnect backoff and a
  concurrent `server-pump-eof` reconnect.
- Reusing the `initialize` id for a later request still returns that request's
  real reply (result and error).

## Checklist

- [x] Follows the project's commit + code conventions
- [x] No ticket IDs / competitor names / local-doc paths in code comments
- [x] Docs updated if needed (CHANGELOG entry added; `MEMWAL_MCP_CONNECT_TIMEOUT_MS` documented there)
- [x] Respects the privacy floor (no server-readable plaintext index)
- [x] All new and existing tests pass

## Related

- GitHub: #415
- Linear: WALM-321
