### PR TITLE
fix(chatbot): isolate memory by authenticated user

### DIFF
--- a/apps/chatbot/app/(chat)/api/chat/route.ts
+++ b/apps/chatbot/app/(chat)/api/chat/route.ts
@@ -15,6 +15,7 @@ import { after } from "next/server";
 import { createResumableStreamContext } from "resumable-stream";
 import { auth, type UserType } from "@/app/(auth)/auth";
 import { entitlementsByUserType } from "@/lib/ai/entitlements";
+import { memoryNamespaceForUser } from "@/lib/ai/memory-namespace";
 import { allowedModelIds } from "@/lib/ai/models";
 import { type RequestHints, systemPrompt } from "@/lib/ai/prompts";
 import { getLanguageModel, getMemWalModel } from "@/lib/ai/providers";
@@ -76,6 +77,10 @@ export async function POST(request: Request) {
     }
 
     if (!session?.user) {
+      return new ChatbotError("unauthorized:chat").toResponse();
+    }
+    const memoryNamespace = memoryNamespaceForUser(session.user.id);
+    if (!memoryNamespace) {
       return new ChatbotError("unauthorized:chat").toResponse();
     }
 
@@ -160,7 +165,13 @@ export async function POST(request: Request) {
       originalMessages: isToolApprovalFlow ? uiMessages : undefined,
       execute: async ({ writer: dataStream }) => {
         const result = streamText({
-          model: useMemWal !== false ? getMemWalModel(selectedChatModel, memwalKey, memwalAccountId) : getLanguageModel(selectedChatModel),
+          model: useMemWal !== false
+            ? getMemWalModel(selectedChatModel, {
+                namespace: memoryNamespace,
+                memwalKey,
+                memwalAccountId,
+              })
+            : getLanguageModel(selectedChatModel),
           system: systemPrompt({ selectedChatModel, requestHints }),
           messages: modelMessages,
           stopWhen: stepCountIs(5),
@@ -185,7 +196,11 @@ export async function POST(request: Request) {
             createDocument: createDocument({ session, dataStream }),
             updateDocument: updateDocument({ session, dataStream }),
             requestSuggestions: requestSuggestions({ session, dataStream }),
-            saveMemory: saveMemory({ memwalKey, memwalAccountId }),
+            saveMemory: saveMemory({
+              namespace: memoryNamespace,
+              memwalKey,
+              memwalAccountId,
+            }),
           },
           experimental_telemetry: {
             isEnabled: isProductionEnvironment,

--- a/apps/chatbot/lib/ai/memory-isolation.unit.test.ts
+++ b/apps/chatbot/lib/ai/memory-isolation.unit.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { memoryNamespaceForUser } from "./memory-namespace";
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  rememberAndWait: vi.fn(),
+  withMemWal: vi.fn(),
+}));
+
+vi.mock("@mysten-incubation/memwal", () => ({
+  MemWal: {
+    create: mocks.create,
+  },
+}));
+
+vi.mock("@mysten-incubation/memwal/ai", () => ({
+  withMemWal: mocks.withMemWal,
+}));
+
+const USER_A = "11111111-1111-1111-1111-111111111111";
+const USER_B = "22222222-2222-2222-2222-222222222222";
+const KEY = "a".repeat(64);
+const ACCOUNT_ID = `0x${"b".repeat(64)}`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.create.mockReturnValue({ rememberAndWait: mocks.rememberAndWait });
+  mocks.rememberAndWait.mockResolvedValue({});
+  mocks.withMemWal.mockImplementation((_model, options) => ({ options }));
+});
+
+describe("chatbot memory namespace isolation", () => {
+  it("derives stable, distinct namespaces and fails closed without a user id", () => {
+    expect(memoryNamespaceForUser(USER_A)).toBe(`chatbot-user:${USER_A}`);
+    expect(memoryNamespaceForUser(USER_B)).toBe(`chatbot-user:${USER_B}`);
+    expect(memoryNamespaceForUser(USER_A)).not.toBe(memoryNamespaceForUser(USER_B));
+    expect(memoryNamespaceForUser(undefined)).toBeNull();
+    expect(memoryNamespaceForUser("   ")).toBeNull();
+  });
+
+  it("binds explicit memory saves to each authenticated user's namespace", async () => {
+    const { saveMemory } = await import("./tools/save-memory");
+    const namespaceA = memoryNamespaceForUser(USER_A)!;
+    const namespaceB = memoryNamespaceForUser(USER_B)!;
+
+    const toolA = saveMemory({
+      namespace: namespaceA,
+      memwalKey: KEY,
+      memwalAccountId: ACCOUNT_ID,
+    });
+    const toolB = saveMemory({
+      namespace: namespaceB,
+      memwalKey: KEY,
+      memwalAccountId: ACCOUNT_ID,
+    });
+    // @ts-expect-error — tool().execute is intentionally called at the unit-test boundary.
+    await toolA.execute({ text: "User A private memory" });
+    // @ts-expect-error — tool().execute is intentionally called at the unit-test boundary.
+    await toolB.execute({ text: "User B private memory" });
+
+    expect(mocks.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ namespace: namespaceA })
+    );
+    expect(mocks.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ namespace: namespaceB })
+    );
+  });
+
+  it("binds automatic recall and auto-save middleware to the user namespace", async () => {
+    const { getMemWalModel } = await import("./providers");
+    const namespace = memoryNamespaceForUser(USER_A)!;
+
+    getMemWalModel("openai/gpt-4o", {
+      namespace,
+      memwalKey: KEY,
+      memwalAccountId: ACCOUNT_ID,
+    });
+
+    expect(mocks.withMemWal).toHaveBeenCalledOnce();
+    expect(mocks.withMemWal.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ namespace })
+    );
+  });
+
+  it("wires the authenticated session namespace into both chatbot memory paths", () => {
+    const route = readFileSync(
+      resolve("app/(chat)/api/chat/route.ts"),
+      "utf8"
+    );
+    expect(route).toContain(
+      "memoryNamespaceForUser(session.user.id)"
+    );
+    expect(route).toMatch(
+      /getMemWalModel\(selectedChatModel, \{[\s\S]*?namespace: memoryNamespace/
+    );
+    expect(route).toMatch(
+      /saveMemory\(\{[\s\S]*?namespace: memoryNamespace/
+    );
+  });
+
+  it("refuses explicit saves when the authenticated namespace is missing", async () => {
+    const { saveMemory } = await import("./tools/save-memory");
+    const tool = saveMemory({
+      namespace: "",
+      memwalKey: KEY,
+      memwalAccountId: ACCOUNT_ID,
+    });
+    // @ts-expect-error — tool().execute is intentionally called at the unit-test boundary.
+    const result = await tool.execute({ text: "must not be stored" });
+
+    expect(result).toMatchObject({ saved: false });
+    expect(mocks.create).not.toHaveBeenCalled();
+    expect(mocks.rememberAndWait).not.toHaveBeenCalled();
+  });
+});

--- a/apps/chatbot/lib/ai/memory-namespace.ts
+++ b/apps/chatbot/lib/ai/memory-namespace.ts
@@ -1,0 +1,13 @@
+const CHATBOT_USER_NAMESPACE_PREFIX = "chatbot-user:";
+
+/**
+ * Derive the private memory namespace for an authenticated chatbot user.
+ * Returning null for a missing identity lets the request path fail closed
+ * instead of falling back to the shared `default` namespace.
+ */
+export function memoryNamespaceForUser(userId: unknown): string | null {
+  if (typeof userId !== "string") return null;
+  const normalized = userId.trim();
+  if (!normalized) return null;
+  return `${CHATBOT_USER_NAMESPACE_PREFIX}${normalized}`;
+}

--- a/apps/chatbot/lib/ai/providers.ts
+++ b/apps/chatbot/lib/ai/providers.ts
@@ -73,12 +73,28 @@ export function getArtifactModel() {
  * Wrap a language model with Walrus Memory layer.
  * Requires MEMWAL_PRIVATE_KEY env var. Falls back to base model if not configured.
  */
-export function getMemWalModel(modelId: string, memwalKey?: string, memwalAccountId?: string) {
+export function getMemWalModel(
+  modelId: string,
+  {
+    namespace,
+    memwalKey,
+    memwalAccountId,
+  }: {
+    namespace: string;
+    memwalKey?: string;
+    memwalAccountId?: string;
+  }
+) {
   const baseModel = getLanguageModel(modelId);
 
   const key = memwalKey || process.env.MEMWAL_PRIVATE_KEY;
   const memwalServerUrl = process.env.MEMWAL_SERVER_URL;
   const accountId = memwalAccountId || process.env.MEMWAL_ACCOUNT_ID;
+
+  if (!namespace.trim()) {
+    console.warn("[Walrus Memory] authenticated user namespace missing — memory layer disabled");
+    return baseModel;
+  }
 
   if (!key) {
     console.warn("[Walrus Memory] MEMWAL_PRIVATE_KEY not set — memory layer disabled");
@@ -94,6 +110,7 @@ export function getMemWalModel(modelId: string, memwalKey?: string, memwalAccoun
     key,
     accountId,
     serverUrl: memwalServerUrl || "http://localhost:8000",
+    namespace,
     maxMemories: 5,
     autoSave: true,
     minRelevance: 0,

--- a/apps/chatbot/lib/ai/tools/save-memory.ts
+++ b/apps/chatbot/lib/ai/tools/save-memory.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 import { MemWal } from "@mysten-incubation/memwal";
 
 export const saveMemory = ({
+  namespace,
   memwalKey,
   memwalAccountId,
 }: {
+  namespace: string;
   memwalKey?: string;
   memwalAccountId?: string;
 }) =>
@@ -31,9 +33,16 @@ export const saveMemory = ({
           error: "Walrus Memory not configured — MEMWAL_PRIVATE_KEY or MEMWAL_ACCOUNT_ID missing",
         };
       }
+      if (!namespace.trim()) {
+        return {
+          saved: false,
+          text,
+          error: "Walrus Memory authenticated user namespace missing",
+        };
+      }
 
       try {
-        const memwal = MemWal.create({ key, accountId, serverUrl });
+        const memwal = MemWal.create({ key, accountId, serverUrl, namespace });
         await memwal.rememberAndWait(text);
         return { saved: true, text };
       } catch (error) {


### PR DESCRIPTION
## Summary

- derive a stable memory namespace from the authenticated chatbot user ID and reject missing/blank identities
- pass that namespace to the AI middleware so automatic recall and auto-save no longer use the shared default namespace
- pass the same namespace to the explicit `saveMemory` tool
- add regression coverage for distinct user namespaces, middleware/tool configuration, route wiring, and fail-closed behavior

Existing memories in the previously shared `default` namespace are intentionally not recalled because they cannot be attributed safely to an individual user.

## Testing

- `pnpm --filter @mysten-incubation/memwal build`
- `pnpm --dir apps/chatbot test:unit` (15/15 passed)
- `pnpm --dir apps/chatbot exec tsc --noEmit`
- `pnpm --dir apps/chatbot exec next build`
- `git diff --check`

Note: the existing `ultracite check` command still hits the documented `--skip`/Biome version mismatch and is soft-failed on `dev` CI.

Closes #587