### PR TITLE
docs: explain using Walrus Memory from any agent runtime

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
           {
             "group": "Guides",
             "pages": [
+              "guides/agent-runtimes",
               "guides/delete-old-memories",
               "guides/delete-memories-programmatically"
             ]

--- a/docs/guides/agent-runtimes.md
+++ b/docs/guides/agent-runtimes.md
@@ -46,20 +46,20 @@ answer: >-
 
 Agents built on EVM, Base, Virtuals, or any other stack can use Walrus Memory. The runtime your agent executes in and the chain it transacts on are independent of where its memory lives.
 
-That surprises people who expect a bridge, so it is worth stating plainly: **you need not bridge anything.** Walrus Memory stores memories as encrypted blobs on Walrus and records ownership in a Sui account. Your agent proves who it is with an Ed25519 delegate key that the account owner registers on that account. Whether the same agent also signs Ethereum transactions, holds an ERC-20 balance, or runs inside a Virtuals runtime makes no difference to any of that.
+Walrus Memory stores memories as encrypted blobs on Walrus and records ownership in a Sui account. Your agent authenticates with an Ed25519 delegate key that the account owner registers on that account. An agent that also signs Ethereum transactions, holds an ERC-20 balance, or runs inside a Virtuals runtime uses Walrus Memory the same way as any other agent.
 
-## What your agent actually needs
+## Requirements
 
-Two things, regardless of language or chain:
+Your agent needs two things, whatever its language or chain:
 
-1. **Register an Ed25519 delegate key on a Walrus Memory account.** The account owner registers the public key onchain, which grants the agent permission to read and write that account's memory. See [Ownership and Delegates](/fundamentals/concepts/ownership-and-access).
-2. **Network access to a relayer.** The relayer performs the encryption, storage, and indexing work, so your agent does not need a Sui node, a Walrus node, or WAL tokens.
+1. **An Ed25519 delegate key registered on a Walrus Memory account.** The account owner registers the public key onchain, which grants the agent permission to read and write that account's memory. See [Ownership and Delegates](/fundamentals/concepts/ownership-and-access).
+2. **Network access to a relayer.** The relayer performs the encryption, storage, and indexing work, so your agent needs no Sui node, Walrus node, or WAL tokens.
 
-What your agent does **not** need: a Sui wallet for its own funds, a bridge, a wrapped token, or any change to how it transacts on its own chain.
+Your agent needs no Sui wallet of its own, no bridge, no wrapped token, and no change to how it transacts on its own chain.
 
-## Path 1: use an SDK
+## Use an SDK
 
-If your agent runs in TypeScript or Python, use the SDK. It handles the request signing, the encryption session, and retries for you.
+For agents in TypeScript or Python, the SDK handles request signing, the encryption session, and retries:
 
 ```ts
 import { MemWal } from "@mysten-incubation/memwal";
@@ -77,17 +77,19 @@ await memwal.remember("The user prefers dark mode.");
 const hits = await memwal.recall({ query: "user preferences", limit: 5 });
 ```
 
-For loading credentials from the environment, validating connectivity at boot, and handling credential errors, see [Headless SDK Setup](/sdk/headless-setup). For the write-confirm-recall cycle, see the [Agent Storage Loop](/sdk/agent-storage-loop).
+To load credentials from the environment, validate connectivity at boot, and handle credential errors, see [Headless SDK Setup](/sdk/headless-setup). For the write-confirm-recall cycle, see the [Agent Storage Loop](/sdk/agent-storage-loop).
 
-## Path 2: sign requests directly
+## Sign requests directly
 
-If your agent runs in a language with no SDK, such as Go, Rust, or Elixir, call the relayer API directly. Every authenticated route takes the same signed headers, so you need an Ed25519 signer, SHA-256, and an HTTP client.
+For agents in a language with no SDK, such as Go, Rust, or Elixir, call the relayer API directly. Every authenticated route takes the same signed headers, so your agent needs an Ed25519 signer, SHA-256, and an HTTP client.
 
-Build the canonical message, sign it, and send the signature as hex:
+Build this canonical message and sign it:
 
 ```text
 {timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
 ```
+
+Send the result as hex in these headers:
 
 | **Header** | **Value** |
 |---|---|
@@ -99,25 +101,18 @@ Build the canonical message, sign it, and send the signature as hex:
 
 The relayer verifies the signature, then resolves the owner by looking up your public key in the account's onchain delegate keys. For every route, request shape, and response shape, see the [Relayer API Reference](/relayer/api-reference).
 
+Confirm the agent reaches the relayer before you debug signing, using the unauthenticated health route:
+
 ```sh
 $ curl -sS "$MEMWAL_RELAYER_URL/health"
 ```
 
-Start with `/health`, which needs no authentication, to confirm the agent can reach the relayer before you debug signing.
+## Limits of cross-chain support
 
-## What "cross-chain" does not mean here
+Walrus Memory does not do the following. A design that assumes otherwise does not work:
 
-Three things are outside what Walrus Memory does, and assuming otherwise leads to designs that cannot work:
+1. Walrus Memory never mirrors, wraps, or relays a memory onto another chain. Ownership records live on Sui.
+2. An Ethereum address cannot own a memory account. The delegate key is Ed25519, and the account is a Sui object.
+3. Walrus charges storage in WAL. Your agent neither holds nor spends it when a relayer fronts that cost.
 
-1. **No bridging.** Walrus Memory never mirrors, wraps, or relays a memory onto another chain. Ownership records live on Sui.
-2. **No EVM-native ownership.** An Ethereum address cannot own a memory account. The delegate key is Ed25519, and the account is a Sui object.
-3. **No payment in other tokens.** Walrus charges storage in WAL. Your agent neither holds nor spends it when a relayer fronts that cost.
-
-If your design needs an onchain link between an EVM contract and a memory account, model it in your own application: keep the mapping in your contract or database, and have your agent present the matching delegate key.
-
-## See also
-
-- [Ownership and Delegates](/fundamentals/concepts/ownership-and-access) for how delegate keys grant access.
-- [Headless SDK Setup](/sdk/headless-setup) for credentials and boot-time checks in a server runtime.
-- [Relayer API Reference](/relayer/api-reference) for the full authenticated surface.
-- [How AI Agent Memory Works](/fundamentals/concepts/how-agent-memory-works) for the embed, store, and recall loop.
+To link an EVM contract to a memory account, model the mapping in your own application: store it in your contract or database, and have your agent present the matching delegate key. For how the embed, store, and recall loop works underneath, see [How AI Agent Memory Works](/fundamentals/concepts/how-agent-memory-works).

--- a/docs/guides/agent-runtimes.md
+++ b/docs/guides/agent-runtimes.md
@@ -59,7 +59,7 @@ Your agent needs no Sui wallet of its own, no bridge, no wrapped token, and no c
 
 ## Use an SDK
 
-For agents in TypeScript or Python, the SDK handles request signing, the encryption session, and retries:
+For agents in TypeScript or Python, the SDK signs each request, builds and caches the Seal session key, and polls asynchronous jobs for you:
 
 ```ts
 import { MemWal } from "@mysten-incubation/memwal";
@@ -100,6 +100,24 @@ Send the result as hex in these headers:
 | `x-account-id` | The account object ID. Official SDKs always send it and include it in the signed message |
 
 The relayer verifies the signature, then resolves the owner by looking up your public key in the account's onchain delegate keys. For every route, request shape, and response shape, see the [Relayer API Reference](/relayer/api-reference).
+
+### Reads need a Seal credential too
+
+Signed headers authenticate the caller, but they do not decrypt anything. The routes that return stored memories, `/api/recall`, `/api/ask`, and `/api/restore`, also need a Seal credential, and the relayer rejects the call without one:
+
+```text
+SEAL credential required (x-seal-session, x-delegate-key, or SERVER_SUI_PRIVATE_KEY)
+```
+
+Supply it one of three ways:
+
+| **Credential** | **How it works** |
+|---|---|
+| `x-seal-session` | A base64 exported Seal `SessionKey`. The official SDKs build, cache, and send this, and it is the path to follow for new clients |
+| `x-delegate-key` | The legacy delegate private key header. Deprecated, and it hands the relayer your key |
+| Server fallback | A relayer configured with `SERVER_SUI_PRIVATE_KEY` decrypts on its own key, so the client sends neither header |
+
+A client that sends only the five signed headers authenticates successfully and then fails to decrypt, which is the failure to expect if recall returns nothing usable. Building a `SessionKey` outside the SDK means implementing the Seal client flow yourself, so plan for that work before choosing the direct path for reads. Writes through `/api/remember` do not need it.
 
 Confirm the agent reaches the relayer before you debug signing, using the unauthenticated health route:
 

--- a/docs/guides/agent-runtimes.md
+++ b/docs/guides/agent-runtimes.md
@@ -1,0 +1,123 @@
+---
+title: Use Walrus Memory from Any Agent Runtime
+description: >-
+  Walrus Memory works with agents built on any chain or runtime, including EVM, Base, and Virtuals
+  agents. Covers the ownership model, the SDK path, the signed HTTP path for languages with no SDK,
+  and what cross-chain does and does not mean here.
+keywords:
+  - agent runtime
+  - EVM
+  - Base
+  - Virtuals
+  - cross-chain
+  - multi-chain
+  - Walrus Memory
+  - MemWal
+  - delegate key
+  - relayer API
+goal:
+  description: Connect an agent running on any chain or in any language to Walrus Memory, by registering a delegate key and choosing either an SDK or the signed HTTP API.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 2
+      label: Has code examples
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - Can I use Walrus Memory with an EVM or Base agent?
+  - Does Walrus Memory support cross-chain agents?
+  - How do I call Walrus Memory from a language with no SDK?
+answer: >-
+  Yes. Walrus Memory does not care which chain your agent transacts on, because memory ownership
+  lives in a Sui account and your agent authenticates with an Ed25519 delegate key registered on
+  that account. An EVM, Base, or Virtuals agent uses Walrus Memory the same way any other agent
+  does, either through an SDK or by signing relayer requests directly. Nothing is bridged between
+  chains.
+---
+
+Agents built on EVM, Base, Virtuals, or any other stack can use Walrus Memory. The runtime your agent executes in and the chain it transacts on are independent of where its memory lives.
+
+That surprises people who expect a bridge, so it is worth stating plainly: **you need not bridge anything.** Walrus Memory stores memories as encrypted blobs on Walrus and records ownership in a Sui account. Your agent proves who it is with an Ed25519 delegate key that the account owner registers on that account. Whether the same agent also signs Ethereum transactions, holds an ERC-20 balance, or runs inside a Virtuals runtime makes no difference to any of that.
+
+## What your agent actually needs
+
+Two things, regardless of language or chain:
+
+1. **Register an Ed25519 delegate key on a Walrus Memory account.** The account owner registers the public key onchain, which grants the agent permission to read and write that account's memory. See [Ownership and Delegates](/fundamentals/concepts/ownership-and-access).
+2. **Network access to a relayer.** The relayer performs the encryption, storage, and indexing work, so your agent does not need a Sui node, a Walrus node, or WAL tokens.
+
+What your agent does **not** need: a Sui wallet for its own funds, a bridge, a wrapped token, or any change to how it transacts on its own chain.
+
+## Path 1: use an SDK
+
+If your agent runs in TypeScript or Python, use the SDK. It handles the request signing, the encryption session, and retries for you.
+
+```ts
+import { MemWal } from "@mysten-incubation/memwal";
+
+const memwal = MemWal.create({
+  key: process.env.MEMWAL_PRIVATE_KEY,
+  accountId: process.env.MEMWAL_ACCOUNT_ID,
+  // Mainnet relayer. Use https://relayer-staging.memory.walrus.xyz for Testnet.
+  serverUrl: "https://relayer.memory.walrus.xyz",
+  namespace: "agent-memory",
+});
+
+await memwal.health();
+await memwal.remember("The user prefers dark mode.");
+const hits = await memwal.recall({ query: "user preferences", limit: 5 });
+```
+
+For loading credentials from the environment, validating connectivity at boot, and handling credential errors, see [Headless SDK Setup](/sdk/headless-setup). For the write-confirm-recall cycle, see the [Agent Storage Loop](/sdk/agent-storage-loop).
+
+## Path 2: sign requests directly
+
+If your agent runs in a language with no SDK, such as Go, Rust, or Elixir, call the relayer API directly. Every authenticated route takes the same signed headers, so you need an Ed25519 signer, SHA-256, and an HTTP client.
+
+Build the canonical message, sign it, and send the signature as hex:
+
+```text
+{timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
+```
+
+| **Header** | **Value** |
+|---|---|
+| `x-public-key` | Hex-encoded Ed25519 public key, 32 bytes |
+| `x-signature` | Hex-encoded Ed25519 signature of the message above, 64 bytes |
+| `x-timestamp` | Unix timestamp in seconds, valid for five minutes |
+| `x-nonce` | UUID v4, which the relayer records for replay protection |
+| `x-account-id` | The account object ID. Official SDKs always send it and include it in the signed message |
+
+The relayer verifies the signature, then resolves the owner by looking up your public key in the account's onchain delegate keys. For every route, request shape, and response shape, see the [Relayer API Reference](/relayer/api-reference).
+
+```sh
+$ curl -sS "$MEMWAL_RELAYER_URL/health"
+```
+
+Start with `/health`, which needs no authentication, to confirm the agent can reach the relayer before you debug signing.
+
+## What "cross-chain" does not mean here
+
+Three things are outside what Walrus Memory does, and assuming otherwise leads to designs that cannot work:
+
+1. **No bridging.** Walrus Memory never mirrors, wraps, or relays a memory onto another chain. Ownership records live on Sui.
+2. **No EVM-native ownership.** An Ethereum address cannot own a memory account. The delegate key is Ed25519, and the account is a Sui object.
+3. **No payment in other tokens.** Walrus charges storage in WAL. Your agent neither holds nor spends it when a relayer fronts that cost.
+
+If your design needs an onchain link between an EVM contract and a memory account, model it in your own application: keep the mapping in your contract or database, and have your agent present the matching delegate key.
+
+## See also
+
+- [Ownership and Delegates](/fundamentals/concepts/ownership-and-access) for how delegate keys grant access.
+- [Headless SDK Setup](/sdk/headless-setup) for credentials and boot-time checks in a server runtime.
+- [Relayer API Reference](/relayer/api-reference) for the full authenticated surface.
+- [How AI Agent Memory Works](/fundamentals/concepts/how-agent-memory-works) for the embed, store, and recall loop.


### PR DESCRIPTION
Addresses BEDU-1086, BEDU-1114, and BEDU-1120, which are three separately-filed tickets for the same gap, citing 8, 18, and 11 builder questions respectively. About 37 questions total, with no documentation coverage.

## A note on the tickets' premise

All three ask for a "cross-chain integration guide" for EVM, Base, and Virtuals agents. There is no EVM support to document: the codebase has no EVM, Ethereum, or bridging code, and authentication is Ed25519 delegate keys resolved against a Sui account throughout.

Writing a literal cross-chain guide would document a capability that does not exist. What the askers actually need is the answer to the question behind the question, which is real and verifiable: **an agent's own chain is irrelevant to Walrus Memory.** An EVM or Base agent holds an Ed25519 delegate key and calls the relayer over HTTP, exactly like any other agent. Nothing is bridged.

## Changes

New `guides/agent-runtimes`, added to the Guides group in `docs.json`:

- **What the agent needs** — a delegate key registered on the account, and network access to a relayer. It does not need a Sui wallet of its own, a bridge, or a wrapped token.
- **Path 1, the SDK** — for TypeScript and Python runtimes, linking Headless SDK Setup rather than restating credential handling.
- **Path 2, signed requests** — for Go, Rust, or any language with no SDK: the canonical signed message, the five headers, and the advice to verify `/health` before debugging signatures.
- **What "cross-chain" does not mean** — no bridging, no EVM-native ownership, no payment in other tokens, plus the pattern to use when an application genuinely needs a link between an EVM contract and a memory account.

The page is written so the EVM, Base, Virtuals, and cross-chain search terms land on it, since that is what builders are searching for, while the content corrects the mental model rather than reinforcing it.

## Sources

| Claim | Source |
| --- | --- |
| Signed-header auth: the canonical message, the five headers, and the five-minute window | `docs/relayer/api-reference.md` (Required Headers, Signature Format) |
| The relayer resolves the owner from the delegate public key in onchain `MemWalAccount.delegate_keys` | same page, authentication section |
| `MemWal.create` fields (`key`, `accountId`, `serverUrl`, `namespace`), and `health()` at boot | `docs/sdk/headless-setup.md`, including the config table |
| `remember(string)` and `recall({ query, limit })` shapes | `docs/sdk/quick-start.md` and `docs/sdk/agent-storage-loop.md` |
| Mainnet and Testnet relayer URLs | the commented example in `docs/sdk/headless-setup.md` |
| No EVM or bridging support exists | absence verified by grep across `packages/`, `services/server/src`, and `apps/app/src` |

Prose written fresh for this page. The SDK snippet mirrors the verified field names rather than inventing them.

## Verification

- Style audit gates passed on push.
- All five internal links resolve to existing pages.
- `docs.json` validates as JSON with the new Guides entry.

Closes BEDU-1086, closes BEDU-1114, closes BEDU-1120.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_