### PR TITLE
fix(sdk): encode large manual payloads safely

### DIFF
--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -131,6 +131,16 @@ function sealServerConfigTotalWeight(configs: ResolvedSealServerConfig[]): numbe
     return configs.reduce((sum, config) => sum + config.weight, 0);
 }
 
+/** Encode arbitrary-size bytes without passing the whole payload as function arguments. */
+function bytesToBase64(bytes: Uint8Array): string {
+    const chunkSize = 0x8000;
+    const chunks: string[] = [];
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+        chunks.push(String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)));
+    }
+    return btoa(chunks.join(""));
+}
+
 // ============================================================
 // MemWalManual Client
 // ============================================================
@@ -349,7 +359,7 @@ export class MemWalManual {
 
         // Step 3: Send encrypted bytes (base64) + vector to server.
         // Server will upload to Walrus via upload-relay and return the blob_id.
-        const encryptedBase64 = btoa(String.fromCharCode(...encrypted));
+        const encryptedBase64 = bytesToBase64(encrypted);
         return this.signedRequest<RememberManualResult>("POST", "/api/remember/manual", {
             encrypted_data: encryptedBase64,
             vector,

--- a/packages/sdk/test/manual-seal-identity.test.mjs
+++ b/packages/sdk/test/manual-seal-identity.test.mjs
@@ -144,6 +144,27 @@ test("inactive accounts fail before encryption", async () => {
     assert.equal(encryptCalls.length, 0);
 });
 
+test("manual remember base64-encodes large ciphertext without argument spread overflow", async () => {
+    const { manual } = manualWithAccountResponse({});
+    const encrypted = Uint8Array.from({ length: 256 * 1024 }, (_, index) => index % 256);
+    let request;
+
+    manual.embed = async () => [0.25, 0.75];
+    manual.sealEncrypt = async () => encrypted;
+    manual.signedRequest = async (method, path, body) => {
+        request = { method, path, body };
+        return { blob_id: "large-blob" };
+    };
+
+    await manual.rememberManual("large memory", "large-namespace");
+
+    assert.equal(request.method, "POST");
+    assert.equal(request.path, "/api/remember/manual");
+    assert.equal(request.body.namespace, "large-namespace");
+    assert.deepEqual(request.body.vector, [0.25, 0.75]);
+    assert.deepEqual(Buffer.from(request.body.encrypted_data, "base64"), Buffer.from(encrypted));
+});
+
 test("manual recall skips a foreign ciphertext package before fetching keys", async () => {
     const { manual } = manualWithAccountResponse({});
     let fetchCalls = 0;


### PR DESCRIPTION
## Summary

- replace whole-array argument spreading in `rememberManual` base64 encoding with fixed-size chunks
- keep the encoder portable across browser and Node runtimes
- add a 256 KiB ciphertext regression test that verifies exact byte round-tripping and request construction

## Testing

- `pnpm --dir packages/sdk test` (23/23 passed)
- `git diff --check`

Closes #593