### PR TITLE
chore(mcp): separate SDK release from marketplace plugin

### DIFF
--- a/.changeset/fresh-dogs-login.md
+++ b/.changeset/fresh-dogs-login.md
@@ -1,0 +1,5 @@
+---
+"@mysten-incubation/memwal-mcp": patch
+---
+
+Refresh live MCP credentials after browser login without restarting the client, while rejecting stale handshakes and cross-account request replay.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,6 +4,10 @@ Walrus Memory MCP is a stdio Model Context Protocol server for Walrus Memory. It
 
 On first use, the package advertises a `memwal_login` tool to the MCP client. The agent can call it inline — no separate CLI command needed. The tool opens a browser-based wallet login flow and stores local credentials at `~/.memwal/credentials.json`. A matching `memwal_logout` tool clears the saved credentials.
 
+## Source and release ownership
+
+This directory is the canonical source for the `@mysten-incubation/memwal-mcp` SDK, its tests, versioning, and npm releases. The Claude Code marketplace package is maintained separately in [`CommandOSSLabs/walrus-memory-mcp-plugin`](https://github.com/CommandOSSLabs/walrus-memory-mcp-plugin) for transfer to MystenLabs. The npm package intentionally ships the MCP runtime only and does not bundle a second copy of the marketplace plugin.
+
 ## Quick Start
 
 Add Walrus Memory MCP to your MCP client config:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -36,7 +36,6 @@
     },
     "files": [
         "dist",
-        "plugin",
         "README.md"
     ],
     "keywords": [


### PR DESCRIPTION
## Summary

Keep MCP SDK and npm release ownership in the MemWal monorepo while the Claude marketplace package is prepared in `CommandOSSLabs/walrus-memory-mcp-plugin`.

- document `packages/mcp` as the canonical SDK/npm source
- stop bundling the duplicate marketplace plugin directory in npm tarballs
- add the missing patch changeset for PR #597's live credential refresh/security behavior

The existing monorepo plugin files are deliberately not deleted in this PR: current public docs still point at the monorepo marketplace. They can be retired after the standalone plugin PR lands, the repository is transferred, and docs are switched atomically.

## Validation

- MCP typecheck passed
- MCP tests 10/10 passed
- MCP build passed
- `npm pack --dry-run` contains 38 runtime files and no `plugin/` copy
- `git diff --check` passed

Related marketplace handoff: CommandOSSLabs/walrus-memory-mcp-plugin#4.
