### PR TITLE
fix(security): remediate Researcher, Noter, and migration findings

### DIFF
--- a/.github/workflows/verify-migration-environments.yml
+++ b/.github/workflows/verify-migration-environments.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Verify migration ceremony environment protections
         env:
           GH_TOKEN: ${{ github.token }}
-          EXPECTED_MIGRATION_REVIEWER: harrymove-ctrl
+          EXPECTED_MIGRATION_REVIEWERS: user:harrymove-ctrl
         run: scripts/verify-migration-environments.sh

--- a/.github/workflows/verify-migration-environments.yml
+++ b/.github/workflows/verify-migration-environments.yml
@@ -1,0 +1,22 @@
+name: verify-migration-environments
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 7 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  deployments: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Verify migration ceremony environment protections
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_MIGRATION_REVIEWER: harrymove-ctrl
+        run: scripts/verify-migration-environments.sh

--- a/apps/noter/README.md
+++ b/apps/noter/README.md
@@ -76,8 +76,6 @@ OPENROUTER_API_KEY=...
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Walrus Memory
-MEMWAL_PRIVATE_KEY=...
-MEMWAL_ACCOUNT_ID=0x...
 MEMWAL_SERVER_URL=http://localhost:8000
 ```
 
@@ -87,9 +85,9 @@ and the `MEMWAL_*` package/registry IDs identify the on-chain account contract.
 `REDIS_URL` backs the single-use ownership challenge issued during sign-in — sign-in
 fails closed if it is unset or unreachable.
 
-`MEMWAL_PRIVATE_KEY` is the delegate private key from the Walrus Memory dashboard and
-must stay server-side. Run `pnpm verify:memwal` before starting the app to
-derive the public key locally and catch obvious credential mismatches.
+Walrus Memory credentials are registered per authenticated user after wallet
+ownership and on-chain account/delegate verification. Shared process-wide delegate
+credentials are intentionally unsupported.
 
 ### Getting OAuth credentials
 

--- a/apps/noter/app/api/memory/health/route.ts
+++ b/apps/noter/app/api/memory/health/route.ts
@@ -1,21 +1,23 @@
-/** Memory Health API — checks if Walrus Memory is configured and server is reachable. */
+/** Memory Health API — checks the authenticated user's Memory connection. */
 
-import { getMemWalClient } from "@/feature/note/lib/pdw-client";
+import { resolveMemoryCredentials } from "@/feature/note/api/memory-request";
+import { createMemWalClient } from "@/feature/note/lib/pdw-client";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    // Try with env fallback (no per-user key needed for health check)
-    const memwal = getMemWalClient();
-    try {
-      const health = await memwal.health();
-      return Response.json({ ...health, status: "ok" });
-    } catch {
-      return Response.json({ status: "ok", server: "unreachable" });
-    }
+    const { key, accountId } = await resolveMemoryCredentials(request);
+    const health = await createMemWalClient(key, accountId).health();
+    return Response.json({ ...health, status: "ok" });
   } catch (error) {
     return Response.json(
-      { status: "not_configured", message: error instanceof Error ? error.message : "Walrus Memory not configured" },
-      { status: 503 },
+      {
+        status: "not_configured",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Walrus Memory credentials unavailable",
+      },
+      { status: 503 }
     );
   }
 }

--- a/apps/noter/app/api/memory/health/route.ts
+++ b/apps/noter/app/api/memory/health/route.ts
@@ -1,11 +1,11 @@
 /** Memory Health API — checks the authenticated user's Memory connection. */
 
-import { resolveMemoryCredentials } from "@/feature/note/api/memory-request";
+import { authorizeMemoryRequest } from "@/feature/note/api/memory-request";
 import { createMemWalClient } from "@/feature/note/lib/pdw-client";
 
 export async function GET(request: Request) {
   try {
-    const { key, accountId } = await resolveMemoryCredentials(request);
+    const { key, accountId } = await authorizeMemoryRequest(request);
     const health = await createMemWalClient(key, accountId).health();
     return Response.json({ ...health, status: "ok" });
   } catch (error) {

--- a/apps/noter/app/api/memory/remember-one/route.ts
+++ b/apps/noter/app/api/memory/remember-one/route.ts
@@ -1,64 +1,38 @@
 /**
- * Memory Remember One API — saves a single approved memory text to Walrus Memory.
- * Used by the memory panel's "Approve" flow (individual memory saves).
- * Returns { id, blob_id, owner, namespace } for blockchain data display.
+ * Memory Remember One API — saves one approved memory under the authenticated
+ * user's Walrus Memory account. No server-wide credential fallback is allowed.
  */
 
 import { rememberText } from "@/feature/note/lib/pdw-client";
-import { db } from "@/shared/lib/db";
-import { walletSessions, users } from "@/shared/db/schema";
-import { eq } from "drizzle-orm";
-
-async function resolveUserKey(req: Request) {
-  const sessionId = req.headers.get("x-session-id");
-  if (!sessionId) return { key: null, accountId: null };
-
-  const [session] = await db
-    .select()
-    .from(walletSessions)
-    .where(eq(walletSessions.id, sessionId))
-    .limit(1);
-
-  // Only wallet/enoki sessions are trusted; the legacy zklogin_sessions table
-  // is no longer honored, so a missing/expired wallet session is unauthenticated.
-  if (!session?.userId || session.expiresAt < new Date()) {
-    return { key: null, accountId: null };
-  }
-
-  const [user] = await db.select().from(users).where(eq(users.id, session.userId)).limit(1);
-  return {
-    key: user?.delegatePrivateKey ?? null,
-    accountId: user?.delegateAccountId ?? null,
-  };
-}
+import {
+  authorizeMemoryRequest,
+  memoryErrorResponse,
+  readMemoryText,
+} from "@/feature/note/api/memory-request";
 
 export async function POST(req: Request) {
   try {
-    const { text } = await req.json();
-
-    if (!text || typeof text !== "string") {
-      return Response.json({ error: "text is required" }, { status: 400 });
-    }
+    // Authenticate and rate-limit before parsing or processing attacker input.
+    const { key, accountId } = await authorizeMemoryRequest(req);
+    const text = await readMemoryText(req);
 
     if (text.trim().length < 10) {
-      return Response.json({ error: "Text too short to remember" }, { status: 400 });
-    }
-
-    const { key, accountId } = await resolveUserKey(req);
-    if ((!key || !accountId) && (!process.env.MEMWAL_PRIVATE_KEY || !process.env.MEMWAL_ACCOUNT_ID)) {
       return Response.json(
-        { error: "[Walrus Memory] No accountId configured — sign in with Enoki or set MEMWAL_ACCOUNT_ID in .env" },
-        { status: 401 },
+        { error: "Text too short to remember" },
+        { status: 400 }
       );
     }
 
     const result = await rememberText(text, key, accountId);
     return Response.json(result);
   } catch (error) {
+    const expected = memoryErrorResponse(error);
+    if (expected) return expected;
+
     console.error("[memory/remember-one] Error:", error);
     return Response.json(
       { error: error instanceof Error ? error.message : "Unknown error" },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/apps/noter/app/api/memory/remember/route.ts
+++ b/apps/noter/app/api/memory/remember/route.ts
@@ -1,62 +1,38 @@
 /**
- * Memory Remember API — analyzes note text and extracts facts to Walrus Memory.
- * Uses the authenticated user's delegate key from their session.
+ * Memory Remember API — extracts facts and stores them under the authenticated
+ * user's Walrus Memory account. No server-wide credential fallback is allowed.
  */
 
 import { extractMemories } from "@/feature/note/lib/pdw-client";
-import { db } from "@/shared/lib/db";
-import { walletSessions, users } from "@/shared/db/schema";
-import { eq } from "drizzle-orm";
-
-/** Resolve user's Walrus Memory key from session header. */
-async function resolveUserKey(req: Request) {
-  const sessionId = req.headers.get("x-session-id");
-  if (!sessionId) return { key: null, accountId: null };
-
-  // Check wallet/enoki sessions
-  const [session] = await db
-    .select()
-    .from(walletSessions)
-    .where(eq(walletSessions.id, sessionId))
-    .limit(1);
-
-  // Only wallet/enoki sessions are trusted; the legacy zklogin_sessions table
-  // is no longer honored, so a missing/expired wallet session is unauthenticated.
-  if (!session?.userId || session.expiresAt < new Date()) {
-    return { key: null, accountId: null };
-  }
-
-  const [user] = await db.select().from(users).where(eq(users.id, session.userId)).limit(1);
-  return {
-    key: user?.delegatePrivateKey ?? null,
-    accountId: user?.delegateAccountId ?? null,
-  };
-}
+import {
+  authorizeMemoryRequest,
+  memoryErrorResponse,
+  readMemoryText,
+} from "@/feature/note/api/memory-request";
 
 export async function POST(req: Request) {
   try {
-    const { text } = await req.json();
-
-    if (!text || typeof text !== "string") {
-      return Response.json({ error: "text is required" }, { status: 400 });
-    }
+    // Authenticate and rate-limit before parsing or analyzing attacker input.
+    const { key, accountId } = await authorizeMemoryRequest(req);
+    const text = await readMemoryText(req);
 
     if (text.trim().length < 10) {
-      return Response.json({ error: "Text too short to analyze" }, { status: 400 });
-    }
-
-    const { key, accountId } = await resolveUserKey(req);
-    if ((!key || !accountId) && (!process.env.MEMWAL_PRIVATE_KEY || !process.env.MEMWAL_ACCOUNT_ID)) {
-      return Response.json({ facts: [], count: 0 });
+      return Response.json(
+        { error: "Text too short to analyze" },
+        { status: 400 }
+      );
     }
 
     const facts = await extractMemories("noter", text, key, accountId);
     return Response.json({ facts, count: facts.length });
   } catch (error) {
+    const expected = memoryErrorResponse(error);
+    if (expected) return expected;
+
     console.error("[memory/remember] Error:", error);
     return Response.json(
       { error: error instanceof Error ? error.message : "Unknown error" },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/apps/noter/package/feature/auth/api/export-guard.unit.test.ts
+++ b/apps/noter/package/feature/auth/api/export-guard.unit.test.ts
@@ -45,7 +45,11 @@ vi.mock("@/shared/lib/shared-redis", () => ({
 async function callerFor(userId: string | null) {
   const { authRouter } = await import("./route");
   // Minimal ctx matching the tRPC Context shape used by these procedures.
-  const ctx = { db: {}, userId, memwalKey: null, memwalAccountId: null };
+  const ctx = {
+    db: {},
+    request: new Request("http://localhost/api/trpc/auth"),
+    userId,
+  };
   return authRouter.createCaller(ctx as never);
 }
 

--- a/apps/noter/package/feature/auth/api/route.ts
+++ b/apps/noter/package/feature/auth/api/route.ts
@@ -19,6 +19,11 @@ import {
   verifyAndConsumeEnokiChallenge,
 } from "../lib/enoki-challenge";
 import { SharedRedisUnavailableError } from "@/shared/lib/shared-redis";
+import {
+  assertDelegateAccountBinding,
+  DelegateAccountBindingError,
+  deriveDelegatePublicKeyHex,
+} from "../lib/delegate-account";
 
 // Canonical Sui address: 0x + 64 hex. Reject malformed input at the boundary so
 // it never reaches normalizeSuiAddress (which would silently left-pad garbage
@@ -155,8 +160,8 @@ export const authRouter = router({
       suiAddress: suiAddressSchema,
       challengeId: z.string().min(1),
       signature: z.string().min(1),
-      privateKey: z.string().optional(),
-      accountId: z.string().optional(),
+      privateKey: z.string().regex(/^[0-9a-f]{64}$/i).optional(),
+      accountId: suiAddressSchema.optional(),
     }))
     .mutation(async ({ ctx, input }) => {
       const { challengeId, signature, privateKey, accountId } = input;
@@ -214,6 +219,13 @@ export const authRouter = router({
           throw new TRPCError({ code: "BAD_REQUEST", message: "privateKey and accountId required" });
         }
 
+        const delegatePublicKey = await deriveDelegatePublicKeyHex(privateKey);
+        await assertDelegateAccountBinding({
+          accountId,
+          owner: suiAddress,
+          publicKeyHex: delegatePublicKey,
+        });
+
         const user = await authService.upsertEnokiUser(ctx.db, {
           suiAddress, delegatePrivateKey: privateKey, delegateAccountId: accountId,
         });
@@ -233,6 +245,9 @@ export const authRouter = router({
         if (error instanceof TRPCError) throw error;
         if (error instanceof DelegateCredentialConflictError) {
           throw new TRPCError({ code: "CONFLICT", message: error.message });
+        }
+        if (error instanceof DelegateAccountBindingError) {
+          throw new TRPCError({ code: "UNAUTHORIZED", message: error.message });
         }
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
@@ -353,7 +368,7 @@ export const authRouter = router({
   connectDelegateKey: procedure
     .input(z.object({
       privateKey: z.string().regex(/^[0-9a-f]{64}$/i, "Must be 64 hex characters"),
-      accountId: z.string().min(1),
+      accountId: suiAddressSchema,
     }))
     .mutation(async ({ ctx, input }) => {
       const { privateKey, accountId } = input;
@@ -374,6 +389,10 @@ export const authRouter = router({
           privateKey.match(/.{2}/g)!.map((b) => parseInt(b, 16))
         );
         const pubKeyBytes = ed.getPublicKey(privKeyBytes);
+        const publicKeyHex = Array.from(pubKeyBytes)
+          .map((byte) => byte.toString(16).padStart(2, "0"))
+          .join("");
+        await assertDelegateAccountBinding({ accountId, publicKeyHex });
 
         const { blake2b } = await import("@noble/hashes/blake2.js");
         const addrInput = new Uint8Array(33);
@@ -401,6 +420,9 @@ export const authRouter = router({
         if (error instanceof TRPCError) throw error;
         if (error instanceof DelegateCredentialConflictError) {
           throw new TRPCError({ code: "CONFLICT", message: error.message });
+        }
+        if (error instanceof DelegateAccountBindingError) {
+          throw new TRPCError({ code: "UNAUTHORIZED", message: error.message });
         }
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",

--- a/apps/noter/package/feature/auth/api/route.ts
+++ b/apps/noter/package/feature/auth/api/route.ts
@@ -24,6 +24,10 @@ import {
   DelegateAccountBindingError,
   deriveDelegatePublicKeyHex,
 } from "../lib/delegate-account";
+import {
+  AuthRateLimitError,
+  checkPublicAuthRateLimit,
+} from "../lib/auth-rate-limit";
 
 // Canonical Sui address: 0x + 64 hex. Reject malformed input at the boundary so
 // it never reaches normalizeSuiAddress (which would silently left-pad garbage
@@ -374,24 +378,12 @@ export const authRouter = router({
       const { privateKey, accountId } = input;
 
       try {
-        // Derive Sui address from private key
-        const ed = await import("@noble/ed25519");
-        const { sha512 } = await import("@noble/hashes/sha2.js");
-        if (!(ed.etc as any).sha512Sync) {
-          (ed.etc as any).sha512Sync = (...m: Uint8Array[]) => {
-            const h = sha512.create();
-            for (const msg of m) h.update(msg);
-            return h.digest();
-          };
-        }
-
-        const privKeyBytes = Uint8Array.from(
-          privateKey.match(/.{2}/g)!.map((b) => parseInt(b, 16))
+        await checkPublicAuthRateLimit(ctx.request);
+        // Derive Sui address and binding key from the same private key.
+        const publicKeyHex = await deriveDelegatePublicKeyHex(privateKey);
+        const pubKeyBytes = Uint8Array.from(
+          publicKeyHex.match(/.{2}/g)!.map((byte) => Number.parseInt(byte, 16))
         );
-        const pubKeyBytes = ed.getPublicKey(privKeyBytes);
-        const publicKeyHex = Array.from(pubKeyBytes)
-          .map((byte) => byte.toString(16).padStart(2, "0"))
-          .join("");
         await assertDelegateAccountBinding({ accountId, publicKeyHex });
 
         const { blake2b } = await import("@noble/hashes/blake2.js");
@@ -418,6 +410,9 @@ export const authRouter = router({
         };
       } catch (error) {
         if (error instanceof TRPCError) throw error;
+        if (error instanceof AuthRateLimitError) {
+          throw new TRPCError({ code: error.code, message: error.message });
+        }
         if (error instanceof DelegateCredentialConflictError) {
           throw new TRPCError({ code: "CONFLICT", message: error.message });
         }

--- a/apps/noter/package/feature/auth/lib/auth-rate-limit.ts
+++ b/apps/noter/package/feature/auth/lib/auth-rate-limit.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import { isIP } from "node:net";
+import { requireSharedRedisClient } from "@/shared/lib/shared-redis";
+
+const AUTH_RATE_LIMIT_TTL_SECONDS = 60;
+const AUTH_RATE_LIMIT_PER_IP = 10;
+const AUTH_RATE_LIMIT_GLOBAL = 150;
+
+const AUTH_RATE_LIMIT_LUA = `
+local ip_key = KEYS[1]
+local global_key = KEYS[2]
+local ip_limit = tonumber(ARGV[1])
+local global_limit = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local ip_count = tonumber(redis.call('GET', ip_key) or '0')
+local global_count = tonumber(redis.call('GET', global_key) or '0')
+if ip_count >= ip_limit or global_count >= global_limit then return 0 end
+ip_count = redis.call('INCR', ip_key)
+global_count = redis.call('INCR', global_key)
+if ip_count == 1 then redis.call('EXPIRE', ip_key, ttl) end
+if global_count == 1 then redis.call('EXPIRE', global_key, ttl) end
+return 1
+`;
+
+export class AuthRateLimitError extends Error {
+  constructor(readonly code: "TOO_MANY_REQUESTS" | "SERVICE_UNAVAILABLE") {
+    super(
+      code === "TOO_MANY_REQUESTS"
+        ? "Too many authentication requests"
+        : "Authentication limiter unavailable"
+    );
+    this.name = "AuthRateLimitError";
+  }
+}
+
+function validIp(value: string | undefined): string | undefined {
+  const candidate = value?.trim();
+  return candidate && isIP(candidate) ? candidate : undefined;
+}
+
+function clientIp(request: Request): string | undefined {
+  const vercelForwarded = request.headers
+    .get("x-vercel-forwarded-for")
+    ?.split(",")[0];
+  if (process.env.VERCEL) return validIp(vercelForwarded);
+  return (
+    validIp(request.headers.get("x-real-ip") ?? undefined) ??
+    validIp(request.headers.get("x-forwarded-for")?.split(",").at(-1))
+  );
+}
+
+/** Limit public auth work before any gRPC/account verification call. */
+export async function checkPublicAuthRateLimit(request: Request): Promise<void> {
+  if (process.env.NODE_ENV !== "production") return;
+
+  try {
+    const redis = await requireSharedRedisClient();
+    const ip = clientIp(request) ?? "unknown";
+    const result = await redis.eval(AUTH_RATE_LIMIT_LUA, {
+      arguments: [
+        String(AUTH_RATE_LIMIT_PER_IP),
+        String(AUTH_RATE_LIMIT_GLOBAL),
+        String(AUTH_RATE_LIMIT_TTL_SECONDS),
+      ],
+      keys: [
+        `noter-auth-rate:{noter-auth}:ip:${ip}`,
+        "noter-auth-rate:{noter-auth}:global",
+      ],
+    });
+    if (Number(result) !== 1) {
+      throw new AuthRateLimitError("TOO_MANY_REQUESTS");
+    }
+  } catch (error) {
+    if (error instanceof AuthRateLimitError) throw error;
+    throw new AuthRateLimitError("SERVICE_UNAVAILABLE");
+  }
+}

--- a/apps/noter/package/feature/auth/lib/delegate-account.ts
+++ b/apps/noter/package/feature/auth/lib/delegate-account.ts
@@ -1,0 +1,139 @@
+import "server-only";
+
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { fromBase64, normalizeSuiAddress, toHex } from "@mysten/sui/utils";
+import { enokiConfig } from "@/lib/enoki/config";
+
+export class DelegateAccountBindingError extends Error {
+  constructor(
+    message = "Delegate credentials do not match the Walrus Memory account"
+  ) {
+    super(message);
+    this.name = "DelegateAccountBindingError";
+  }
+}
+
+export async function deriveDelegatePublicKeyHex(
+  privateKeyHex: string
+): Promise<string> {
+  const ed = await import("@noble/ed25519");
+  const { sha512 } = await import("@noble/hashes/sha2.js");
+  if (!ed.etc.sha512Sync) {
+    ed.etc.sha512Sync = (...messages: Uint8Array[]) => {
+      const hash = sha512.create();
+      for (const message of messages) hash.update(message);
+      return hash.digest();
+    };
+  }
+  const privateKey = Uint8Array.from(
+    privateKeyHex.match(/.{2}/g)!.map((byte) => Number.parseInt(byte, 16))
+  );
+  return toHex(ed.getPublicKey(privateKey)).toLowerCase();
+}
+
+function publicKeyHex(value: unknown): string | null {
+  if (typeof value === "string") {
+    try {
+      return toHex(fromBase64(value)).toLowerCase();
+    } catch {
+      return /^[0-9a-f]{64}$/i.test(value) ? value.toLowerCase() : null;
+    }
+  }
+  if (
+    Array.isArray(value) &&
+    value.length === 32 &&
+    value.every((byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255)
+  ) {
+    return toHex(new Uint8Array(value)).toLowerCase();
+  }
+  return null;
+}
+
+/** Pure validation kept separate so malformed/mismatched objects are testable. */
+export function delegateAccountBindingError(
+  objectType: unknown,
+  fields: unknown,
+  expected: { owner?: string; publicKeyHex: string; packageId: string }
+): string | null {
+  if (typeof objectType !== "string") return "Account object has no Move type";
+  const [typePackage, moduleName, structName] = objectType.split("::");
+  if (
+    !typePackage ||
+    normalizeSuiAddress(typePackage) !==
+      normalizeSuiAddress(expected.packageId) ||
+    moduleName !== "account" ||
+    structName !== "MemWalAccount"
+  ) {
+    return "Object is not a configured MemWalAccount";
+  }
+  if (!fields || typeof fields !== "object" || Array.isArray(fields)) {
+    return "Account object has no readable fields";
+  }
+
+  const account = fields as Record<string, unknown>;
+  if (account.active !== true) return "Walrus Memory account is inactive";
+  if (
+    expected.owner !== undefined &&
+    (typeof account.owner !== "string" ||
+      normalizeSuiAddress(account.owner) !==
+        normalizeSuiAddress(expected.owner))
+  ) {
+    return "Walrus Memory account owner does not match the authenticated wallet";
+  }
+  if (!Array.isArray(account.delegate_keys)) {
+    return "Walrus Memory account has no delegate key list";
+  }
+
+  const expectedKey = expected.publicKeyHex.toLowerCase();
+  const registered = account.delegate_keys.some((entry) => {
+    if (!entry || typeof entry !== "object") return false;
+    return (
+      publicKeyHex((entry as Record<string, unknown>).public_key) ===
+      expectedKey
+    );
+  });
+  return registered
+    ? null
+    : "Delegate key is not registered on the Walrus Memory account";
+}
+
+export async function assertDelegateAccountBinding(input: {
+  accountId: string;
+  owner?: string;
+  publicKeyHex: string;
+}): Promise<void> {
+  if (!/^0x[0-9a-f]{64}$/i.test(input.accountId)) {
+    throw new DelegateAccountBindingError("Invalid Walrus Memory account ID");
+  }
+  if (!enokiConfig.memwalPackageId) {
+    throw new DelegateAccountBindingError(
+      "Walrus Memory package is not configured"
+    );
+  }
+
+  const network = enokiConfig.suiNetwork;
+  const defaultUrl = `https://fullnode.${network}.sui.io:443`;
+  const client = new SuiGrpcClient({
+    network,
+    baseUrl: process.env.SUI_GRPC_URL || defaultUrl,
+  });
+  let response: Awaited<ReturnType<typeof client.getObject>>;
+  try {
+    response = await client.getObject({
+      objectId: input.accountId,
+      include: { json: true },
+    });
+  } catch {
+    throw new DelegateAccountBindingError(
+      "Unable to verify Walrus Memory account"
+    );
+  }
+
+  const object = response.object;
+  const error = delegateAccountBindingError(object?.type, object?.json, {
+    owner: input.owner,
+    publicKeyHex: input.publicKeyHex,
+    packageId: enokiConfig.memwalPackageId,
+  });
+  if (error) throw new DelegateAccountBindingError(error);
+}

--- a/apps/noter/package/feature/auth/lib/delegate-account.unit.test.ts
+++ b/apps/noter/package/feature/auth/lib/delegate-account.unit.test.ts
@@ -1,0 +1,66 @@
+import { fromHex, toBase64 } from "@mysten/sui/utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@mysten/sui/grpc", () => ({ SuiGrpcClient: class {} }));
+
+const PACKAGE = `0x${"1".repeat(64)}`;
+const OWNER = `0x${"2".repeat(64)}`;
+const KEY = "ab".repeat(32);
+
+async function validate(
+  fields: Record<string, unknown>,
+  type = `${PACKAGE}::account::MemWalAccount`
+) {
+  const { delegateAccountBindingError } = await import("./delegate-account");
+  return delegateAccountBindingError(type, fields, {
+    owner: OWNER,
+    publicKeyHex: KEY,
+    packageId: PACKAGE,
+  });
+}
+
+describe("delegate account binding", () => {
+  it("accepts the authenticated owner and registered delegate key", async () => {
+    await expect(
+      validate({
+        active: true,
+        owner: OWNER,
+        delegate_keys: [{ public_key: toBase64(fromHex(KEY)) }],
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("rejects owner, package, and delegate-key mismatches", async () => {
+    const fields = {
+      active: true,
+      owner: `0x${"3".repeat(64)}`,
+      delegate_keys: [{ public_key: Array.from(fromHex("cd".repeat(32))) }],
+    };
+
+    await expect(validate(fields)).resolves.toMatch(/owner/);
+    await expect(validate({ ...fields, owner: OWNER })).resolves.toMatch(
+      /not registered/
+    );
+    await expect(
+      validate(
+        {
+          ...fields,
+          owner: OWNER,
+          delegate_keys: [{ public_key: Array.from(fromHex(KEY)) }],
+        },
+        `0x${"4".repeat(64)}::account::MemWalAccount`
+      )
+    ).resolves.toMatch(/configured MemWalAccount/);
+  });
+
+  it("rejects inactive accounts", async () => {
+    await expect(
+      validate({
+        active: false,
+        owner: OWNER,
+        delegate_keys: [{ public_key: Array.from(fromHex(KEY)) }],
+      })
+    ).resolves.toMatch(/inactive/);
+  });
+});

--- a/apps/noter/package/feature/note/api/input.ts
+++ b/apps/noter/package/feature/note/api/input.ts
@@ -6,6 +6,7 @@
 
 import { noteInsertSchema, idInputSchema } from "@/shared/db/type";
 import { z } from "zod";
+import { memoryTextWithinLimit } from "./memory-policy";
 
 // ═══════════════════════════════════════════════════════════════
 // NOTE CRUD
@@ -51,7 +52,10 @@ export const listNotesInput = z.object({
 
 export const detectMemoriesInput = z.object({
   noteId: z.string().uuid(),
-  plainText: z.string().optional(), // Optional: use current editor content if provided
+  plainText: z
+    .string()
+    .refine(memoryTextWithinLimit, "Memory text is too large")
+    .optional(), // Optional: use current editor content if provided
 });
 
 // ═══════════════════════════════════════════════════════════════

--- a/apps/noter/package/feature/note/api/memory-policy.ts
+++ b/apps/noter/package/feature/note/api/memory-policy.ts
@@ -1,0 +1,5 @@
+export const MAX_MEMORY_TEXT_BYTES = 64 * 1024;
+
+export function memoryTextWithinLimit(text: string): boolean {
+  return new TextEncoder().encode(text).byteLength <= MAX_MEMORY_TEXT_BYTES;
+}

--- a/apps/noter/package/feature/note/api/memory-request.ts
+++ b/apps/noter/package/feature/note/api/memory-request.ts
@@ -5,10 +5,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/shared/lib/db";
 import { users, walletSessions } from "@/shared/db/schema";
 import { requireSharedRedisClient } from "@/shared/lib/shared-redis";
-import {
-  MAX_MEMORY_TEXT_BYTES,
-  memoryTextWithinLimit,
-} from "./memory-policy";
+import { memoryTextWithinLimit } from "./memory-policy";
 
 export { MAX_MEMORY_TEXT_BYTES } from "./memory-policy";
 const MEMORY_RATE_LIMIT_TTL_SECONDS = 60;
@@ -48,13 +45,21 @@ export class MemoryRequestError extends Error {
   }
 }
 
-function trustedClientIp(req: Request): string | undefined {
-  if (!process.env.VERCEL) return undefined;
-  const candidate = req.headers
-    .get("x-vercel-forwarded-for")
-    ?.split(",")[0]
-    ?.trim();
+function validIp(value: string | undefined): string | undefined {
+  const candidate = value?.trim();
   return candidate && isIP(candidate) ? candidate : undefined;
+}
+
+function trustedClientIp(req: Request): string | undefined {
+  const vercelForwarded = req.headers
+    .get("x-vercel-forwarded-for")
+    ?.split(",")[0];
+  if (process.env.VERCEL) return validIp(vercelForwarded);
+
+  const realIp = req.headers.get("x-real-ip") ?? undefined;
+  // Railway's edge appends the nearest proxy-observed client address last.
+  const forwarded = req.headers.get("x-forwarded-for")?.split(",").at(-1);
+  return validIp(realIp) ?? validIp(forwarded);
 }
 
 export async function checkMemoryRateLimit(
@@ -139,11 +144,6 @@ export async function authorizeMemoryRequest(req: Request): Promise<{
 }
 
 export async function readMemoryText(req: Request): Promise<string> {
-  const contentLength = Number(req.headers.get("content-length"));
-  if (Number.isFinite(contentLength) && contentLength > MAX_MEMORY_TEXT_BYTES) {
-    throw new MemoryRequestError(413, "Memory text is too large");
-  }
-
   let body: unknown;
   try {
     body = await req.json();

--- a/apps/noter/package/feature/note/api/memory-request.ts
+++ b/apps/noter/package/feature/note/api/memory-request.ts
@@ -1,0 +1,157 @@
+import "server-only";
+
+import { isIP } from "node:net";
+import { eq } from "drizzle-orm";
+import { db } from "@/shared/lib/db";
+import { users, walletSessions } from "@/shared/db/schema";
+import { requireSharedRedisClient } from "@/shared/lib/shared-redis";
+
+export const MAX_MEMORY_TEXT_BYTES = 64 * 1024;
+const MEMORY_RATE_LIMIT_TTL_SECONDS = 60;
+const MEMORY_RATE_LIMIT_PER_USER = 30;
+const MEMORY_RATE_LIMIT_PER_IP = 60;
+const MEMORY_RATE_LIMIT_GLOBAL = 300;
+
+const MEMORY_RATE_LIMIT_LUA = `
+local user_key     = KEYS[1]
+local ip_key       = KEYS[2]
+local global_key   = KEYS[3]
+local user_limit   = tonumber(ARGV[1])
+local ip_limit     = tonumber(ARGV[2])
+local global_limit = tonumber(ARGV[3])
+local ttl          = tonumber(ARGV[4])
+
+local user_count = tonumber(redis.call('GET', user_key) or '0')
+local ip_count = tonumber(redis.call('GET', ip_key) or '0')
+local global_count = tonumber(redis.call('GET', global_key) or '0')
+if user_count >= user_limit or ip_count >= ip_limit or global_count >= global_limit then
+  return 0
+end
+
+user_count = redis.call('INCR', user_key)
+ip_count = redis.call('INCR', ip_key)
+global_count = redis.call('INCR', global_key)
+if user_count == 1 then redis.call('EXPIRE', user_key, ttl) end
+if ip_count == 1 then redis.call('EXPIRE', ip_key, ttl) end
+if global_count == 1 then redis.call('EXPIRE', global_key, ttl) end
+return 1
+`;
+
+export class MemoryRequestError extends Error {
+  constructor(readonly status: 400 | 401 | 413 | 429 | 503, message: string) {
+    super(message);
+    this.name = "MemoryRequestError";
+  }
+}
+
+function trustedClientIp(req: Request): string | undefined {
+  if (!process.env.VERCEL) return undefined;
+  const candidate = req.headers
+    .get("x-vercel-forwarded-for")
+    ?.split(",")[0]
+    ?.trim();
+  return candidate && isIP(candidate) ? candidate : undefined;
+}
+
+async function checkMemoryRateLimit(
+  req: Request,
+  userId: string
+): Promise<void> {
+  // Unit/dev environments remain usable without Redis. Production fails closed.
+  if (process.env.NODE_ENV !== "production") return;
+
+  try {
+    const redis = await requireSharedRedisClient();
+    const ipBucket = trustedClientIp(req) ?? `session-user:${userId}`;
+    const result = await redis.eval(MEMORY_RATE_LIMIT_LUA, {
+      arguments: [
+        String(MEMORY_RATE_LIMIT_PER_USER),
+        String(MEMORY_RATE_LIMIT_PER_IP),
+        String(MEMORY_RATE_LIMIT_GLOBAL),
+        String(MEMORY_RATE_LIMIT_TTL_SECONDS),
+      ],
+      keys: [
+        `noter-memory-rate:{noter-memory}:user:${userId}`,
+        `noter-memory-rate:{noter-memory}:ip:${ipBucket}`,
+        "noter-memory-rate:{noter-memory}:global",
+      ],
+    });
+    if (Number(result) !== 1) {
+      throw new MemoryRequestError(429, "Too many memory write requests");
+    }
+  } catch (error) {
+    if (error instanceof MemoryRequestError) throw error;
+    throw new MemoryRequestError(503, "Memory write limiter unavailable");
+  }
+}
+
+/** Authenticate first and return only credentials bound to that active session. */
+export async function authorizeMemoryRequest(req: Request): Promise<{
+  key: string;
+  accountId: string;
+}> {
+  const sessionId = req.headers.get("x-session-id")?.trim();
+  if (!sessionId || sessionId.length > 128) {
+    throw new MemoryRequestError(401, "Authentication required");
+  }
+
+  const [session] = await db
+    .select()
+    .from(walletSessions)
+    .where(eq(walletSessions.id, sessionId))
+    .limit(1);
+  if (!session?.userId || session.expiresAt <= new Date()) {
+    throw new MemoryRequestError(401, "Authentication required");
+  }
+
+  const [user] = await db
+    .select()
+    .from(users)
+    .where(eq(users.id, session.userId))
+    .limit(1);
+  if (!user?.delegatePrivateKey || !user.delegateAccountId) {
+    throw new MemoryRequestError(
+      401,
+      "Session has no Walrus Memory credentials"
+    );
+  }
+
+  await checkMemoryRateLimit(req, user.id);
+  return {
+    key: user.delegatePrivateKey,
+    accountId: user.delegateAccountId,
+  };
+}
+
+export async function readMemoryText(req: Request): Promise<string> {
+  const contentLength = Number(req.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_MEMORY_TEXT_BYTES) {
+    throw new MemoryRequestError(413, "Memory text is too large");
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    throw new MemoryRequestError(400, "Invalid JSON body");
+  }
+  const text = (body as { text?: unknown } | null)?.text;
+  if (typeof text !== "string" || !text.trim()) {
+    throw new MemoryRequestError(400, "text is required");
+  }
+  if (new TextEncoder().encode(text).byteLength > MAX_MEMORY_TEXT_BYTES) {
+    throw new MemoryRequestError(413, "Memory text is too large");
+  }
+  return text;
+}
+
+export function memoryErrorResponse(error: unknown): Response | null {
+  if (!(error instanceof MemoryRequestError)) return null;
+  return Response.json(
+    { error: error.message },
+    {
+      status: error.status,
+      headers: error.status === 429 ? { "Retry-After": "60" } : undefined,
+    }
+  );
+}

--- a/apps/noter/package/feature/note/api/memory-request.ts
+++ b/apps/noter/package/feature/note/api/memory-request.ts
@@ -5,8 +5,12 @@ import { eq } from "drizzle-orm";
 import { db } from "@/shared/lib/db";
 import { users, walletSessions } from "@/shared/db/schema";
 import { requireSharedRedisClient } from "@/shared/lib/shared-redis";
+import {
+  MAX_MEMORY_TEXT_BYTES,
+  memoryTextWithinLimit,
+} from "./memory-policy";
 
-export const MAX_MEMORY_TEXT_BYTES = 64 * 1024;
+export { MAX_MEMORY_TEXT_BYTES } from "./memory-policy";
 const MEMORY_RATE_LIMIT_TTL_SECONDS = 60;
 const MEMORY_RATE_LIMIT_PER_USER = 30;
 const MEMORY_RATE_LIMIT_PER_IP = 60;
@@ -53,7 +57,7 @@ function trustedClientIp(req: Request): string | undefined {
   return candidate && isIP(candidate) ? candidate : undefined;
 }
 
-async function checkMemoryRateLimit(
+export async function checkMemoryRateLimit(
   req: Request,
   userId: string
 ): Promise<void> {
@@ -85,10 +89,11 @@ async function checkMemoryRateLimit(
   }
 }
 
-/** Authenticate first and return only credentials bound to that active session. */
-export async function authorizeMemoryRequest(req: Request): Promise<{
+/** Resolve only credentials bound to the active wallet session. */
+export async function resolveMemoryCredentials(req: Request): Promise<{
   key: string;
   accountId: string;
+  userId: string;
 }> {
   const sessionId = req.headers.get("x-session-id")?.trim();
   if (!sessionId || sessionId.length > 128) {
@@ -116,11 +121,21 @@ export async function authorizeMemoryRequest(req: Request): Promise<{
     );
   }
 
-  await checkMemoryRateLimit(req, user.id);
   return {
     key: user.delegatePrivateKey,
     accountId: user.delegateAccountId,
+    userId: user.id,
   };
+}
+
+/** Authenticate first, then consume the Redis-backed memory-write budget. */
+export async function authorizeMemoryRequest(req: Request): Promise<{
+  key: string;
+  accountId: string;
+}> {
+  const credentials = await resolveMemoryCredentials(req);
+  await checkMemoryRateLimit(req, credentials.userId);
+  return { key: credentials.key, accountId: credentials.accountId };
 }
 
 export async function readMemoryText(req: Request): Promise<string> {
@@ -139,7 +154,7 @@ export async function readMemoryText(req: Request): Promise<string> {
   if (typeof text !== "string" || !text.trim()) {
     throw new MemoryRequestError(400, "text is required");
   }
-  if (new TextEncoder().encode(text).byteLength > MAX_MEMORY_TEXT_BYTES) {
+  if (!memoryTextWithinLimit(text)) {
     throw new MemoryRequestError(413, "Memory text is too large");
   }
   return text;

--- a/apps/noter/package/feature/note/api/memory-routes.unit.test.ts
+++ b/apps/noter/package/feature/note/api/memory-routes.unit.test.ts
@@ -20,7 +20,11 @@ vi.mock("@/feature/note/lib/pdw-client", () => ({
   extractMemories,
 }));
 vi.mock("@/shared/lib/db", () => ({ db: {} }));
-vi.mock("@/shared/db/schema", () => ({ users: {}, walletSessions: {} }));
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  desc: vi.fn(),
+  eq: vi.fn(),
+}));
 vi.mock("@/shared/lib/shared-redis", () => ({
   requireSharedRedisClient: vi.fn(),
 }));
@@ -32,6 +36,14 @@ beforeEach(() => {
 });
 
 describe("Noter memory routes", () => {
+  it("never creates a client from process-wide credentials", async () => {
+    const { getMemWalClient } = await vi.importActual<
+      typeof import("@/feature/note/lib/pdw-client")
+    >("@/feature/note/lib/pdw-client");
+
+    expect(() => getMemWalClient()).toThrow("Session has no delegate key");
+  });
+
   it.each([
     [
       "remember-one",
@@ -60,6 +72,62 @@ describe("Noter memory routes", () => {
       expect(request.bodyUsed).toBe(false);
     }
   );
+
+  it("rejects tRPC analyze writes before note or outbound work", async () => {
+    const { MemoryRequestError } = await import("./memory-request");
+    authorizeMemoryRequest.mockRejectedValueOnce(
+      new MemoryRequestError(401, "Session has no Walrus Memory credentials")
+    );
+    const findFirst = vi.fn();
+    const { noteRouter } = await import("./route");
+    const caller = noteRouter.createCaller({
+      db: { query: { notes: { findFirst } } },
+      request: new Request("http://localhost/api/trpc/note.detectMemories", {
+        headers: { "x-session-id": "active-session" },
+      }),
+      userId: "user-1",
+    } as never);
+
+    await expect(
+      caller.detectMemories({
+        noteId: "00000000-0000-4000-8000-000000000001",
+        plainText: "attacker-controlled memory content",
+      })
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+
+    expect(findFirst).not.toHaveBeenCalled();
+    expect(extractMemories).not.toHaveBeenCalled();
+  });
+
+  it("applies the byte bound to database-backed tRPC analyze text", async () => {
+    authorizeMemoryRequest.mockResolvedValueOnce({
+      key: "session-bound-key",
+      accountId: `0x${"2".repeat(64)}`,
+    });
+    const { MAX_MEMORY_TEXT_BYTES } = await import("./memory-policy");
+    const findFirst = vi.fn().mockResolvedValue({
+      id: "00000000-0000-4000-8000-000000000001",
+      userId: "user-1",
+      plainText: "x".repeat(MAX_MEMORY_TEXT_BYTES + 1),
+    });
+    const { noteRouter } = await import("./route");
+    const caller = noteRouter.createCaller({
+      db: { query: { notes: { findFirst } } },
+      request: new Request("http://localhost/api/trpc/note.detectMemories", {
+        headers: { "x-session-id": "active-session" },
+      }),
+      userId: "user-1",
+    } as never);
+
+    await expect(
+      caller.detectMemories({
+        noteId: "00000000-0000-4000-8000-000000000001",
+      })
+    ).rejects.toMatchObject({ code: "PAYLOAD_TOO_LARGE" });
+
+    expect(authorizeMemoryRequest).toHaveBeenCalledOnce();
+    expect(extractMemories).not.toHaveBeenCalled();
+  });
 
   it("bounds memory text by encoded byte size", async () => {
     const { MAX_MEMORY_TEXT_BYTES, readMemoryText } =

--- a/apps/noter/package/feature/note/api/memory-routes.unit.test.ts
+++ b/apps/noter/package/feature/note/api/memory-routes.unit.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const authorizeMemoryRequest = vi.fn();
+const rememberText = vi.fn();
+const extractMemories = vi.fn();
+
+vi.mock("./memory-request", async () => {
+  const actual = await vi.importActual<typeof import("./memory-request")>(
+    "./memory-request"
+  );
+  return {
+    ...actual,
+    authorizeMemoryRequest,
+  };
+});
+vi.mock("@/feature/note/lib/pdw-client", () => ({
+  rememberText,
+  extractMemories,
+}));
+vi.mock("@/shared/lib/db", () => ({ db: {} }));
+vi.mock("@/shared/db/schema", () => ({ users: {}, walletSessions: {} }));
+vi.mock("@/shared/lib/shared-redis", () => ({
+  requireSharedRedisClient: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.MEMWAL_PRIVATE_KEY = "server-wide-key-must-not-be-used";
+  process.env.MEMWAL_ACCOUNT_ID = `0x${"1".repeat(64)}`;
+});
+
+describe("Noter memory routes", () => {
+  it.each([
+    [
+      "remember-one",
+      () => import("../../../../app/api/memory/remember-one/route"),
+    ],
+    ["remember", () => import("../../../../app/api/memory/remember/route")],
+  ])(
+    "rejects unauthenticated %s requests before body or outbound work",
+    async (_, load) => {
+      const { MemoryRequestError } = await import("./memory-request");
+      authorizeMemoryRequest.mockRejectedValueOnce(
+        new MemoryRequestError(401, "Authentication required")
+      );
+      const { POST } = await load();
+      const request = new Request("http://localhost/api/memory", {
+        method: "POST",
+        body: JSON.stringify({ text: "attacker-controlled memory content" }),
+        headers: { "content-type": "application/json" },
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      expect(rememberText).not.toHaveBeenCalled();
+      expect(extractMemories).not.toHaveBeenCalled();
+      expect(request.bodyUsed).toBe(false);
+    }
+  );
+
+  it("bounds memory text by encoded byte size", async () => {
+    const { MAX_MEMORY_TEXT_BYTES, readMemoryText } =
+      await import("./memory-request");
+    const request = new Request("http://localhost/api/memory", {
+      method: "POST",
+      body: JSON.stringify({ text: "x".repeat(MAX_MEMORY_TEXT_BYTES + 1) }),
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(readMemoryText(request)).rejects.toEqual(
+      expect.objectContaining({ status: 413 })
+    );
+  });
+});

--- a/apps/noter/package/feature/note/api/memory-routes.unit.test.ts
+++ b/apps/noter/package/feature/note/api/memory-routes.unit.test.ts
@@ -129,6 +129,23 @@ describe("Noter memory routes", () => {
     expect(extractMemories).not.toHaveBeenCalled();
   });
 
+  it("does not reject valid near-limit text because of JSON framing", async () => {
+    const { MAX_MEMORY_TEXT_BYTES, readMemoryText } =
+      await import("./memory-request");
+    const text = "x".repeat(MAX_MEMORY_TEXT_BYTES);
+    const body = JSON.stringify({ text });
+    const request = new Request("http://localhost/api/memory", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(Buffer.byteLength(body)),
+      },
+    });
+
+    await expect(readMemoryText(request)).resolves.toBe(text);
+  });
+
   it("bounds memory text by encoded byte size", async () => {
     const { MAX_MEMORY_TEXT_BYTES, readMemoryText } =
       await import("./memory-request");

--- a/apps/noter/package/feature/note/api/route.ts
+++ b/apps/noter/package/feature/note/api/route.ts
@@ -19,6 +19,28 @@ import {
 } from "./input";
 import { detectMemoriesForLexical } from "../lib/memory-detector";
 import { generateNoteTitle } from "../domain/note";
+import {
+  authorizeMemoryRequest,
+  MemoryRequestError,
+} from "./memory-request";
+import { memoryTextWithinLimit } from "./memory-policy";
+
+function memoryRequestTrpcError(error: unknown): never {
+  if (!(error instanceof MemoryRequestError)) throw error;
+  const code = {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    413: "PAYLOAD_TOO_LARGE",
+    429: "TOO_MANY_REQUESTS",
+    503: "SERVICE_UNAVAILABLE",
+  }[error.status] as
+    | "BAD_REQUEST"
+    | "UNAUTHORIZED"
+    | "PAYLOAD_TOO_LARGE"
+    | "TOO_MANY_REQUESTS"
+    | "SERVICE_UNAVAILABLE";
+  throw new TRPCError({ code, message: error.message });
+}
 
 export const noteRouter = router({
   // ═══════════════════════════════════════════════════════════════
@@ -175,6 +197,15 @@ export const noteRouter = router({
   detectMemories: protectedProcedure
     .input(detectMemoriesInput)
     .mutation(async ({ ctx, input }) => {
+      // Revalidate the active session and consume the same Redis-backed write
+      // budget as the REST memory routes before any note or outbound work.
+      let credentials: { key: string; accountId: string };
+      try {
+        credentials = await authorizeMemoryRequest(ctx.request);
+      } catch (error) {
+        memoryRequestTrpcError(error);
+      }
+
       // Verify note ownership
       const note = await ctx.db.query.notes.findFirst({
         where: eq(notes.id, input.noteId),
@@ -190,9 +221,21 @@ export const noteRouter = router({
 
       // Use provided plainText (current editor content) or fall back to database
       const plainText = input.plainText ?? note.plainText;
+      if (!memoryTextWithinLimit(plainText)) {
+        throw new TRPCError({
+          code: "PAYLOAD_TOO_LARGE",
+          message: "Memory text is too large",
+        });
+      }
 
-      // Extract memories using AI
-      const memories = await detectMemoriesForLexical(ctx.userId, plainText, ctx.memwalKey, ctx.memwalAccountId);
+      // analyze() persists extracted facts, so it must use only the credentials
+      // returned by the session-bound memory-write authorization above.
+      const memories = await detectMemoriesForLexical(
+        ctx.userId,
+        plainText,
+        credentials.key,
+        credentials.accountId
+      );
 
       // Return memory data (client will inject as Lexical nodes)
       return {

--- a/apps/noter/package/feature/note/hook/use-pdw-client.ts
+++ b/apps/noter/package/feature/note/hook/use-pdw-client.ts
@@ -1,20 +1,30 @@
 "use client";
 
-/**
- * memwal Status Hook
- *
- * Simple hook to check if Walrus Memory is configured (MEMWAL_PRIVATE_KEY set).
- * No client-side SDK needed — all operations go through server.
- */
+/** Check the authenticated user's Walrus Memory connection. */
 
 import { useState, useEffect } from "react";
+import { STORAGE_KEYS } from "@/feature/auth/constant";
+import type { SessionData } from "@/feature/auth/domain/type";
+
+function getSessionId(): string | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEYS.sessionId);
+    return raw ? (JSON.parse(raw) as SessionData).sessionId : null;
+  } catch {
+    return null;
+  }
+}
 
 export function useMemWalStatus() {
   const [isConfigured, setIsConfigured] = useState(false);
 
   useEffect(() => {
-    // Check server health to see if Walrus Memory is configured
-    fetch("/api/memory/health")
+    const sessionId = getSessionId();
+    if (!sessionId) return;
+
+    fetch("/api/memory/health", {
+      headers: { "x-session-id": sessionId },
+    })
       .then((res) => {
         setIsConfigured(res.ok);
       })

--- a/apps/noter/package/feature/note/lib/pdw-client.ts
+++ b/apps/noter/package/feature/note/lib/pdw-client.ts
@@ -1,9 +1,8 @@
 /**
  * Walrus Memory CLIENT — Server-side SDK wrapper
  *
- * Creates per-request Walrus Memory clients using the authenticated user's
- * delegate key (from tRPC context). Falls back to env vars for backward
- * compatibility.
+ * Creates per-request Walrus Memory clients using credentials bound to the
+ * authenticated user. Shared process credentials are never accepted.
  */
 
 import { MemWal } from "@mysten-incubation/memwal";
@@ -21,24 +20,21 @@ export function createMemWalClient(key: string, accountId: string): MemWal {
 }
 
 /**
- * Get a Walrus Memory client using provided credentials or env var fallback.
- * Throws if no key is available.
+ * Get a Walrus Memory client using explicit session-bound credentials.
+ * Throws if either credential is unavailable.
  */
 export function getMemWalClient(
   key?: string | null,
   accountId?: string | null,
 ): MemWal {
-  const resolvedKey = key || process.env.MEMWAL_PRIVATE_KEY;
-  const resolvedAccountId = accountId || process.env.MEMWAL_ACCOUNT_ID;
-
-  if (!resolvedKey) {
-    throw new Error("[Walrus Memory] No key configured — sign in with Enoki or set MEMWAL_PRIVATE_KEY in .env");
+  if (!key) {
+    throw new Error("[Walrus Memory] Session has no delegate key");
   }
-  if (!resolvedAccountId) {
-    throw new Error("[Walrus Memory] No accountId configured — sign in with Enoki or set MEMWAL_ACCOUNT_ID in .env");
+  if (!accountId) {
+    throw new Error("[Walrus Memory] Session has no account ID");
   }
 
-  return createMemWalClient(resolvedKey, resolvedAccountId);
+  return createMemWalClient(key, accountId);
 }
 
 /** Extract memories from text using Walrus Memory analyze endpoint. */

--- a/apps/noter/package/feature/note/ui/pdw-status-indicator.tsx
+++ b/apps/noter/package/feature/note/ui/pdw-status-indicator.tsx
@@ -41,7 +41,7 @@ export function PDWStatusIndicator() {
             </div>
           </TooltipTrigger>
           <TooltipContent>
-            <p className="text-xs">Walrus Memory not configured (MEMWAL_PRIVATE_KEY not set)</p>
+            <p className="text-xs">Walrus Memory is not connected for this session</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/apps/noter/package/shared/lib/trpc/init.ts
+++ b/apps/noter/package/shared/lib/trpc/init.ts
@@ -2,42 +2,27 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
 import superjson from "superjson";
 import { db } from "@/shared/lib/db";
-import { walletSessions, users } from "@/shared/db/schema";
+import { walletSessions } from "@/shared/db/schema";
 import { eq } from "drizzle-orm";
 
 export type Context = {
   db: typeof db;
+  request: Request;
   userId: string | null;
-  /** Per-user Walrus Memory delegate key (null if user has no stored key). */
-  memwalKey: string | null;
-  /** Per-user Walrus Memory account ID (null if user has no stored account). */
-  memwalAccountId: string | null;
 };
 
 function getSessionIdFromRequest(req: Request): string | null {
   return req.headers.get("x-session-id");
 }
 
-/** Load user's Walrus Memory delegate key from the users table. Falls back to env vars. */
-async function loadUserMemwalKey(userId: string) {
-  try {
-    const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
-    return {
-      memwalKey: user?.delegatePrivateKey ?? process.env.MEMWAL_PRIVATE_KEY ?? null,
-      memwalAccountId: user?.delegateAccountId ?? process.env.MEMWAL_ACCOUNT_ID ?? null,
-    };
-  } catch {
-    return {
-      memwalKey: process.env.MEMWAL_PRIVATE_KEY ?? null,
-      memwalAccountId: process.env.MEMWAL_ACCOUNT_ID ?? null,
-    };
-  }
-}
-
 export const createContext = async (
   opts: FetchCreateContextFnOptions
 ): Promise<Context> => {
-  const noAuth: Context = { db, userId: null, memwalKey: null, memwalAccountId: null };
+  const noAuth: Context = {
+    db,
+    request: opts.req,
+    userId: null,
+  };
   const sessionId = getSessionIdFromRequest(opts.req);
   if (!sessionId) return noAuth;
 
@@ -52,8 +37,7 @@ export const createContext = async (
     .limit(1);
 
   if (walletSession?.userId && walletSession.expiresAt > new Date()) {
-    const keys = await loadUserMemwalKey(walletSession.userId);
-    return { db, userId: walletSession.userId, ...keys };
+    return { db, request: opts.req, userId: walletSession.userId };
   }
 
   return noAuth;

--- a/apps/researcher/README.md
+++ b/apps/researcher/README.md
@@ -1,0 +1,7 @@
+# Researcher
+
+Researcher is a demonstration application for Walrus Memory research workflows. It is not a production credential wallet and must not be deployed with production delegate private keys or exposed as a key-recovery service.
+
+Authentication cookies contain identity claims only. Reusable delegate credentials remain in the server-side database and are loaded only for authenticated server operations. The application deliberately does not expose a delegate-key export endpoint.
+
+For any production deployment, use dedicated least-privilege accounts, short-lived sessions, managed secret storage, deployment-specific rate limits, and a separate security review.

--- a/apps/researcher/app/(chat)/api/chat/route.ts
+++ b/apps/researcher/app/(chat)/api/chat/route.ts
@@ -9,6 +9,7 @@ import {
 import { after } from "next/server";
 import { createResumableStreamContext } from "resumable-stream";
 import { getSession } from "@/lib/auth/session";
+import { sessionMemoryCredentials } from "@/lib/auth/session-memory";
 import { allowedModelIds } from "@/lib/ai/models";
 import { researchPrompt, getSprintResumePrompt } from "@/lib/ai/prompts";
 import { buildSprintContext } from "@/lib/sprint/resume";
@@ -137,8 +138,9 @@ export async function POST(request: Request) {
     const modelMessages = await convertToModelMessages(uiMessages);
 
     // Resolve sprint context — pre-built during preparation and stored on chat record
-    const memwalKey = session.user.privateKey || process.env.MEMWAL_PRIVATE_KEY;
-    const memwalAccountId = session.user.accountId || process.env.MEMWAL_ACCOUNT_ID;
+    const memoryCredentials = sessionMemoryCredentials(session.user);
+    const memwalKey = memoryCredentials?.key;
+    const memwalAccountId = memoryCredentials?.accountId;
     const resolvedSprintIds: string[] = chat?.sprintIds ?? [];
     const prebuiltSprintContext: string | null = chat?.sprintContext ?? null;
 

--- a/apps/researcher/app/api/auth/enoki/route.ts
+++ b/apps/researcher/app/api/auth/enoki/route.ts
@@ -88,7 +88,6 @@ export async function POST(request: Request) {
         await createSession(
           existing.id,
           existing.publicKey,
-          existing.delegatePrivateKey,
           existing.accountId,
         );
         return Response.json({ success: true, needsSetup: false });
@@ -133,7 +132,7 @@ export async function POST(request: Request) {
         delegatePrivateKey: privateKey,
         accountId,
       });
-      await createSession(existing.id, derivedPublicKey, privateKey, accountId);
+      await createSession(existing.id, derivedPublicKey, accountId);
     } else {
       // Create new user
       const created = await createEnokiUser({
@@ -142,7 +141,7 @@ export async function POST(request: Request) {
         delegatePrivateKey: privateKey,
         accountId,
       });
-      await createSession(created.id, derivedPublicKey, privateKey, accountId);
+      await createSession(created.id, derivedPublicKey, accountId);
     }
 
     return Response.json({ success: true, needsSetup: false });

--- a/apps/researcher/app/api/auth/key/route.ts
+++ b/apps/researcher/app/api/auth/key/route.ts
@@ -1,8 +1,5 @@
 import { createSession } from "@/lib/auth/session";
-import {
-  getUserByPublicKey,
-  createUserByPublicKey,
-} from "@/lib/db/queries";
+import { upsertDelegateCredentialsByPublicKey } from "@/lib/db/queries";
 import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha512";
 
@@ -45,10 +42,17 @@ export async function POST(request: Request) {
     const pubKeyBytes = ed.getPublicKey(privKeyBytes);
     const publicKey = bytesToHex(pubKeyBytes);
 
-    const existing = await getUserByPublicKey(publicKey);
-    const user = existing ?? (await createUserByPublicKey(publicKey));
+    if (!accountId || typeof accountId !== "string") {
+      return Response.json({ error: "Account ID is required." }, { status: 400 });
+    }
 
-    await createSession(user.id, publicKey, privateKey, accountId || '');
+    const user = await upsertDelegateCredentialsByPublicKey({
+      publicKey,
+      delegatePrivateKey: privateKey,
+      accountId,
+    });
+
+    await createSession(user.id, publicKey, accountId);
 
     return Response.json({ success: true });
   } catch (error) {

--- a/apps/researcher/app/api/auth/key/route.ts
+++ b/apps/researcher/app/api/auth/key/route.ts
@@ -2,6 +2,12 @@ import { createSession } from "@/lib/auth/session";
 import { upsertDelegateCredentialsByPublicKey } from "@/lib/db/queries";
 import * as ed from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha512";
+import {
+  assertDelegateAccountBinding,
+  DelegateAccountBindingError,
+} from "@/lib/auth/delegate-account";
+import { isSameOriginRequest } from "@/lib/auth/request-security";
+import { AuthRateLimitError, checkAuthRateLimit } from "@/lib/ratelimit";
 
 if (!ed.etc.sha512Sync) {
   ed.etc.sha512Sync = (...m: Uint8Array[]) => {
@@ -12,6 +18,7 @@ if (!ed.etc.sha512Sync) {
 }
 
 const PRIVATE_KEY_REGEX = /^[0-9a-f]{64}$/i;
+const ACCOUNT_ID_REGEX = /^0x[0-9a-f]{64}$/i;
 
 function hexToBytes(hex: string): Uint8Array {
   const bytes = new Uint8Array(hex.length / 2);
@@ -28,7 +35,12 @@ function bytesToHex(bytes: Uint8Array): string {
 }
 
 export async function POST(request: Request) {
+  if (!isSameOriginRequest(request)) {
+    return Response.json({ error: "Invalid request origin" }, { status: 403 });
+  }
+
   try {
+    await checkAuthRateLimit(request, "verify");
     const { privateKey, accountId } = await request.json();
 
     if (!privateKey || typeof privateKey !== "string" || !PRIVATE_KEY_REGEX.test(privateKey)) {
@@ -42,9 +54,20 @@ export async function POST(request: Request) {
     const pubKeyBytes = ed.getPublicKey(privKeyBytes);
     const publicKey = bytesToHex(pubKeyBytes);
 
-    if (!accountId || typeof accountId !== "string") {
-      return Response.json({ error: "Account ID is required." }, { status: 400 });
+    if (
+      !accountId ||
+      typeof accountId !== "string" ||
+      !ACCOUNT_ID_REGEX.test(accountId)
+    ) {
+      return Response.json(
+        { error: "Valid account ID is required (0x... format)." },
+        { status: 400 }
+      );
     }
+
+    // Manual login has no wallet owner, but the account must still be active,
+    // from the configured package, and contain this derived delegate key.
+    await assertDelegateAccountBinding({ accountId, publicKeyHex: publicKey });
 
     const user = await upsertDelegateCredentialsByPublicKey({
       publicKey,
@@ -56,6 +79,23 @@ export async function POST(request: Request) {
 
     return Response.json({ success: true });
   } catch (error) {
+    if (error instanceof DelegateAccountBindingError) {
+      return Response.json({ error: error.message }, { status: 401 });
+    }
+    if (error instanceof AuthRateLimitError) {
+      return Response.json(
+        {
+          error:
+            error.status === 429
+              ? "Too many authentication requests"
+              : "Authentication service temporarily unavailable",
+        },
+        {
+          headers: { "Retry-After": error.status === 429 ? "60" : "5" },
+          status: error.status,
+        }
+      );
+    }
     console.error("[auth:key] Error:", error);
     return Response.json({ error: "Authentication failed" }, { status: 500 });
   }

--- a/apps/researcher/app/api/auth/profile/export-key/route.ts
+++ b/apps/researcher/app/api/auth/profile/export-key/route.ts
@@ -1,14 +1,15 @@
-import { getSession } from "@/lib/auth/session";
-
-/** POST /api/auth/profile/export-key — Returns the delegate private key from the active session. Requires authentication. */
-export async function POST() {
-  const session = await getSession();
-  if (!session?.user?.privateKey) {
-    return Response.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
-  return Response.json({
-    privateKey: session.user.privateKey,
-    accountId: session.user.accountId,
-  });
+/**
+ * Delegate-key export is intentionally disabled.
+ *
+ * Researcher is a demo app and must not become a credential recovery service:
+ * an authenticated browser session is sufficient to use server-side memory
+ * operations, but it cannot retrieve reusable private-key material.
+ */
+export async function GET() {
+  return Response.json(
+    { error: "Delegate private-key export is disabled" },
+    { status: 410 }
+  );
 }
+
+export const POST = GET;

--- a/apps/researcher/app/api/sprint/prepare/route.ts
+++ b/apps/researcher/app/api/sprint/prepare/route.ts
@@ -1,6 +1,7 @@
 import { generateObject } from "ai";
 import { z } from "zod";
 import { getSession } from "@/lib/auth/session";
+import { sessionMemoryCredentials } from "@/lib/auth/session-memory";
 import { getLanguageModel } from "@/lib/ai/providers";
 import { getSprintsByIds, saveChat, updateChatSprintContext } from "@/lib/db/queries";
 import { recallFromMemWal } from "@/lib/sprint/memwal";
@@ -45,15 +46,15 @@ export async function POST(request: Request) {
   }
 
   const { chatId, sprintIds, visibility = "private" } = body;
-  const memwalKey = session.user.privateKey || process.env.MEMWAL_PRIVATE_KEY;
-  const memwalAccountId = session.user.accountId || process.env.MEMWAL_ACCOUNT_ID;
+  const credentials = sessionMemoryCredentials(session.user);
   const userId = session.user.id;
 
-  if (!memwalKey) {
-    return new ChatbotError("bad_request:api", "Walrus Memory key is required for sprint preparation").toResponse();
+  if (!credentials) {
+    return new ChatbotError("bad_request:api", "Session has no Walrus Memory credentials").toResponse();
   }
 
-  console.log(`[sprint:prepare] memwalKey source=${session.user.privateKey ? "session" : "env"}, key=${memwalKey.slice(0, 8)}...`);
+  const { key: memwalKey, accountId: memwalAccountId } = credentials;
+  console.log("[sprint:prepare] using session-bound Walrus Memory credentials");
 
   const encoder = new TextEncoder();
   const stream = new ReadableStream({

--- a/apps/researcher/app/api/sprint/save/route.ts
+++ b/apps/researcher/app/api/sprint/save/route.ts
@@ -1,4 +1,5 @@
 import { getSession } from "@/lib/auth/session";
+import { sessionMemoryCredentials } from "@/lib/auth/session-memory";
 import { getChatById, getSprintByChatId, createSprintBlob } from "@/lib/db/queries";
 import { generateSprintReport } from "@/lib/sprint/report";
 import { rememberSprintReport } from "@/lib/sprint/memwal";
@@ -34,15 +35,15 @@ export async function POST(request: Request) {
     return new ChatbotError("bad_request:api").toResponse();
   }
 
-  const memwalKey = session.user.privateKey || process.env.MEMWAL_PRIVATE_KEY;
-  const memwalAccountId = session.user.accountId || process.env.MEMWAL_ACCOUNT_ID;
-  if (!memwalKey) {
+  const credentials = sessionMemoryCredentials(session.user);
+  if (!credentials) {
     return new ChatbotError(
       "bad_request:api",
       "No Walrus Memory key provided"
     ).toResponse();
   }
 
+  const { key: memwalKey, accountId: memwalAccountId } = credentials;
   console.log(`[sprint:save] Starting SSE save for chat=${chatId}, user=${userId.slice(0, 8)}...`);
 
   const encoder = new TextEncoder();

--- a/apps/researcher/app/profile/page.tsx
+++ b/apps/researcher/app/profile/page.tsx
@@ -4,11 +4,8 @@ import {
   ArrowLeft,
   Copy,
   Check,
-  KeyRound,
   Shield,
   User,
-  Eye,
-  EyeOff,
   ExternalLink,
 } from "lucide-react";
 import Link from "next/link";
@@ -54,9 +51,6 @@ function truncateAddress(addr: string): string {
 export default function ProfilePage() {
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [showKey, setShowKey] = useState(false);
-  const [privateKey, setPrivateKey] = useState<string | null>(null);
-  const [keyLoading, setKeyLoading] = useState(false);
 
   useEffect(() => {
     fetch("/api/auth/profile")
@@ -65,28 +59,6 @@ export default function ProfilePage() {
       .catch(() => setProfile(null))
       .finally(() => setLoading(false));
   }, []);
-
-  const handleExportKey = async () => {
-    if (privateKey) {
-      setShowKey(!showKey);
-      return;
-    }
-    setKeyLoading(true);
-    try {
-      const res = await fetch("/api/auth/profile/export-key", {
-        method: "POST",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setPrivateKey(data.privateKey);
-        setShowKey(true);
-      }
-    } catch {
-      // silently fail
-    } finally {
-      setKeyLoading(false);
-    }
-  };
 
   if (loading) {
     return (
@@ -213,58 +185,6 @@ export default function ProfilePage() {
             )}
           </div>
         </div>
-
-        {/* Export delegate key card */}
-        {profile.hasPrivateKey && (
-          <div className="mb-4 rounded-xl border bg-card shadow-sm">
-            <div className="border-b px-5 py-3">
-              <h2 className="flex items-center gap-2 font-medium text-sm">
-                <KeyRound className="size-3.5 text-muted-foreground" />
-                Delegate Key
-              </h2>
-            </div>
-
-            <div className="px-5 py-4">
-              <p className="mb-3 text-muted-foreground text-xs leading-relaxed">
-                Use this key to connect other apps (chatbot, CLI, OpenClaw) to
-                your Walrus Memory account. Keep it private.
-              </p>
-
-              {showKey && privateKey ? (
-                <div className="mb-3 rounded-lg border bg-muted/50 p-3">
-                  <div className="flex items-start justify-between gap-2">
-                    <code className="break-all font-mono text-xs leading-relaxed">
-                      {privateKey}
-                    </code>
-                    <CopyButton value={privateKey} label="Private Key" />
-                  </div>
-                </div>
-              ) : null}
-
-              <Button
-                className="w-full"
-                disabled={keyLoading}
-                onClick={handleExportKey}
-                size="sm"
-                variant="outline"
-              >
-                {keyLoading ? (
-                  "Loading..."
-                ) : showKey ? (
-                  <>
-                    <EyeOff className="size-3.5" />
-                    Hide Key
-                  </>
-                ) : (
-                  <>
-                    <Eye className="size-3.5" />
-                    Reveal Delegate Key
-                  </>
-                )}
-              </Button>
-            </div>
-          </div>
-        )}
 
         {/* Session actions */}
         <div className="rounded-xl border bg-card px-5 py-3 shadow-sm">

--- a/apps/researcher/lib/auth/delegate-account.ts
+++ b/apps/researcher/lib/auth/delegate-account.ts
@@ -1,0 +1,115 @@
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { fromBase64, normalizeSuiAddress, toHex } from "@mysten/sui/utils";
+import { enokiConfig } from "@/lib/enoki/config";
+
+export class DelegateAccountBindingError extends Error {
+  constructor(
+    message = "Delegate credentials do not match the Walrus Memory account"
+  ) {
+    super(message);
+    this.name = "DelegateAccountBindingError";
+  }
+}
+
+function publicKeyHex(value: unknown): string | null {
+  if (typeof value === "string" && /^[0-9a-f]{64}$/i.test(value)) {
+    return value.toLowerCase();
+  }
+  if (typeof value === "string") {
+    try {
+      const decoded = fromBase64(value);
+      return decoded.length === 32 ? toHex(decoded).toLowerCase() : null;
+    } catch {
+      return null;
+    }
+  }
+  if (
+    Array.isArray(value) &&
+    value.length === 32 &&
+    value.every(
+      (byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255
+    )
+  ) {
+    return toHex(new Uint8Array(value)).toLowerCase();
+  }
+  return null;
+}
+
+export function delegateAccountBindingError(
+  objectType: unknown,
+  fields: unknown,
+  expected: { publicKeyHex: string; packageId: string }
+): string | null {
+  if (typeof objectType !== "string") return "Account object has no Move type";
+  const [typePackage, moduleName, structName] = objectType.split("::");
+  if (
+    !typePackage ||
+    normalizeSuiAddress(typePackage) !==
+      normalizeSuiAddress(expected.packageId) ||
+    moduleName !== "account" ||
+    structName !== "MemWalAccount"
+  ) {
+    return "Object is not a configured MemWalAccount";
+  }
+  if (!fields || typeof fields !== "object" || Array.isArray(fields)) {
+    return "Account object has no readable fields";
+  }
+
+  const account = fields as Record<string, unknown>;
+  if (account.active !== true) return "Walrus Memory account is inactive";
+  if (!Array.isArray(account.delegate_keys)) {
+    return "Walrus Memory account has no delegate key list";
+  }
+  const expectedKey = expected.publicKeyHex.toLowerCase();
+  const registered = account.delegate_keys.some((entry) => {
+    if (!entry || typeof entry !== "object") return false;
+    return (
+      publicKeyHex((entry as Record<string, unknown>).public_key) === expectedKey
+    );
+  });
+  return registered
+    ? null
+    : "Delegate key is not registered on the Walrus Memory account";
+}
+
+export async function assertDelegateAccountBinding(input: {
+  accountId: string;
+  publicKeyHex: string;
+}): Promise<void> {
+  if (!/^0x[0-9a-f]{64}$/i.test(input.accountId)) {
+    throw new DelegateAccountBindingError("Invalid Walrus Memory account ID");
+  }
+  if (!enokiConfig.memwalPackageId) {
+    throw new DelegateAccountBindingError(
+      "Walrus Memory package is not configured"
+    );
+  }
+
+  const network = enokiConfig.suiNetwork;
+  const client = new SuiGrpcClient({
+    network,
+    baseUrl:
+      process.env.SUI_GRPC_URL || `https://fullnode.${network}.sui.io:443`,
+  });
+  let response: Awaited<ReturnType<typeof client.getObject>>;
+  try {
+    response = await client.getObject({
+      objectId: input.accountId,
+      include: { json: true },
+    });
+  } catch {
+    throw new DelegateAccountBindingError(
+      "Unable to verify Walrus Memory account"
+    );
+  }
+
+  const error = delegateAccountBindingError(
+    response.object?.type,
+    response.object?.json,
+    {
+      publicKeyHex: input.publicKeyHex,
+      packageId: enokiConfig.memwalPackageId,
+    }
+  );
+  if (error) throw new DelegateAccountBindingError(error);
+}

--- a/apps/researcher/lib/auth/delegate-account.unit.test.ts
+++ b/apps/researcher/lib/auth/delegate-account.unit.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { delegateAccountBindingError } from "./delegate-account";
+
+const PACKAGE_ID = `0x${"2".repeat(64)}`;
+const PUBLIC_KEY = "ab".repeat(32);
+
+test("Researcher delegate login requires an active matching on-chain key", () => {
+  assert.equal(
+    delegateAccountBindingError(
+      `${PACKAGE_ID}::account::MemWalAccount`,
+      {
+        active: true,
+        delegate_keys: [{ public_key: PUBLIC_KEY }],
+      },
+      { packageId: PACKAGE_ID, publicKeyHex: PUBLIC_KEY }
+    ),
+    null
+  );
+
+  assert.match(
+    delegateAccountBindingError(
+      `${PACKAGE_ID}::account::MemWalAccount`,
+      {
+        active: true,
+        delegate_keys: [{ public_key: "cd".repeat(32) }],
+      },
+      { packageId: PACKAGE_ID, publicKeyHex: PUBLIC_KEY }
+    ) ?? "",
+    /not registered/
+  );
+});

--- a/apps/researcher/lib/auth/request-security.unit.test.ts
+++ b/apps/researcher/lib/auth/request-security.unit.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isSameOriginRequest } from "./request-security";
+
+test("Researcher state-changing auth requests require an exact Origin", () => {
+  assert.equal(
+    isSameOriginRequest(
+      new Request("https://researcher.example/api/auth/key", {
+        headers: { origin: "https://researcher.example" },
+      })
+    ),
+    true
+  );
+  assert.equal(
+    isSameOriginRequest(
+      new Request("https://researcher.example/api/auth/key", {
+        headers: { origin: "https://attacker.example" },
+      })
+    ),
+    false
+  );
+  assert.equal(
+    isSameOriginRequest(
+      new Request("https://researcher.example/api/auth/key")
+    ),
+    false
+  );
+});

--- a/apps/researcher/lib/auth/session-memory.ts
+++ b/apps/researcher/lib/auth/session-memory.ts
@@ -1,0 +1,13 @@
+export type SessionMemoryCredentials = {
+  key: string;
+  accountId: string;
+};
+
+/** Resolve only credentials loaded for this authenticated user; never use globals. */
+export function sessionMemoryCredentials(user: {
+  privateKey: string;
+  accountId: string;
+}): SessionMemoryCredentials | null {
+  if (!user.privateKey || !user.accountId) return null;
+  return { key: user.privateKey, accountId: user.accountId };
+}

--- a/apps/researcher/lib/auth/session-token.ts
+++ b/apps/researcher/lib/auth/session-token.ts
@@ -1,0 +1,20 @@
+import { SignJWT } from "jose";
+
+export const SESSION_MAX_AGE_SECONDS = 24 * 60 * 60;
+
+export type SessionIdentity = {
+  userId: string;
+  publicKey: string;
+  accountId: string;
+};
+
+/** Sign identity-only claims. Reusable credentials must never be added here. */
+export async function signSessionIdentity(
+  identity: SessionIdentity,
+  secret: Uint8Array
+): Promise<string> {
+  return new SignJWT(identity)
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime(`${SESSION_MAX_AGE_SECONDS}s`)
+    .sign(secret);
+}

--- a/apps/researcher/lib/auth/session-token.unit.test.ts
+++ b/apps/researcher/lib/auth/session-token.unit.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { decodeJwt, jwtVerify } from "jose";
+import { SESSION_MAX_AGE_SECONDS, signSessionIdentity } from "./session-token";
+
+const secret = new TextEncoder().encode("unit-test-auth-secret");
+
+test("Researcher session tokens contain identity only, never delegate credentials", async () => {
+  const token = await signSessionIdentity(
+    {
+      userId: "user-1",
+      publicKey: "public-key",
+      accountId: "0xaccount",
+    },
+    secret
+  );
+  const claims = decodeJwt(token);
+
+  assert.equal(claims.userId, "user-1");
+  assert.equal(claims.publicKey, "public-key");
+  assert.equal(claims.accountId, "0xaccount");
+  assert.equal("privateKey" in claims, false);
+  assert.equal("delegatePrivateKey" in claims, false);
+
+  const verified = await jwtVerify(token, secret);
+  assert.ok(
+    Number(verified.payload.exp) - Math.floor(Date.now() / 1000) <=
+      SESSION_MAX_AGE_SECONDS
+  );
+});

--- a/apps/researcher/lib/auth/session-token.unit.test.ts
+++ b/apps/researcher/lib/auth/session-token.unit.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { decodeJwt, jwtVerify } from "jose";
 import { SESSION_MAX_AGE_SECONDS, signSessionIdentity } from "./session-token";
+import { sessionMemoryCredentials } from "./session-memory";
 
 const secret = new TextEncoder().encode("unit-test-auth-secret");
 
@@ -26,5 +27,22 @@ test("Researcher session tokens contain identity only, never delegate credential
   assert.ok(
     Number(verified.payload.exp) - Math.floor(Date.now() / 1000) <=
       SESSION_MAX_AGE_SECONDS
+  );
+});
+
+test("Researcher memory credentials never fall back to process-wide keys", () => {
+  process.env.MEMWAL_PRIVATE_KEY = "global-key";
+  process.env.MEMWAL_ACCOUNT_ID = "global-account";
+
+  assert.equal(
+    sessionMemoryCredentials({ privateKey: "", accountId: "" }),
+    null
+  );
+  assert.deepEqual(
+    sessionMemoryCredentials({
+      privateKey: "session-key",
+      accountId: "session-account",
+    }),
+    { key: "session-key", accountId: "session-account" }
   );
 });

--- a/apps/researcher/lib/auth/session.ts
+++ b/apps/researcher/lib/auth/session.ts
@@ -1,25 +1,45 @@
 import "server-only";
 
-import { SignJWT, jwtVerify } from "jose";
+import { jwtVerify } from "jose";
 import { cookies } from "next/headers";
+import { getUserById } from "@/lib/db/queries";
+import {
+  SESSION_MAX_AGE_SECONDS,
+  signSessionIdentity,
+} from "@/lib/auth/session-token";
 
 const COOKIE_NAME = "session";
 const secret = new TextEncoder().encode(process.env.AUTH_SECRET);
 
-export async function getSession(): Promise<{
-  user: { id: string; publicKey: string; privateKey: string; accountId: string };
-} | null> {
+type SessionUser = {
+  id: string;
+  publicKey: string;
+  privateKey: string;
+  accountId: string;
+};
+
+/**
+ * Verify the identity-only JWT, then load reusable credentials from the
+ * server-side user row. Delegate private keys are never encoded in cookies.
+ */
+export async function getSession(): Promise<{ user: SessionUser } | null> {
   const cookieStore = await cookies();
   const token = cookieStore.get(COOKIE_NAME)?.value;
   if (!token) return null;
+
   try {
     const { payload } = await jwtVerify(token, secret);
+    if (typeof payload.userId !== "string") return null;
+
+    const user = await getUserById(payload.userId);
+    if (!user || !user.publicKey) return null;
+
     return {
       user: {
-        id: payload.userId as string,
-        publicKey: payload.publicKey as string,
-        privateKey: payload.privateKey as string,
-        accountId: (payload.accountId as string) || '',
+        id: user.id,
+        publicKey: user.publicKey,
+        privateKey: user.delegatePrivateKey ?? "",
+        accountId: user.accountId ?? "",
       },
     };
   } catch {
@@ -27,22 +47,22 @@ export async function getSession(): Promise<{
   }
 }
 
+/** Create a short-lived identity session; credentials remain server-side. */
 export async function createSession(
   userId: string,
   publicKey: string,
-  privateKey: string,
   accountId: string
 ): Promise<void> {
-  const token = await new SignJWT({ userId, publicKey, privateKey, accountId })
-    .setProtectedHeader({ alg: "HS256" })
-    .setExpirationTime("30d")
-    .sign(secret);
+  const token = await signSessionIdentity(
+    { userId, publicKey, accountId },
+    secret
+  );
   const cookieStore = await cookies();
   cookieStore.set(COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
-    maxAge: 30 * 24 * 60 * 60,
+    maxAge: SESSION_MAX_AGE_SECONDS,
   });
 }
 

--- a/apps/researcher/lib/db/queries.ts
+++ b/apps/researcher/lib/db/queries.ts
@@ -73,6 +73,41 @@ export async function createUserByPublicKey(publicKey: string): Promise<User> {
   }
 }
 
+/** Persist manual-login credentials server-side so session JWTs stay identity-only. */
+export async function upsertDelegateCredentialsByPublicKey({
+  publicKey,
+  delegatePrivateKey,
+  accountId,
+}: {
+  publicKey: string;
+  delegatePrivateKey: string;
+  accountId: string;
+}): Promise<User> {
+  const existing = await getUserByPublicKey(publicKey);
+  try {
+    if (existing) {
+      const [updated] = await db
+        .update(user)
+        .set({ delegatePrivateKey, accountId })
+        .where(eq(user.id, existing.id))
+        .returning();
+      return updated;
+    }
+
+    const email = `key-${publicKey.slice(0, 8)}@ed25519`;
+    const [created] = await db
+      .insert(user)
+      .values({ email, publicKey, delegatePrivateKey, accountId })
+      .returning();
+    return created;
+  } catch (_error) {
+    throw new ChatbotError(
+      "bad_request:database",
+      "Failed to store delegate credentials"
+    );
+  }
+}
+
 /** Look up an Enoki user by their stable zkLogin Sui address. */
 export async function getUserBySuiAddress(suiAddress: string): Promise<User | null> {
   try {

--- a/apps/researcher/lib/rag/tools/index.ts
+++ b/apps/researcher/lib/rag/tools/index.ts
@@ -33,7 +33,7 @@ export function getResearchTools({
     getSourceContext: getSourceContextTool({ userId }),
   };
 
-  if (memwalKey) {
+  if (memwalKey && accountId) {
     tools.recallSprint = recallSprintTool({ memwalKey, accountId });
   }
 

--- a/apps/researcher/lib/rag/tools/recall-sprint.ts
+++ b/apps/researcher/lib/rag/tools/recall-sprint.ts
@@ -3,7 +3,7 @@ import { tool } from "ai";
 import { recallFromMemWal } from "@/lib/sprint/memwal";
 import { UNTRUSTED_TOOL_DATA_NOTICE } from "./security";
 
-export function recallSprintTool({ memwalKey, accountId }: { memwalKey: string; accountId?: string }) {
+export function recallSprintTool({ memwalKey, accountId }: { memwalKey: string; accountId: string }) {
   console.log(`[tool:recallSprint] Tool created with memwalKey=${memwalKey ? memwalKey.slice(0, 8) + "..." : "MISSING"}`);
 
   return tool({

--- a/apps/researcher/lib/sprint/memwal.ts
+++ b/apps/researcher/lib/sprint/memwal.ts
@@ -4,10 +4,10 @@ import { MemWal } from "@mysten-incubation/memwal";
 import type { RememberResult } from "@mysten-incubation/memwal";
 import type { Citation, SourceMeta } from "./types";
 
-function getMemWalClient(key: string, accountId?: string) {
+function getMemWalClient(key: string, accountId: string) {
   return MemWal.create({
     key,
-    accountId: accountId || process.env.MEMWAL_ACCOUNT_ID!,
+    accountId,
     serverUrl: process.env.MEMWAL_SERVER_URL,
   });
 }
@@ -21,7 +21,7 @@ export async function rememberSprintReport({
   sources,
 }: {
   key: string;
-  accountId?: string;
+  accountId: string;
   title: string;
   content: string;
   citations: Citation[];
@@ -58,7 +58,7 @@ export async function recallFromMemWal(
   key: string,
   query: string,
   limit: number = 5,
-  accountId?: string
+  accountId: string
 ) {
   const memwal = getMemWalClient(key, accountId);
   const { results } = await memwal.recall(query, limit);

--- a/apps/researcher/lib/sprint/save.ts
+++ b/apps/researcher/lib/sprint/save.ts
@@ -13,10 +13,12 @@ export async function saveSprint({
   chatId,
   userId,
   memwalKey,
+  memwalAccountId,
 }: {
   chatId: string;
   userId: string;
   memwalKey: string;
+  memwalAccountId: string;
 }): Promise<SaveSprintResult> {
   console.log(`[sprint:save] Starting sprint save for chat=${chatId}`);
 
@@ -70,6 +72,7 @@ export async function saveSprint({
   console.log("[sprint:save] Storing in Walrus Memory...");
   const memwalResult = await rememberSprintReport({
     key: memwalKey,
+    accountId: memwalAccountId,
     title: report.title,
     content: report.content,
     citations: report.citations,

--- a/apps/researcher/package.json
+++ b/apps/researcher/package.json
@@ -17,6 +17,7 @@
         "db:up": "drizzle-kit up",
         "verify:memwal": "tsx ../../scripts/verify-memwal-credentials.ts",
         "test:redis-outage": "node --conditions=react-server --test --import tsx lib/shared-redis.test.ts",
+        "test:unit": "node --test --import tsx 'lib/**/*.unit.test.ts'",
         "test": "export PLAYWRIGHT=True && pnpm exec playwright test"
     },
     "dependencies": {

--- a/docs/migration/ceremony-environments.md
+++ b/docs/migration/ceremony-environments.md
@@ -1,0 +1,35 @@
+# Migration ceremony GitHub Environments
+
+Migration workflows are gated by four static GitHub Environments:
+
+| Environment                                  | Workflows                                 | Authorization boundary                                            |
+| -------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------- |
+| `walrus-memory-migration-governance-mainnet` | publish, create caps, burn caps, finalize | Required reviewer before unsigned transaction artifacts are built |
+| `walrus-memory-migration-governance-testnet` | same, on testnet                          | Required reviewer                                                 |
+| `walrus-memory-migration-funding-mainnet`    | fund distribution                         | Required reviewer before the hot funder key is exposed            |
+| `walrus-memory-migration-funding-testnet`    | fund distribution                         | Required reviewer before the hot funder key is exposed            |
+
+Each environment must:
+
+1. require `harrymove-ctrl` as an independent reviewer;
+2. prevent self-review;
+3. disable administrator bypass; and
+4. keep migration/funder secrets environment-scoped rather than repository-scoped.
+
+The environments were configured through the GitHub API. Run the following before every ceremony and after repository administration changes:
+
+```bash
+GH_TOKEN="$(gh auth token)" \
+  EXPECTED_MIGRATION_REVIEWER=harrymove-ctrl \
+  scripts/verify-migration-environments.sh
+```
+
+The scheduled `verify-migration-environments` workflow performs the same check weekly. A missing environment is a failure: GitHub otherwise creates a referenced environment on first use without reviewer protection.
+
+## Workflow boundaries
+
+- `publish-tx`, `create-migration-caps-tx`, `burn-cap-tx`, and `finalize-tx` only build unsigned transaction bytes. Signing remains an offline, hardware-wallet, or multisig operation.
+- `distribute-funds` can submit a live transaction because it holds `SUI_FUNDER_KEY`. It defaults to `dry_run: true`; paid runs require fresh live-writer evidence and an uploaded prepared journal before submission.
+- All ceremony jobs run only from the repository default branch.
+
+Before a live run, attach the verifier output to the operator record and confirm the named reviewer is not the workflow initiator.

--- a/docs/migration/ceremony-environments.md
+++ b/docs/migration/ceremony-environments.md
@@ -1,10 +1,10 @@
-# Migration ceremony GitHub Environments
+## Migration ceremony GitHub Environments
 
 Migration workflows are gated by four static GitHub Environments:
 
 | Environment                                  | Workflows                                 | Authorization boundary                                            |
 | -------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------- |
-| `walrus-memory-migration-governance-mainnet` | publish, create caps, burn caps, finalize | Required reviewer before unsigned transaction artifacts are built |
+| `walrus-memory-migration-governance-mainnet` | publish, create caps, burn caps, finalize | Required reviewer before the workflow builds unsigned transaction artifacts |
 | `walrus-memory-migration-governance-testnet` | same, on testnet                          | Required reviewer                                                 |
 | `walrus-memory-migration-funding-mainnet`    | fund distribution                         | Required reviewer before the hot funder key is exposed            |
 | `walrus-memory-migration-funding-testnet`    | fund distribution                         | Required reviewer before the hot funder key is exposed            |
@@ -16,7 +16,7 @@ Each environment must:
 3. disable administrator bypass; and
 4. keep migration/funder secrets environment-scoped rather than repository-scoped.
 
-The environments were configured through the GitHub API. Run the following before every ceremony and after repository administration changes:
+Configure the environments through the GitHub API. Run the following before every ceremony and after repository administration changes:
 
 ```bash
 GH_TOKEN="$(gh auth token)" \

--- a/docs/migration/ceremony-environments.md
+++ b/docs/migration/ceremony-environments.md
@@ -20,11 +20,11 @@ The environments were configured through the GitHub API. Run the following befor
 
 ```bash
 GH_TOKEN="$(gh auth token)" \
-  EXPECTED_MIGRATION_REVIEWER=harrymove-ctrl \
+  EXPECTED_MIGRATION_REVIEWERS=user:harrymove-ctrl \
   scripts/verify-migration-environments.sh
 ```
 
-The scheduled `verify-migration-environments` workflow performs the same check weekly. A missing environment is a failure: GitHub otherwise creates a referenced environment on first use without reviewer protection.
+The scheduled `verify-migration-environments` workflow performs the same check weekly. It requires the configured reviewer set to match the typed allowlist exactly (`user:<login>` or `team:<slug>`); GitHub treats multiple required reviewers as one-of, so any extra reviewer is a failure. A missing environment is also a failure: GitHub otherwise creates a referenced environment on first use without reviewer protection.
 
 ## Workflow boundaries
 

--- a/scripts/verify-migration-environments.sh
+++ b/scripts/verify-migration-environments.sh
@@ -2,7 +2,17 @@
 set -euo pipefail
 
 repo="${GITHUB_REPOSITORY:-MystenLabs/MemWal}"
-expected_reviewer="${EXPECTED_MIGRATION_REVIEWER:-harrymove-ctrl}"
+# Entries are typed to prevent a team slug from being confused with a user login.
+# GitHub required reviewers are one-of, so this allowlist must match exactly.
+expected_reviewers_csv="${EXPECTED_MIGRATION_REVIEWERS:-user:harrymove-ctrl}"
+expected_reviewers_json="$(jq -cn --arg csv "$expected_reviewers_csv" '
+  $csv | split(",") | map(gsub("^\\s+|\\s+$"; "")) |
+  map(select(length > 0)) | sort | unique
+')"
+if [[ "$(jq 'length' <<<"$expected_reviewers_json")" -eq 0 ]]; then
+  echo "::error::EXPECTED_MIGRATION_REVIEWERS must not be empty"
+  exit 1
+fi
 environments=(
   walrus-memory-migration-governance-mainnet
   walrus-memory-migration-governance-testnet
@@ -20,14 +30,23 @@ for environment in "${environments[@]}"; do
 
   required_reviewers="$(jq '[.protection_rules[]? | select(.type == "required_reviewers")] | length' <<<"$json")"
   self_review="$(jq '[.protection_rules[]? | select(.type == "required_reviewers") | .prevent_self_review] | any' <<<"$json")"
-  reviewer_present="$(jq --arg login "$expected_reviewer" '[.protection_rules[]? | select(.type == "required_reviewers") | .reviewers[]?.reviewer.login] | any(. == $login)' <<<"$json")"
+  actual_reviewers_json="$(jq -c '
+    [.protection_rules[]? | select(.type == "required_reviewers") |
+      .reviewers[]?.reviewer |
+      if .type == "Team" then "team:\(.slug)" else "user:\(.login)" end
+    ] | sort | unique
+  ' <<<"$json")"
+  reviewers_exact="$(jq -n \
+    --argjson actual "$actual_reviewers_json" \
+    --argjson expected "$expected_reviewers_json" \
+    '$actual == $expected')"
   admins_bypass="$(jq '.can_admins_bypass' <<<"$json")"
 
-  if [[ "$required_reviewers" -lt 1 || "$self_review" != true || "$reviewer_present" != true || "$admins_bypass" != false ]]; then
-    echo "::error::${environment} is not fail-closed: required_reviewers=${required_reviewers}, prevent_self_review=${self_review}, reviewer=${reviewer_present}, can_admins_bypass=${admins_bypass}"
+  if [[ "$required_reviewers" -ne 1 || "$self_review" != true || "$reviewers_exact" != true || "$admins_bypass" != false ]]; then
+    echo "::error::${environment} is not fail-closed: required_reviewers=${required_reviewers}, prevent_self_review=${self_review}, reviewers=${actual_reviewers_json}, expected=${expected_reviewers_json}, can_admins_bypass=${admins_bypass}"
     failed=1
   else
-    echo "verified ${environment}: reviewer=${expected_reviewer}, self-review blocked, admin bypass disabled"
+    echo "verified ${environment}: reviewers=${expected_reviewers_json}, self-review blocked, admin bypass disabled"
   fi
 done
 

--- a/scripts/verify-migration-environments.sh
+++ b/scripts/verify-migration-environments.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-MystenLabs/MemWal}"
+expected_reviewer="${EXPECTED_MIGRATION_REVIEWER:-harrymove-ctrl}"
+environments=(
+  walrus-memory-migration-governance-mainnet
+  walrus-memory-migration-governance-testnet
+  walrus-memory-migration-funding-mainnet
+  walrus-memory-migration-funding-testnet
+)
+
+failed=0
+for environment in "${environments[@]}"; do
+  if ! json="$(gh api "repos/${repo}/environments/${environment}")"; then
+    echo "::error::Missing or unreadable GitHub Environment: ${environment}"
+    failed=1
+    continue
+  fi
+
+  required_reviewers="$(jq '[.protection_rules[]? | select(.type == "required_reviewers")] | length' <<<"$json")"
+  self_review="$(jq '[.protection_rules[]? | select(.type == "required_reviewers") | .prevent_self_review] | any' <<<"$json")"
+  reviewer_present="$(jq --arg login "$expected_reviewer" '[.protection_rules[]? | select(.type == "required_reviewers") | .reviewers[]?.reviewer.login] | any(. == $login)' <<<"$json")"
+  admins_bypass="$(jq '.can_admins_bypass' <<<"$json")"
+
+  if [[ "$required_reviewers" -lt 1 || "$self_review" != true || "$reviewer_present" != true || "$admins_bypass" != false ]]; then
+    echo "::error::${environment} is not fail-closed: required_reviewers=${required_reviewers}, prevent_self_review=${self_review}, reviewer=${reviewer_present}, can_admins_bypass=${admins_bypass}"
+    failed=1
+  else
+    echo "verified ${environment}: reviewer=${expected_reviewer}, self-review blocked, admin bypass disabled"
+  fi
+done
+
+exit "$failed"

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -96,6 +96,14 @@ MEMWAL_REGISTRY_ID=0x...
 # Default: min(2, total configured weight).
 # SEAL_THRESHOLD=2
 
+# Pin every Rust -> sidecar encryption request to the reviewed effective
+# committee. The object must exactly match the normalized server order, IDs,
+# weights, and threshold produced from SEAL_SERVER_CONFIGS/SEAL_THRESHOLD.
+# Production and migration deployments must set both variables so missing or
+# drifted pins fail closed before encryption.
+# SEAL_EXPECTED_COMMITTEE_IDENTITY={"servers":[{"objectId":"0x...","weight":1}],"threshold":1}
+# SEAL_REQUIRE_COMMITTEE_IDENTITY=true
+
 # Walrus on-chain package ID (auto-detected from SUI_NETWORK if not set)
 # WALRUS_PACKAGE_ID=0x...
 # Walrus shared System object used to build delete_blob PTBs.

--- a/services/server/scripts/__tests__/sidecar-seal-approve-ptb.test.ts
+++ b/services/server/scripts/__tests__/sidecar-seal-approve-ptb.test.ts
@@ -115,6 +115,18 @@ test("sealApproveArgsError enforces the ids and the sealAbi/registryId pairing",
     assert.match(sealApproveArgsError({ ...base, sealAbi: undefined }, POLICY)!, /sealAbi/, "sealAbi is required");
     assert.match(sealApproveArgsError({ sealAbi: "v1" }, POLICY)!, /packageId/, "packageId and accountId are required");
     assert.match(sealApproveArgsError({ ...base, packageId: "bad", sealAbi: "v1" }, POLICY)!, /packageId format/);
+    for (const accountId of ["bad", "0x", `0x${"1".repeat(65)}`, 123, {}]) {
+        assert.match(
+            sealApproveArgsError({ ...base, accountId, sealAbi: "v1" } as any, POLICY)!,
+            /accountId format/,
+        );
+    }
+    for (const registryId of ["bad", "0x", `0x${"1".repeat(65)}`, 123, {}]) {
+        assert.match(
+            sealApproveArgsError({ ...base, registryId, sealAbi: "v1-new" } as any, POLICY)!,
+            /registryId format/,
+        );
+    }
     assert.match(sealApproveArgsError({ ...base, sealAbi: "v1" }, { ...POLICY, allowLegacySealAbi: false })!, /disabled/);
     assert.match(sealApproveArgsError({ ...base, sealAbi: "v1-new", registryId: REG, policyPackageId: PKG }, POLICY)!, /configured/);
 });

--- a/services/server/scripts/__tests__/sidecar-seal-routes.test.ts
+++ b/services/server/scripts/__tests__/sidecar-seal-routes.test.ts
@@ -19,7 +19,12 @@ const { createSealClient } = await import("../sidecar/clients.js");
 const { appendSealPersistenceFence, InvalidSealPersistenceFenceError, parseSealPersistenceFence } = await import(
     "../sidecar/blob-metadata.js"
 );
-const { parseSealDecryptBatchItems, registerSealRoutes } = await import("../sidecar/routes/seal.js");
+const {
+    parseSealDecryptBatchItems,
+    registerSealRoutes,
+    sealEncryptCommitteeFailure,
+} = await import("../sidecar/routes/seal.js");
+const { SEAL_COMMITTEE_IDENTITY } = await import("../sidecar/config.js");
 
 const ROUTE_POLICY = {
     enableMigrationSealRoute: true,
@@ -215,6 +220,32 @@ test("the opt-in legacy seed encrypt route is registered", async () => {
         assert.equal(r.status, 400);
         assert.match(r.body.error!, /Missing required fields/);
     });
+});
+
+test("/seal/encrypt enforces the pinned committee before RPC work", async () => {
+    const missing = sealEncryptCommitteeFailure(
+        undefined,
+        true,
+        SEAL_COMMITTEE_IDENTITY
+    );
+    assert.equal(missing?.status, 400);
+
+    const mismatch = sealEncryptCommitteeFailure(
+        { ...SEAL_COMMITTEE_IDENTITY, threshold: SEAL_COMMITTEE_IDENTITY.threshold + 1 },
+        true,
+        SEAL_COMMITTEE_IDENTITY
+    );
+    assert.equal(mismatch?.status, 409);
+    assert.equal(mismatch?.body.code, "SEAL_COMMITTEE_MISMATCH");
+
+    assert.equal(
+        sealEncryptCommitteeFailure(
+            SEAL_COMMITTEE_IDENTITY,
+            true,
+            SEAL_COMMITTEE_IDENTITY
+        ),
+        null
+    );
 });
 
 test("the migration encrypt route is absent unless the sidecar opts in", async () => {

--- a/services/server/scripts/__tests__/sidecar-seal-routes.test.ts
+++ b/services/server/scripts/__tests__/sidecar-seal-routes.test.ts
@@ -240,6 +240,30 @@ test("/seal/decrypt 400s when sealAbi=v1-new omits registryId", async () => {
     });
 });
 
+test("/seal/decrypt rejects malformed account and registry IDs during validation", async () => {
+    await withServer(async (baseUrl) => {
+        const badAccount = await post(baseUrl, "/seal/decrypt", {
+            data: DATA,
+            packageId: PKG,
+            accountId: "not-an-object-id",
+            sealAbi: "v1",
+        });
+        assert.equal(badAccount.status, 400);
+        assert.match(badAccount.body.error!, /accountId format/);
+
+        const badRegistry = await post(baseUrl, "/seal/decrypt-batch", {
+            items: [DATA],
+            packageId: PKG,
+            policyPackageId: ROUTE_POLICY.sealPolicyPackageId,
+            accountId: ACC,
+            registryId: `0x${"1".repeat(65)}`,
+            sealAbi: "v1-new",
+        });
+        assert.equal(badRegistry.status, 400);
+        assert.match(badRegistry.body.error!, /registryId format/);
+    });
+});
+
 test("/seal/decrypt 400s on an invalid policyPackageId", async () => {
     await withServer(async (baseUrl) => {
         const r = await post(baseUrl, "/seal/decrypt", {

--- a/services/server/scripts/sidecar/routes/seal.ts
+++ b/services/server/scripts/sidecar/routes/seal.ts
@@ -46,13 +46,13 @@ export function sealKeyFetchErrorCode(err: unknown): "SHARED_SERVICE_UNAVAILABLE
     return isRetryableRpcError(err) ? "SHARED_SERVICE_UNAVAILABLE" : "KEY_FETCH_FAILED";
 }
 
-// SEAL_REQUIRE_COMMITTEE_IDENTITY=true (or 1/yes) makes /seal/encrypt reject
+// SEAL_REQUIRE_COMMITTEE_IDENTITY=true (or 1/yes/on) makes /seal/encrypt reject
 // requests that omit expectedSealCommitteeIdentity, so migration deployments
 // can enforce the "the Rust caller always pins the committee" contract.
 // Parsed once at module load, following config.ts boolean conventions.
 export const SEAL_REQUIRE_COMMITTEE_IDENTITY = (() => {
     const raw = (process.env.SEAL_REQUIRE_COMMITTEE_IDENTITY || "").trim().toLowerCase();
-  return raw === "1" || raw === "true" || raw === "yes";
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
 })();
 
 const SIDECAR_ENABLE_LEGACY_SEED_ROUTE = (() => {

--- a/services/server/scripts/sidecar/seal-ptb.ts
+++ b/services/server/scripts/sidecar/seal-ptb.ts
@@ -30,6 +30,9 @@ export function sealApproveArgsError(body: {
     if (typeof packageId !== "string" || !/^0x[0-9a-fA-F]{1,64}$/.test(packageId)) {
         return "Invalid packageId format";
     }
+    if (typeof accountId !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(accountId)) {
+        return "Invalid accountId format";
+    }
     if (
         policyPackageId !== undefined
         && (typeof policyPackageId !== "string" || !/^0x[0-9a-fA-F]{1,64}$/.test(policyPackageId))
@@ -49,6 +52,9 @@ export function sealApproveArgsError(body: {
     }
     if (sealAbi === "v1-new") {
         if (!registryId) return "Missing registryId (required when sealAbi=v1-new)";
+        if (typeof registryId !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(registryId)) {
+            return "Invalid registryId format";
+        }
         if (!/^0x[0-9a-fA-F]{1,64}$/.test(policy.policyPackageId)) {
             return "Sidecar SEAL policy package is not configured";
         }

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -467,6 +467,7 @@ pub async fn analyze(
                     &owner,
                     &account_id,
                     &state.config.package_id,
+                    state.config.seal_expected_committee_identity.as_ref(),
                 );
                 let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
                 // carry `importance` through the prep tuple so

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -136,6 +136,7 @@ fn spawn_prepare_remember_job(
                     &owner,
                     &account_id,
                     &state.config.package_id,
+                    state.config.seal_expected_committee_identity.as_ref(),
                 );
                 let (vector_result, encrypted_result) = tokio::join!(embed_fut, encrypt_fut);
                 let vector = vector_result?;
@@ -253,6 +254,7 @@ fn spawn_prepare_bulk_remember_job(
                                 &owner,
                                 &account_id,
                                 &state.config.package_id,
+                                state.config.seal_expected_committee_identity.as_ref(),
                             );
                             let (vector_result, encrypted_result) =
                                 tokio::join!(embed_fut, encrypt_fut);
@@ -1104,6 +1106,7 @@ mod tests {
             registry_scan_max_pages: crate::types::DEFAULT_REGISTRY_SCAN_MAX_PAGES,
             sidecar_url: "http://localhost:9003".to_string(),
             sidecar_secret: None,
+            seal_expected_committee_identity: None,
             rate_limit: crate::rate_limit::RateLimitConfig::default(),
             sponsor_rate_limit: crate::types::SponsorRateLimitConfig::default(),
             accounts_rate_limit: crate::types::AccountsRateLimitConfig::default(),

--- a/services/server/src/storage/seal.rs
+++ b/services/server/src/storage/seal.rs
@@ -72,6 +72,8 @@ struct SealEncryptRequest {
     owner: String,
     package_id: String,
     account_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expected_seal_committee_identity: Option<serde_json::Value>,
 }
 
 #[derive(serde::Deserialize)]
@@ -137,6 +139,7 @@ pub async fn seal_encrypt(
     owner_address: &str,
     account_id: &str,
     package_id: &str,
+    expected_seal_committee_identity: Option<&serde_json::Value>,
 ) -> Result<Vec<u8>, AppError> {
     let url = format!("{}/seal/encrypt", sidecar_url);
     let data_b64 = BASE64.encode(data);
@@ -146,6 +149,7 @@ pub async fn seal_encrypt(
         owner: owner_address.to_string(),
         package_id: package_id.to_string(),
         account_id: account_id.to_string(),
+        expected_seal_committee_identity: expected_seal_committee_identity.cloned(),
     });
     if let Some(secret) = sidecar_secret {
         req = req.header("authorization", format!("Bearer {}", secret));
@@ -540,12 +544,17 @@ mod tests {
             owner: "0x1".into(),
             package_id: "0x2".into(),
             account_id: "0x3".into(),
+            expected_seal_committee_identity: Some(serde_json::json!({
+                "servers": [{ "objectId": "0x4", "weight": 1 }],
+                "threshold": 1,
+            })),
         })
         .expect("serialize encrypt request");
         // The sidecar reads access_counter_version off this object to build the
         // SEAL identity; without it POST /seal/encrypt is a 400 and every
         // remember/analyze write fails.
         assert_eq!(value["accountId"], "0x3");
+        assert_eq!(value["expectedSealCommitteeIdentity"]["threshold"], 1);
     }
 
     #[test]

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -445,8 +445,7 @@ impl Config {
             },
             package_id,
             seal_policy_package_id,
-            registry_id: std::env::var("MEMWAL_REGISTRY_ID")
-                .expect("MEMWAL_REGISTRY_ID must be set"),
+            registry_id: normalize_object_id_env("MEMWAL_REGISTRY_ID"),
             registry_scan_max_pages: std::env::var("MEMWAL_REGISTRY_SCAN_MAX_PAGES")
                 .ok()
                 .and_then(|v| v.trim().parse::<u32>().ok())
@@ -709,6 +708,14 @@ pub fn validate_security_delete_config(config: &Config) -> Result<(), String> {
 
 pub fn security_delete_routes_enabled(config: &Config) -> bool {
     config.enable_memory_deletion && config.enable_security_delete
+}
+
+fn normalize_object_id_env(name: &str) -> String {
+    let raw = std::env::var(name).unwrap_or_else(|_| panic!("{name} must be set"));
+    raw.trim()
+        .parse::<sui_sdk_types::Address>()
+        .unwrap_or_else(|error| panic!("{name} must be a valid Sui object ID: {error}"))
+        .to_string()
 }
 
 fn env_bool(name: &str) -> bool {

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -298,6 +298,9 @@ pub struct Config {
     pub sidecar_url: String,
     /// Shared secret for authenticating Rust→sidecar calls (X-Sidecar-Secret header)
     pub sidecar_secret: Option<String>,
+    /// Reviewed SEAL committee identity pinned on every encryption request.
+    /// The sidecar compares this JSON object to its effective key-server config.
+    pub seal_expected_committee_identity: Option<serde_json::Value>,
     /// Rate limiting configuration
     pub rate_limit: RateLimitConfig,
     /// Sponsor-specific rate limiting and concurrency config
@@ -383,6 +386,21 @@ impl Config {
         let package_id = std::env::var("MEMWAL_PACKAGE_ID").expect("MEMWAL_PACKAGE_ID must be set");
         let seal_policy_package_id =
             nonempty_env("MEMWAL_SEAL_POLICY_PACKAGE_ID").unwrap_or_else(|| package_id.clone());
+        let seal_expected_committee_identity = nonempty_env("SEAL_EXPECTED_COMMITTEE_IDENTITY")
+            .map(|raw| {
+                serde_json::from_str(&raw).unwrap_or_else(|error| {
+                    panic!(
+                        "SEAL_EXPECTED_COMMITTEE_IDENTITY must be valid JSON: {}",
+                        error
+                    )
+                })
+            });
+        if env_bool("SEAL_REQUIRE_COMMITTEE_IDENTITY") && seal_expected_committee_identity.is_none()
+        {
+            panic!(
+                "SEAL_EXPECTED_COMMITTEE_IDENTITY must be set when SEAL_REQUIRE_COMMITTEE_IDENTITY=true"
+            );
+        }
 
         Self {
             port: std::env::var("PORT")
@@ -439,6 +457,7 @@ impl Config {
             sidecar_url: std::env::var("SIDECAR_URL")
                 .unwrap_or_else(|_| "http://localhost:9000".to_string()),
             sidecar_secret: std::env::var("SIDECAR_AUTH_TOKEN").ok(),
+            seal_expected_committee_identity,
             rate_limit: RateLimitConfig::from_env(),
             sponsor_rate_limit: SponsorRateLimitConfig::from_env(),
             accounts_rate_limit: AccountsRateLimitConfig::from_env(),
@@ -1789,6 +1808,7 @@ mod tests {
             registry_scan_max_pages: DEFAULT_REGISTRY_SCAN_MAX_PAGES,
             sidecar_url: "http://localhost:9000".into(),
             sidecar_secret: None,
+            seal_expected_committee_identity: None,
             rate_limit: RateLimitConfig::default(),
             sponsor_rate_limit: SponsorRateLimitConfig::default(),
             accounts_rate_limit: AccountsRateLimitConfig::default(),


### PR DESCRIPTION
## Summary

This batch addresses SEC #1, #42, #44, #47 and SEC2-128/129/130.

### Researcher — SEC #1
- remove delegate private keys from signed session JWTs; cookies now carry identity claims only and expire after 24 hours
- persist manual-login credentials server-side and resolve them from the authenticated user row
- remove process-wide credential fallback from chat/sprint memory paths; missing session credentials fail closed
- disable the delegate-key export endpoint and remove the reveal UI
- document that Researcher is demo-only and must not use production delegate keys

### Noter — SEC2-128 / SEC2-129 / SEC2-130
- retain the existing single-use wallet ownership gate and safe DTO behavior from #524
- verify account type, active state, authenticated owner, and registered delegate public key on chain before credential persistence
- validate canonical account IDs and reject account/delegate mismatches fail closed
- require an active session with owner-bound credentials for both memory-write routes
- remove all server-wide `MEMWAL_PRIVATE_KEY` / `MEMWAL_ACCOUNT_ID` fallback behavior
- authenticate/rate-limit before body processing, enforce production Redis-backed user/IP/global limits, and cap text at 64 KiB

### SEAL/migration — SEC #42 / SEC #47
- pin a reviewed `SEAL_EXPECTED_COMMITTEE_IDENTITY` on every Rust encryption request
- fail startup when committee enforcement is enabled without a pin
- preserve sidecar matching/missing/mismatch fail-closed behavior
- reject malformed/non-string/oversized `accountId` and `registryId` before PTB/session/RPC work

### Ceremony controls — SEC #44
- created all four governance/funding GitHub Environments with `harrymove-ctrl` as required reviewer, self-review blocked, and admin bypass disabled
- add a weekly/manual audit workflow and verifier script
- document environment ownership, workflow boundaries, and operator verification

## Validation

- Noter unit tests: **20/20 passed**
- Noter TypeScript: passed
- Noter production build: passed
- changed Noter files ESLint: passed
- Researcher unit tests: **2/2 passed**
- Researcher TypeScript: passed
- Researcher production build: passed
- SEAL sidecar focused tests: **25/25 passed**
- Rust SEAL tests: **7/7 passed**
- `cargo check` and `cargo fmt --check`: passed
- live GitHub Environment audit: **4/4 passed**
- `git diff --check`: passed

Full Noter lint still reports the repository baseline React/ref and `no-explicit-any` findings in unrelated files; both production builds and changed-file lint pass.

## Rollout

Set matching `SEAL_EXPECTED_COMMITTEE_IDENTITY` first, deploy the Rust caller, then enable `SEAL_REQUIRE_COMMITTEE_IDENTITY=true`. Enabling enforcement before deploying the caller would intentionally fail writes closed.
