### PR TITLE
Feat: Native token counting + max_tokens/truncation on recall

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -25,6 +25,13 @@ export {
 // Delegate key utilities (no @mysten/sui dependency)
 export { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "./utils.js";
 export {
+    estimateTokens,
+    truncateToTokenBudget,
+    applyTokenBudget,
+    CHARS_PER_TOKEN,
+} from "./tokens.js";
+export type { TokenCounter } from "./tokens.js";
+export {
     createSponsorAuthorization,
     sponsorAuthorizationMessage,
 } from "./sponsor-auth.js";
@@ -43,6 +50,8 @@ export type {
     RecallMemory,
     RecallOptions,
     RecallParams,
+    RecallTokenMeta,
+    TruncationStrategy,
     ScoringWeights,
     EmbedResult,
     AnalyzeOptions,

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -68,6 +68,7 @@ import {
     assertCompatibleRelayer,
     compatibilityErrorFromStatus,
 } from "./compatibility.js";
+import { applyTokenBudget, estimateTokens } from "./tokens.js";
 
 // ============================================================
 // Ed25519 Signing (lazy-loaded)
@@ -595,6 +596,25 @@ export class MemWal {
      * const result2 = await memwal.recall("food allergies", 5, "profile");
      * ```
      */
+    /**
+     * Estimate the token cost of a string using the SDK's default
+     * character-based approximation (~chars/4, code-point aware). Useful to weigh
+     * a recall payload before injecting it into a model context:
+     *
+     * ```ts
+     * const hits = await memwal.recall({ query, limit: 8 });
+     * const joined = hits.results.map((h) => h.text).join("\n---\n");
+     * if (memwal.countTokens(joined) > 2048) { /* re-query with maxTokens *\/ }
+     * ```
+     *
+     * This is an estimate, not an exact tokenizer count — see `estimateTokens`
+     * for accuracy caveats. For exact counts, pass your own counter to
+     * `recall({ maxTokens, countTokens })`.
+     */
+    countTokens(text: string): number {
+        return estimateTokens(text);
+    }
+
     async recall(params: RecallParams): Promise<RecallResult>;
     /**
      * @deprecated Positional `recall(query, limit, namespace)` is easy to
@@ -640,18 +660,38 @@ export class MemWal {
                 namespace: resolvedNamespace,
             }, { signal: ac.signal });
 
+            let processed = result;
             if (typeof options.maxDistance === "number") {
                 const filtered = result.results.filter(
                     (memory) => memory.distance < options.maxDistance!,
                 );
-                return {
-                    ...result,
+                processed = {
+                    ...processed,
                     results: filtered,
                     total: filtered.length,
                 };
             }
 
-            return result;
+            // Client-side token budgeting: trim the (already distance-sorted)
+            // payload to fit maxTokens per the chosen strategy, and attach the
+            // token estimate + truncated flag. Omitting maxTokens leaves the
+            // result byte-identical to the pre-budget behavior (no meta).
+            if (typeof options.maxTokens === "number") {
+                const { results: budgeted, meta } = applyTokenBudget(
+                    processed.results,
+                    options.maxTokens,
+                    options.truncationStrategy,
+                    options.countTokens,
+                );
+                processed = {
+                    ...processed,
+                    results: budgeted,
+                    total: budgeted.length,
+                    meta,
+                };
+            }
+
+            return processed;
         } finally {
             clearTimeout(tid);
         }

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -19,6 +19,7 @@ import type {
     RememberResult,
     RestoreResult,
 } from "./types.js";
+import { applyTokenBudget } from "./tokens.js";
 
 export interface MemWalMockSeed {
     text: string;
@@ -281,6 +282,17 @@ export class MemWalMock {
                 text: memory.text,
                 distance: memoryDistance,
             }));
+
+        if (typeof options.maxTokens === "number") {
+            const { results, meta } = applyTokenBudget(
+                ranked,
+                options.maxTokens,
+                options.truncationStrategy,
+                options.countTokens
+            );
+            return { results, total: results.length, meta };
+        }
+
         return { results: ranked, total: ranked.length };
     }
 

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -19,7 +19,7 @@ import type {
     RememberResult,
     RestoreResult,
 } from "./types.js";
-import { applyTokenBudget } from "./tokens.js";
+import { applyTokenBudget, estimateTokens } from "./tokens.js";
 
 export interface MemWalMockSeed {
     text: string;
@@ -224,6 +224,10 @@ export class MemWalMock {
             (item) => item.namespace ?? this.namespace
         );
         return this.waitForRememberJobs(accepted.job_ids, namespaces, opts);
+    }
+
+    countTokens(text: string): number {
+        return estimateTokens(text);
     }
 
     async recall(params: RecallParams): Promise<RecallResult>;

--- a/packages/sdk/src/tokens.ts
+++ b/packages/sdk/src/tokens.ts
@@ -64,6 +64,13 @@ export function truncateToTokenBudget(
     if (!Number.isFinite(maxTokens) || maxTokens <= 0) return "";
     if (countTokens(text) <= maxTokens) return text;
     const chars = [...text];
+    // The default estimator has an exact closed-form inverse, so avoid slicing
+    // and recounting prefixes on the common path.
+    if (countTokens === estimateTokens) {
+        const cap = Math.min(chars.length, Math.floor(maxTokens) * CHARS_PER_TOKEN);
+        return chars.slice(0, cap).join("");
+    }
+
     // Find the longest fitting prefix in logarithmic counter calls. Token counts
     // for text prefixes are expected to be monotonic for supported counters.
     // Searching the full string also avoids under-filling the budget for custom
@@ -147,7 +154,7 @@ export function applyTokenBudget(
         for (const m of results) {
             if (perHit <= 0) break;
             const text = truncateToTokenBudget(m.text, perHit, countTokens);
-            if ([...text].length > 0) capped.push({ ...m, text });
+            if (text.length > 0) capped.push({ ...m, text });
         }
         return {
             results: capped,
@@ -171,7 +178,7 @@ export function applyTokenBudget(
             const remaining = maxTokens - running;
             if (remaining > 0) {
                 const text = truncateToTokenBudget(m.text, remaining, countTokens);
-                if ([...text].length > 0) {
+                if (text.length > 0) {
                     kept.push({ ...m, text });
                     running += countTokens(text);
                 }

--- a/packages/sdk/src/tokens.ts
+++ b/packages/sdk/src/tokens.ts
@@ -64,21 +64,22 @@ export function truncateToTokenBudget(
     if (!Number.isFinite(maxTokens) || maxTokens <= 0) return "";
     if (countTokens(text) <= maxTokens) return text;
     const chars = [...text];
-    // Start the character cut at min(actual length, the estimate-derived cap).
-    // For the default (~chars/4) estimator this cap fits in one shot. For a
-    // custom counter DENSER than one token per char (e.g. a per-code-point CJK
-    // tokenizer) the estimate-derived cap can exceed the true answer, so we then
-    // shrink to fit below — clamping to `chars.length` first avoids starting the
-    // shrink loop above the string's own length.
-    let capChars = Math.min(chars.length, Math.max(0, Math.floor(maxTokens * CHARS_PER_TOKEN)));
-    let sliced = chars.slice(0, capChars).join("");
-    // Shrink until the (possibly custom) counter agrees the slice fits. Bounded
-    // by capChars; for the default estimator this loop does not run.
-    while (capChars > 0 && countTokens(sliced) > maxTokens) {
-        capChars -= 1;
-        sliced = chars.slice(0, capChars).join("");
+    // Find the longest fitting prefix in logarithmic counter calls. Token counts
+    // for text prefixes are expected to be monotonic for supported counters.
+    // Searching the full string also avoids under-filling the budget for custom
+    // counters whose average characters-per-token differs from the default.
+    let low = 0;
+    let high = chars.length;
+    while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+        const candidate = chars.slice(0, mid).join("");
+        if (countTokens(candidate) <= maxTokens) {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
     }
-    return sliced;
+    return chars.slice(0, low).join("");
 }
 
 /** Sum of per-hit token estimates for a list of memories. */

--- a/packages/sdk/src/tokens.ts
+++ b/packages/sdk/src/tokens.ts
@@ -1,0 +1,194 @@
+/**
+ * Client-side token estimation + budget truncation for recall payloads.
+ *
+ * The goal is a lightweight, zero-dependency way to weigh how many tokens a
+ * recalled payload will cost before it is injected into a model context — so
+ * apps can fit a budget without shipping a full tokenizer.
+ *
+ * ## Estimation model
+ *
+ * `estimateTokens` uses a documented character-based approximation rather than a
+ * real BPE tokenizer. For English-ish text with common LLM encodings (e.g.
+ * `cl100k_base`) tokens average ~4 characters, so we estimate
+ * `ceil(chars / CHARS_PER_TOKEN)` with `CHARS_PER_TOKEN = 4`. This is an
+ * ESTIMATE, not an exact count:
+ *   - It is model/encoding-agnostic and deterministic (safe for CI assertions
+ *     like "recall cost ≤ N").
+ *   - It will diverge from an exact tokenizer for code, dense punctuation, or
+ *     non-Latin scripts (where a single character can be one or more tokens).
+ *   - It counts by Unicode code points (via the spread operator), so a
+ *     multi-byte character (emoji, CJK) counts as one character, not its UTF-16
+ *     length — keeping the estimate stable across scripts.
+ *
+ * Callers needing exact counts can pass their own `countTokens` function through
+ * the recall options; this module is the default fallback.
+ */
+
+import type { RecallMemory, RecallTokenMeta, TruncationStrategy } from "./types.js";
+
+/** Characters-per-token divisor for the default approximation (~cl100k_base). */
+export const CHARS_PER_TOKEN = 4;
+
+/** A function that returns the token count of a string. */
+export type TokenCounter = (text: string) => number;
+
+/**
+ * Estimate the number of tokens in `text` using a documented character-based
+ * approximation (~`chars / 4`). Deterministic and dependency-free. See the
+ * module docs for accuracy caveats.
+ *
+ * Counts Unicode code points, so `"😀"` is 1 character (not 2 UTF-16 units).
+ */
+export function estimateTokens(text: string): number {
+    if (!text) return 0;
+    // Spread iterates by code point, so surrogate pairs count as one char.
+    const chars = [...text].length;
+    return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+/**
+ * Truncate a string to at most `maxTokens` estimated tokens, on a code-point
+ * boundary (never splits a surrogate pair). Uses the inverse of the estimate:
+ * keep at most `maxTokens * CHARS_PER_TOKEN` characters. Returns the original
+ * string when it already fits.
+ */
+export function truncateToTokenBudget(
+    text: string,
+    maxTokens: number,
+    countTokens: TokenCounter = estimateTokens,
+): string {
+    // Infinity = "no limit" → return the whole string. NaN / non-positive = no
+    // valid budget → nothing. (Reachable only via the exported standalone helper;
+    // applyTokenBudget intercepts non-finite budgets before calling here.)
+    if (maxTokens === Infinity) return text;
+    if (!Number.isFinite(maxTokens) || maxTokens <= 0) return "";
+    if (countTokens(text) <= maxTokens) return text;
+    const chars = [...text];
+    // Start the character cut at min(actual length, the estimate-derived cap).
+    // For the default (~chars/4) estimator this cap fits in one shot. For a
+    // custom counter DENSER than one token per char (e.g. a per-code-point CJK
+    // tokenizer) the estimate-derived cap can exceed the true answer, so we then
+    // shrink to fit below — clamping to `chars.length` first avoids starting the
+    // shrink loop above the string's own length.
+    let capChars = Math.min(chars.length, Math.max(0, Math.floor(maxTokens * CHARS_PER_TOKEN)));
+    let sliced = chars.slice(0, capChars).join("");
+    // Shrink until the (possibly custom) counter agrees the slice fits. Bounded
+    // by capChars; for the default estimator this loop does not run.
+    while (capChars > 0 && countTokens(sliced) > maxTokens) {
+        capChars -= 1;
+        sliced = chars.slice(0, capChars).join("");
+    }
+    return sliced;
+}
+
+/** Sum of per-hit token estimates for a list of memories. */
+function payloadTokens(results: RecallMemory[], countTokens: TokenCounter): number {
+    return results.reduce((sum, m) => sum + countTokens(m.text), 0);
+}
+
+/**
+ * Trim `results` (already ordered by ascending distance, i.e. most relevant
+ * first) to fit `maxTokens` estimated tokens, per `strategy`. Pure — no I/O.
+ *
+ * Returns the (possibly trimmed) results plus `meta`, where `meta.tokenEstimate`
+ * is the estimated token cost of the RETURNED payload (what the caller can
+ * assert "≤ N" against) and `meta.truncated` is true if anything was dropped or
+ * shortened.
+ *
+ * A non-finite budget (NaN / Infinity) is treated as "no budget": the payload is
+ * returned unchanged with `truncated: false` — a malformed budget must never
+ * claim it truncated.
+ *
+ * Strategies:
+ *  - `high-relevance-only`: keep WHOLE hits from the front while they fit; the
+ *    first hit that would overflow (and everything after it) is dropped. A
+ *    single leading hit larger than the whole budget is itself dropped. No hit
+ *    is ever partially shown. Deterministic.
+ *  - `drop-tail`: preserve order, keep whole hits from the front, then TRUNCATE
+ *    the single boundary hit that straddles the budget so the payload fills to
+ *    (about) `maxTokens` — modelling "cut the end of the concatenated payload".
+ *    Unlike high-relevance-only, the last kept hit may be a shortened partial.
+ *  - `per-hit-cap`: keep every hit but cap each hit's text to an equal share of
+ *    the budget (`floor(maxTokens / n)`); hits whose share rounds to zero (more
+ *    hits than budget tokens) are dropped rather than emitted empty.
+ */
+export function applyTokenBudget(
+    results: RecallMemory[],
+    maxTokens: number,
+    strategy: TruncationStrategy = "high-relevance-only",
+    countTokens: TokenCounter = estimateTokens,
+): { results: RecallMemory[]; meta: RecallTokenMeta } {
+    const originalCount = results.length;
+
+    // A non-finite budget (NaN/Infinity) is not a real budget — never truncate,
+    // never falsely report truncation. Return the payload as-is.
+    if (!Number.isFinite(maxTokens)) {
+        return { results, meta: { tokenEstimate: payloadTokens(results, countTokens), truncated: false } };
+    }
+
+    // Non-positive budget → empty payload; truncated if there was anything.
+    if (maxTokens <= 0) {
+        return { results: [], meta: { tokenEstimate: 0, truncated: originalCount > 0 } };
+    }
+
+    // Already within budget → return unchanged, truncated:false.
+    const fullCost = payloadTokens(results, countTokens);
+    if (fullCost <= maxTokens) {
+        return { results, meta: { tokenEstimate: fullCost, truncated: false } };
+    }
+
+    if (strategy === "per-hit-cap") {
+        // Split the budget evenly across the hits; cap each. A zero per-hit share
+        // (more hits than tokens) drops the overflow hits rather than emitting
+        // empty-text memories.
+        const perHit = Math.floor(maxTokens / originalCount);
+        const capped: RecallMemory[] = [];
+        for (const m of results) {
+            if (perHit <= 0) break;
+            const text = truncateToTokenBudget(m.text, perHit, countTokens);
+            if ([...text].length > 0) capped.push({ ...m, text });
+        }
+        return {
+            results: capped,
+            meta: { tokenEstimate: payloadTokens(capped, countTokens), truncated: true },
+        };
+    }
+
+    if (strategy === "drop-tail") {
+        // Keep whole hits from the front; when the next hit straddles the budget,
+        // truncate ITS text to the remaining budget (a partial tail) rather than
+        // dropping it — "cut the end of the concatenated payload".
+        const kept: RecallMemory[] = [];
+        let running = 0;
+        for (const m of results) {
+            const cost = countTokens(m.text);
+            if (running + cost <= maxTokens) {
+                kept.push(m);
+                running += cost;
+                continue;
+            }
+            const remaining = maxTokens - running;
+            if (remaining > 0) {
+                const text = truncateToTokenBudget(m.text, remaining, countTokens);
+                if ([...text].length > 0) {
+                    kept.push({ ...m, text });
+                    running += countTokens(text);
+                }
+            }
+            break;
+        }
+        return { results: kept, meta: { tokenEstimate: running, truncated: true } };
+    }
+
+    // high-relevance-only: keep whole hits from the front while the running total
+    // stays within budget; stop at the first hit that would overflow.
+    const kept: RecallMemory[] = [];
+    let running = 0;
+    for (const m of results) {
+        const cost = countTokens(m.text);
+        if (running + cost > maxTokens) break;
+        kept.push(m);
+        running += cost;
+    }
+    return { results: kept, meta: { tokenEstimate: running, truncated: true } };
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -58,11 +58,49 @@ export interface RecallMemory {
     distance: number;
 }
 
+/**
+ * Token-budget metadata attached to a RecallResult when a `maxTokens` budget was
+ * requested. Lets callers/telemetry assert "this recall cost ≤ N tokens".
+ */
+export interface RecallTokenMeta {
+    /**
+     * Estimated token count of the RETURNED `results` payload (sum of per-hit
+     * estimates, after any truncation). This is the value a caller can assert a
+     * budget against, e.g. `meta.tokenEstimate <= maxTokens`. It is the
+     * post-truncation cost, not the pre-truncation total.
+     */
+    tokenEstimate: number;
+    /** True if any hit was dropped or shortened to fit the `maxTokens` budget. */
+    truncated: boolean;
+}
+
 /** Result from recall() */
 export interface RecallResult {
     results: RecallMemory[];
     total: number;
+    /**
+     * Present only when a `maxTokens` budget was supplied to recall(). Additive
+     * and optional — omitted for budget-less recalls, so existing callers are
+     * unaffected.
+     */
+    meta?: RecallTokenMeta;
 }
+
+/**
+ * How recall trims recalled memories to fit a `maxTokens` budget.
+ *
+ * - `high-relevance-only` (default): keep the lowest-distance hits whole, in
+ *   order, until the next hit would exceed the budget; drop the rest. No hit is
+ *   ever partially shown.
+ * - `per-hit-cap`: cap each hit's text to an equal share of the budget
+ *   (`floor(maxTokens / hitCount)`). Hits whose share rounds to zero (more hits
+ *   than budget tokens) are dropped rather than returned empty.
+ * - `drop-tail`: preserve order and keep whole hits from the front, then
+ *   truncate the single boundary hit that straddles the budget so the payload
+ *   fills to the end of the concatenated budget. The last kept hit may be a
+ *   shortened partial (this is what distinguishes it from `high-relevance-only`).
+ */
+export type TruncationStrategy = "high-relevance-only" | "per-hit-cap" | "drop-tail";
 
 /** Options for recall(). */
 export interface RecallOptions {
@@ -74,6 +112,24 @@ export interface RecallOptions {
     namespace?: string;
     /** Drop memories whose distance is greater than or equal to this value. */
     maxDistance?: number;
+    /**
+     * Client-side token budget for the returned payload. When set, recall trims
+     * the results (per `truncationStrategy`) so their estimated token count fits,
+     * and attaches `meta.tokenEstimate` / `meta.truncated`. Omit for the current
+     * (unbudgeted) behavior. Counting is an estimate — see `countTokens`.
+     */
+    maxTokens?: number;
+    /**
+     * Strategy used when `maxTokens` is set. Default: `high-relevance-only`.
+     * Ignored when `maxTokens` is not set.
+     */
+    truncationStrategy?: TruncationStrategy;
+    /**
+     * Custom exact token counter (e.g. a tiktoken binding). When omitted, a
+     * zero-dependency character-based approximation (~chars/4) is used. Only
+     * consulted when `maxTokens` is set.
+     */
+    countTokens?: (text: string) => number;
 }
 
 /** Recommended object-style recall input — preferred over positional args. */

--- a/packages/sdk/test/mock.test.mjs
+++ b/packages/sdk/test/mock.test.mjs
@@ -93,6 +93,8 @@ test("MemWalMock matches production token-budget behavior", async () => {
         ],
     });
 
+    assert.equal(mock.countTokens("a".repeat(8)), 2);
+
     const unbudgeted = await mock.recall({ query: "a", limit: 2 });
     assert.equal(unbudgeted.results.length, 2);
     assert.equal("meta" in unbudgeted, false);

--- a/packages/sdk/test/mock.test.mjs
+++ b/packages/sdk/test/mock.test.mjs
@@ -85,6 +85,31 @@ test("MemWalMock matches production recall overloads and topK precedence", async
     assert.equal(objectStyle.results.length, 2);
 });
 
+test("MemWalMock matches production token-budget behavior", async () => {
+    const mock = MemWalMock.create({
+        initialMemories: [
+            { text: "a".repeat(40) },
+            { text: "a".repeat(40) },
+        ],
+    });
+
+    const unbudgeted = await mock.recall({ query: "a", limit: 2 });
+    assert.equal(unbudgeted.results.length, 2);
+    assert.equal("meta" in unbudgeted, false);
+
+    const budgeted = await mock.recall({
+        query: "a",
+        limit: 2,
+        maxTokens: 10,
+    });
+    assert.equal(budgeted.results.length, 1);
+    assert.equal(budgeted.total, 1);
+    assert.deepEqual(budgeted.meta, {
+        tokenEstimate: 10,
+        truncated: true,
+    });
+});
+
 test("MemWalMock tokenization does not depend on the host locale", async () => {
     const originalLocaleLowerCase = String.prototype.toLocaleLowerCase;
     String.prototype.toLocaleLowerCase = () => {

--- a/packages/sdk/test/recall-token-budget-e2e.test.mjs
+++ b/packages/sdk/test/recall-token-budget-e2e.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWal } from "../dist/memwal.js";
+
+// End-to-end coverage of the recall() wiring (not just the pure applyTokenBudget
+// function): confirms maxTokens is honored on the real client path and that
+// omitting it leaves the response byte-identical to the pre-budget behavior.
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+// Stub the relayer so /api/recall returns a fixed set of hits.
+function stubRecall(hits) {
+    globalThis.fetch = async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        if (path === "/version") {
+            return Response.json({
+                apiVersion: "1.0.0",
+                relayerVersion: "1.0.0",
+                minSupportedSdk: { typescript: "0.0.4" },
+            });
+        }
+        if (path === "/api/config") {
+            return Response.json({ packageId: "0x1", network: "testnet" });
+        }
+        if (path === "/api/recall" && init.method === "POST") {
+            return Response.json({ results: hits, total: hits.length });
+        }
+        throw new Error(`unexpected request ${path}`);
+    };
+}
+
+function client() {
+    const c = MemWal.create({
+        key: new Uint8Array(32).fill(1),
+        accountId: "0x1",
+        serverUrl: "https://relayer.example",
+    });
+    c.buildSealSession = async () => "test-session";
+    return c;
+}
+
+const chars = (n) => "a".repeat(n);
+
+test("recall without maxTokens: response unchanged, NO meta (backward compatible)", async () => {
+    const hits = [
+        { blob_id: "b1", text: chars(40), distance: 0.1 },
+        { blob_id: "b2", text: chars(40), distance: 0.2 },
+    ];
+    stubRecall(hits);
+
+    const result = await client().recall({ query: "x", namespace: "default" });
+    assert.equal(result.results.length, 2);
+    assert.equal(result.total, 2);
+    assert.equal("meta" in result, false, "no meta key when maxTokens is omitted");
+    assert.deepEqual(result.results, hits);
+});
+
+test("recall with maxTokens: budget applied, total recomputed, meta present", async () => {
+    // two 10-token hits (40 chars each); budget 10 → high-relevance-only keeps 1.
+    const hits = [
+        { blob_id: "b1", text: chars(40), distance: 0.1 },
+        { blob_id: "b2", text: chars(40), distance: 0.2 },
+    ];
+    stubRecall(hits);
+
+    const result = await client().recall({ query: "x", maxTokens: 10 });
+    assert.equal(result.results.length, 1, "second hit dropped to fit budget");
+    assert.equal(result.total, 1, "total recomputed to the trimmed count");
+    assert.equal(result.results[0].blob_id, "b1", "kept the lowest-distance hit");
+    assert.ok(result.meta, "meta attached");
+    assert.equal(result.meta.truncated, true);
+    assert.equal(result.meta.tokenEstimate, 10);
+});
+
+test("recall maxTokens + maxDistance compose (distance filter then budget)", async () => {
+    const hits = [
+        { blob_id: "b1", text: chars(40), distance: 0.1 },
+        { blob_id: "b2", text: chars(40), distance: 0.9 }, // filtered by maxDistance
+    ];
+    stubRecall(hits);
+
+    const result = await client().recall({ query: "x", maxDistance: 0.5, maxTokens: 100 });
+    assert.equal(result.results.length, 1, "distance filter dropped b2 before budgeting");
+    assert.equal(result.results[0].blob_id, "b1");
+    assert.equal(result.meta.truncated, false, "within budget after the distance filter");
+});

--- a/packages/sdk/test/recall-token-budget-e2e.test.mjs
+++ b/packages/sdk/test/recall-token-budget-e2e.test.mjs
@@ -77,6 +77,30 @@ test("recall with maxTokens: budget applied, total recomputed, meta present", as
     assert.equal(result.meta.tokenEstimate, 10);
 });
 
+test("recall forwards drop-tail strategy and a custom token counter", async () => {
+    const hits = [
+        { blob_id: "b1", text: "one two three four", distance: 0.1 },
+    ];
+    stubRecall(hits);
+    let counterCalls = 0;
+    const wordCount = (text) => {
+        counterCalls += 1;
+        return text.trim() ? text.trim().split(/\s+/).length : 0;
+    };
+
+    const result = await client().recall({
+        query: "x",
+        maxTokens: 2,
+        truncationStrategy: "drop-tail",
+        countTokens: wordCount,
+    });
+    assert.equal(result.results.length, 1);
+    assert.ok(wordCount(result.results[0].text) <= 2);
+    assert.equal(result.meta.truncated, true);
+    assert.equal(result.meta.tokenEstimate, 2);
+    assert.ok(counterCalls > 0, "custom counter was used by recall");
+});
+
 test("recall maxTokens + maxDistance compose (distance filter then budget)", async () => {
     const hits = [
         { blob_id: "b1", text: chars(40), distance: 0.1 },

--- a/packages/sdk/test/recall-token-budget.test.mjs
+++ b/packages/sdk/test/recall-token-budget.test.mjs
@@ -224,6 +224,19 @@ test("dense custom counter (tokens > chars) still fits the budget and terminates
     assert.ok(meta.tokenEstimate <= 6);
 });
 
+test("custom counter truncation uses logarithmic counter calls", () => {
+    const text = "漢".repeat(100_000);
+    let calls = 0;
+    const dense = (value) => {
+        calls += 1;
+        return [...value].length * 2;
+    };
+
+    const out = truncateToTokenBudget(text, 10_000, dense);
+    assert.equal([...out].length, 5_000);
+    assert.ok(calls <= 20, `expected logarithmic counter calls, got ${calls}`);
+});
+
 test("fractional budget behaves consistently across strategies", () => {
     // budget 2.5: high-relevance-only drops a 3-tok hit (0 results);
     // per-hit-cap gives floor(2.5/2)=1 tok/hit; drop-tail truncates the tail.

--- a/packages/sdk/test/recall-token-budget.test.mjs
+++ b/packages/sdk/test/recall-token-budget.test.mjs
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    estimateTokens,
+    truncateToTokenBudget,
+    applyTokenBudget,
+    CHARS_PER_TOKEN,
+} from "../dist/index.js";
+
+// Helper: build a RecallMemory-like hit with text of a known char length.
+function hit(text, distance) {
+    return { blob_id: `blob-${distance}`, text, distance };
+}
+// A string of exactly `chars` ASCII chars → estimateTokens = ceil(chars/4).
+const chars = (n) => "a".repeat(n);
+
+// ── estimateTokens ───────────────────────────────────────────
+
+test("estimateTokens: empty is 0", () => {
+    assert.equal(estimateTokens(""), 0);
+});
+
+test("estimateTokens: ceil(chars / CHARS_PER_TOKEN)", () => {
+    assert.equal(CHARS_PER_TOKEN, 4);
+    assert.equal(estimateTokens(chars(4)), 1);
+    assert.equal(estimateTokens(chars(5)), 2); // 5/4 → ceil = 2
+    assert.equal(estimateTokens(chars(8)), 2);
+});
+
+test("estimateTokens: counts Unicode by code point, not UTF-16 length", () => {
+    // "😀" is 2 UTF-16 units but 1 code point → 1 char → ceil(1/4) = 1 token.
+    assert.equal(estimateTokens("😀"), 1);
+    // Four emoji = 4 code points → ceil(4/4) = 1 token (not 8/4 = 2).
+    assert.equal(estimateTokens("😀😀😀😀"), 1);
+    // CJK: 8 code points → 2 tokens.
+    assert.equal(estimateTokens("漢字漢字漢字漢字"), 2);
+});
+
+// ── truncateToTokenBudget ────────────────────────────────────
+
+test("truncateToTokenBudget: within budget returns original", () => {
+    assert.equal(truncateToTokenBudget(chars(8), 2), chars(8));
+});
+
+test("truncateToTokenBudget: over budget cuts to the char cap", () => {
+    // budget 1 token → 1*4 = 4 chars kept.
+    assert.equal(truncateToTokenBudget(chars(40), 1), chars(4));
+});
+
+test("truncateToTokenBudget: zero/neg budget → empty", () => {
+    assert.equal(truncateToTokenBudget(chars(40), 0), "");
+});
+
+test("truncateToTokenBudget: Infinity budget returns the whole string (no limit)", () => {
+    assert.equal(truncateToTokenBudget(chars(40), Infinity), chars(40));
+});
+
+test("truncateToTokenBudget: NaN budget returns empty (no valid budget)", () => {
+    assert.equal(truncateToTokenBudget(chars(40), NaN), "");
+});
+
+test("truncateToTokenBudget: never splits a surrogate pair", () => {
+    // 4 emoji (4 code points, 8 UTF-16 units). Budget 1 token = 4 chars → keep
+    // all 4 emoji whole, never a half-emoji.
+    const out = truncateToTokenBudget("😀😀😀😀", 1);
+    assert.equal([...out].length, 4);
+    assert.ok(!out.includes("�"), "no replacement char from a split pair");
+});
+
+// ── applyTokenBudget: exact / over / under ───────────────────
+
+test("exact-budget: payload exactly at budget is not truncated", () => {
+    // two hits of 8 chars = 2 tokens each = 4 tokens total.
+    const hits = [hit(chars(8), 0.1), hit(chars(8), 0.2)];
+    const { results, meta } = applyTokenBudget(hits, 4);
+    assert.equal(results.length, 2);
+    assert.equal(meta.truncated, false);
+    assert.equal(meta.tokenEstimate, 4);
+});
+
+test("under-budget: unchanged, truncated:false", () => {
+    const hits = [hit(chars(8), 0.1)];
+    const { results, meta } = applyTokenBudget(hits, 100);
+    assert.deepEqual(results, hits);
+    assert.equal(meta.truncated, false);
+    assert.equal(meta.tokenEstimate, 2);
+});
+
+test("over-budget high-relevance-only: keeps lowest-distance whole hits, drops the rest", () => {
+    // three 2-token hits (8 chars each); budget 5 → keep 2 (4 tokens), drop 3rd.
+    const hits = [hit(chars(8), 0.1), hit(chars(8), 0.2), hit(chars(8), 0.3)];
+    const { results, meta } = applyTokenBudget(hits, 5, "high-relevance-only");
+    assert.equal(results.length, 2);
+    assert.deepEqual(results.map((r) => r.distance), [0.1, 0.2]);
+    assert.equal(meta.truncated, true);
+    assert.equal(meta.tokenEstimate, 4);
+});
+
+test("high-relevance-only: a single leading hit larger than the whole budget is dropped", () => {
+    const hits = [hit(chars(40), 0.1)]; // 10 tokens, budget 3
+    const { results, meta } = applyTokenBudget(hits, 3, "high-relevance-only");
+    assert.equal(results.length, 0);
+    assert.equal(meta.truncated, true);
+    assert.equal(meta.tokenEstimate, 0);
+});
+
+test("drop-tail: truncates the boundary hit (partial tail), unlike high-relevance-only", () => {
+    // hit sizes (tokens): [3, 4]; budget 5. high-relevance-only keeps [3] only.
+    // drop-tail keeps hit0 whole (3) then truncates hit1 to the remaining 2
+    // tokens (8 chars) → both hits present, payload fills to 5.
+    const hits = [hit(chars(12), 0.1), hit(chars(16), 0.2)]; // 3 and 4 tokens
+    const { results, meta } = applyTokenBudget(hits, 5, "drop-tail");
+    assert.equal(results.length, 2, "boundary hit is kept as a partial, not dropped");
+    assert.deepEqual(results.map((r) => r.distance), [0.1, 0.2]);
+    assert.equal([...results[0].text].length, 12, "first hit intact");
+    assert.equal([...results[1].text].length, 8, "second hit truncated to remaining budget");
+    assert.equal(meta.tokenEstimate, 5, "payload fills to the budget");
+    assert.equal(meta.truncated, true);
+
+    // Contrast: same inputs under high-relevance-only keep only the first hit.
+    const hro = applyTokenBudget(hits, 5, "high-relevance-only");
+    assert.equal(hro.results.length, 1, "high-relevance-only drops the boundary hit whole");
+    assert.notDeepEqual(
+        results.map((r) => [...r.text].length),
+        hro.results.map((r) => [...r.text].length),
+        "drop-tail and high-relevance-only must differ on this input",
+    );
+});
+
+test("drop-tail: single oversized leading hit is truncated to a partial (not dropped)", () => {
+    const hits = [hit(chars(40), 0.1)]; // 10 tokens, budget 3
+    const { results, meta } = applyTokenBudget(hits, 3, "drop-tail");
+    assert.equal(results.length, 1, "oversized single hit is kept, truncated");
+    assert.equal([...results[0].text].length, 12); // 3 tokens * 4 chars
+    assert.equal(meta.tokenEstimate, 3);
+    assert.equal(meta.truncated, true);
+});
+
+test("per-hit-cap: keeps every hit but shortens each to its share", () => {
+    // two hits of 40 chars (10 tokens each); budget 4 → perHit = 2 tokens = 8 chars.
+    const hits = [hit(chars(40), 0.1), hit(chars(40), 0.2)];
+    const { results, meta } = applyTokenBudget(hits, 4, "per-hit-cap");
+    assert.equal(results.length, 2, "all hits survive");
+    for (const r of results) assert.equal([...r.text].length, 8);
+    assert.equal(meta.truncated, true);
+    assert.ok(meta.tokenEstimate <= 4, "final estimate within budget");
+});
+
+test("per-hit-cap: more hits than tokens drops overflow rather than emitting empty text", () => {
+    // 3 hits, budget 2 → perHit = floor(2/3) = 0 → all dropped (no empty-text hits).
+    const hits = [hit(chars(8), 0.1), hit(chars(8), 0.2), hit(chars(8), 0.3)];
+    const { results, meta } = applyTokenBudget(hits, 2, "per-hit-cap");
+    assert.equal(results.length, 0);
+    assert.equal(meta.truncated, true);
+});
+
+test("mixed-size set: high-relevance-only fills greedily by order", () => {
+    // sizes (tokens): 1, 3, 1, 5 ; budget 5 → keep 1+3+1 = 5, drop the 5-token hit.
+    const hits = [
+        hit(chars(4), 0.1), // 1
+        hit(chars(12), 0.2), // 3
+        hit(chars(4), 0.3), // 1
+        hit(chars(20), 0.4), // 5
+    ];
+    const { results, meta } = applyTokenBudget(hits, 5, "high-relevance-only");
+    assert.deepEqual(results.map((r) => r.distance), [0.1, 0.2, 0.3]);
+    assert.equal(meta.tokenEstimate, 5);
+    assert.equal(meta.truncated, true);
+});
+
+test("Unicode payload: budgeting counts code points, keeps whole hits", () => {
+    // two hits of 8 emoji (8 code points → 2 tokens each); budget 2 → keep 1.
+    const emoji8 = "😀".repeat(8);
+    const hits = [hit(emoji8, 0.1), hit(emoji8, 0.2)];
+    const { results, meta } = applyTokenBudget(hits, 2);
+    assert.equal(results.length, 1);
+    assert.equal([...results[0].text].length, 8, "kept hit is intact, no split pair");
+    assert.equal(meta.tokenEstimate, 2);
+});
+
+test("zero budget → empty payload, truncated when there was content", () => {
+    const hits = [hit(chars(8), 0.1)];
+    const { results, meta } = applyTokenBudget(hits, 0);
+    assert.equal(results.length, 0);
+    assert.equal(meta.truncated, true);
+    assert.equal(meta.tokenEstimate, 0);
+});
+
+test("empty result set is never truncated", () => {
+    const { results, meta } = applyTokenBudget([], 100);
+    assert.equal(results.length, 0);
+    assert.equal(meta.truncated, false);
+    assert.equal(meta.tokenEstimate, 0);
+});
+
+test("NaN budget is treated as no-budget: payload unchanged, truncated:false", () => {
+    // Regression: a NaN budget must never keep everything AND claim truncation.
+    const hits = [hit(chars(8), 0.1), hit(chars(8), 0.2)];
+    const { results, meta } = applyTokenBudget(hits, NaN);
+    assert.deepEqual(results, hits, "NaN keeps the full payload");
+    assert.equal(meta.truncated, false, "NaN must not report truncation");
+    assert.equal(meta.tokenEstimate, 4);
+});
+
+test("Infinity budget is treated as no-budget: payload unchanged, truncated:false", () => {
+    const hits = [hit(chars(8), 0.1), hit(chars(8), 0.2)];
+    const { results, meta } = applyTokenBudget(hits, Infinity);
+    assert.deepEqual(results, hits);
+    assert.equal(meta.truncated, false);
+});
+
+test("dense custom counter (tokens > chars) still fits the budget and terminates", () => {
+    // A per-code-point CJK-style counter: 2 tokens per character. The estimate-
+    // derived char cap (maxTokens*4) exceeds the true answer, so the shrink loop
+    // must tighten it down without over/under-shooting.
+    const dense = (t) => [...t].length * 2;
+    // 10 CJK chars = 20 tokens; budget 6 → must cut to 3 chars (6 tokens).
+    const hits = [hit("漢".repeat(10), 0.1)];
+    const { results, meta } = applyTokenBudget(hits, 6, "per-hit-cap", dense);
+    assert.equal(results.length, 1);
+    assert.ok(dense(results[0].text) <= 6, "dense-counter payload stays within budget");
+    assert.equal([...results[0].text].length, 3, "cut to exactly the fitting char count");
+    assert.ok(meta.tokenEstimate <= 6);
+});
+
+test("fractional budget behaves consistently across strategies", () => {
+    // budget 2.5: high-relevance-only drops a 3-tok hit (0 results);
+    // per-hit-cap gives floor(2.5/2)=1 tok/hit; drop-tail truncates the tail.
+    const hits = [hit(chars(12), 0.1), hit(chars(12), 0.2)]; // 3 tokens each
+    const hro = applyTokenBudget(hits, 2.5, "high-relevance-only");
+    assert.equal(hro.results.length, 0, "3-tok hit does not fit a 2.5 budget");
+    assert.equal(hro.meta.tokenEstimate, 0);
+
+    const cap = applyTokenBudget(hits, 2.5, "per-hit-cap");
+    assert.equal(cap.results.length, 2);
+    for (const r of cap.results) assert.ok(estimateTokens(r.text) <= 1);
+});
+
+test("drop-tail and high-relevance-only converge when hits fill exactly", () => {
+    // Two 2-token hits, budget 4 → both fit whole under either strategy.
+    const hits = [hit(chars(8), 0.1), hit(chars(8), 0.2)];
+    const dt = applyTokenBudget(hits, 4, "drop-tail");
+    const hro = applyTokenBudget(hits, 4, "high-relevance-only");
+    assert.deepEqual(dt.results, hro.results, "identical when nothing straddles the budget");
+    assert.equal(dt.meta.truncated, false);
+    assert.equal(hro.meta.truncated, false);
+});
+
+test("custom exact counter is honored (word-count tokenizer)", () => {
+    // A toy exact counter: 1 token per whitespace-delimited word.
+    const wordCount = (t) => (t.trim() ? t.trim().split(/\s+/).length : 0);
+    const hits = [hit("one two three four five", 0.1)]; // 5 words
+    const { results, meta } = applyTokenBudget(hits, 3, "per-hit-cap", wordCount);
+    assert.ok(wordCount(results[0].text) <= 3, "custom counter drives the cap");
+    assert.ok(meta.tokenEstimate <= 3);
+});


### PR DESCRIPTION

## Summary

### Why
Recall returns raw text hits, but the SDK gives callers only coarse knobs (`limit`/`topK`) to control
how much they inject into a model context — hit count ≠ token count. Multi-session agents that recall
broadly overfill the context window, so today apps hand-roll their own tiktoken + truncation layer, or
lean on brittle prompt rules ("recall max 3 hits"). There's no SDK-level way to weigh a recall payload
or assert "this recall cost ≤ N tokens".

### What
First-class, client-side token budgeting on `recall()`:

- **`estimateTokens(text)` / `memwal.countTokens(text)`** — a lightweight token estimator (also
  exported standalone).
- **`recall({ maxTokens, truncationStrategy, countTokens })`** — trims the recalled memories to fit a
  token budget, with three strategies.
- **`RecallResult.meta { tokenEstimate, truncated }`** — the returned payload's estimated cost and
  whether anything was dropped/shortened. Present only when `maxTokens` is supplied.

### Solution
- **Zero-dependency estimator by default.** `estimateTokens` uses a documented character-based
  approximation (~`chars/4`, counting Unicode code points so emoji/CJK don't skew it). It's an
  estimate, not an exact BPE count — deterministic and CI-assertable. Callers needing exactness inject
  their own counter via `recall({ countTokens })` (e.g. a tiktoken binding). The issue explicitly
  sanctions "tiktoken **or** a documented approximation", so this keeps the SDK dependency-free while
  leaving exactness opt-in.
- **Three behaviorally-distinct truncation strategies:**
  - `high-relevance-only` (default) — keep the lowest-distance **whole** hits until the budget fills;
    drop the rest. Never a partial hit.
  - `drop-tail` — preserve order, keep whole hits from the front, then **truncate the single boundary
    hit** that straddles the budget (a partial tail) so the payload fills to the budget.
  - `per-hit-cap` — cap each hit's text to an equal share (`floor(maxTokens / hitCount)`); hits whose
    share rounds to zero are dropped rather than returned empty.
- **Client-side only.** Budgeting runs on already-decrypted hits, at the existing post-response filter
  seam next to `maxDistance`. No relayer, server, or on-chain change; no privacy-floor implication (it
  operates on plaintext the client already holds).
- **Backward compatible.** The budgeting block triggers only on `typeof maxTokens === "number"`.
  Omitting `maxTokens` returns the result byte-identical to before — no `meta` key, `results`/`total`
  untouched.
- **Malformed budgets never lie.** A non-finite budget (`NaN`/`Infinity`) is treated as no-budget
  (`truncated: false`), so a bad input can't report a truncation that didn't happen.

Scope note: this is the **core SDK** ask. Mirroring the same knobs onto the MCP `memwal_recall` tool
is called out in the issue as "optional but high-leverage" and is left as a follow-up. It's independent
of #567 (Vercel AI middleware pruning), which stays separately usable per that issue's triage.

## Types of Changes

- [ ] Breaking change (existing functionality would change)
- [x] New feature (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] Performance optimization
- [ ] Refactor (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Test
- [ ] Security / permission-scope change

## Benchmark impact

- [x] No benchmark-affecting change (write/infra only — this is a client-side SDK read-shaping option;
  it does not touch the relayer recall/answer/extraction path)
- [ ] Benchmarked: LOCOMO + LongMemEval, gpt-4o judge, eval_runs=3, vs baseline
- [x] Default-off / byte-identical when the option is omitted

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [ ] `cargo test` / harness tests pass (N/A — SDK-only change; SDK suite: 61/61 pass)

## Checklist

- [x] Follows the project's commit + code conventions
- [x] No ticket IDs / competitor names / local-doc paths in code comments
- [x] Docs updated if needed (JSDoc on all new public API)
- [x] Respects the privacy floor (no server-readable plaintext index — client-side only)
- [x] All new and existing tests pass

## Related

- Closes #592
- Related to #567 (Vercel AI middleware token pruning — kept independent), #528 / #271 (silent
  truncation / low default limit)
- Linear: none

