### PR TITLE
fix(mcp): refresh bridge credentials after login

### DIFF
--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -387,7 +387,10 @@ function writeStdoutMessage(msg: RpcMessage): void {
  * mode, but available even when creds already exist (so user can re-login,
  * switch wallets, or refresh). Returns a click-able URL near-instantly;
  * listener stays alive in the background until callback or timeout. */
-async function handleLocalLogin(config: BridgeConfig): Promise<{ text: string; isError: boolean }> {
+async function handleLocalLogin(
+    config: BridgeConfig,
+    onCredentials: (creds: MemWalCredentials) => Promise<void>,
+): Promise<{ text: string; isError: boolean }> {
     const urlReady = new Promise<string>((resolve) => {
         loginFlow({
             relayerUrl: config.relayerUrl,
@@ -397,7 +400,8 @@ async function handleLocalLogin(config: BridgeConfig): Promise<{ text: string; i
             openBrowser: false,
             onUrl: (url) => resolve(url),
         })
-            .then((creds) => {
+            .then(async (creds) => {
+                await onCredentials(creds);
                 log.info("memwal_login.bridge.success", {
                     accountId: creds.accountId,
                     delegateAddress: creds.delegateAddress,
@@ -514,8 +518,10 @@ export async function runBridge(
     log.info("bridge.connected", { relayer: creds.relayerUrl });
 
     let stdinClosed = false;
-    let reconnecting = false;
     let reconnectAttempt = 0;
+    let reconnectPromise: Promise<void> | null = null;
+    let credentialGeneration = 0;
+    let activeCredentialGeneration = 0;
 
     // In-flight requests pending a response. We replay them after a forced
     // reconnect so a server-side session swap doesn't strand a tool call
@@ -529,47 +535,138 @@ export async function runBridge(
      * client surfaces them in its tool palette. */
     const pendingListIds = new Set<string | number>();
 
-    async function reconnect(reason: string): Promise<void> {
-        if (stdinClosed || reconnecting) return;
-        reconnecting = true;
-        try {
-            sse.abort();
-        } catch {
-            /* already dead */
-        }
-        const backoff = Math.min(15_000, 500 * Math.pow(2, reconnectAttempt));
-        reconnectAttempt += 1;
-        log.warn("bridge.reconnecting", { reason, backoffMs: backoff, attempt: reconnectAttempt });
-        await new Promise((r) => setTimeout(r, backoff));
-        try {
-            sse = await openSseStream(creds.relayerUrl, creds);
-            reconnectAttempt = 0;
-            log.info("bridge.reconnected", {
-                relayer: creds.relayerUrl,
-                replayCount: inFlight.size,
-            });
-            // Replay any requests that haven't been answered yet against the
-            // fresh session. Iterate over a snapshot — postMessage is async
-            // and the SSE pump may delete entries concurrently as replies
-            // start arriving on the new session.
-            for (const [id, msg] of Array.from(inFlight.entries())) {
-                try {
-                    const status = await postMessage(sse.postUrl, msg, creds);
-                    log.info("bridge.replayed", { id, status });
-                } catch (err) {
-                    log.error("bridge.replay_failed", {
-                        id,
-                        err: err instanceof Error ? err.message : String(err),
-                    });
-                }
+    async function reconnect(reason: string, immediate = false): Promise<void> {
+        if (stdinClosed) return;
+        // All callers await the same reconnect. Returning immediately while a
+        // reconnect is active lets the server pump spin on the aborted stream
+        // and lets client messages race the stale POST URL.
+        if (reconnectPromise) return reconnectPromise;
+
+        reconnectPromise = (async () => {
+            try {
+                sse.abort();
+            } catch {
+                /* already dead */
             }
-        } catch (err) {
-            log.error("bridge.reconnect_failed", {
-                err: err instanceof Error ? err.message : String(err),
+            const backoff = immediate
+                ? 0
+                : Math.min(15_000, 500 * Math.pow(2, reconnectAttempt));
+            reconnectAttempt += 1;
+            log.warn("bridge.reconnecting", {
+                reason,
+                backoffMs: backoff,
+                attempt: reconnectAttempt,
             });
-            // Try again on the next stdin message rather than spinning.
+            if (backoff > 0) await new Promise((r) => setTimeout(r, backoff));
+            try {
+                while (!stdinClosed) {
+                    const openingGeneration = credentialGeneration;
+                    const openingCreds = creds;
+                    const candidate = await openSseStream(
+                        openingCreds.relayerUrl,
+                        openingCreds,
+                    );
+
+                    // Login can finish while an older handshake is awaiting its
+                    // endpoint event. Never publish that stale session: its GET
+                    // used the old key, while subsequent POSTs would use the new
+                    // key and fail session authentication.
+                    if (openingGeneration !== credentialGeneration) {
+                        candidate.abort();
+                        log.info("bridge.reconnect_discarded_stale_credentials", {
+                            openingGeneration,
+                            credentialGeneration,
+                        });
+                        continue;
+                    }
+
+                    sse = candidate;
+                    activeCredentialGeneration = openingGeneration;
+                    reconnectAttempt = 0;
+                    log.info("bridge.reconnected", {
+                        relayer: openingCreds.relayerUrl,
+                        replayCount: inFlight.size,
+                    });
+                    // Replay any requests that haven't been answered yet against the
+                    // fresh session. Iterate over a snapshot — postMessage is async
+                    // and the SSE pump may delete entries concurrently as replies
+                    // start arriving on the new session.
+                    for (const [id, msg] of Array.from(inFlight.entries())) {
+                        try {
+                            const status = await postMessage(sse.postUrl, msg, openingCreds);
+                            log.info("bridge.replayed", { id, status });
+                        } catch (err) {
+                            log.error("bridge.replay_failed", {
+                                id,
+                                err: err instanceof Error ? err.message : String(err),
+                            });
+                        }
+                    }
+                    // Credentials can also rotate while replay awaits POSTs.
+                    // In that case this candidate is already stale even though
+                    // it passed the first generation check.
+                    if (openingGeneration !== credentialGeneration) {
+                        candidate.abort();
+                        continue;
+                    }
+                    break;
+                }
+            } catch (err) {
+                log.error("bridge.reconnect_failed", {
+                    err: err instanceof Error ? err.message : String(err),
+                });
+                // Try again on the next stdin message rather than spinning.
+            }
+        })();
+
+        try {
+            await reconnectPromise;
         } finally {
-            reconnecting = false;
+            reconnectPromise = null;
+        }
+    }
+
+    async function adoptCredentials(nextCreds: MemWalCredentials): Promise<void> {
+        const previousAccountId = creds.accountId;
+        const accountChanged = previousAccountId !== nextCreds.accountId;
+
+        // Never replay an operation authorized for account A against account B.
+        // Return explicit retryable errors instead; the caller can decide which
+        // operations belong in the newly-selected account.
+        if (accountChanged) {
+            try {
+                sse.abort();
+            } catch {
+                /* already dead */
+            }
+            for (const [id] of Array.from(inFlight.entries())) {
+                writeStdoutMessage({
+                    jsonrpc: "2.0",
+                    id,
+                    error: {
+                        code: -32001,
+                        message:
+                            "Walrus Memory account changed during login; retry this request for the new account",
+                    },
+                });
+                pendingListIds.delete(id);
+            }
+            inFlight.clear();
+        }
+
+        creds = nextCreds;
+        credentialGeneration += 1;
+        reconnectAttempt = 0;
+        log.info("bridge.credentials_updated", {
+            previousAccountId,
+            accountId: creds.accountId,
+            delegate: creds.delegateAddress,
+        });
+        await reconnect("login-credentials-updated", true);
+        // Covers the narrow case where this update joined a reconnect just as
+        // its promise was resolving, after its final generation check.
+        if (activeCredentialGeneration !== credentialGeneration) {
+            await reconnect("login-credentials-generation-mismatch", true);
         }
     }
 
@@ -635,7 +732,7 @@ export async function runBridge(
                 if (msg.method === "tools/call" && msg.id != null) {
                     const params = (msg.params ?? {}) as { name?: string };
                     if (params.name === "memwal_login") {
-                        const result = await handleLocalLogin(config);
+                        const result = await handleLocalLogin(config, adoptCredentials);
                         writeStdoutMessage({
                             jsonrpc: "2.0",
                             id: msg.id,
@@ -680,6 +777,13 @@ export async function runBridge(
                     msg.id !== null
                 ) {
                     inFlight.set(msg.id, msg);
+                }
+                // A successful background login swaps credentials and SSE
+                // sessions asynchronously. Wait for that swap before sending a
+                // new request so it cannot race the stale session URL/key.
+                if (reconnectPromise) await reconnectPromise;
+                if (activeCredentialGeneration !== credentialGeneration) {
+                    await reconnect("post-credential-generation-mismatch", true);
                 }
                 const status = await postMessage(sse.postUrl, msg, creds);
                 if (status === 404) {

--- a/packages/mcp/test/live-login-credentials.test.mjs
+++ b/packages/mcp/test/live-login-credentials.test.mjs
@@ -1,0 +1,294 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const INITIAL_BEARER = "a".repeat(64);
+const ACCOUNT_A = `0x${"1".repeat(64)}`;
+const ACCOUNT_B = `0x${"2".repeat(64)}`;
+const WALLET = `0x${"3".repeat(64)}`;
+const PACKAGE = `0x${"4".repeat(64)}`;
+
+function makeCreds(relayerUrl) {
+    return {
+        delegatePrivateKey: INITIAL_BEARER,
+        delegatePublicKeyHex: "b".repeat(64),
+        delegateAddress: `0x${"5".repeat(64)}`,
+        walletAddress: WALLET,
+        accountId: ACCOUNT_A,
+        packageId: PACKAGE,
+        relayerUrl,
+        label: "Live Login Test",
+        createdAt: new Date(0).toISOString(),
+        version: 1,
+    };
+}
+
+function startMockRelayer() {
+    const sessions = new Map();
+    const handshakes = [];
+    let nextSession = 1;
+    let delayNextHandshake = false;
+    let delayedHandshake = null;
+
+    function establishSession(sessionId, res) {
+        res.write(`event: endpoint\ndata: /api/mcp/messages?sessionId=${sessionId}\n\n`);
+        const heartbeat = setInterval(() => res.write(": keepalive\n\n"), 250);
+        heartbeat.unref?.();
+        res.on("close", () => clearInterval(heartbeat));
+    }
+
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    apiVersion: "1.0.0",
+                    relayerVersion: "1.0.0",
+                    minSupportedSdk: { mcp: "0.0.1" },
+                }),
+            );
+            return;
+        }
+        if (req.method === "GET" && url.pathname === "/api/mcp/sse") {
+            const bearer = req.headers.authorization;
+            const accountId = req.headers["x-memwal-account-id"];
+            const sessionId = `session-${nextSession++}`;
+            handshakes.push({ bearer, accountId, sessionId });
+            res.writeHead(200, {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+            });
+            res.flushHeaders();
+            sessions.set(sessionId, { res, bearer, accountId });
+            if (delayNextHandshake) {
+                delayNextHandshake = false;
+                delayedHandshake = { sessionId, res };
+            } else {
+                establishSession(sessionId, res);
+            }
+            return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/mcp/messages") {
+            const session = sessions.get(url.searchParams.get("sessionId"));
+            if (!session) {
+                res.writeHead(404);
+                res.end();
+                return;
+            }
+            if (
+                req.headers.authorization !== session.bearer ||
+                req.headers["x-memwal-account-id"] !== session.accountId
+            ) {
+                res.writeHead(401);
+                res.end();
+                return;
+            }
+            let body = "";
+            req.on("data", (chunk) => (body += chunk));
+            req.on("end", () => {
+                res.writeHead(202);
+                res.end();
+                const msg = JSON.parse(body);
+                const result =
+                    msg.method === "initialize"
+                        ? {
+                              protocolVersion: "2024-11-05",
+                              capabilities: { tools: { listChanged: true } },
+                              serverInfo: { name: "memwal", version: "0.0.1" },
+                          }
+                        : {
+                              content: [
+                                  {
+                                      type: "text",
+                                      text: `RECALL_OK account=${session.accountId} bearer=${session.bearer}`,
+                                  },
+                              ],
+                              isError: false,
+                          };
+                session.res.write(
+                    `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: msg.id, result })}\n\n`,
+                );
+            });
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+
+    return new Promise((resolveStart) => {
+        server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address();
+            resolveStart({
+                server,
+                base: `http://127.0.0.1:${port}`,
+                handshakes,
+                delayNextHandshake() {
+                    delayNextHandshake = true;
+                },
+                closeSession(sessionId) {
+                    sessions.get(sessionId)?.res.end();
+                },
+                releaseDelayedHandshake() {
+                    assert.ok(delayedHandshake, "expected a delayed SSE handshake");
+                    establishSession(delayedHandshake.sessionId, delayedHandshake.res);
+                    delayedHandshake = null;
+                },
+            });
+        });
+    });
+}
+
+function collectMessages(child) {
+    const received = [];
+    const listeners = new Set();
+    let stdout = "";
+    let stderr = "";
+    child.stderr.on("data", (data) => (stderr += data.toString()));
+    child.stdout.on("data", (data) => {
+        stdout += data.toString();
+        let newline;
+        while ((newline = stdout.indexOf("\n")) >= 0) {
+            const line = stdout.slice(0, newline);
+            stdout = stdout.slice(newline + 1);
+            if (!line.trim()) continue;
+            try {
+                const message = JSON.parse(line);
+                received.push(message);
+                for (const listener of [...listeners]) listener(message);
+            } catch {
+                // Ignore non-JSON diagnostics.
+            }
+        }
+    });
+
+    return {
+        send: (message) => child.stdin.write(`${JSON.stringify(message)}\n`),
+        waitFor(predicate, timeoutMs = 10_000) {
+            const existing = received.find(predicate);
+            if (existing) return Promise.resolve(existing);
+            return new Promise((resolveWait, reject) => {
+                const listener = (message) => {
+                    if (!predicate(message)) return;
+                    clearTimeout(timer);
+                    listeners.delete(listener);
+                    resolveWait(message);
+                };
+                const timer = setTimeout(() => {
+                    listeners.delete(listener);
+                    reject(
+                        new Error(
+                            `timed out waiting for bridge message\n--- stderr ---\n${stderr}\n--- received ---\n${received.map((message) => JSON.stringify(message)).join("\n")}`,
+                        ),
+                    );
+                }, timeoutMs);
+                listeners.add(listener);
+            });
+        },
+    };
+}
+
+async function completeLogin(connectUrl, accountId) {
+    const url = new URL(connectUrl);
+    const callbackBase = `http://127.0.0.1:${url.searchParams.get("port")}`;
+    const state = url.searchParams.get("connectState");
+    const publicKey = url.searchParams.get("publicKey");
+    const relayer = url.searchParams.get("relayer");
+    const origin = url.origin;
+    const headers = { origin, "content-type": "application/json" };
+
+    const preflight = await fetch(`${callbackBase}/preflight`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ state, publicKey, relayer }),
+    });
+    assert.equal(preflight.status, 200);
+
+    const callback = await fetch(`${callbackBase}/callback`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ state, accountId, walletAddress: WALLET, packageId: PACKAGE }),
+    });
+    assert.equal(callback.status, 200);
+}
+
+async function waitUntil(predicate, timeoutMs = 10_000) {
+    const started = Date.now();
+    while (!predicate()) {
+        if (Date.now() - started > timeoutMs) throw new Error("timed out waiting for condition");
+        await new Promise((resolveWait) => setTimeout(resolveWait, 25));
+    }
+}
+
+test("in-session memwal_login reconnects the bridge with the new credentials", async (t) => {
+    const mock = await startMockRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-live-login-test-"));
+    const credentialsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credentialsPath), { recursive: true });
+    writeFileSync(credentialsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    const bridge = collectMessages(child);
+
+    t.after(() => {
+        child.kill("SIGKILL");
+        mock.server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    bridge.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    await bridge.waitFor((message) => message.id === 1 && message.result);
+    assert.equal(mock.handshakes[0].bearer, `Bearer ${INITIAL_BEARER}`);
+    assert.equal(mock.handshakes[0].accountId, ACCOUNT_A);
+
+    // Force a reconnect whose SSE endpoint event is delayed. Login completes
+    // while this old-credential handshake is in progress, reproducing the race
+    // where a shared reconnect promise previously published a stale session.
+    mock.delayNextHandshake();
+    mock.closeSession(mock.handshakes[0].sessionId);
+    await waitUntil(() => mock.handshakes.length >= 2);
+    assert.equal(mock.handshakes[1].bearer, `Bearer ${INITIAL_BEARER}`);
+    assert.equal(mock.handshakes[1].accountId, ACCOUNT_A);
+
+    bridge.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "memwal_login", arguments: {} },
+    });
+    const login = await bridge.waitFor((message) => message.id === 2);
+    const text = login.result.content[0].text;
+    const connectUrl = text.match(/\*\*URL:\*\* (http[^\n]+)/)?.[1];
+    assert.ok(connectUrl, "memwal_login should return the browser URL");
+
+    await completeLogin(connectUrl, ACCOUNT_B);
+    mock.releaseDelayedHandshake();
+    await waitUntil(() => mock.handshakes.some((entry) => entry.accountId === ACCOUNT_B));
+
+    const updatedHandshake = mock.handshakes.find((entry) => entry.accountId === ACCOUNT_B);
+    assert.notEqual(updatedHandshake.bearer, `Bearer ${INITIAL_BEARER}`);
+    const saved = JSON.parse(readFileSync(credentialsPath, "utf8"));
+    assert.equal(updatedHandshake.bearer, `Bearer ${saved.delegatePrivateKey}`);
+
+    bridge.send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "memwal_recall", arguments: { query: "new account" } },
+    });
+    const recall = await bridge.waitFor((message) => message.id === 3);
+    assert.notEqual(recall.result?.isError, true);
+    assert.match(recall.result.content[0].text, new RegExp(`account=${ACCOUNT_B}`));
+    assert.match(recall.result.content[0].text, new RegExp(`bearer=${updatedHandshake.bearer}`));
+});


### PR DESCRIPTION
## Summary

- adopt credentials returned by an in-session `memwal_login` and immediately reopen the SSE bridge with the new delegate key/account
- make concurrent reconnect callers await one shared reconnect so requests cannot race the stale session URL
- preserve in-flight replay for same-account key rotation, while failing old-account requests explicitly instead of replaying them against a newly selected account
- add an end-to-end regression test that completes the browser preflight/callback flow, verifies the second SSE handshake uses the new credentials, and recalls successfully without restarting the MCP process

## Testing

- `pnpm --dir packages/mcp test` (10/10 passed)
- `git diff --check`

Closes #580