### PR TITLE
feat(mcp): resolve OAuth bearers in the proxy, cutting over /api/mcp (3/3)

### DIFF
--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -261,6 +261,21 @@ claude mcp add --transport http memwal https://relayer.memory.walrus.xyz/api/mcp
 
 If your client cannot attach headers from the CLI, edit the generated MCP config file to add them manually.
 
+### OAuth (Claude custom connectors)
+
+Claude's native "Add custom connector" flow speaks OAuth 2.1, not the explicit-header model above — it discovers an authorization server, dynamically registers itself as a client, and drives the user through a hosted consent screen instead of expecting a pasted bearer token.
+
+When enabled (`MCP_OAUTH_ENABLED=true`), the hosted relayer additionally exposes:
+
+- `GET /.well-known/oauth-protected-resource` (+ the `/api/mcp`-suffixed variant Claude probes first) — RFC 9728 resource metadata.
+- `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata, advertising `code_challenge_methods_supported: ["S256"]` and `offline_access` (the scope that triggers Claude to request a refresh token).
+- `POST /oauth/register` — RFC 7591 dynamic client registration. Redirect URIs are checked against an allowlist (Anthropic's own callback domain, plus RFC 8252 loopback for Claude Code) rather than accepted from anywhere — self-serve registration for an *arbitrary* redirect target is not offered.
+- `GET /oauth/authorize`, `POST /oauth/token`, `POST /oauth/revoke` — the standard authorization-code + PKCE + refresh flow (RFC 6749/7636/7009). `/oauth/token` accepts both `application/x-www-form-urlencoded` (the spec-required content type) and `application/json`.
+
+Unlike the explicit-header and stdio flows, the OAuth path has the server generate and custody an encrypted delegate key on the user's behalf (`v1.<nonce>.<ciphertext>`, AES-256-GCM) — Claude cannot hold a Sui wallet key itself, so something server-side has to be able to sign on its behalf. The consent screen states this plainly; the underlying delegate key is still revocable from the dashboard like any other.
+
+Adding the connector in Claude: use the hosted MCP URL (`https://relayer.memory.walrus.xyz/api/mcp`) as the connector URL — Claude handles discovery, registration, and consent automatically from there.
+
 ### When to prefer HTTP vs stdio
 
 Prefer **stdio** when:
@@ -286,6 +301,10 @@ The hosted relayer (and any self-hosted relayer) exposes the same MCP routes:
 | `GET /api/mcp` | Streamable HTTP server-to-client stream |
 | `POST /api/mcp` | Streamable HTTP JSON-RPC messages |
 | `DELETE /api/mcp` | Close a Streamable HTTP session |
+| `GET /.well-known/oauth-protected-resource` | OAuth resource metadata (RFC 9728, when `MCP_OAUTH_ENABLED=true`) |
+| `GET /.well-known/oauth-authorization-server` | OAuth authorization-server metadata (RFC 8414) |
+| `POST /oauth/register` | Dynamic client registration (RFC 7591) |
+| `GET /oauth/authorize`, `POST /oauth/token`, `POST /oauth/revoke` | Authorization-code + PKCE + refresh flow |
 
 The Rust relayer auto-starts a TypeScript sidecar and forwards MCP traffic to it over loopback. The sidecar resolves MCP bearer credentials into normal Walrus Memory SDK sessions, so MCP tool calls go through the **same SEAL, Walrus, and pgvector paths** as direct SDK calls.
 

--- a/services/server/src/mcp_proxy.rs
+++ b/services/server/src/mcp_proxy.rs
@@ -99,6 +99,109 @@ fn out_set(
     }
 }
 
+// ---------------------------------------------------------------------
+// MCP OAuth bearer resolution (Claude custom connectors). Runs before the
+// sidecar ever sees the request: classifies the inbound bearer, and when
+// it's an OAuth access token, translates it into the legacy
+// `Authorization: Bearer <delegate-key-hex>` + `X-MemWal-Account-Id` shape
+// the sidecar's `resolveAuth()` already accepts — so the sidecar itself
+// needs zero changes. See `oauth.rs` for the crypto/DB side.
+// ---------------------------------------------------------------------
+
+enum McpAuthOutcome {
+    /// `MCP_OAUTH_ENABLED=false`, or the bearer is the legacy 64-hex
+    /// delegate key — forward exactly as today, byte for byte.
+    Passthrough,
+    Oauth(Box<crate::oauth::ResolvedOAuthIdentity>),
+    /// OAuth is enabled and the bearer is missing/malformed/expired/
+    /// revoked — respond with the RFC 9728 challenge ourselves instead of
+    /// forwarding to the sidecar (which wouldn't know how to build the
+    /// `resource_metadata` pointer anyway).
+    Unauthorized(Option<crate::oauth::OAuthBearerError>),
+}
+
+fn is_legacy_delegate_bearer(token: &str) -> bool {
+    let hex_part = token.strip_prefix("0x").unwrap_or(token);
+    hex_part.len() == 64 && hex_part.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+async fn classify_and_resolve(state: &AppState, headers: &HeaderMap) -> McpAuthOutcome {
+    if state.config.mcp_oauth.is_none() {
+        return McpAuthOutcome::Passthrough;
+    }
+    let Some(auth_value) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return McpAuthOutcome::Unauthorized(None);
+    };
+    let Some(token) = auth_value
+        .strip_prefix("Bearer ")
+        .or_else(|| auth_value.strip_prefix("bearer "))
+        .map(str::trim)
+    else {
+        return McpAuthOutcome::Unauthorized(None);
+    };
+
+    if is_legacy_delegate_bearer(token) {
+        return McpAuthOutcome::Passthrough;
+    }
+
+    match crate::oauth::resolve_oauth_bearer(state, token).await {
+        Ok(identity) => McpAuthOutcome::Oauth(Box::new(identity)),
+        Err(crate::oauth::OAuthBearerError::NotOAuthToken) => McpAuthOutcome::Unauthorized(None),
+        Err(err) => {
+            tracing::debug!("mcp_proxy oauth bearer rejected: {:?}", err);
+            McpAuthOutcome::Unauthorized(Some(err))
+        }
+    }
+}
+
+/// Overwrite (never merge) `authorization` + `x-memwal-account-id` on the
+/// outbound headers. This MUST be an overwrite: `build_forwarded_headers`
+/// already copies any client-supplied `x-memwal-*` header verbatim (that's
+/// how the legacy explicit-header flow works), so a caller presenting a
+/// valid OAuth token alongside a forged `X-MemWal-Account-Id` must have the
+/// forged value discarded, not merged with the token's real account.
+fn apply_oauth_headers(
+    forwarded: &mut reqwest::header::HeaderMap,
+    identity: &crate::oauth::ResolvedOAuthIdentity,
+) {
+    if let Ok(v) = reqwest::header::HeaderValue::from_str(&format!(
+        "Bearer {}",
+        identity.delegate_private_key.as_str()
+    )) {
+        forwarded.insert(reqwest::header::AUTHORIZATION, v);
+    }
+    if let (Ok(name), Ok(v)) = (
+        reqwest::header::HeaderName::from_bytes(b"x-memwal-account-id"),
+        reqwest::header::HeaderValue::from_str(&identity.account_id),
+    ) {
+        forwarded.insert(name, v);
+    }
+}
+
+/// RFC 9728 401 challenge. `state.config.mcp_oauth` must be `Some` — only
+/// called from `classify_and_resolve`'s `Unauthorized` arm, which only
+/// returns that when OAuth is enabled.
+fn oauth_unauthorized_response(state: &AppState, err: Option<&crate::oauth::OAuthBearerError>) -> Response {
+    let Some(cfg) = state.config.mcp_oauth.as_ref() else {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    };
+    let mut challenge = format!(
+        "Bearer resource_metadata=\"{}/.well-known/oauth-protected-resource\"",
+        cfg.issuer
+    );
+    if let Some(err) = err {
+        challenge.push_str(&format!(", error=\"{}\"", err.error_code()));
+    }
+    let mut resp = (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    if let Ok(v) = HeaderValue::from_str(&challenge) {
+        resp.headers_mut().insert(axum::http::header::WWW_AUTHENTICATE, v);
+    }
+    resp
+}
+
 /// `GET /api/mcp/sse` — open the SSE stream to the sidecar and stream the
 /// response body back to the client without buffering. The sidecar emits an
 /// `event: endpoint` line carrying `/api/mcp/messages?sessionId=…`; the
@@ -123,6 +226,11 @@ pub async fn sse_proxy(
         peer,
         state.config.trusted_proxy_hops,
     );
+    match classify_and_resolve(&state, &headers).await {
+        McpAuthOutcome::Passthrough => {}
+        McpAuthOutcome::Oauth(identity) => apply_oauth_headers(&mut forwarded, &identity),
+        McpAuthOutcome::Unauthorized(err) => return oauth_unauthorized_response(&state, err.as_ref()),
+    }
     let req = state
         .http_client
         .get(&url)
@@ -219,6 +327,11 @@ pub async fn messages_proxy(
         peer,
         state.config.trusted_proxy_hops,
     );
+    match classify_and_resolve(&state, &headers).await {
+        McpAuthOutcome::Passthrough => {}
+        McpAuthOutcome::Oauth(identity) => apply_oauth_headers(&mut forwarded, &identity),
+        McpAuthOutcome::Unauthorized(err) => return oauth_unauthorized_response(&state, err.as_ref()),
+    }
     let upstream = state
         .http_client
         .post(&url)
@@ -322,6 +435,11 @@ pub async fn streamable_proxy(
         peer,
         state.config.trusted_proxy_hops,
     );
+    match classify_and_resolve(&state, &headers).await {
+        McpAuthOutcome::Passthrough => {}
+        McpAuthOutcome::Oauth(identity) => apply_oauth_headers(&mut forwarded, &identity),
+        McpAuthOutcome::Unauthorized(err) => return oauth_unauthorized_response(&state, err.as_ref()),
+    }
     req = req.headers(forwarded);
 
     // Same 24h request timeout as the SSE proxy — a streamable response
@@ -500,5 +618,60 @@ mod tests {
         );
         assert!(out.get("cookie").is_none(), "cookie must not be forwarded");
         assert!(out.get("host").is_none(), "host must not be forwarded");
+    }
+
+    // -- MCP OAuth bearer classification ---------------------------------
+
+    #[test]
+    fn legacy_bearer_classification_accepts_64_hex_with_or_without_0x() {
+        let hex64 = "a".repeat(64);
+        assert!(is_legacy_delegate_bearer(&hex64));
+        assert!(is_legacy_delegate_bearer(&format!("0x{hex64}")));
+    }
+
+    #[test]
+    fn legacy_bearer_classification_rejects_oauth_and_garbage_tokens() {
+        assert!(!is_legacy_delegate_bearer("mwo_abcdefgh"));
+        assert!(!is_legacy_delegate_bearer("not-hex-at-all"));
+        assert!(!is_legacy_delegate_bearer(&"a".repeat(63))); // one short
+        assert!(!is_legacy_delegate_bearer(&"a".repeat(65))); // one long
+    }
+
+    #[test]
+    fn apply_oauth_headers_overwrites_forwarded_authorization_and_account_id() {
+        // Simulates the case build_forwarded_headers already copied a
+        // client-supplied (potentially forged) x-memwal-account-id — the
+        // OAuth resolution must win, not merge.
+        let mut forwarded = reqwest::header::HeaderMap::new();
+        forwarded.insert(
+            reqwest::header::AUTHORIZATION,
+            "Bearer mwo_whatever".parse().unwrap(),
+        );
+        forwarded.insert(
+            reqwest::header::HeaderName::from_bytes(b"x-memwal-account-id").unwrap(),
+            "0xforged".parse().unwrap(),
+        );
+
+        let key = [3u8; 32];
+        let envelope = crate::oauth::encrypt_delegate_private_key(&key, &"b".repeat(64)).unwrap();
+        let secret = crate::oauth::decrypt_delegate_private_key(&key, &envelope).unwrap();
+        let identity = crate::oauth::ResolvedOAuthIdentity {
+            account_id: "0xrealaccount".to_string(),
+            delegate_private_key: secret,
+            grant_id: "mwg_test".to_string(),
+        };
+
+        apply_oauth_headers(&mut forwarded, &identity);
+
+        assert_eq!(
+            forwarded.get("authorization").and_then(|v| v.to_str().ok()),
+            Some(format!("Bearer {}", "b".repeat(64)).as_str())
+        );
+        assert_eq!(
+            forwarded
+                .get("x-memwal-account-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("0xrealaccount")
+        );
     }
 }

--- a/services/server/src/oauth.rs
+++ b/services/server/src/oauth.rs
@@ -28,6 +28,7 @@ use blake2::{
     digest::{Update, VariableOutput},
     Blake2bVar,
 };
+use chrono::Utc;
 use ed25519_dalek::SigningKey;
 use ipnet::IpNet;
 use rand::rngs::OsRng;
@@ -677,6 +678,96 @@ pub fn sanitize_label(raw: &str, default: &str) -> String {
     } else {
         cleaned
     }
+}
+
+// ---------------------------------------------------------------------
+// Resource-server bearer resolution — the PR3 piece `mcp_proxy.rs` calls on
+// every `/api/mcp*` request to translate an OAuth access token into the
+// legacy delegate-key credential the TS sidecar already understands.
+// ---------------------------------------------------------------------
+
+/// Everything the proxy needs to rewrite an inbound request's headers into
+/// the legacy `Authorization: Bearer <hex>` + `X-MemWal-Account-Id` shape.
+pub struct ResolvedOAuthIdentity {
+    pub account_id: String,
+    pub delegate_private_key: DelegateSecret,
+    #[allow(dead_code)]
+    pub grant_id: String,
+}
+
+#[derive(Debug)]
+pub enum OAuthBearerError {
+    /// Not shaped like an OAuth token at all (no `mwo_` prefix) — the
+    /// caller should fall back to the legacy bearer check.
+    NotOAuthToken,
+    Invalid,
+    Expired,
+    Revoked,
+    /// Delegate was revoked independently of the grant (e.g. the on-chain
+    /// key was removed) — same external symptom as `Revoked` but a
+    /// distinct internal cause, useful in logs.
+    DelegateNotActive,
+    Internal(String),
+}
+
+impl OAuthBearerError {
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            OAuthBearerError::NotOAuthToken => "invalid_token",
+            OAuthBearerError::Invalid => "invalid_token",
+            OAuthBearerError::Expired => "invalid_token",
+            OAuthBearerError::Revoked => "invalid_token",
+            OAuthBearerError::DelegateNotActive => "invalid_token",
+            OAuthBearerError::Internal(_) => "invalid_token",
+        }
+    }
+}
+
+/// Resolve a presented bearer token to a signable delegate identity.
+/// Returns `Err(NotOAuthToken)` immediately (no DB call) for anything not
+/// prefixed `mwo_`, so the legacy 64-hex path costs nothing extra.
+pub async fn resolve_oauth_bearer(
+    state: &crate::types::AppState,
+    token: &str,
+) -> Result<ResolvedOAuthIdentity, OAuthBearerError> {
+    if !token.starts_with(ACCESS_TOKEN_PREFIX) {
+        return Err(OAuthBearerError::NotOAuthToken);
+    }
+    let cfg = state
+        .config
+        .mcp_oauth
+        .as_ref()
+        .ok_or(OAuthBearerError::NotOAuthToken)?;
+
+    let hash = hash_token(token);
+    let row = state
+        .db
+        .fetch_oauth_token_with_delegate(&hash)
+        .await
+        .map_err(|e| OAuthBearerError::Internal(e.to_string()))?
+        .ok_or(OAuthBearerError::Invalid)?;
+
+    if row.token_type != "access" {
+        return Err(OAuthBearerError::Invalid);
+    }
+    if row.revoked_at.is_some() || row.grant_revoked_at.is_some() {
+        return Err(OAuthBearerError::Revoked);
+    }
+    if row.expires_at <= Utc::now() {
+        return Err(OAuthBearerError::Expired);
+    }
+    if row.delegate_status != "active" {
+        return Err(OAuthBearerError::DelegateNotActive);
+    }
+
+    let delegate_private_key = decrypt_delegate_private_key(&cfg.encryption_key, &row.encrypted_private_key)
+        .map_err(|_| OAuthBearerError::Internal("failed to decrypt delegate private key".to_string()))?;
+
+    Ok(ResolvedOAuthIdentity {
+        account_id: row.account_id,
+        delegate_private_key,
+        grant_id: row.grant_id,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Step 3 of 3 — stacked on #584 (base branch is `feat/mcp-oauth-connector`, not `dev`, so this diff is just the proxy-side change; merge #584 first, then this).

Wires the actual resource-server side: `/api/mcp*` now accepts OAuth access tokens minted by #584's authorization server, alongside the existing static-bearer flow, unchanged.

- `classify_and_resolve` runs before every proxied request (SSE, messages, streamable): legacy 64-hex bearer → passthrough (byte-for-byte, unchanged), `MCP_OAUTH_ENABLED` off → passthrough (unchanged), `mwo_`-prefixed OAuth token → resolved via `oauth::resolve_oauth_bearer` and rewritten into the legacy `Authorization` + `X-MemWal-Account-Id` shape before proxying to the sidecar. **Zero changes to the TS sidecar** (`services/server/scripts/mcp/*`) — that's the whole point of doing the translation in the Rust proxy layer.
- The rewrite is an overwrite, not a merge: tested explicitly (`apply_oauth_headers_overwrites_forwarded_authorization_and_account_id`) that a forged `X-MemWal-Account-Id` alongside a valid OAuth token gets discarded, not honored.
- Missing/invalid/expired/revoked tokens get an RFC 9728 401 challenge (`WWW-Authenticate: Bearer resource_metadata="..."`) straight from the proxy, since only it knows the discovery URL.
- `docs/mcp/reference.md` documents the new flow and routes.

Still behind `MCP_OAUTH_ENABLED=false`.

## Test plan
- [x] `cargo test --bin memwal-server mcp_proxy::` — includes new classification/overwrite tests, all passing
- [x] `cargo test --bin memwal-server` — full suite green (477 passed, 30 ignored)
- [ ] Manual: enable `MCP_OAUTH_ENABLED` on staging, add the connector from a real Claude account, confirm `tools/list` + a representative tool call succeed with no `X-MemWal-Account-Id` header sent — this is the actual acceptance criterion and can't be verified by CI alone.