### PR TITLE
fix(app): use object-form recall in quickstarts

### DIFF
--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -696,7 +696,7 @@ const job = await memwal.remember("I'm allergic to peanuts")
 await memwal.waitForRememberJob(job.job_id)
 
 // Recall memories
-const result = await memwal.recall("food allergies")
+const result = await memwal.recall({ query: "food allergies" })
 console.log(result.results[0].text)`
 
     const sdkPythonSnippet = `import asyncio
@@ -712,7 +712,7 @@ async def main():
 
     await memwal.remember_and_wait("I'm allergic to peanuts")
 
-    result = await memwal.recall("food allergies")
+    result = await memwal.recall(query="food allergies")
     print(result.results[0].text)
 
     await memwal.close()

--- a/apps/app/src/pages/Playground.tsx
+++ b/apps/app/src/pages/Playground.tsx
@@ -423,7 +423,7 @@ export default function Playground() {
         setRecallResult(null)
         setRecallError(null)
         try {
-            const data = await memwal.recall(recallQuery, 5)
+            const data = await memwal.recall({ query: recallQuery, limit: 5 })
             setRecallResult(JSON.stringify(data, null, 2))
             trackPlaygroundOperation('recall', 'complete')
         } catch (err: unknown) {
@@ -485,7 +485,7 @@ export default function Playground() {
         try {
             // Phase 1: Recall memories using SDK
             setAskPhase('step 1/3 — recalling memories from Walrus Memory...')
-            const recallData = await memwal.recall(askQuestion, 5)
+            const recallData = await memwal.recall({ query: askQuestion, limit: 5 })
             const memories = recallData.results || []
 
             // Phase 2: Build prompt with memory context
@@ -757,7 +757,7 @@ while (true) {
                     number={3}
                     title="recall"
                     description="semantic search → download → decrypt"
-                    code={`const result = await memwal.recall("${recallQuery}", 5)
+                    code={`const result = await memwal.recall({ query: "${recallQuery}", limit: 5 })
 // Server: embed query → cosine search → download → decrypt
 // namespace: "${namespace || 'default'}" — only searches within this namespace
 // → { results: [{ text, blob_id, distance }], total }`}

--- a/apps/app/src/test/recallQuickstarts.test.ts
+++ b/apps/app/src/test/recallQuickstarts.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const dashboardSource = readFileSync(resolve('src/pages/Dashboard.tsx'), 'utf8')
+const playgroundSource = readFileSync(resolve('src/pages/Playground.tsx'), 'utf8')
+
+test('Dashboard quickstarts use the preferred recall API', () => {
+    expect(dashboardSource).toContain('memwal.recall({ query: "food allergies" })')
+    expect(dashboardSource).toContain('memwal.recall(query="food allergies")')
+    expect(dashboardSource).not.toContain('memwal.recall("food allergies")')
+})
+
+test('Playground calls and snippets use object-form recall', () => {
+    expect(playgroundSource).toContain('memwal.recall({ query: recallQuery, limit: 5 })')
+    expect(playgroundSource).toContain('memwal.recall({ query: askQuestion, limit: 5 })')
+    expect(playgroundSource).toContain('memwal.recall({ query: "${recallQuery}", limit: 5 })')
+    expect(playgroundSource).not.toContain('memwal.recall(recallQuery, 5)')
+    expect(playgroundSource).not.toContain('memwal.recall(askQuestion, 5)')
+    expect(playgroundSource).not.toContain('memwal.recall("${recallQuery}", 5)')
+})


### PR DESCRIPTION
## Summary

- update Dashboard TypeScript quickstart to the preferred object-form `recall` API
- update Dashboard Python quickstart to use the keyword argument form
- migrate Playground live recall calls and displayed snippets away from deprecated positional arguments
- add regression tests that keep deprecated examples from returning

## Testing

- `pnpm --dir apps/app test` (73/73 passed)
- `pnpm --dir apps/app lint`
- `pnpm --dir apps/app build`
- `git diff --check`

Closes #582