### PR TITLE
feat(sdk): add deterministic offline mock clients

### DIFF
--- a/packages/python-sdk-memwal/README.md
+++ b/packages/python-sdk-memwal/README.md
@@ -85,6 +85,23 @@ matches = client.recall(RecallParams(query="food allergies"))
 client.close()
 ```
 
+### Offline tests and CI
+
+`MemWalMock` and `MemWalMockSync` implement the common memory API in process. They require no credentials, relayer, chain, or paid storage and use deterministic token-overlap ranking.
+
+```python
+from memwal import MemWalMock, RecallParams
+
+async def test_memory_flow():
+    memwal = MemWalMock.create(namespace="test-user")
+    await memwal.remember_and_wait("The user prefers dark mode")
+
+    result = await memwal.recall(RecallParams(query="display preference"))
+    assert "dark mode" in result.results[0].text
+```
+
+The mock supports remember/job polling, bulk remember, recall, analyze, embed, ask, health, restore, `forget(blob_id)`, and `clear(namespace)`. For deterministic behavior, `analyze` stores its full input as one fact instead of invoking an LLM extractor. Its simple relevance score is for application tests, not production search-quality evaluation.
+
 ### Context Manager
 
 ```python

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -32,6 +32,7 @@ from .client import (
     MemWalSync,
 )
 from .middleware import with_memwal_langchain, with_memwal_openai
+from .mock import MemWalMock, MemWalMockSeed, MemWalMockSync
 from .types import (
     ENV_PRESETS,
     AnalyzedFact,
@@ -72,6 +73,9 @@ __all__ = [
     # Core client
     "MemWal",
     "MemWalSync",
+    "MemWalMock",
+    "MemWalMockSync",
+    "MemWalMockSeed",
     "MemWalError",
     "MemWalCompatibilityError",
     "MemWalRememberJobFailed",

--- a/packages/python-sdk-memwal/memwal/mock.py
+++ b/packages/python-sdk-memwal/memwal/mock.py
@@ -1,0 +1,533 @@
+"""Deterministic, dependency-free in-memory Walrus Memory client for tests."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from .types import (
+    AnalyzedFact,
+    AnalyzeResult,
+    AnalyzeWaitResult,
+    AskMemory,
+    AskResult,
+    EmbedResult,
+    HealthResult,
+    RecallMemory,
+    RecallParams,
+    RecallResult,
+    RememberAcceptedResult,
+    RememberBulkAcceptedResult,
+    RememberBulkItem,
+    RememberBulkItemResult,
+    RememberBulkOptions,
+    RememberBulkResult,
+    RememberBulkStatusItem,
+    RememberBulkStatusResult,
+    RememberJobStatus,
+    RememberResult,
+    RestoreResult,
+)
+
+
+@dataclass
+class MemWalMockSeed:
+    """One optional memory loaded when a mock is created."""
+
+    text: str
+    namespace: Optional[str] = None
+    blob_id: Optional[str] = None
+
+
+@dataclass
+class _Memory:
+    id: str
+    job_id: str
+    blob_id: str
+    text: str
+    namespace: str
+    sequence: int
+
+
+def _tokens(text: str) -> set[str]:
+    normalized = unicodedata.normalize("NFKC", text).casefold()
+    return set(re.findall(r"[^\W_]+", normalized, flags=re.UNICODE))
+
+
+def _distance(query_tokens: set[str], text: str) -> float:
+    if not query_tokens:
+        return 1.0
+    matches = len(query_tokens.intersection(_tokens(text)))
+    return 1.0 - matches / len(query_tokens)
+
+
+def _validate_text(text: str, field: str = "text") -> None:
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError(f"{field} cannot be empty")
+
+
+class MemWalMock:
+    """In-memory implementation of the common async :class:`MemWal` API.
+
+    The mock never creates an HTTP client or contacts Sui/Walrus. Recall uses
+    deterministic token-overlap distance; it is intentionally simple and is
+    designed for application tests, not relevance benchmarking.
+    """
+
+    def __init__(
+        self,
+        namespace: str = "default",
+        owner: str = "mock-owner",
+        initial_memories: Optional[Sequence[MemWalMockSeed]] = None,
+    ) -> None:
+        if not namespace:
+            raise ValueError("namespace cannot be empty")
+        self._namespace = namespace
+        self._owner = owner
+        self._memories: List[_Memory] = []
+        self._jobs: Dict[str, _Memory] = {}
+        self._sequence = 0
+        for seed in initial_memories or []:
+            self._store(seed.text, seed.namespace, seed.blob_id)
+
+    @classmethod
+    def create(
+        cls,
+        namespace: str = "default",
+        owner: str = "mock-owner",
+        initial_memories: Optional[Sequence[MemWalMockSeed]] = None,
+    ) -> "MemWalMock":
+        return cls(namespace, owner, initial_memories)
+
+    async def close(self) -> None:
+        """No-op for API parity with :class:`MemWal`."""
+
+    async def __aenter__(self) -> "MemWalMock":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+    async def remember(
+        self, text: str, namespace: Optional[str] = None
+    ) -> RememberAcceptedResult:
+        memory = self._store(text, namespace)
+        return RememberAcceptedResult(job_id=memory.job_id, status="done")
+
+    async def remember_async(
+        self, text: str, namespace: Optional[str] = None
+    ) -> RememberAcceptedResult:
+        return await self.remember(text, namespace)
+
+    async def wait_for_remember_job(
+        self,
+        job_id: str,
+        poll_interval_ms: int = 1500,
+        timeout_ms: int = 60_000,
+    ) -> RememberResult:
+        del poll_interval_ms, timeout_ms
+        memory = self._jobs.get(job_id)
+        if memory is None:
+            raise KeyError(f"Remember job not found: {job_id}")
+        return self._remember_result(memory)
+
+    async def remember_and_wait(
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        poll_interval_ms: int = 1500,
+        timeout_ms: int = 60_000,
+    ) -> RememberResult:
+        accepted = await self.remember(text, namespace)
+        return await self.wait_for_remember_job(
+            accepted.job_id, poll_interval_ms, timeout_ms
+        )
+
+    async def get_remember_status(self, job_id: str) -> RememberJobStatus:
+        memory = self._jobs.get(job_id)
+        if memory is None:
+            return RememberJobStatus(job_id=job_id, status="not_found")
+        return RememberJobStatus(
+            job_id=job_id,
+            status="done",
+            owner=self._owner,
+            namespace=memory.namespace,
+            blob_id=memory.blob_id,
+        )
+
+    async def remember_bulk_async(
+        self, items: Sequence[RememberBulkItem]
+    ) -> RememberBulkAcceptedResult:
+        job_ids = [self._store(item.text, item.namespace).job_id for item in items]
+        return RememberBulkAcceptedResult(
+            job_ids=job_ids, total=len(job_ids), status="done"
+        )
+
+    async def remember_bulk(
+        self, items: Sequence[RememberBulkItem]
+    ) -> RememberBulkAcceptedResult:
+        return await self.remember_bulk_async(items)
+
+    async def get_remember_bulk_status(
+        self, job_ids: Sequence[str]
+    ) -> RememberBulkStatusResult:
+        results = []
+        for job_id in job_ids:
+            memory = self._jobs.get(job_id)
+            results.append(
+                RememberBulkStatusItem(
+                    job_id=job_id,
+                    status="done" if memory else "not_found",
+                    blob_id=memory.blob_id if memory else None,
+                )
+            )
+        return RememberBulkStatusResult(results=results)
+
+    async def wait_for_remember_jobs(
+        self,
+        job_ids: Sequence[str],
+        opts: Optional[RememberBulkOptions] = None,
+    ) -> RememberBulkResult:
+        del opts
+        results: List[RememberBulkItemResult] = []
+        for job_id in job_ids:
+            memory = self._jobs.get(job_id)
+            results.append(
+                RememberBulkItemResult(
+                    id=job_id,
+                    blob_id=memory.blob_id if memory else "",
+                    status="done" if memory else "failed",
+                    error=None if memory else "Remember job not found",
+                )
+            )
+        succeeded = sum(result.status == "done" for result in results)
+        return RememberBulkResult(
+            results=results,
+            total=len(results),
+            succeeded=succeeded,
+            failed=len(results) - succeeded,
+            timed_out=0,
+        )
+
+    async def remember_bulk_and_wait(
+        self,
+        items: Sequence[RememberBulkItem],
+        opts: Optional[RememberBulkOptions] = None,
+    ) -> RememberBulkResult:
+        accepted = await self.remember_bulk_async(items)
+        return await self.wait_for_remember_jobs(accepted.job_ids, opts)
+
+    async def recall(
+        self,
+        query: Union[str, RecallParams],
+        limit: int = 10,
+        namespace: Optional[str] = None,
+        max_distance: Optional[float] = None,
+    ) -> RecallResult:
+        if isinstance(query, RecallParams):
+            limit = query.limit
+            namespace = query.namespace
+            max_distance = query.max_distance
+            query_text = query.query
+        else:
+            query_text = query
+        _validate_text(query_text, "query")
+        if not isinstance(limit, int) or limit < 0:
+            raise ValueError("limit must be a non-negative integer")
+        resolved_namespace = namespace or self._namespace
+        query_tokens = _tokens(query_text)
+        ranked = [
+            (memory, _distance(query_tokens, memory.text))
+            for memory in self._memories
+            if memory.namespace == resolved_namespace
+        ]
+        if max_distance is not None:
+            ranked = [item for item in ranked if item[1] < max_distance]
+        ranked.sort(key=lambda item: (item[1], item[0].sequence))
+        results = [
+            RecallMemory(blob_id=memory.blob_id, text=memory.text, distance=score)
+            for memory, score in ranked[:limit]
+        ]
+        return RecallResult(results=results, total=len(results))
+
+    async def analyze(
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        occurred_at: Any = None,
+    ) -> AnalyzeResult:
+        del occurred_at
+        memory = self._store(text, namespace)
+        return AnalyzeResult(
+            facts=[
+                AnalyzedFact(
+                    text=text, id=memory.id, blob_id=memory.blob_id
+                )
+            ],
+            fact_count=1,
+            job_ids=[memory.job_id],
+            status="done",
+            owner=self._owner,
+        )
+
+    async def analyze_and_wait(
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        opts: Optional[RememberBulkOptions] = None,
+        occurred_at: Any = None,
+    ) -> AnalyzeWaitResult:
+        analyzed = await self.analyze(text, namespace, occurred_at)
+        settled = await self.wait_for_remember_jobs(analyzed.job_ids, opts)
+        return AnalyzeWaitResult(
+            results=settled.results,
+            total=settled.total,
+            succeeded=settled.succeeded,
+            failed=settled.failed,
+            timed_out=settled.timed_out,
+            facts=analyzed.facts,
+            owner=self._owner,
+        )
+
+    async def embed(self, text: str) -> EmbedResult:
+        _validate_text(text)
+        vector = [0.0] * 16
+        for token in _tokens(text):
+            value = 2166136261
+            for char in token:
+                value ^= ord(char)
+                value = (value * 16777619) & 0xFFFFFFFF
+            vector[value % len(vector)] += 1.0
+        magnitude = math.sqrt(sum(value * value for value in vector)) or 1.0
+        return EmbedResult(vector=[value / magnitude for value in vector])
+
+    async def ask(
+        self, question: str, limit: int = 5, namespace: Optional[str] = None
+    ) -> AskResult:
+        recalled = await self.recall(question, limit, namespace)
+        memories = [
+            AskMemory(
+                blob_id=memory.blob_id,
+                text=memory.text,
+                distance=memory.distance,
+            )
+            for memory in recalled.results
+        ]
+        return AskResult(
+            answer="\n".join(memory.text for memory in memories),
+            memories_used=len(memories),
+            memories=memories,
+        )
+
+    async def restore(self, namespace: str, limit: int = 10) -> RestoreResult:
+        del limit
+        return RestoreResult(
+            restored=0,
+            skipped=0,
+            total=0,
+            namespace=namespace,
+            owner=self._owner,
+            truncated=False,
+        )
+
+    async def health(self) -> HealthResult:
+        return HealthResult(
+            status="ok",
+            version="memwal-mock",
+            relayer_version="memwal-mock",
+            api_version="1.0.0",
+            min_supported_sdk={"typescript": "0.0.0", "python": "0.0.0", "mcp": "0.0.0"},
+            feature_flags={"offlineMock": True},
+            deprecations=[],
+            build={},
+        )
+
+    async def compatibility(self) -> Dict[str, Any]:
+        return {
+            "relayerVersion": "memwal-mock",
+            "apiVersion": "1.0.0",
+            "minSupportedSdk": {
+                "typescript": "0.0.0",
+                "python": "0.0.0",
+                "mcp": "0.0.0",
+            },
+            "featureFlags": {"offlineMock": True},
+            "deprecations": [],
+            "build": {},
+        }
+
+    def forget(self, blob_id: str) -> bool:
+        for index, memory in enumerate(self._memories):
+            if memory.blob_id == blob_id:
+                self._memories.pop(index)
+                self._jobs.pop(memory.job_id, None)
+                return True
+        return False
+
+    def clear(self, namespace: Optional[str] = None) -> int:
+        removed = [
+            memory
+            for memory in self._memories
+            if namespace is None or memory.namespace == namespace
+        ]
+        self._memories = [
+            memory
+            for memory in self._memories
+            if namespace is not None and memory.namespace != namespace
+        ]
+        for memory in removed:
+            self._jobs.pop(memory.job_id, None)
+        return len(removed)
+
+    def _store(
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        blob_id: Optional[str] = None,
+    ) -> _Memory:
+        _validate_text(text)
+        resolved_namespace = namespace or self._namespace
+        if not resolved_namespace:
+            raise ValueError("namespace cannot be empty")
+        self._sequence += 1
+        suffix = f"{self._sequence:06d}"
+        memory = _Memory(
+            id=f"mock-job-{suffix}",
+            job_id=f"mock-job-{suffix}",
+            blob_id=blob_id or f"mock-blob-{suffix}",
+            text=text,
+            namespace=resolved_namespace,
+            sequence=self._sequence,
+        )
+        self._memories.append(memory)
+        self._jobs[memory.job_id] = memory
+        return memory
+
+    def _remember_result(self, memory: _Memory) -> RememberResult:
+        return RememberResult(
+            id=memory.id,
+            blob_id=memory.blob_id,
+            owner=self._owner,
+            namespace=memory.namespace,
+        )
+
+
+class MemWalMockSync:
+    """Synchronous wrapper around :class:`MemWalMock` for non-async tests."""
+
+    def __init__(self, inner: MemWalMock) -> None:
+        self._inner = inner
+
+    @classmethod
+    def create(
+        cls,
+        namespace: str = "default",
+        owner: str = "mock-owner",
+        initial_memories: Optional[Sequence[MemWalMockSeed]] = None,
+    ) -> "MemWalMockSync":
+        return cls(MemWalMock.create(namespace, owner, initial_memories))
+
+    @staticmethod
+    def _run(coro: Any) -> Any:
+        return asyncio.run(coro)
+
+    def remember(self, text: str, namespace: Optional[str] = None) -> RememberAcceptedResult:
+        return self._run(self._inner.remember(text, namespace))
+
+    def remember_async(
+        self, text: str, namespace: Optional[str] = None
+    ) -> RememberAcceptedResult:
+        return self.remember(text, namespace)
+
+    def wait_for_remember_job(self, job_id: str) -> RememberResult:
+        return self._run(self._inner.wait_for_remember_job(job_id))
+
+    def get_remember_status(self, job_id: str) -> RememberJobStatus:
+        return self._run(self._inner.get_remember_status(job_id))
+
+    def remember_and_wait(
+        self, text: str, namespace: Optional[str] = None
+    ) -> RememberResult:
+        return self._run(self._inner.remember_and_wait(text, namespace))
+
+    def remember_bulk_async(
+        self, items: Sequence[RememberBulkItem]
+    ) -> RememberBulkAcceptedResult:
+        return self._run(self._inner.remember_bulk_async(items))
+
+    def remember_bulk(
+        self, items: Sequence[RememberBulkItem]
+    ) -> RememberBulkAcceptedResult:
+        return self.remember_bulk_async(items)
+
+    def get_remember_bulk_status(
+        self, job_ids: Sequence[str]
+    ) -> RememberBulkStatusResult:
+        return self._run(self._inner.get_remember_bulk_status(job_ids))
+
+    def wait_for_remember_jobs(
+        self, job_ids: Sequence[str]
+    ) -> RememberBulkResult:
+        return self._run(self._inner.wait_for_remember_jobs(job_ids))
+
+    def remember_bulk_and_wait(
+        self, items: Sequence[RememberBulkItem]
+    ) -> RememberBulkResult:
+        return self._run(self._inner.remember_bulk_and_wait(items))
+
+    def recall(
+        self,
+        query: Union[str, RecallParams],
+        limit: int = 10,
+        namespace: Optional[str] = None,
+        max_distance: Optional[float] = None,
+    ) -> RecallResult:
+        return self._run(
+            self._inner.recall(query, limit, namespace, max_distance)
+        )
+
+    def analyze(
+        self, text: str, namespace: Optional[str] = None
+    ) -> AnalyzeResult:
+        return self._run(self._inner.analyze(text, namespace))
+
+    def analyze_and_wait(
+        self, text: str, namespace: Optional[str] = None
+    ) -> AnalyzeWaitResult:
+        return self._run(self._inner.analyze_and_wait(text, namespace))
+
+    def embed(self, text: str) -> EmbedResult:
+        return self._run(self._inner.embed(text))
+
+    def ask(
+        self, question: str, limit: int = 5, namespace: Optional[str] = None
+    ) -> AskResult:
+        return self._run(self._inner.ask(question, limit, namespace))
+
+    def restore(self, namespace: str, limit: int = 10) -> RestoreResult:
+        return self._run(self._inner.restore(namespace, limit))
+
+    def health(self) -> HealthResult:
+        return self._run(self._inner.health())
+
+    def compatibility(self) -> Dict[str, Any]:
+        return self._run(self._inner.compatibility())
+
+    def forget(self, blob_id: str) -> bool:
+        return self._inner.forget(blob_id)
+
+    def clear(self, namespace: Optional[str] = None) -> int:
+        return self._inner.clear(namespace)
+
+    def close(self) -> None:
+        self._run(self._inner.close())
+
+    def __enter__(self) -> "MemWalMockSync":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/packages/python-sdk-memwal/memwal/mock.py
+++ b/packages/python-sdk-memwal/memwal/mock.py
@@ -7,6 +7,7 @@ import math
 import re
 import unicodedata
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from .types import (
@@ -258,7 +259,7 @@ class MemWalMock:
         self,
         text: str,
         namespace: Optional[str] = None,
-        occurred_at: Any = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
     ) -> AnalyzeResult:
         del occurred_at
         memory = self._store(text, namespace)
@@ -279,9 +280,9 @@ class MemWalMock:
         text: str,
         namespace: Optional[str] = None,
         opts: Optional[RememberBulkOptions] = None,
-        occurred_at: Any = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
     ) -> AnalyzeWaitResult:
-        analyzed = await self.analyze(text, namespace, occurred_at)
+        analyzed = await self.analyze(text, namespace, occurred_at=occurred_at)
         settled = await self.wait_for_remember_jobs(analyzed.job_ids, opts)
         return AnalyzeWaitResult(
             results=settled.results,
@@ -433,6 +434,18 @@ class MemWalMockSync:
 
     @staticmethod
     def _run(coro: Any) -> Any:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None and loop.is_running():
+            # Match MemWalSync in notebooks and other hosts with a live loop:
+            # execute the coroutine on a fresh event loop in a worker thread.
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(asyncio.run, coro).result()
         return asyncio.run(coro)
 
     def remember(self, text: str, namespace: Optional[str] = None) -> RememberAcceptedResult:
@@ -443,16 +456,38 @@ class MemWalMockSync:
     ) -> RememberAcceptedResult:
         return self.remember(text, namespace)
 
-    def wait_for_remember_job(self, job_id: str) -> RememberResult:
-        return self._run(self._inner.wait_for_remember_job(job_id))
+    def wait_for_remember_job(
+        self,
+        job_id: str,
+        poll_interval_ms: int = 1500,
+        timeout_ms: int = 60_000,
+    ) -> RememberResult:
+        return self._run(
+            self._inner.wait_for_remember_job(
+                job_id,
+                poll_interval_ms=poll_interval_ms,
+                timeout_ms=timeout_ms,
+            )
+        )
 
     def get_remember_status(self, job_id: str) -> RememberJobStatus:
         return self._run(self._inner.get_remember_status(job_id))
 
     def remember_and_wait(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        poll_interval_ms: int = 1500,
+        timeout_ms: int = 60_000,
     ) -> RememberResult:
-        return self._run(self._inner.remember_and_wait(text, namespace))
+        return self._run(
+            self._inner.remember_and_wait(
+                text,
+                namespace,
+                poll_interval_ms=poll_interval_ms,
+                timeout_ms=timeout_ms,
+            )
+        )
 
     def remember_bulk_async(
         self, items: Sequence[RememberBulkItem]
@@ -470,14 +505,18 @@ class MemWalMockSync:
         return self._run(self._inner.get_remember_bulk_status(job_ids))
 
     def wait_for_remember_jobs(
-        self, job_ids: Sequence[str]
+        self,
+        job_ids: Sequence[str],
+        opts: Optional[RememberBulkOptions] = None,
     ) -> RememberBulkResult:
-        return self._run(self._inner.wait_for_remember_jobs(job_ids))
+        return self._run(self._inner.wait_for_remember_jobs(job_ids, opts))
 
     def remember_bulk_and_wait(
-        self, items: Sequence[RememberBulkItem]
+        self,
+        items: Sequence[RememberBulkItem],
+        opts: Optional[RememberBulkOptions] = None,
     ) -> RememberBulkResult:
-        return self._run(self._inner.remember_bulk_and_wait(items))
+        return self._run(self._inner.remember_bulk_and_wait(items, opts))
 
     def recall(
         self,
@@ -491,14 +530,27 @@ class MemWalMockSync:
         )
 
     def analyze(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
     ) -> AnalyzeResult:
-        return self._run(self._inner.analyze(text, namespace))
+        return self._run(
+            self._inner.analyze(text, namespace, occurred_at=occurred_at)
+        )
 
     def analyze_and_wait(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        opts: Optional[RememberBulkOptions] = None,
+        occurred_at: Optional[Union[str, datetime]] = None,
     ) -> AnalyzeWaitResult:
-        return self._run(self._inner.analyze_and_wait(text, namespace))
+        return self._run(
+            self._inner.analyze_and_wait(
+                text, namespace, opts, occurred_at=occurred_at
+            )
+        )
 
     def embed(self, text: str) -> EmbedResult:
         return self._run(self._inner.embed(text))

--- a/packages/python-sdk-memwal/tests/test_mock.py
+++ b/packages/python-sdk-memwal/tests/test_mock.py
@@ -1,0 +1,103 @@
+"""Offline mock client regression tests."""
+
+import pytest
+
+from memwal import (
+    MemWalMock,
+    MemWalMockSeed,
+    MemWalMockSync,
+    RecallParams,
+    RememberBulkItem,
+)
+
+
+@pytest.mark.asyncio
+async def test_mock_remember_and_recall_are_deterministic_and_offline(monkeypatch):
+    def reject_network(*args, **kwargs):
+        raise AssertionError("MemWalMock must not create a network client")
+
+    monkeypatch.setattr("httpx.AsyncClient", reject_network)
+    mock = MemWalMock.create(namespace="user-a", owner="test-owner")
+    coffee = await mock.remember_and_wait("I prefer coffee in the morning")
+    tea = await mock.remember_and_wait("I drink tea at night")
+
+    assert coffee.id == "mock-job-000001"
+    assert coffee.blob_id == "mock-blob-000001"
+    assert coffee.namespace == "user-a"
+    assert tea.blob_id == "mock-blob-000002"
+
+    recalled = await mock.recall(RecallParams(query="morning coffee", limit=2))
+    assert [memory.text for memory in recalled.results] == [
+        "I prefer coffee in the morning",
+        "I drink tea at night",
+    ]
+    assert recalled.results[0].distance == 0
+    assert recalled.results[1].distance == 1
+
+
+@pytest.mark.asyncio
+async def test_mock_isolates_namespaces_and_honors_max_distance():
+    mock = MemWalMock.create()
+    await mock.remember_and_wait("Alice likes ramen", "user-a")
+    await mock.remember_and_wait("Bob likes tacos", "user-b")
+
+    alice = await mock.recall(
+        RecallParams(query="likes", namespace="user-a", max_distance=0.5)
+    )
+    bob = await mock.recall("likes", namespace="user-b")
+    empty = await mock.recall("likes")
+
+    assert [memory.text for memory in alice.results] == ["Alice likes ramen"]
+    assert [memory.text for memory in bob.results] == ["Bob likes tacos"]
+    assert empty.total == 0
+
+
+@pytest.mark.asyncio
+async def test_mock_supports_jobs_bulk_analyze_forget_and_clear():
+    mock = MemWalMock.create()
+    accepted = await mock.remember("single fact")
+    status = await mock.get_remember_status(accepted.job_id)
+    assert status.status == "done"
+    assert status.blob_id == "mock-blob-000001"
+
+    bulk = await mock.remember_bulk_and_wait(
+        [
+            RememberBulkItem(text="bulk one", namespace="one"),
+            RememberBulkItem(text="bulk two", namespace="two"),
+        ]
+    )
+    assert bulk.succeeded == 2
+    assert bulk.failed == 0
+
+    analyzed = await mock.analyze_and_wait("durable analyzed fact", "analysis")
+    assert analyzed.facts[0].text == "durable analyzed fact"
+
+    assert mock.forget("mock-blob-000001") is True
+    assert mock.forget("missing") is False
+    assert mock.clear("one") == 1
+    assert (await mock.recall("bulk", namespace="one")).total == 0
+
+
+@pytest.mark.asyncio
+async def test_mock_seed_embed_health_and_compatibility():
+    first = MemWalMock.create(
+        initial_memories=[
+            MemWalMockSeed(text="seed memory", namespace="seed", blob_id="seed-blob")
+        ]
+    )
+    second = MemWalMock.create()
+
+    assert await first.embed("same text") == await second.embed("same text")
+    recalled = await first.recall("seed", namespace="seed")
+    assert recalled.results[0].blob_id == "seed-blob"
+    assert (await first.health()).status == "ok"
+    assert (await first.compatibility())["featureFlags"]["offlineMock"] is True
+
+
+def test_sync_mock_wraps_core_flows():
+    mock = MemWalMockSync.create(namespace="sync")
+    stored = mock.remember_and_wait("sync memory")
+    recalled = mock.recall("sync")
+
+    assert stored.namespace == "sync"
+    assert recalled.results[0].text == "sync memory"

--- a/packages/python-sdk-memwal/tests/test_mock.py
+++ b/packages/python-sdk-memwal/tests/test_mock.py
@@ -1,13 +1,17 @@
 """Offline mock client regression tests."""
 
+import inspect
+
 import pytest
 
 from memwal import (
     MemWalMock,
     MemWalMockSeed,
     MemWalMockSync,
+    MemWalSync,
     RecallParams,
     RememberBulkItem,
+    RememberBulkOptions,
 )
 
 
@@ -94,10 +98,65 @@ async def test_mock_seed_embed_health_and_compatibility():
     assert (await first.compatibility())["featureFlags"]["offlineMock"] is True
 
 
-def test_sync_mock_wraps_core_flows():
+def test_sync_mock_wraps_core_flows_and_accepts_production_options():
     mock = MemWalMockSync.create(namespace="sync")
-    stored = mock.remember_and_wait("sync memory")
+    opts = RememberBulkOptions(poll_interval_ms=1, timeout_ms=10)
+
+    accepted = mock.remember("accepted memory")
+    stored = mock.wait_for_remember_job(
+        accepted.job_id, poll_interval_ms=1, timeout_ms=10
+    )
+    waited = mock.remember_and_wait(
+        "sync memory", poll_interval_ms=1, timeout_ms=10
+    )
+    bulk = mock.remember_bulk_and_wait(
+        [RememberBulkItem(text="bulk memory")], opts=opts
+    )
+    assert mock.wait_for_remember_jobs([accepted.job_id], opts=opts).succeeded == 1
+    analyzed = mock.analyze("analyzed memory", occurred_at="2024-01-01T00:00:00Z")
+    analyzed_wait = mock.analyze_and_wait(
+        "analyzed and waited",
+        opts=opts,
+        occurred_at="2024-01-01T00:00:00Z",
+    )
     recalled = mock.recall("sync")
 
-    assert stored.namespace == "sync"
+    assert stored.blob_id == "mock-blob-000001"
+    assert waited.namespace == "sync"
+    assert bulk.succeeded == 1
+    assert analyzed.fact_count == 1
+    assert analyzed_wait.succeeded == 1
     assert recalled.results[0].text == "sync memory"
+
+
+def test_sync_mock_polling_and_analyze_signatures_match_production():
+    methods = (
+        "wait_for_remember_job",
+        "remember_and_wait",
+        "wait_for_remember_jobs",
+        "remember_bulk_and_wait",
+        "analyze",
+        "analyze_and_wait",
+    )
+
+    def parameter_contract(method):
+        return [
+            (parameter.name, parameter.kind, parameter.default)
+            for parameter in inspect.signature(method).parameters.values()
+        ]
+
+    for method_name in methods:
+        assert parameter_contract(getattr(MemWalMockSync, method_name)) == parameter_contract(
+            getattr(MemWalSync, method_name)
+        )
+
+
+@pytest.mark.asyncio
+async def test_sync_mock_works_inside_an_existing_event_loop():
+    mock = MemWalMockSync.create(namespace="notebook")
+
+    stored = mock.remember_and_wait("called from a running loop")
+    recalled = mock.recall("running loop")
+
+    assert stored.namespace == "notebook"
+    assert recalled.results[0].text == "called from a running loop"

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -59,11 +59,27 @@ await memwal.restore("demo");
 
 If you are self-hosting the relayer and do not have an account ID yet, see [Self-Hosting](../../docs/relayer/self-hosting.md) for the account creation and delegate key setup flow.
 
+## Offline tests and CI
+
+`MemWalMock` implements the core async memory API entirely in memory. It requires no key, account, relayer, chain, or paid storage and uses deterministic token-overlap ranking.
+
+```ts
+import { MemWalMock } from "@mysten-incubation/memwal";
+
+const memwal = MemWalMock.create({ namespace: "test-user" });
+await memwal.rememberAndWait("The user prefers dark mode");
+
+const result = await memwal.recall({ query: "display preference" });
+expect(result.results[0].text).toContain("dark mode");
+```
+
+The mock supports remember/job polling, bulk remember, recall, analyze, embed, health, restore, `forget(blobId)`, and `clear(namespace?)`. For deterministic behavior, `analyze` stores its full input as one fact instead of invoking an LLM extractor. Its simple relevance score is for application tests, not production search-quality evaluation.
+
 ## Exports
 
 | Entry | Description |
 |---|---|
-| `@mysten-incubation/memwal` | Default client (`MemWal`). The relayer handles embedding, encryption, Walrus upload/download, retrieval, and restore. |
+| `@mysten-incubation/memwal` | Default client (`MemWal`) and offline test client (`MemWalMock`). The production client delegates embedding, encryption, storage, retrieval, and restore to the relayer. |
 | `@mysten-incubation/memwal/manual` | Manual client flow (`MemWalManual`). You handle embedding calls and local SEAL operations. The relayer still handles upload relay, registration, search, and restore. |
 | `@mysten-incubation/memwal/ai` | Vercel AI SDK integration - wraps `MemWal` as middleware for use with `streamText`, `generateText`, etc. |
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,9 @@
 
 // Core client (server-mode: server handles SEAL + Walrus + embedding)
 export { MemWal } from "./memwal.js";
+// Deterministic, dependency-free in-memory client for tests and CI.
+export { MemWalMock } from "./mock.js";
+export type { MemWalMockConfig, MemWalMockSeed } from "./mock.js";
 export {
     MEMWAL_TYPESCRIPT_COMPATIBILITY_VERSION,
     MemWalCompatibilityError,

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -1,0 +1,418 @@
+import type {
+    AnalyzeOptions,
+    AnalyzeResult,
+    AnalyzeWaitResult,
+    EmbedResult,
+    HealthResult,
+    RecallOptions,
+    RecallParams,
+    RecallResult,
+    RelayerVersionMetadata,
+    RememberAcceptedResult,
+    RememberBulkAcceptedResult,
+    RememberBulkItem,
+    RememberBulkItemResult,
+    RememberBulkOptions,
+    RememberBulkResult,
+    RememberBulkStatusResult,
+    RememberJobStatus,
+    RememberResult,
+    RestoreResult,
+} from "./types.js";
+
+export interface MemWalMockSeed {
+    text: string;
+    namespace?: string;
+    blobId?: string;
+}
+
+export interface MemWalMockConfig {
+    /** Default namespace, matching MemWalConfig (default: "default"). */
+    namespace?: string;
+    /** Stable owner value returned by result objects (default: "mock-owner"). */
+    owner?: string;
+    /** Optional records loaded synchronously when the mock is created. */
+    initialMemories?: MemWalMockSeed[];
+}
+
+interface MockMemory {
+    id: string;
+    jobId: string;
+    blobId: string;
+    text: string;
+    namespace: string;
+    sequence: number;
+}
+
+const MOCK_VERSION: RelayerVersionMetadata = {
+    relayerVersion: "memwal-mock",
+    apiVersion: "1.0.0",
+    minSupportedSdk: { typescript: "0.0.0", python: "0.0.0", mcp: "0.0.0" },
+    featureFlags: { offlineMock: true },
+    deprecations: [],
+    build: {},
+};
+
+function tokenize(text: string): Set<string> {
+    return new Set(
+        text
+            .normalize("NFKC")
+            .toLocaleLowerCase()
+            .match(/[\p{L}\p{N}]+/gu) ?? []
+    );
+}
+
+function distance(queryTokens: Set<string>, text: string): number {
+    if (queryTokens.size === 0) return 1;
+    const memoryTokens = tokenize(text);
+    let matches = 0;
+    for (const token of queryTokens) {
+        if (memoryTokens.has(token)) matches += 1;
+    }
+    return 1 - matches / queryTokens.size;
+}
+
+function validateText(text: string, field = "text"): void {
+    if (typeof text !== "string" || text.trim().length === 0) {
+        throw new Error(`${field} cannot be empty`);
+    }
+}
+
+/**
+ * Deterministic, dependency-free in-memory implementation of the core MemWal API.
+ * It never opens a socket, reads credentials, or contacts Sui/Walrus. Recall uses
+ * token-overlap distance so tests are stable across machines and runs.
+ */
+export class MemWalMock {
+    private readonly owner: string;
+    private readonly namespace: string;
+    private readonly memories: MockMemory[] = [];
+    private readonly jobs = new Map<string, MockMemory>();
+    private sequence = 0;
+
+    private constructor(config: MemWalMockConfig = {}) {
+        this.owner = config.owner ?? "mock-owner";
+        this.namespace = config.namespace ?? "default";
+        if (!this.namespace) throw new Error("namespace cannot be empty");
+        for (const seed of config.initialMemories ?? []) {
+            this.store(seed.text, seed.namespace, seed.blobId);
+        }
+    }
+
+    static create(config: MemWalMockConfig = {}): MemWalMock {
+        return new MemWalMock(config);
+    }
+
+    destroy(): void {
+        this.memories.length = 0;
+        this.jobs.clear();
+    }
+
+    async rememberAsync(
+        text: string,
+        namespace?: string
+    ): Promise<RememberAcceptedResult> {
+        const memory = this.store(text, namespace);
+        return { job_id: memory.jobId, status: "done" };
+    }
+
+    async remember(
+        text: string,
+        namespace?: string
+    ): Promise<RememberAcceptedResult> {
+        return this.rememberAsync(text, namespace);
+    }
+
+    async getRememberStatus(jobId: string): Promise<RememberJobStatus> {
+        const memory = this.jobs.get(jobId);
+        if (!memory) return { job_id: jobId, status: "not_found" };
+        return {
+            job_id: jobId,
+            status: "done",
+            owner: this.owner,
+            namespace: memory.namespace,
+            blob_id: memory.blobId,
+        };
+    }
+
+    async waitForRememberJob(
+        jobId: string,
+        _opts: { pollIntervalMs?: number; timeoutMs?: number } = {}
+    ): Promise<RememberResult> {
+        const memory = this.jobs.get(jobId);
+        if (!memory) throw new Error(`Remember job not found: ${jobId}`);
+        return this.toRememberResult(memory);
+    }
+
+    async rememberAndWait(
+        text: string,
+        namespace?: string,
+        opts: { pollIntervalMs?: number; timeoutMs?: number } = {}
+    ): Promise<RememberResult> {
+        const accepted = await this.rememberAsync(text, namespace);
+        return this.waitForRememberJob(accepted.job_id, opts);
+    }
+
+    async rememberBulkAsync(
+        items: RememberBulkItem[]
+    ): Promise<RememberBulkAcceptedResult> {
+        const jobIds = items.map(
+            (item) => this.store(item.text, item.namespace).jobId
+        );
+        return { job_ids: jobIds, total: jobIds.length, status: "done" };
+    }
+
+    async rememberBulk(
+        items: RememberBulkItem[]
+    ): Promise<RememberBulkAcceptedResult> {
+        return this.rememberBulkAsync(items);
+    }
+
+    async getRememberBulkStatus(
+        jobIds: string[]
+    ): Promise<RememberBulkStatusResult> {
+        return {
+            results: jobIds.map((jobId) => {
+                const memory = this.jobs.get(jobId);
+                return memory
+                    ? { job_id: jobId, status: "done", blob_id: memory.blobId }
+                    : { job_id: jobId, status: "not_found" };
+            }),
+        };
+    }
+
+    async waitForRememberJobs(
+        jobIds: string[],
+        namespaces: string[] = [],
+        _opts: RememberBulkOptions = {}
+    ): Promise<RememberBulkResult> {
+        const results: RememberBulkItemResult[] = jobIds.map((jobId, index) => {
+            const memory = this.jobs.get(jobId);
+            return memory
+                ? {
+                      id: jobId,
+                      blob_id: memory.blobId,
+                      status: "done",
+                      namespace: memory.namespace,
+                  }
+                : {
+                      id: jobId,
+                      blob_id: "",
+                      status: "failed",
+                      namespace: namespaces[index] ?? this.namespace,
+                      error: "Remember job not found",
+                  };
+        });
+        const succeeded = results.filter(
+            (result) => result.status === "done"
+        ).length;
+        return {
+            results,
+            total: results.length,
+            succeeded,
+            failed: results.length - succeeded,
+        };
+    }
+
+    async rememberBulkAndWait(
+        items: RememberBulkItem[],
+        opts: RememberBulkOptions = {}
+    ): Promise<RememberBulkResult> {
+        const accepted = await this.rememberBulkAsync(items);
+        const namespaces = items.map(
+            (item) => item.namespace ?? this.namespace
+        );
+        return this.waitForRememberJobs(accepted.job_ids, namespaces, opts);
+    }
+
+    async recall(params: RecallParams): Promise<RecallResult>;
+    async recall(
+        query: string,
+        limit?: number,
+        namespace?: string
+    ): Promise<RecallResult>;
+    async recall(
+        queryOrParams: string | RecallParams,
+        limit = 10,
+        namespace?: string
+    ): Promise<RecallResult> {
+        const query =
+            typeof queryOrParams === "string"
+                ? queryOrParams
+                : queryOrParams.query;
+        validateText(query, "query");
+        const options: RecallOptions =
+            typeof queryOrParams === "string"
+                ? { limit, namespace }
+                : queryOrParams;
+        const resolvedNamespace = options.namespace ?? this.namespace;
+        const resolvedLimit = options.limit ?? options.topK ?? 10;
+        if (!Number.isInteger(resolvedLimit) || resolvedLimit < 0) {
+            throw new Error("limit must be a non-negative integer");
+        }
+        const queryTokens = tokenize(query);
+        const ranked = this.memories
+            .filter((memory) => memory.namespace === resolvedNamespace)
+            .map((memory) => ({
+                memory,
+                distance: distance(queryTokens, memory.text),
+            }))
+            .filter((entry) =>
+                options.maxDistance === undefined
+                    ? true
+                    : entry.distance < options.maxDistance
+            )
+            .sort(
+                (left, right) =>
+                    left.distance - right.distance ||
+                    left.memory.sequence - right.memory.sequence
+            )
+            .slice(0, resolvedLimit)
+            .map(({ memory, distance: memoryDistance }) => ({
+                blob_id: memory.blobId,
+                text: memory.text,
+                distance: memoryDistance,
+            }));
+        return { results: ranked, total: ranked.length };
+    }
+
+    async analyze(
+        text: string,
+        namespaceOrOptions?: string | AnalyzeOptions
+    ): Promise<AnalyzeResult> {
+        validateText(text);
+        const namespace =
+            typeof namespaceOrOptions === "string"
+                ? namespaceOrOptions
+                : namespaceOrOptions?.namespace;
+        const memory = this.store(text, namespace);
+        return {
+            job_ids: [memory.jobId],
+            facts: [
+                {
+                    text,
+                    id: memory.id,
+                    job_id: memory.jobId,
+                    blob_id: memory.blobId,
+                },
+            ],
+            fact_count: 1,
+            status: "done",
+            owner: this.owner,
+        };
+    }
+
+    async analyzeAndWait(
+        text: string,
+        namespaceOrOptions?: string | AnalyzeOptions,
+        opts: RememberBulkOptions = {}
+    ): Promise<AnalyzeWaitResult> {
+        const analyzed = await this.analyze(text, namespaceOrOptions);
+        const namespace =
+            typeof namespaceOrOptions === "string"
+                ? namespaceOrOptions
+                : namespaceOrOptions?.namespace;
+        const settled = await this.waitForRememberJobs(
+            analyzed.job_ids,
+            analyzed.job_ids.map(() => namespace ?? this.namespace),
+            opts
+        );
+        return { ...settled, facts: analyzed.facts, owner: this.owner };
+    }
+
+    async embed(text: string): Promise<EmbedResult> {
+        validateText(text);
+        const vector = new Array<number>(16).fill(0);
+        for (const token of tokenize(text)) {
+            let hash = 2166136261;
+            for (const char of token) {
+                hash ^= char.codePointAt(0) ?? 0;
+                hash = Math.imul(hash, 16777619);
+            }
+            vector[(hash >>> 0) % vector.length] += 1;
+        }
+        const magnitude = Math.hypot(...vector) || 1;
+        return { vector: vector.map((value) => value / magnitude) };
+    }
+
+    async restore(namespace: string, _limit = 10): Promise<RestoreResult> {
+        return {
+            restored: 0,
+            skipped: 0,
+            total: 0,
+            namespace,
+            owner: this.owner,
+            truncated: false,
+        };
+    }
+
+    async health(): Promise<HealthResult> {
+        return { status: "ok", version: "memwal-mock", ...MOCK_VERSION };
+    }
+
+    async compatibility(): Promise<RelayerVersionMetadata> {
+        return structuredClone(MOCK_VERSION);
+    }
+
+    /** Delete one mock record by blob id. Returns whether a record was removed. */
+    forget(blobId: string): boolean {
+        const index = this.memories.findIndex(
+            (memory) => memory.blobId === blobId
+        );
+        if (index < 0) return false;
+        const [memory] = this.memories.splice(index, 1);
+        this.jobs.delete(memory.jobId);
+        return true;
+    }
+
+    /** Clear one namespace, or every mock record when omitted. */
+    clear(namespace?: string): number {
+        const removed = this.memories.filter(
+            (memory) =>
+                namespace === undefined || memory.namespace === namespace
+        );
+        if (namespace === undefined) {
+            this.memories.length = 0;
+        } else {
+            for (let index = this.memories.length - 1; index >= 0; index -= 1) {
+                if (this.memories[index].namespace === namespace)
+                    this.memories.splice(index, 1);
+            }
+        }
+        for (const memory of removed) this.jobs.delete(memory.jobId);
+        return removed.length;
+    }
+
+    private store(
+        text: string,
+        namespace?: string,
+        blobId?: string
+    ): MockMemory {
+        validateText(text);
+        const resolvedNamespace = namespace ?? this.namespace;
+        if (!resolvedNamespace) throw new Error("namespace cannot be empty");
+        this.sequence += 1;
+        const suffix = this.sequence.toString().padStart(6, "0");
+        const memory: MockMemory = {
+            id: `mock-job-${suffix}`,
+            jobId: `mock-job-${suffix}`,
+            blobId: blobId ?? `mock-blob-${suffix}`,
+            text,
+            namespace: resolvedNamespace,
+            sequence: this.sequence,
+        };
+        this.memories.push(memory);
+        this.jobs.set(memory.jobId, memory);
+        return memory;
+    }
+
+    private toRememberResult(memory: MockMemory): RememberResult {
+        return {
+            id: memory.id,
+            job_id: memory.jobId,
+            blob_id: memory.blobId,
+            owner: this.owner,
+            namespace: memory.namespace,
+        };
+    }
+}

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -57,7 +57,7 @@ function tokenize(text: string): Set<string> {
     return new Set(
         text
             .normalize("NFKC")
-            .toLocaleLowerCase()
+            .toLowerCase()
             .match(/[\p{L}\p{N}]+/gu) ?? []
     );
 }
@@ -228,25 +228,33 @@ export class MemWalMock {
     async recall(params: RecallParams): Promise<RecallResult>;
     async recall(
         query: string,
-        limit?: number,
+        limitOrOptions?: number | RecallOptions,
         namespace?: string
     ): Promise<RecallResult>;
     async recall(
         queryOrParams: string | RecallParams,
-        limit = 10,
+        limitOrOptions: number | RecallOptions | undefined = 10,
         namespace?: string
     ): Promise<RecallResult> {
-        const query =
-            typeof queryOrParams === "string"
-                ? queryOrParams
-                : queryOrParams.query;
+        let query: string;
+        let options: RecallOptions;
+        if (typeof queryOrParams === "object") {
+            const { query: objectQuery, ...rest } = queryOrParams;
+            query = objectQuery;
+            options = rest;
+        } else {
+            query = queryOrParams;
+            if (limitOrOptions == null) {
+                options = { limit: 10, namespace };
+            } else if (typeof limitOrOptions === "number") {
+                options = { limit: limitOrOptions, namespace };
+            } else {
+                options = limitOrOptions;
+            }
+        }
         validateText(query, "query");
-        const options: RecallOptions =
-            typeof queryOrParams === "string"
-                ? { limit, namespace }
-                : queryOrParams;
         const resolvedNamespace = options.namespace ?? this.namespace;
-        const resolvedLimit = options.limit ?? options.topK ?? 10;
+        const resolvedLimit = options.topK ?? options.limit ?? 10;
         if (!Number.isInteger(resolvedLimit) || resolvedLimit < 0) {
             throw new Error("limit must be a non-negative integer");
         }

--- a/packages/sdk/test/mock.test.mjs
+++ b/packages/sdk/test/mock.test.mjs
@@ -62,6 +62,46 @@ test("MemWalMock isolates namespaces and honors maxDistance", async () => {
     assert.equal(empty.total, 0);
 });
 
+test("MemWalMock matches production recall overloads and topK precedence", async () => {
+    const mock = MemWalMock.create();
+    await mock.rememberAndWait("shared first", "options");
+    await mock.rememberAndWait("shared second", "options");
+
+    const optionsStyle = await mock.recall("shared", {
+        namespace: "options",
+        limit: 2,
+    });
+    const objectStyle = await mock.recall({
+        query: "shared",
+        namespace: "options",
+        limit: 1,
+        topK: 2,
+    });
+
+    assert.deepEqual(
+        optionsStyle.results.map((memory) => memory.text),
+        ["shared first", "shared second"]
+    );
+    assert.equal(objectStyle.results.length, 2);
+});
+
+test("MemWalMock tokenization does not depend on the host locale", async () => {
+    const originalLocaleLowerCase = String.prototype.toLocaleLowerCase;
+    String.prototype.toLocaleLowerCase = () => {
+        throw new Error("locale-dependent lowercase must not be used");
+    };
+    try {
+        const mock = MemWalMock.create();
+        await mock.rememberAndWait("I LIKE COFFEE");
+        const recalled = await mock.recall({ query: "i like coffee" });
+
+        assert.equal(recalled.results[0].distance, 0);
+        assert.equal((await mock.embed("I LIKE COFFEE")).vector.length, 16);
+    } finally {
+        String.prototype.toLocaleLowerCase = originalLocaleLowerCase;
+    }
+});
+
 test("MemWalMock supports job, bulk, analyze, forget, and clear flows", async () => {
     const mock = MemWalMock.create();
     const accepted = await mock.remember("single fact");

--- a/packages/sdk/test/mock.test.mjs
+++ b/packages/sdk/test/mock.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWalMock } from "../dist/index.js";
+
+test("MemWalMock remembers and recalls deterministically without network access", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+        throw new Error("MemWalMock must not access the network");
+    };
+    try {
+        const mock = MemWalMock.create({
+            namespace: "user-a",
+            owner: "test-owner",
+        });
+        const coffee = await mock.rememberAndWait(
+            "I prefer coffee in the morning"
+        );
+        const tea = await mock.rememberAndWait("I drink tea at night");
+
+        assert.equal(coffee.id, "mock-job-000001");
+        assert.equal(coffee.job_id, "mock-job-000001");
+        assert.equal(coffee.namespace, "user-a");
+        assert.equal(tea.blob_id, "mock-blob-000002");
+
+        const recalled = await mock.recall({
+            query: "morning coffee",
+            limit: 2,
+        });
+        assert.deepEqual(
+            recalled.results.map((memory) => memory.text),
+            ["I prefer coffee in the morning", "I drink tea at night"]
+        );
+        assert.equal(recalled.results[0].distance, 0);
+        assert.equal(recalled.results[1].distance, 1);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test("MemWalMock isolates namespaces and honors maxDistance", async () => {
+    const mock = MemWalMock.create({ namespace: "default" });
+    await mock.rememberAndWait("Alice likes ramen", "user-a");
+    await mock.rememberAndWait("Bob likes tacos", "user-b");
+
+    const alice = await mock.recall({
+        query: "likes",
+        namespace: "user-a",
+        maxDistance: 0.5,
+    });
+    const bob = await mock.recall({ query: "likes", namespace: "user-b" });
+    const empty = await mock.recall({ query: "likes", namespace: "default" });
+
+    assert.deepEqual(
+        alice.results.map((memory) => memory.text),
+        ["Alice likes ramen"]
+    );
+    assert.deepEqual(
+        bob.results.map((memory) => memory.text),
+        ["Bob likes tacos"]
+    );
+    assert.equal(empty.total, 0);
+});
+
+test("MemWalMock supports job, bulk, analyze, forget, and clear flows", async () => {
+    const mock = MemWalMock.create();
+    const accepted = await mock.remember("single fact");
+    assert.deepEqual(await mock.getRememberStatus(accepted.job_id), {
+        job_id: "mock-job-000001",
+        status: "done",
+        owner: "mock-owner",
+        namespace: "default",
+        blob_id: "mock-blob-000001",
+    });
+
+    const bulk = await mock.rememberBulkAndWait([
+        { text: "bulk one", namespace: "one" },
+        { text: "bulk two", namespace: "two" },
+    ]);
+    assert.equal(bulk.succeeded, 2);
+    assert.equal(bulk.failed, 0);
+
+    const analyzed = await mock.analyzeAndWait(
+        "durable analyzed fact",
+        "analysis"
+    );
+    assert.equal(analyzed.facts[0].text, "durable analyzed fact");
+    assert.equal(analyzed.results[0].namespace, "analysis");
+
+    assert.equal(mock.forget("mock-blob-000001"), true);
+    assert.equal(mock.forget("missing"), false);
+    assert.equal(mock.clear("one"), 1);
+    assert.equal(
+        (await mock.recall({ query: "bulk", namespace: "one" })).total,
+        0
+    );
+});
+
+test("MemWalMock provides deterministic embeddings and seed data", async () => {
+    const first = MemWalMock.create({
+        initialMemories: [
+            { text: "seed memory", namespace: "seed", blobId: "seed-blob" },
+        ],
+    });
+    const second = MemWalMock.create();
+
+    assert.deepEqual(
+        await first.embed("same text"),
+        await second.embed("same text")
+    );
+    const recalled = await first.recall({ query: "seed", namespace: "seed" });
+    assert.equal(recalled.results[0].blob_id, "seed-blob");
+    assert.equal((await first.health()).status, "ok");
+    assert.equal((await first.compatibility()).featureFlags.offlineMock, true);
+});


### PR DESCRIPTION
## Summary

- add dependency-free `MemWalMock` for TypeScript and async/sync `MemWalMock` clients for Python
- mirror core production flows: remember/job polling, bulk remember, recall, analyze, embed, health, compatibility, and restore
- isolate records by namespace and provide deterministic token-overlap ranking and embeddings for non-flaky tests
- support deterministic seed data plus mock-only `forget` and `clear` helpers
- export the clients from both SDK entry points and document offline CI usage and mock semantics

The mocks never read credentials or create network clients. `analyze` deliberately stores the full input as one fact instead of pretending to reproduce production LLM extraction, and the relevance score is intended for application behavior tests rather than search-quality benchmarks.

## Testing

- TypeScript SDK: `pnpm --dir packages/sdk test` (26/26 passed)
- Python SDK: `python3 -m pytest -q` (121 passed, 16 skipped)
- Python changed-file lint: `python3 -m ruff check memwal/mock.py tests/test_mock.py memwal/__init__.py`
- `git diff --check`

Closes #581