### PR TITLE
docs(mcp): Claude custom connector guide, plus OAuth reference corrections

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -174,6 +174,7 @@
               "mcp/codex",
               "mcp/cursor",
               "mcp/claude-desktop",
+              "mcp/claude-connector",
               "mcp/antigravity",
               "mcp/opencode",
               "mcp/reference",

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -66,8 +66,8 @@ The OAuth path and the header path reach the same tools through the same relayer
 
 | **Environment** | **Connector URL** |
 | --- | --- |
-| Production (mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` |
-| Staging (testnet) | `https://relayer-staging.memory.walrus.xyz/api/mcp` |
+| Production (Mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` |
+| Staging (Testnet) | `https://relayer-staging.memory.walrus.xyz/api/mcp` |
 | Dev | `https://relayer.dev.memwal.ai/api/mcp` |
 
 ## Add the connector

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -33,9 +33,9 @@ questions:
   - How do I disconnect the Walrus Memory connector from Claude?
 answer: >-
   Add Walrus Memory in Claude's custom connector settings by pasting the MCP URL
-  of a relayer that has OAuth enabled. Staging and dev serve the discovery routes
-  today; the production relayer has not enabled OAuth yet. Claude
-  discovers the authorization server, registers itself, and opens the Walrus
+  of a relayer that has OAuth enabled. Production, staging, and dev serve the
+  discovery routes today. Claude discovers the authorization server, registers
+  itself, and opens the Walrus
   Memory consent screen, where you connect your Sui wallet and authorize a
   delegate key onchain. The relayer generates that delegate key, encrypts it at rest, and
   custodies it, because Claude cannot hold a Sui wallet key itself. To
@@ -71,11 +71,7 @@ The relayer's redirect allowlist accepts RFC 8252 loopback addresses and unit te
 | --- | --- | --- |
 | Staging (Testnet) | `https://relayer-staging.memory.walrus.xyz/api/mcp` | Discovery routes serve traffic |
 | Dev | `https://relayer.dev.memwal.ai/api/mcp` | Discovery routes serve traffic |
-| Production (Mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` | The operator has not enabled OAuth here yet. Both discovery routes return `404`, so the connector cannot complete. |
-
-<Warning>
-Do not hand the production URL to users until its discovery routes answer. Confirm with `curl -i https://relayer.memory.walrus.xyz/.well-known/oauth-authorization-server` first.
-</Warning>
+| Production (Mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` | OAuth is live and the discovery routes serve traffic |
 
 ## Add the connector
 
@@ -140,7 +136,7 @@ The same split applies to the stdio client: `memwal_logout` clears local credent
 ## Troubleshooting
 
 **Claude reports that it cannot find an authorization server.**
-That relayer has no OAuth configuration, which is the expected result on production today. Check `GET /.well-known/oauth-authorization-server` on the host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets to enable it.
+That relayer may have no OAuth configuration. Check `GET /.well-known/oauth-authorization-server` on the host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets to enable it.
 
 **The consent screen rejects the link.**
 The session ID never arrived, or the relayer already expired it. Consent sessions last 15 minutes by default. Start the connector flow again from Claude.

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -34,11 +34,11 @@ questions:
 answer: >-
   Add Walrus Memory in Claude's custom connector settings by pasting the MCP URL
   of a relayer that has OAuth enabled. Staging and dev serve the discovery routes
-  today; production is not enabled yet. Claude
+  today; the production relayer has not enabled OAuth yet. Claude
   discovers the authorization server, registers itself, and opens the Walrus
   Memory consent screen, where you connect your Sui wallet and authorize a
-  delegate key onchain. The relayer generates and custodies that delegate key,
-  encrypted at rest, because Claude cannot hold a Sui wallet key itself. To
+  delegate key onchain. The relayer generates that delegate key, encrypts it at rest, and
+  custodies it, because Claude cannot hold a Sui wallet key itself. To
   disconnect, remove the connector in Claude, then remove the delegate key from
   the Walrus Memory dashboard.
 ---
@@ -54,12 +54,12 @@ The connector flow needs a relayer that has OAuth turned on. Confirm the endpoin
 | **Client** | **Flow** | **Where to look** |
 | --- | --- | --- |
 | Claude web and Claude Desktop | Custom connector over OAuth | The steps below |
-| Claude Code | Header authentication, or the same OAuth flow over an RFC 8252 loopback redirect | [Claude Code](/mcp/claude-code) |
+| Claude Code | Header authentication, the verified path | [Claude Code](/mcp/claude-code) |
 | Cursor, Codex, Antigravity, OpenCode | stdio MCP server | [Overview](/mcp/overview) |
 
 The OAuth path and the header path reach the same tools through the same relayer. They differ in who holds the delegate key, which [What you approve](#what-you-approve) explains.
 
-The relayer's redirect allowlist accepts RFC 8252 loopback addresses, so a native-app OAuth client such as Claude Code can complete the same flow against a loopback callback.
+The relayer's redirect allowlist accepts RFC 8252 loopback addresses and unit tests cover that path, so a native-app OAuth client such as Claude Code can complete the same flow against a loopback callback. Nobody has run a Claude Code OAuth connection end to end yet, so header authentication stays the documented path for Claude Code until someone does.
 
 ## Prerequisites
 
@@ -71,7 +71,7 @@ The relayer's redirect allowlist accepts RFC 8252 loopback addresses, so a nativ
 | --- | --- | --- |
 | Staging (Testnet) | `https://relayer-staging.memory.walrus.xyz/api/mcp` | Discovery routes serve traffic |
 | Dev | `https://relayer.dev.memwal.ai/api/mcp` | Discovery routes serve traffic |
-| Production (Mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` | Not enabled yet. Both discovery routes return `404`, so the connector cannot complete. |
+| Production (Mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` | The operator has not enabled OAuth here yet. Both discovery routes return `404`, so the connector cannot complete. |
 
 <Warning>
 Do not hand the production URL to users until its discovery routes answer. Confirm with `curl -i https://relayer.memory.walrus.xyz/.well-known/oauth-authorization-server` first.
@@ -131,7 +131,7 @@ The connector flow puts a delegate private key on the server. Claude cannot hold
 Disconnecting takes two steps, because removing the connector does not remove the onchain delegate.
 
 1. **Remove the connector in Claude.** This stops Claude from using it. Whether Claude also calls the relayer's revoke endpoint is not documented, so do not rely on removal alone to end the grant. On the relayer side, revoking a refresh token ends the whole grant and every access token issued under it, while revoking an access token ends only that token.
-2. **Remove the delegate key in the dashboard.** Open [memory.walrus.xyz](https://memory.walrus.xyz), find the delegate that matches the address the consent screen showed, and remove it. Until you do, the delegate remains authorized on your account onchain.
+2. **Remove the delegate key in the dashboard.** Open [memory.walrus.xyz](https://memory.walrus.xyz), find the delegate that matches the address the consent screen showed, and remove it. Until you do, that delegate keeps its onchain authorization on your account.
 
 <Note>
 The same split applies to the stdio client: `memwal_logout` clears local credentials but leaves the onchain delegate in place. See [Logout semantics](/mcp/reference#logout-semantics).

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -43,7 +43,7 @@ answer: >-
   the Walrus Memory dashboard.
 ---
 
-Claude's built-in custom connector flow adds Walrus Memory over OAuth 2.1. You approve access in the browser with your Sui wallet, and Claude never asks you for a delegate private key or a custom header.
+Claude's built-in custom connector flow adds Walrus Memory over [OAuth 2.1](https://oauth.net/2.1/). You approve access in the browser with your [Sui wallet](https://docs.sui.io/guides/developer/wallets/what-is-a-wallet), and Claude never asks you for a delegate private key or a custom header.
 
 <Note>
 The connector flow needs a relayer that has OAuth turned on. Confirm the endpoint you plan to use answers `GET /.well-known/oauth-authorization-server` before you hand the URL to someone else. A relayer without the OAuth configuration returns `404` on that route and works only with [header authentication](/mcp/reference#streamable-http).
@@ -54,17 +54,15 @@ The connector flow needs a relayer that has OAuth turned on. Confirm the endpoin
 | **Client** | **Flow** | **Where to look** |
 | --- | --- | --- |
 | Claude web and Claude Desktop | Custom connector over OAuth | The steps below |
-| Claude Code | Header authentication, the verified path | [Claude Code](/mcp/claude-code) |
+| Claude Code | Header authentication | [Claude Code](/mcp/claude-code) |
 | Cursor, Codex, Antigravity, OpenCode | stdio MCP server | [Overview](/mcp/overview) |
 
-The OAuth path and the header path reach the same tools through the same relayer. They differ in who holds the delegate key, which [What you approve](#what-you-approve) explains.
-
-The relayer's redirect allowlist accepts RFC 8252 loopback addresses and unit tests cover that path, so a native-app OAuth client such as Claude Code can complete the same flow against a loopback callback. Nobody has run a Claude Code OAuth connection end to end yet, so header authentication stays the documented path for Claude Code until someone does.
+The OAuth path and the header path reach the same tools through the same relayer. They differ in [who holds the delegate key](#what-you-approve).
 
 ## Prerequisites
 
-- A Sui wallet in the browser you use for the consent screen.
-- A Walrus Memory account that the wallet owns. If the wallet owns no account yet, the consent screen sends you through the one-time setup and returns you to the connector flow.
+- A [Sui wallet](https://docs.sui.io/guides/developer/wallets/what-is-a-wallet) in the browser you use for the consent screen.
+- A [Walrus Memory account](/fundamentals/concepts/ownership-and-access) that the wallet owns. If the wallet owns no account yet, the consent screen sends you through the one-time setup and returns you to the connector flow.
 - The MCP URL of a relayer that has OAuth turned on.
 
 | **Environment** | **Connector URL** | **OAuth status** |
@@ -119,30 +117,34 @@ The relayer supports three scopes, and a client requests the subset it needs. Th
 Access tokens last 1 hour and refresh tokens last 30 days by default. A self-hosted relayer can change both. See [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration).
 
 <Warning>
-The connector flow puts a delegate private key on the server. Claude cannot hold a Sui wallet key, so the relayer generates a delegate keypair, encrypts the private key with AES-256-GCM before it stores the key, and decrypts it in memory to sign your MCP calls. The [stdio](/mcp/overview) and header flows keep the delegate key on your own machine instead. Choose the flow whose trust boundary you accept, and use the dashboard to remove a delegate you no longer want.
+The connector flow puts a delegate private key on the server. Claude cannot hold a Sui wallet key, so the relayer generates a delegate keypair, encrypts the private key with AES-256-GCM before it stores the key, and decrypts it in memory to sign your MCP calls. The [stdio client](/mcp/overview) and the header flow keep the delegate key on your own machine instead. Choose the flow whose trust boundary you accept, and use the dashboard to remove a delegate you no longer want.
 </Warning>
 
 ## Disconnect
 
 Disconnecting takes two steps, because removing the connector does not remove the onchain delegate.
 
-1. **Remove the connector in Claude.** This stops Claude from using it. Whether Claude also calls the relayer's revoke endpoint is not documented, so do not rely on removal alone to end the grant. On the relayer side, revoking a refresh token ends the whole grant and every access token issued under it, while revoking an access token ends only that token.
-2. **Remove the delegate key in the dashboard.** Open [memory.walrus.xyz](https://memory.walrus.xyz), find the delegate that matches the address the consent screen showed, and remove it. Until you do, that delegate keeps its onchain authorization on your account.
+<Steps>
+  <Step>
+    ### Remove the connector in Claude
+
+    This stops Claude from using it. Claude's documentation does not say whether removal also calls the relayer's revoke endpoint, so do not rely on removal alone to end the grant. On the relayer side, revoking a refresh token ends the whole grant and every access token the relayer issued under it, while revoking an access token ends only that token.
+  </Step>
+
+  <Step>
+    ### Remove the delegate key in the dashboard
+
+    Open [memory.walrus.xyz](https://memory.walrus.xyz), find the delegate that matches the address the consent screen showed, and remove it. Until you do, that delegate keeps its onchain authorization on your account.
+  </Step>
+</Steps>
 
 <Note>
-The same split applies to the stdio client: `memwal_logout` clears local credentials but leaves the onchain delegate in place. See [Logout semantics](/mcp/reference#logout-semantics).
+The same split applies to the [stdio client](/mcp/overview): `memwal_logout` clears local credentials but leaves the onchain delegate in place. See [Logout semantics](/mcp/reference#logout-semantics).
 </Note>
 
 ## Troubleshooting
 
-**Claude reports that it cannot find an authorization server.**
-That relayer might have no OAuth configuration. Check `GET /.well-known/oauth-authorization-server` on the host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets to enable it.
-
-**The consent screen rejects the link.**
-The session ID never arrived, or the relayer already expired it. Consent sessions last 15 minutes by default. Start the connector flow again from Claude.
-
-**The consent screen asks you to create an account.**
-The connected wallet owns no Walrus Memory account. Follow the setup link, create the account, and the app returns you to the connector flow.
-
-**Claude connects but the tools never appear.**
-Restart the client. MCP clients load their tool list at startup.
+- **Claude reports that it cannot find an authorization server**: that relayer might have no OAuth configuration. Check `GET /.well-known/oauth-authorization-server` on the host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets to enable it.
+- **The consent screen rejects the link**: the session ID never arrived, or the relayer already expired it. Consent sessions last 15 minutes by default. Start the connector flow again from Claude.
+- **The consent screen asks you to create an account**: the connected wallet owns no Walrus Memory account. Follow the setup link, create the account, and the app returns you to the connector flow.
+- **Claude connects but the tools never appear**: restart the client. MCP clients load their tool list at startup.

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -32,8 +32,9 @@ questions:
   - Who holds the delegate key when I connect Walrus Memory to Claude?
   - How do I disconnect the Walrus Memory connector from Claude?
 answer: >-
-  Add Walrus Memory in Claude's custom connector settings by pasting the relayer
-  MCP URL, for example https://relayer.memory.walrus.xyz/api/mcp. Claude
+  Add Walrus Memory in Claude's custom connector settings by pasting the MCP URL
+  of a relayer that has OAuth enabled. Staging and dev serve the discovery routes
+  today; production is not enabled yet. Claude
   discovers the authorization server, registers itself, and opens the Walrus
   Memory consent screen, where you connect your Sui wallet and authorize a
   delegate key onchain. The relayer generates and custodies that delegate key,
@@ -58,17 +59,23 @@ The connector flow needs a relayer that has OAuth turned on. Confirm the endpoin
 
 The OAuth path and the header path reach the same tools through the same relayer. They differ in who holds the delegate key, which [What you approve](#what-you-approve) explains.
 
+The relayer's redirect allowlist accepts RFC 8252 loopback addresses, so a native-app OAuth client such as Claude Code can complete the same flow against a loopback callback.
+
 ## Prerequisites
 
 - A Sui wallet in the browser you use for the consent screen.
 - A Walrus Memory account that the wallet owns. If the wallet owns no account yet, the consent screen sends you through the one-time setup and returns you to the connector flow.
 - The MCP URL of a relayer that has OAuth turned on.
 
-| **Environment** | **Connector URL** |
-| --- | --- |
-| Production (Mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` |
-| Staging (Testnet) | `https://relayer-staging.memory.walrus.xyz/api/mcp` |
-| Dev | `https://relayer.dev.memwal.ai/api/mcp` |
+| **Environment** | **Connector URL** | **OAuth status** |
+| --- | --- | --- |
+| Staging (Testnet) | `https://relayer-staging.memory.walrus.xyz/api/mcp` | Discovery routes serve traffic |
+| Dev | `https://relayer.dev.memwal.ai/api/mcp` | Discovery routes serve traffic |
+| Production (Mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` | Not enabled yet. Both discovery routes return `404`, so the connector cannot complete. |
+
+<Warning>
+Do not hand the production URL to users until its discovery routes answer. Confirm with `curl -i https://relayer.memory.walrus.xyz/.well-known/oauth-authorization-server` first.
+</Warning>
 
 ## Add the connector
 
@@ -95,7 +102,7 @@ The OAuth path and the header path reach the same tools through the same relayer
 
     Connect the Sui wallet that owns your Walrus Memory account. Approve the `add_delegate_key` transaction, which records onchain that this delegate can act for your account. Walrus Memory sponsors the transaction through Enoki, so you pay no gas.
 
-    If you already granted this client access before, the relayer reuses the delegate it minted then and skips the transaction.
+    If your account already has an active OAuth delegate from an earlier grant, the relayer reuses it and skips the transaction. The reuse is per account, not per client, so a second connector can end up sharing a delegate with the first.
   </Step>
 
   <Step>
@@ -107,11 +114,11 @@ The OAuth path and the header path reach the same tools through the same relayer
 
 ## What you approve
 
-The grant covers three scopes:
+The relayer supports three scopes, and a client requests the subset it needs. The consent screen shows what the client actually asked for, so read it there rather than assuming all three:
 
 1. `memwal:read`, which lets the client recall memories.
 2. `memwal:write`, which lets the client store memories.
-3. `offline_access`, which lets Claude refresh its access token without sending you back through consent.
+3. `offline_access`, which lets a client refresh its access token without sending you back through consent.
 
 Access tokens last 1 hour and refresh tokens last 30 days by default. A self-hosted relayer can change both. See [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration).
 
@@ -123,7 +130,7 @@ The connector flow puts a delegate private key on the server. Claude cannot hold
 
 Disconnecting takes two steps, because removing the connector does not remove the onchain delegate.
 
-1. **Remove the connector in Claude.** Claude revokes its tokens against the relayer. Revoking a refresh token ends the whole grant, so the access tokens issued under it stop working too.
+1. **Remove the connector in Claude.** This stops Claude from using it. Whether Claude also calls the relayer's revoke endpoint is not documented, so do not rely on removal alone to end the grant. On the relayer side, revoking a refresh token ends the whole grant and every access token issued under it, while revoking an access token ends only that token.
 2. **Remove the delegate key in the dashboard.** Open [memory.walrus.xyz](https://memory.walrus.xyz), find the delegate that matches the address the consent screen showed, and remove it. Until you do, the delegate remains authorized on your account onchain.
 
 <Note>
@@ -132,7 +139,14 @@ The same split applies to the stdio client: `memwal_logout` clears local credent
 
 ## Troubleshooting
 
-- **Claude reports that it cannot find an authorization server.** The relayer has no OAuth configuration. Check `GET /.well-known/oauth-authorization-server` on that host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets.
-- **The consent screen says the link is missing or malformed.** The session ID never arrived or the relayer already expired it. Consent sessions last 15 minutes by default. Start the connector flow again from Claude.
-- **The consent screen asks you to create an account.** The connected wallet owns no Walrus Memory account. Follow the setup link, create the account, and the app returns you to the connector flow.
-- **Claude connects but the tools never appear.** Restart the client. MCP clients load their tool list at startup.
+**Claude reports that it cannot find an authorization server.**
+That relayer has no OAuth configuration, which is the expected result on production today. Check `GET /.well-known/oauth-authorization-server` on the host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets to enable it.
+
+**The consent screen rejects the link.**
+The session ID never arrived, or the relayer already expired it. Consent sessions last 15 minutes by default. Start the connector flow again from Claude.
+
+**The consent screen asks you to create an account.**
+The connected wallet owns no Walrus Memory account. Follow the setup link, create the account, and the app returns you to the connector flow.
+
+**Claude connects but the tools never appear.**
+Restart the client. MCP clients load their tool list at startup.

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -136,7 +136,7 @@ The same split applies to the stdio client: `memwal_logout` clears local credent
 ## Troubleshooting
 
 **Claude reports that it cannot find an authorization server.**
-That relayer may have no OAuth configuration. Check `GET /.well-known/oauth-authorization-server` on the host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets to enable it.
+That relayer might have no OAuth configuration. Check `GET /.well-known/oauth-authorization-server` on the host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets to enable it.
 
 **The consent screen rejects the link.**
 The session ID never arrived, or the relayer already expired it. Consent sessions last 15 minutes by default. Start the connector flow again from Claude.

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -1,0 +1,138 @@
+---
+title: Claude Custom Connector
+description: >-
+  Connect Walrus Memory to Claude through Claude's native custom connector flow.
+  You approve access in the browser with your Sui wallet instead of pasting a
+  delegate key or custom headers.
+keywords:
+  - MCP
+  - Claude
+  - custom connector
+  - OAuth
+  - Walrus Memory
+  - MemWal
+  - delegate key
+goal:
+  description: Add Walrus Memory to Claude as a native custom connector, understand what the consent screen grants, and disconnect it cleanly.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 50
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I add Walrus Memory to Claude as a custom connector?
+  - Does Walrus Memory support Claude's OAuth custom connector flow?
+  - Who holds the delegate key when I connect Walrus Memory to Claude?
+  - How do I disconnect the Walrus Memory connector from Claude?
+answer: >-
+  Add Walrus Memory in Claude's custom connector settings by pasting the relayer
+  MCP URL, for example https://relayer.memory.walrus.xyz/api/mcp. Claude
+  discovers the authorization server, registers itself, and opens the Walrus
+  Memory consent screen, where you connect your Sui wallet and authorize a
+  delegate key onchain. The relayer generates and custodies that delegate key,
+  encrypted at rest, because Claude cannot hold a Sui wallet key itself. To
+  disconnect, remove the connector in Claude, then remove the delegate key from
+  the Walrus Memory dashboard.
+---
+
+Claude's built-in custom connector flow adds Walrus Memory over OAuth 2.1. You approve access in the browser with your Sui wallet, and Claude never asks you for a delegate private key or a custom header.
+
+<Note>
+The connector flow needs a relayer that has OAuth turned on. Confirm the endpoint you plan to use answers `GET /.well-known/oauth-authorization-server` before you hand the URL to someone else. A relayer without the OAuth configuration returns `404` on that route and works only with [header authentication](/mcp/reference#streamable-http).
+</Note>
+
+## Pick the right flow
+
+| **Client** | **Flow** | **Where to look** |
+| --- | --- | --- |
+| Claude web and Claude Desktop | Custom connector over OAuth | The steps below |
+| Claude Code | Header authentication, or the same OAuth flow over an RFC 8252 loopback redirect | [Claude Code](/mcp/claude-code) |
+| Cursor, Codex, Antigravity, OpenCode | stdio MCP server | [Overview](/mcp/overview) |
+
+The OAuth path and the header path reach the same tools through the same relayer. They differ in who holds the delegate key, which [What you approve](#what-you-approve) explains.
+
+## Prerequisites
+
+- A Sui wallet in the browser you use for the consent screen.
+- A Walrus Memory account that the wallet owns. If the wallet owns no account yet, the consent screen sends you through the one-time setup and returns you to the connector flow.
+- The MCP URL of a relayer that has OAuth turned on.
+
+| **Environment** | **Connector URL** |
+| --- | --- |
+| Production (mainnet) | `https://relayer.memory.walrus.xyz/api/mcp` |
+| Staging (testnet) | `https://relayer-staging.memory.walrus.xyz/api/mcp` |
+| Dev | `https://relayer.dev.memwal.ai/api/mcp` |
+
+## Add the connector
+
+<Steps>
+  <Step>
+    ### Paste the connector URL in Claude
+
+    Open Claude's connector settings, choose **Add custom connector**, and paste the MCP URL for your environment. Claude fetches the relayer's OAuth metadata and registers itself as a client. The relayer accepts that registration only for Anthropic's own callback domain or a loopback address, so a stranger cannot register a connector that redirects your grant somewhere else.
+  </Step>
+
+  <Step>
+    ### Review the consent screen
+
+    Claude opens the Walrus Memory consent screen in your browser. Everything the screen shows comes from the relayer, not from the link you arrived on, so the values reflect what the relayer validated:
+
+    - The name the connecting client gave for itself, which the screen labels as unverified.
+    - The redirect host the relayer checked against its allowlist.
+    - The scopes the client asked for.
+    - The Sui address of the delegate key that the grant authorizes.
+  </Step>
+
+  <Step>
+    ### Connect your wallet and authorize the delegate
+
+    Connect the Sui wallet that owns your Walrus Memory account. Approve the `add_delegate_key` transaction, which records onchain that this delegate can act for your account. Walrus Memory sponsors the transaction through Enoki, so you pay no gas.
+
+    If you already granted this client access before, the relayer reuses the delegate it minted then and skips the transaction.
+  </Step>
+
+  <Step>
+    ### Finish in Claude
+
+    The relayer verifies the transaction onchain and hands control back to Claude. The `memwal_*` tools appear in the session. Ask Claude what tools it has to confirm, then state a durable fact and check that it calls `memwal_remember`.
+  </Step>
+</Steps>
+
+## What you approve
+
+The grant covers three scopes:
+
+1. `memwal:read`, which lets the client recall memories.
+2. `memwal:write`, which lets the client store memories.
+3. `offline_access`, which lets Claude refresh its access token without sending you back through consent.
+
+Access tokens last 1 hour and refresh tokens last 30 days by default. A self-hosted relayer can change both. See [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration).
+
+<Warning>
+The connector flow puts a delegate private key on the server. Claude cannot hold a Sui wallet key, so the relayer generates a delegate keypair, encrypts the private key with AES-256-GCM before it stores the key, and decrypts it in memory to sign your MCP calls. The [stdio](/mcp/overview) and header flows keep the delegate key on your own machine instead. Choose the flow whose trust boundary you accept, and use the dashboard to remove a delegate you no longer want.
+</Warning>
+
+## Disconnect
+
+Disconnecting takes two steps, because removing the connector does not remove the onchain delegate.
+
+1. **Remove the connector in Claude.** Claude revokes its tokens against the relayer. Revoking a refresh token ends the whole grant, so the access tokens issued under it stop working too.
+2. **Remove the delegate key in the dashboard.** Open [memory.walrus.xyz](https://memory.walrus.xyz), find the delegate that matches the address the consent screen showed, and remove it. Until you do, the delegate remains authorized on your account onchain.
+
+<Note>
+The same split applies to the stdio client: `memwal_logout` clears local credentials but leaves the onchain delegate in place. See [Logout semantics](/mcp/reference#logout-semantics).
+</Note>
+
+## Troubleshooting
+
+- **Claude reports that it cannot find an authorization server.** The relayer has no OAuth configuration. Check `GET /.well-known/oauth-authorization-server` on that host, and see [MCP OAuth 2.1 configuration](/mcp/reference#mcp-oauth-2-1-configuration) for what an operator sets.
+- **The consent screen says the link is missing or malformed.** The session ID never arrived or the relayer already expired it. Consent sessions last 15 minutes by default. Start the connector flow again from Claude.
+- **The consent screen asks you to create an account.** The connected wallet owns no Walrus Memory account. Follow the setup link, create the account, and the app returns you to the connector flow.
+- **Claude connects but the tools never appear.** Restart the client. MCP clients load their tool list at startup.

--- a/docs/mcp/claude-connector.md
+++ b/docs/mcp/claude-connector.md
@@ -102,7 +102,7 @@ The OAuth path and the header path reach the same tools through the same relayer
   <Step>
     ### Finish in Claude
 
-    The relayer verifies the transaction onchain and hands control back to Claude. The `memwal_*` tools appear in the session. Ask Claude what tools it has to confirm, then state a durable fact and check that it calls `memwal_remember`.
+    The relayer verifies the transaction onchain and hands control back to Claude. The `memwal_*` tools appear in the session. Ask Claude what tools it has to confirm. To check that the grant reached your account, open the [Walrus Memory dashboard](https://memory.walrus.xyz) and look for a delegate at the address the consent screen showed.
   </Step>
 </Steps>
 

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -41,7 +41,7 @@ The MCP server exposes **eight tools**: six **relayer tools** (memory operations
 
 ## First-run behavior
 
-When `~/.memwal/credentials.json` is missing, the stdio package does **not** exit immediately if an MCP host launched it.
+When `~/.memwal/credentials.json` does not exist, the stdio package does **not** exit immediately if an MCP host launched it.
 
 Instead it starts in an auth-required mode that:
 
@@ -90,12 +90,14 @@ Extract memorable facts from a longer passage of text (preferences, habits, biog
 
 ### memwal_restore
 
-Re-index a namespace from Walrus blobs back into the relayer's search index. Returns counts only (`restored` / `skipped` / `total`), does **not** return memory texts. Call `memwal_recall` afterwards to query the rebuilt index.
+Re-index a namespace from Walrus blobs back into the relayer's search index. Returns counts (`restored` / `skipped` / `total`) plus `truncated`, and does **not** return memory texts. Call `memwal_recall` afterwards to query the rebuilt index.
+
+`truncated=true` means the bounded restore did not reach the end of the namespace, so the index is still incomplete. Raising `limit` helps when your own limit was the bound; past the sidecar's own cap it does not, and only a cursor-based restore would.
 
 | **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `namespace` | string | yes | Namespace bucket to restore. |
-| `limit` | integer (1–500) | no | Max memories to re-index. Default `10`. |
+| `limit` | integer (1–100) | no | Max memories to re-index. Default `10`. The relayer clamps values outside that range. |
 
 ### memwal_health
 
@@ -395,7 +397,7 @@ The relayer computes these, so they need no configuration.
 | `MCP_OAUTH_SESSION_TTL_SECS` | `900` | OAuth session lifetime |
 | `MCP_OAUTH_ALLOWED_REGISTRATION_HOSTS` | `claude.ai` | Redirect URI allowlist |
 | `MCP_OAUTH_REGISTRATION_PER_HOUR_PER_IP` | `20` | DCR rate limit |
-| `MCP_OAUTH_REGISTRATION_TRUSTED_CIDRS` | `160.79.104.0/21` | Networks that might register a client. The default is Anthropic's documented connector egress range. |
+| `MCP_OAUTH_REGISTRATION_TRUSTED_CIDRS` | `160.79.104.0/21` | Networks exempt from the per-IP registration throttle. Requests from other addresses still register when the redirect URI passes the allowlist and they stay inside the rate limit. The default is Anthropic's documented connector egress range. |
 
 ## Logout semantics
 

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -263,18 +263,18 @@ If your client cannot attach headers from the CLI, edit the generated MCP config
 
 ### OAuth (Claude custom connectors)
 
-Claude's native "Add custom connector" flow speaks OAuth 2.1, not the explicit-header model above, it discovers an authorization server, dynamically registers itself as a client, and drives the user through a hosted consent screen instead of expecting a pasted bearer token.
+Claude's native "Add custom connector" flow speaks OAuth 2.1 rather than the explicit-header model above. Claude discovers an authorization server, registers itself as a client, and sends the user through a hosted consent screen instead of expecting a pasted bearer token. For the end-user steps, see [Claude custom connector](/mcp/claude-connector).
 
 When configured, the hosted relayer additionally exposes:
 
 - `GET /.well-known/oauth-protected-resource` (+ the `/api/mcp`-suffixed variant Claude probes first), RFC 9728 resource metadata.
 - `GET /.well-known/oauth-authorization-server`, RFC 8414 metadata, advertising `code_challenge_methods_supported: ["S256"]` and `offline_access` (the scope that triggers Claude to request a refresh token).
-- `POST /oauth/register`, RFC 7591 dynamic client registration. Redirect URIs are checked against an allowlist (Anthropic's own callback domain, plus RFC 8252 loopback for Claude Code) rather than accepted from anywhere, self-serve registration for an *arbitrary* redirect target is not offered.
+- `POST /oauth/register`, RFC 7591 dynamic client registration. The relayer checks every redirect URI against an allowlist (Anthropic's own callback domain, plus RFC 8252 loopback for Claude Code) rather than accepting any host, so no client can self-register an arbitrary redirect target.
 - `GET /oauth/authorize`, `POST /oauth/token`, `POST /oauth/revoke`, the standard authorization-code + PKCE + refresh flow (RFC 6749/7636/7009). `/oauth/token` accepts both `application/x-www-form-urlencoded` (the spec-required content type) and `application/json`.
 
-Unlike the explicit-header and stdio flows, the OAuth path has the server generate and custody an encrypted delegate key on the user's behalf (`v1.<nonce>.<ciphertext>`, AES-256-GCM), Claude cannot hold a Sui wallet key itself, so something server-side has to be able to sign on its behalf. The consent screen states this plainly; the underlying delegate key is still revocable from the dashboard like any other.
+Unlike the explicit-header and stdio flows, the OAuth path has the relayer generate and custody a delegate key on the user's behalf, encrypted at rest as `v1.<nonce>.<ciphertext>` with AES-256-GCM. Claude cannot hold a Sui wallet key itself, so something server-side has to sign for it. The consent screen states this plainly, and the user can revoke the delegate key from the dashboard like any other.
 
-Adding the connector in Claude: use the hosted MCP URL (`https://relayer.memory.walrus.xyz/api/mcp`) as the connector URL, Claude handles discovery, registration, and consent automatically from there.
+To add the connector in Claude, paste the relayer's MCP URL as the connector URL. Claude handles discovery, registration, and consent from there.
 
 ### When to prefer HTTP vs stdio
 
@@ -336,54 +336,64 @@ Self-hosted relayers expose the same public MCP routes as the hosted relayer. Th
 
 See [Environment Variables](/reference/environment-variables) for the full list including SEAL, Walrus, embeddings, and database settings.
 
-### MCP OAuth 2.1 Configuration
+### MCP OAuth 2.1 configuration
 
-Claude custom connector support uses OAuth 2.1. Most values are derived from `MEMWAL_RELAYER_URL`, only one secret is required.
+Claude custom connector support uses OAuth 2.1. The relayer derives most values from `MEMWAL_RELAYER_URL` and requires exactly one secret. For the end-user flow, see [Claude custom connector](/mcp/claude-connector).
 
 #### Required delegate encryption key
 
-| Variable | Description |
+| **Variable** | **Description** |
 | --- | --- |
 | `MCP_OAUTH_DELEGATE_ENCRYPTION_KEY` | AES-256-GCM key (32 bytes, base64url-encoded, no padding) |
 
-**Why is this needed?**
+**Why the relayer needs this key**
 
-Claude Code (an AI agent) cannot hold a Sui wallet private key itself. The OAuth flow solves this:
+Claude cannot hold a Sui wallet private key itself, so the OAuth path puts a delegate key on the server instead:
 
+```text
+1. Claude sends the user to GET /oauth/authorize
+2. The relayer generates an Ed25519 delegate keypair server-side
+3. The relayer encrypts the private key with MCP_OAUTH_DELEGATE_ENCRYPTION_KEY
+   and stores only the ciphertext (v1.<nonce>.<ciphertext>)
+4. The user connects a wallet on the consent screen and signs add_delegate_key,
+   which authorizes that delegate on their account onchain
+5. When a request presents an OAuth access token, the relayer decrypts the
+   delegate private key in memory
+6. The relayer signs MCP requests with that delegate key
 ```
-1. User clicks "Add connector" in Claude
-2. Browser generates a delegate key pair (private key NEVER leaves the browser)
-3. Browser encrypts the private key with the server's key → sends to server
-4. Server stores the encrypted key in the database
-5. When an OAuth token is verified → server decrypts the private key
-6. Server uses the private key to sign MCP requests on behalf of the user
-```
 
-The `MCP_OAUTH_DELEGATE_ENCRYPTION_KEY` is the **server's symmetric encryption key** used to encrypt/decrypt every user's delegate private keys stored in the database.
+`MCP_OAUTH_DELEGATE_ENCRYPTION_KEY` is the **server's symmetric encryption key**. It encrypts and decrypts every user's delegate private key in the database.
 
-**Generate a key:**
+Generate a key:
 
 ```bash
 openssl rand -base64 32 | tr -d '=' | tr '+/' '-_'
 # Output example: GxK9pL2mQr8vN3jF5Ys7hT6wZ1cD4eR8
 ```
 
-**Important:**
-- Generate once and persist, changing this key invalidates all existing OAuth tokens
-- The key never leaves the server
-- Delegate private keys are encrypted at rest and only decrypted in-memory when signing
+Three things to know about the key:
 
-#### Derived Values (no config needed)
+1. Generate it once and persist it. Changing the key invalidates every existing OAuth token.
+2. The key never leaves the server.
+3. The relayer encrypts delegate private keys at rest and decrypts them in memory only to sign.
 
-| From | Value |
+<Warning>
+The OAuth path is the only Walrus Memory flow where a server holds a delegate private key. The stdio and explicit-header flows keep the key on the client. Operators who cannot accept server-side key custody should leave `MCP_OAUTH_DELEGATE_ENCRYPTION_KEY` unset, which turns the OAuth routes off and leaves header authentication working.
+</Warning>
+
+#### Derived values
+
+The relayer computes these, so they need no configuration.
+
+| **From** | **Value** |
 | --- | --- |
 | `MEMWAL_RELAYER_URL` | `issuer` |
 | `issuer + "/api/mcp"` | `resource` |
-| `issuer` (relayer → memory) | `consent_url` |
+| `issuer`, with the `relayer.` label dropped, plus `/connect/claude` | `consent_url` |
 
-#### Optional Overrides
+#### Optional overrides
 
-| Variable | Default | Description |
+| **Variable** | **Default** | **Description** |
 | --- | --- | --- |
 | `MCP_OAUTH_ACCESS_TTL_SECS` | `3600` | Access token lifetime |
 | `MCP_OAUTH_REFRESH_TTL_SECS` | `2592000` | Refresh token lifetime (30 days) |
@@ -391,6 +401,7 @@ openssl rand -base64 32 | tr -d '=' | tr '+/' '-_'
 | `MCP_OAUTH_SESSION_TTL_SECS` | `900` | OAuth session lifetime |
 | `MCP_OAUTH_ALLOWED_REGISTRATION_HOSTS` | `claude.ai` | Redirect URI allowlist |
 | `MCP_OAUTH_REGISTRATION_PER_HOUR_PER_IP` | `20` | DCR rate limit |
+| `MCP_OAUTH_REGISTRATION_TRUSTED_CIDRS` | `160.79.104.0/21` | Networks that may register a client. The default is Anthropic's documented connector egress range. |
 
 ## Logout semantics
 

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -259,14 +259,14 @@ If your client cannot attach headers from the CLI, edit the generated MCP config
 
 Claude's native "Add custom connector" flow speaks OAuth 2.1 rather than the explicit-header model above. Claude discovers an authorization server, registers itself as a client, and sends the user through a hosted consent screen instead of expecting a pasted bearer token. For the end-user steps, see [Claude custom connector](/mcp/claude-connector).
 
-When configured, the hosted relayer additionally exposes:
+When an operator configures OAuth, the hosted relayer additionally exposes:
 
 - `GET /.well-known/oauth-protected-resource` (+ the `/api/mcp`-suffixed variant Claude probes first), RFC 9728 resource metadata.
 - `GET /.well-known/oauth-authorization-server`, RFC 8414 metadata, advertising `code_challenge_methods_supported: ["S256"]` and `offline_access` (the scope that triggers Claude to request a refresh token).
 - `POST /oauth/register`, RFC 7591 dynamic client registration. The relayer checks every redirect URI against an allowlist (Anthropic's own callback domain, plus RFC 8252 loopback for Claude Code) rather than accepting any host, so no client can self-register an arbitrary redirect target.
 - `GET /oauth/authorize`, `POST /oauth/token`, `POST /oauth/revoke`, the standard authorization-code + PKCE + refresh flow (RFC 6749/7636/7009). `/oauth/token` accepts both `application/x-www-form-urlencoded` (the spec-required content type) and `application/json`.
 
-Unlike the explicit-header and stdio flows, the OAuth path has the relayer generate and custody a delegate key on the user's behalf, encrypted at rest as `v1.<nonce>.<ciphertext>` with AES-256-GCM. Claude cannot hold a Sui wallet key itself, so something server-side has to sign for it. The consent screen states this plainly, and the user can revoke the delegate key from the dashboard like any other.
+Unlike the explicit-header and stdio flows, the OAuth path has the relayer generate and custody a delegate key on the user's behalf, which it stores as `v1.<nonce>.<ciphertext>` under AES-256-GCM. Claude cannot hold a Sui wallet key itself, so something server-side has to sign for it. The consent screen states this plainly, and the user can revoke the delegate key from the dashboard like any other.
 
 To add the connector in Claude, paste the relayer's MCP URL as the connector URL. Claude handles discovery, registration, and consent from there.
 

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -30,10 +30,10 @@ questions:
   - How do I configure the MemWal MCP CLI flags and environment variables?
   - How do I set up Streamable HTTP transport for Walrus Memory MCP?
 answer: >-
-  The MemWal MCP reference documents eight tools (memwal_remember, memwal_remember_bulk, memwal_recall, memwal_analyze, memwal_restore, memwal_health, memwal_login, memwal_logout) with full parameter details. It covers CLI flags (--relayer, --namespace, --label, etc.), environment presets (prod, staging, local), two transport modes (stdio and Streamable HTTP), credential file format, default namespace precedence, self-hosting configuration, and runtime safety notes for 401 handling and relayer overrides.
+  The MemWal MCP reference documents eight tools (memwal_remember, memwal_remember_bulk, memwal_recall, memwal_analyze, memwal_restore, memwal_health, memwal_login, memwal_logout) with full parameter details. It covers CLI flags such as --relayer, --namespace, and --label, environment presets (prod, staging, local), two transport modes (stdio and Streamable HTTP), credential file format, default namespace precedence, self-hosting configuration, and runtime safety notes for 401 handling and relayer overrides.
 ---
 
-This page documents every tool, flag, environment variable, and transport route the Walrus Memory MCP package exposes. For per-client setup, start with the [MCP overview](/mcp/overview).
+The Walrus Memory MCP package exposes the tools, flags, environment variables, and transport routes below. For per-client setup, start with the [MCP overview](/mcp/overview).
 
 ## Tools
 
@@ -41,7 +41,7 @@ The MCP server exposes **eight tools**: six **relayer tools** (memory operations
 
 ## First-run behavior
 
-When `~/.memwal/credentials.json` is missing, the stdio package does **not** exit immediately if it was launched by an MCP host.
+When `~/.memwal/credentials.json` is missing, the stdio package does **not** exit immediately if an MCP host launched it.
 
 Instead it starts in an auth-required mode that:
 
@@ -55,7 +55,7 @@ This is why many first-run sessions show `memwal_login` before the other tools a
 
 Save a durable fact to the user's Walrus Memory. The agent calls this **proactively** whenever it learns something worth remembering across sessions (preference, decision, constraint, correction, identity), not only when the user explicitly asks. Pass the full statement; do not summarize.
 
-| Parameter | Type | Required | Description |
+| **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `text` | string | yes | The complete fact to save. |
 | `namespace` | string | no | Namespace bucket. Defaults to the session namespace. |
@@ -64,7 +64,7 @@ Save a durable fact to the user's Walrus Memory. The agent calls this **proactiv
 
 Save several durable facts in one batched call. Prefer this over repeated `memwal_remember` calls when the agent learns multiple distinct facts at once.
 
-| Parameter | Type | Required | Description |
+| **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `facts` | string[] (1–20) | yes | Array of complete fact statements, one full fact per entry, no summarizing. |
 | `namespace` | string | no | Namespace bucket applied to every fact. Defaults to the session namespace. |
@@ -73,7 +73,7 @@ Save several durable facts in one batched call. Prefer this over repeated `memwa
 
 Search the user's Walrus Memory for facts relevant to a query. The agent calls this **proactively** at the start of a task or when the user references past work, decisions, or preferences. Returns matches ranked by relevance.
 
-| Parameter | Type | Required | Description |
+| **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `query` | string | yes | Natural-language query to match against stored memories. |
 | `limit` | integer (1–100) | no | Max memories to return. Default `10`. |
@@ -83,7 +83,7 @@ Search the user's Walrus Memory for facts relevant to a query. The agent calls t
 
 Extract memorable facts from a longer passage of text (preferences, habits, biographical info, constraints) and save each as a separate memory.
 
-| Parameter | Type | Required | Description |
+| **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `text` | string | yes | Conversation transcript, note, or arbitrary text to extract from. |
 | `namespace` | string | no | Namespace for the extracted facts. |
@@ -92,7 +92,7 @@ Extract memorable facts from a longer passage of text (preferences, habits, biog
 
 Re-index a namespace from Walrus blobs back into the relayer's search index. Returns counts only (`restored` / `skipped` / `total`), does **not** return memory texts. Call `memwal_recall` afterwards to query the rebuilt index.
 
-| Parameter | Type | Required | Description |
+| **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `namespace` | string | yes | Namespace bucket to restore. |
 | `limit` | integer (1–500) | no | Max memories to re-index. Default `10`. |
@@ -112,7 +112,7 @@ Returns a one-time URL valid for **5 minutes**. If it expires, call the tool aga
 Remove the saved credentials from this machine (`~/.memwal/credentials.json`). Takes no parameters.
 
 <Warning>
-The on-chain delegate key registration is **not** revoked by `memwal_logout`, only the local file is wiped. Visit the [Walrus Memory dashboard](https://memory.walrus.xyz) to remove the delegate key from your account.
+`memwal_logout` does **not** revoke the onchain delegate key registration, it only wipes the local file. Visit the [Walrus Memory dashboard](https://memory.walrus.xyz) to remove the delegate key from your account.
 </Warning>
 
 <Note>
@@ -123,7 +123,7 @@ Both session tools (`memwal_login`, `memwal_logout`) are intercepted locally by 
 
 The stdio package accepts CLI flags and environment variables. **CLI takes precedence** when both are set.
 
-| CLI flag | Environment variable | Description |
+| **CLI flag** | **Environment variable** | **Description** |
 | --- | --- | --- |
 | `--relayer <url>` | `MEMWAL_SERVER_URL` | Override the relayer base URL. |
 | `--web-url <url>` | `MEMWAL_WEB_URL` | Override the dashboard URL used during login. |
@@ -137,27 +137,19 @@ Set `MEMWAL_MCP_DEBUG=1` to enable verbose stderr logging.
 
 ## Default namespace
 
-Set a default memory namespace once in your client config instead of having
-the agent pass `namespace` on every call. The package injects it into
-`memwal_remember`, `memwal_recall`, `memwal_analyze`, and `memwal_restore`
-calls that don't already carry one.
+Set a default memory namespace once in your client config instead of having the agent pass `namespace` on every call. The package injects it into `memwal_remember`, `memwal_recall`, `memwal_analyze`, and `memwal_restore` calls that don't already carry one.
 
 Precedence, highest first:
 
-1. **Explicit per-call `namespace`**, a non-empty `namespace` in the tool
-   call is used as-is. The configured default never overrides it.
+1. **Explicit per-call `namespace`**. The package forwards a non-empty `namespace` in the tool call unchanged, and the configured default never overrides it.
 2. **`--namespace` CLI flag** (alias `--ns`).
 3. **`MEMWAL_NAMESPACE` environment variable**.
-4. **Unset**, the call is forwarded without a `namespace` and the relayer
-   applies its own `"default"` namespace.
+4. **Unset**. The package forwards the call without a `namespace`, and the relayer applies its own `"default"` namespace.
 
-CLI wins over the environment variable when both are set, matching every other
-flag in the table above.
+CLI wins over the environment variable when you set both, which matches every other flag in the table above.
 
 <Note>
-`memwal_restore` still lists `namespace` as **required** in its tool schema,
-so agents normally pass one explicitly. A configured default is only used as a
-fallback if the agent calls `memwal_restore` without a namespace.
+`memwal_restore` still lists `namespace` as **required** in its tool schema, so agents normally pass one explicitly. The configured default only acts as a fallback when the agent calls `memwal_restore` without a namespace.
 </Note>
 
 Example, pin every memory call to a `work` namespace:
@@ -212,7 +204,7 @@ Common local config locations:
 
 Shortcut flags that set both the relayer and the dashboard URL in one switch:
 
-| Flag | Relayer | Dashboard |
+| **Flag** | **Relayer** | **Dashboard** |
 | --- | --- | --- |
 | `--prod` | `https://relayer.memory.walrus.xyz` | `https://memory.walrus.xyz` |
 | `--staging` | `https://relayer-staging.memory.walrus.xyz` | `https://staging.memory.walrus.xyz` |
@@ -224,7 +216,7 @@ Explicit `--relayer` and `--web-url` override the preset. You can also pass eith
 
 Walrus Memory supports two MCP connection modes.
 
-| Mode | Best for | Configured via |
+| **Mode** | **Best for** | **How you configure it** |
 | --- | --- | --- |
 | **stdio package** | Clients that run local MCP commands (most clients today) | `npx -y @mysten-incubation/memwal-mcp` in the client config |
 | **Streamable HTTP** | Clients that support remote HTTP MCP servers | `url: "https://relayer.memory.walrus.xyz/api/mcp"` + auth headers |
@@ -294,7 +286,7 @@ Prefer **Streamable HTTP** when:
 
 The hosted relayer (and any self-hosted relayer) exposes the same MCP routes:
 
-| Route | Purpose |
+| **Route** | **Purpose** |
 | --- | --- |
 | `GET /api/mcp/sse` | Legacy SSE session for the stdio bridge |
 | `POST /api/mcp/messages` | JSON-RPC messages for the legacy SSE transport |
@@ -306,9 +298,11 @@ The hosted relayer (and any self-hosted relayer) exposes the same MCP routes:
 | `POST /oauth/register` | Dynamic client registration (RFC 7591) |
 | `GET /oauth/authorize`, `POST /oauth/token`, `POST /oauth/revoke` | Authorization-code + PKCE + refresh flow |
 
-The Rust relayer auto-starts a TypeScript sidecar and forwards MCP traffic to it over loopback. The sidecar resolves MCP bearer credentials into normal Walrus Memory SDK sessions, so MCP tool calls go through the **same SEAL, Walrus, and pgvector paths** as direct SDK calls.
+The Rust relayer auto-starts a TypeScript sidecar and forwards MCP traffic to it over loopback. The sidecar resolves MCP bearer credentials into normal Walrus Memory SDK sessions, so MCP tool calls go through the **same `@mysten/seal` encryption, Walrus, and pgvector paths** as direct SDK calls.
 
 ## Runtime safety notes
+
+Two behaviors surprise people often enough to spell out: how the package treats a `401`, and what `--relayer` does to a saved credential.
 
 ### 401 behavior
 
@@ -326,7 +320,7 @@ The saved file is not silently rewritten. To rotate the saved relayer permanentl
 
 Self-hosted relayers expose the same public MCP routes as the hosted relayer. The most common operator-tunable settings:
 
-| Variable | Default | Purpose |
+| **Variable** | **Default** | **Purpose** |
 | --- | --- | --- |
 | `SIDECAR_URL` | `http://localhost:9000` | Loopback endpoint the Rust relayer uses to reach the sidecar |
 | `MCP_MAX_TOTAL_SESSIONS` | `1000` | Cap on concurrent MCP sessions across SSE and Streamable HTTP |
@@ -334,7 +328,7 @@ Self-hosted relayers expose the same public MCP routes as the hosted relayer. Th
 | `MCP_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | Rate cap on new sessions per source IP per minute |
 | `TRUSTED_PROXY_HOPS` | `0` | Trusted reverse-proxy hops used to resolve the canonical client IP; keep `0` for direct deployments |
 
-See [Environment Variables](/reference/environment-variables) for the full list including SEAL, Walrus, embeddings, and database settings.
+See [Environment Variables](/reference/environment-variables) for the full list including `@mysten/seal` encryption, Walrus, embeddings, and database settings.
 
 ### MCP OAuth 2.1 configuration
 
@@ -401,7 +395,7 @@ The relayer computes these, so they need no configuration.
 | `MCP_OAUTH_SESSION_TTL_SECS` | `900` | OAuth session lifetime |
 | `MCP_OAUTH_ALLOWED_REGISTRATION_HOSTS` | `claude.ai` | Redirect URI allowlist |
 | `MCP_OAUTH_REGISTRATION_PER_HOUR_PER_IP` | `20` | DCR rate limit |
-| `MCP_OAUTH_REGISTRATION_TRUSTED_CIDRS` | `160.79.104.0/21` | Networks that may register a client. The default is Anthropic's documented connector egress range. |
+| `MCP_OAUTH_REGISTRATION_TRUSTED_CIDRS` | `160.79.104.0/21` | Networks that might register a client. The default is Anthropic's documented connector egress range. |
 
 ## Logout semantics
 
@@ -409,16 +403,18 @@ The relayer computes these, so they need no configuration.
 
 They do **not**:
 
-- revoke the on-chain delegate key
+- revoke the onchain delegate key
 - remove the delegate from the Walrus Memory dashboard
 
 If the delegate itself should stop working, revoke it from the dashboard too.
 
 ## Troubleshooting
 
+Work through the symptom that matches what you see.
+
 ### Tools aren't visible to the agent
 
-Quit and relaunch your MCP client, MCP servers only load at startup. If you used `claude mcp add`, run `claude mcp list` to confirm `memwal` is registered before restarting Claude Code.
+Quit and relaunch your MCP client. MCP servers only load at startup. If you used `claude mcp add`, run `claude mcp list` to confirm `memwal` is registered before restarting Claude Code.
 
 ### Only `memwal_login` shows up
 


### PR DESCRIPTION
## Summary

Follows #584, which shipped OAuth 2.1 on the hosted MCP endpoint. Adds the user-facing how-to Kimberly asked for in Slack, and corrects two things in the reference page that #584 introduced.

### New page: `docs/mcp/claude-connector.md`

Covers the flow end to end: picking the right auth path per client, the four connector steps, what the consent screen actually grants, the two-step disconnect, and troubleshooting. Navigation entry added after `mcp/claude-desktop` (one-line `docs.json` change).

The disconnect section exists because revoking OAuth tokens does **not** remove the onchain delegate key. `POST /oauth/revoke` revokes the token or, for a refresh token, the whole grant, and stops there. Without the second step a user who removes the connector still has an authorized delegate on their account.

### Corrections to `docs/mcp/reference.md`

1. **The delegate-key flow was backwards.** The configuration section described the browser generating the keypair and the private key never leaving it. `/oauth/authorize` calls `oauth::generate_delegate_key()` server-side and stores the encrypted private key, which is *why* `MCP_OAUTH_DELEGATE_ENCRYPTION_KEY` exists at all. The prose two sections up already said this correctly ("the server generate and custody an encrypted delegate key"), so the page contradicted itself. Rewrote the flow block to match the code and added a warning that this is the one flow where a server holds a delegate private key.
2. **Missing variable.** `MCP_OAUTH_REGISTRATION_TRUSTED_CIDRS` (default `160.79.104.0/21`, Anthropic's connector egress range) was absent from the optional-overrides table.
3. **`consent_url` derivation was described imprecisely.** For a `relayer.` host the code drops the label rather than substituting `memory`.
4. Style-guide pass over the same page: bold table headers, sentence-case headings, active voice, unwrapped prose, body text between stacked headings.

## Sources

| Claim | Source |
| --- | --- |
| The relayer generates the delegate keypair server-side and encrypts it before storage | `services/server/src/oauth.rs` `generate_delegate_key()`; `services/server/src/routes/oauth.rs` `authorize`, which calls it then `encrypt_delegate_private_key` |
| Envelope format `v1.<nonce>.<ciphertext>`, AES-256-GCM | `services/server/src/oauth.rs` `encrypt_delegate_private_key` |
| Scopes `memwal:read memwal:write offline_access` | `services/server/src/oauth.rs` `DEFAULT_SCOPES` |
| Access token 1 h, refresh 30 d, code 5 min, session 15 min | `McpOAuthConfig::from_env` defaults in `services/server/src/oauth.rs` |
| Redirect allowlist is `claude.ai` plus RFC 8252 loopback | `CLAUDE_HOSTED_CALLBACK`, `is_loopback_host`, and the `MCP_OAUTH_ALLOWED_REGISTRATION_HOSTS` default in `services/server/src/oauth.rs` |
| `MCP_OAUTH_REGISTRATION_TRUSTED_CIDRS` default `160.79.104.0/21` | same file, `registration_trusted_cidrs` |
| Revoking a refresh token ends the grant; revoking an access token ends only that token | `services/server/src/routes/oauth.rs` `revoke` |
| Unsetting the encryption key turns the OAuth routes off (404) | `from_env` returns `None`; `require_oauth` returns 404 in `services/server/src/routes/oauth.rs` |
| Consent screen renders server-fetched session data, not URL params | `apps/app/src/pages/ConnectClaude.tsx` header comment and `GET /api/oauth/session/{id}` fetch |
| The `add_delegate_key` transaction is Enoki-sponsored | `apps/app/src/hooks/useSponsoredTransaction.ts` |
| No-account path routes to `/setup` and returns to the connector flow | `ConnectClaude.tsx` `no-account` step; `App.tsx` redirect to `/connect/claude` |
| `consent_url` derivation | `McpOAuthConfig::from_env` in `services/server/src/oauth.rs` |
| Environment URLs in the connector table | `docs/relayer/public-relayer.md` (prod, staging), `docs/relayer/benchmark-ci-setup.md` (dev) |

Prose is written fresh; no content was copied from the Notion task, which the docs integration cannot read.

## Remaining review questions

1. **Server-custodied keys are stated plainly, not softened.** The warning tells users the relayer holds a delegate private key for this flow. Worth a look from whoever owns the security messaging before this goes public alongside the connector submission.
2. **Claude Code over OAuth.** The allowlist supports RFC 8252 loopback, which the page attributes to Claude Code. Worth confirming that path has actually been exercised, since the existing Claude Code page documents header auth.

## Test plan

- Internal links and anchors in both edited pages resolve against the docs tree (checked programmatically, including the `#mcp-oauth-2-1-configuration` and `#streamable-http` targets).
- `docs.json` parses and the new entry sits under the MCP group.
- Local style gate passes on both files.
- Production deployment verification: both OAuth discovery routes return `200`, and an unauthenticated request to `https://relayer.memory.walrus.xyz/api/mcp` returns the expected `401`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_
