### PR TITLE
fix(sdk): widen zod peer dependency to support v3 and v4

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "ai": ">=4.0.0",
-        "zod": "^3.23.0",
+        "zod": "^3.23.0 || ^4.0.0",
         "@mysten/sui": ">=2.5.0",
         "@mysten/seal": ">=1.1.0",
         "@mysten/walrus": ">=1.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,7 +1135,7 @@ importers:
         specifier: '>=4.0.0'
         version: 6.0.37(zod@3.25.76)
       zod:
-        specifier: ^3.23.0
+        specifier: ^3.23.0 || ^4.0.0
         version: 3.25.76
     devDependencies:
       '@ai-sdk/provider':


### PR DESCRIPTION
## Summary
- `zod` is not imported anywhere in `packages/sdk/src` — it's an unused, optional peer dependency
- The `^3.23.0`-only range blocks installing `@mysten-incubation/memwal` alongside `ai` v7 or `@modelcontextprotocol/sdk`, both of which are on zod 4
- Widened `peerDependencies.zod` to `^3.23.0 || ^4.0.0`, matching the range `@modelcontextprotocol/sdk` itself already accepts

Reported externally: install fails with
```
npm error ERESOLVE could not resolve
npm error Conflicting peer dependency: zod@3.25.76
npm error   peerOptional zod@"^3.23.0" from @mysten-incubation/memwal@0.1.1
```

## Test plan
- [x] Confirmed no `zod` import anywhere in `packages/sdk/src`
- [x] Packed the SDK with the fix and did a clean `npm install` alongside `zod@^4.0.0`, `ai@^7.0.0`, `@modelcontextprotocol/sdk@latest` in an isolated scratch project — resolves with no ERESOLVE, zod deduped to `4.4.3` across all three