### PR TITLE
chore(release): prepare manual SDK version bumps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.6"
+      "version": "0.0.7"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.6"
+      "version": "0.0.7"
     }
   ]
 }

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,8 +28,16 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The MemWal MCP package (@mysten-incubation/memwal-mcp) changelog tracks releases from the initial 0.0.1 through 0.0.5. Key additions include the automatic memory plugin for Claude Code, Codex, Cursor, and Antigravity (0.0.5), proactive memory tools, memwal_remember_bulk and memwal_health tools, and fixes for plugin bundling and credential handling.
+  The latest MCP package release is 0.0.7. It reloads credentials after browser login, rejects stale credential handshakes and cross-account request replay, and reports bounded restore truncation explicitly.
 ---
+
+## 0.0.7
+
+### Fixed
+
+- Reload credentials after browser login without restarting the MCP client.
+- Reject stale handshakes and prevent request replay across account changes.
+- Report truncated restores and enforce the relayer's bounded restore limit.
 
 ## 0.0.6
 

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,15 +29,30 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The memwal changelog tracks all releases of the Walrus Memory Python SDK. Key milestones
-  include the 0.1.0 initial release with async/sync clients and middleware, 0.1.2 adding
-  max_distance to recall, 0.1.3 introducing RecallParams, and 0.1.4 adding temporal
-  anchoring with occurred_at for analyze methods.
+  The latest Python SDK release is 0.1.7. It adds deterministic async and sync mock clients and idempotency keys that make remember retries reuse the accepted paid job.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
 
 For the latest version, see the [PyPI project page](https://pypi.org/project/memwal/).
+
+## 0.1.7
+
+### Added
+
+- Added deterministic async and sync mock clients for credential-free tests.
+- Added idempotency keys to collapse retries onto one paid remember job.
+
+## 0.1.6
+
+### Added
+
+- Added flush helpers for pending middleware auto-saves.
+- Added `truncated` to restore results for incomplete recovery.
+
+### Fixed
+
+- Linked `AUTH_REJECTED` errors to troubleshooting guidance.
 
 ## 0.1.5
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,8 +28,31 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The MemWal TypeScript SDK changelog tracks releases from 0.0.1 (initial release with MemWal, MemWalManual, withMemWal, and account management) through 0.0.6 (RecallParams and deprecated positional recall). Key additions include bulk remember helpers, async job workflows, relayer compatibility checks, SEAL committee configuration, and per-request nonce signing for replay protection.
+  The latest TypeScript SDK release is 0.1.2. It adds deterministic offline mocks and idempotent remember retries, isolates foreign manual-recall blobs, safely encodes large encrypted payloads, and supports Zod 3 and Zod 4.
 ---
+
+## 0.1.2
+
+### Added
+
+- Added deterministic offline mock clients for credential-free tests.
+- Added idempotency keys to collapse retries onto one paid remember job.
+
+### Fixed
+
+- Isolated foreign manual-recall blobs and encoded large encrypted payloads safely.
+- Added Zod 3 and Zod 4 peer compatibility.
+
+## 0.1.1
+
+### Added
+
+- Added `flush()` for pending `withMemWal` auto-saves.
+- Added `truncated` to restore results for incomplete recovery.
+
+### Fixed
+
+- Linked `AUTH_REJECTED` errors to troubleshooting guidance.
 
 ## 0.1.0
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mysten-incubation/memwal-mcp
 
+## 0.0.7
+
+### Fixed
+
+- Reload credentials after browser login without restarting the MCP client.
+- Reject stale handshakes and prevent request replay across account changes.
+- Report truncated restores and enforce the relayer's bounded restore limit.
+
 ## 0.0.6
 
 ### Security

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,6 +4,10 @@ Walrus Memory MCP is a stdio Model Context Protocol server for Walrus Memory. It
 
 On first use, the package advertises a `memwal_login` tool to the MCP client. The agent can call it inline — no separate CLI command needed. The tool opens a browser-based wallet login flow and stores local credentials at `~/.memwal/credentials.json`. A matching `memwal_logout` tool clears the saved credentials.
 
+## Source and release ownership
+
+This directory is the canonical source for the MCP runtime, tests, versioning, and npm releases. The Claude Code marketplace package is maintained separately in [`CommandOSSLabs/walrus-memory-mcp-plugin`](https://github.com/CommandOSSLabs/walrus-memory-mcp-plugin) for transfer to MystenLabs. npm releases intentionally do not bundle a second marketplace-plugin copy.
+
 ## Quick Start
 
 Add Walrus Memory MCP to your MCP client config:

--- a/packages/mcp/TESTING.md
+++ b/packages/mcp/TESTING.md
@@ -206,7 +206,7 @@ What merging to `dev` triggers, and how to try the result end-to-end.
 
 | Surface | Trigger | Result |
 |---|---|---|
-| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.6-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
+| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.7-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
 | Plugin marketplace | none needed — `dev` is the repo's **default branch** | `/plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge |
 | Sidecar tools (Layer 1) | Railway image rebuild (`services/server/Dockerfile` copies `scripts/mcp/`) | New agentic descriptions + `memwal_remember_bulk`/`memwal_health` on `relayer.dev.memwal.ai` — **verify the Railway dev environment actually redeployed**; this is not a repo workflow |
 
@@ -262,5 +262,5 @@ Enable `codex_hooks = true`, restart Codex, repeat the Step 2 prompts.
 ### Step 5 — Promotion sanity (before merging dev → main later)
 
 - [ ] Prod relayer redeployed with the new sidecar (same Step 1 check against `relayer.memory.walrus.xyz`)
-- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.6-dev.N`; after main merge, `latest` = `0.0.6`
+- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.7-dev.N`; after main merge, `latest` = `0.0.7`
 - [ ] Mintlify docs published (the 6 provider pages + reference + changelog render, nav matches)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {
@@ -36,7 +36,6 @@
     },
     "files": [
         "dist",
-        "plugin",
         "README.md"
     ],
     "keywords": [

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # memwal
 
+## 0.1.7
+
+### Added
+
+- Added deterministic async and sync mock clients for credential-free tests.
+- Added idempotency keys to collapse retries onto one paid remember job.
+
 ## 0.1.6
 
 ### Added

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -120,4 +120,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/packages/python-sdk-memwal/memwal/mock.py
+++ b/packages/python-sdk-memwal/memwal/mock.py
@@ -114,15 +114,22 @@ class MemWalMock:
         await self.close()
 
     async def remember(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> RememberAcceptedResult:
+        del idempotency_key
         memory = self._store(text, namespace)
         return RememberAcceptedResult(job_id=memory.job_id, status="done")
 
     async def remember_async(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> RememberAcceptedResult:
-        return await self.remember(text, namespace)
+        return await self.remember(text, namespace, idempotency_key)
 
     async def wait_for_remember_job(
         self,
@@ -142,8 +149,9 @@ class MemWalMock:
         namespace: Optional[str] = None,
         poll_interval_ms: int = 1500,
         timeout_ms: int = 60_000,
+        idempotency_key: Optional[str] = None,
     ) -> RememberResult:
-        accepted = await self.remember(text, namespace)
+        accepted = await self.remember(text, namespace, idempotency_key)
         return await self.wait_for_remember_job(
             accepted.job_id, poll_interval_ms, timeout_ms
         )
@@ -448,13 +456,21 @@ class MemWalMockSync:
                 return pool.submit(asyncio.run, coro).result()
         return asyncio.run(coro)
 
-    def remember(self, text: str, namespace: Optional[str] = None) -> RememberAcceptedResult:
-        return self._run(self._inner.remember(text, namespace))
+    def remember(
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> RememberAcceptedResult:
+        return self._run(self._inner.remember(text, namespace, idempotency_key))
 
     def remember_async(
-        self, text: str, namespace: Optional[str] = None
+        self,
+        text: str,
+        namespace: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> RememberAcceptedResult:
-        return self.remember(text, namespace)
+        return self.remember(text, namespace, idempotency_key)
 
     def wait_for_remember_job(
         self,
@@ -479,6 +495,7 @@ class MemWalMockSync:
         namespace: Optional[str] = None,
         poll_interval_ms: int = 1500,
         timeout_ms: int = 60_000,
+        idempotency_key: Optional[str] = None,
     ) -> RememberResult:
         return self._run(
             self._inner.remember_and_wait(
@@ -486,6 +503,7 @@ class MemWalMockSync:
                 namespace,
                 poll_interval_ms=poll_interval_ms,
                 timeout_ms=timeout_ms,
+                idempotency_key=idempotency_key,
             )
         )
 

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python SDK for Walrus Memory — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/tests/test_mock.py
+++ b/packages/python-sdk-memwal/tests/test_mock.py
@@ -131,6 +131,8 @@ def test_sync_mock_wraps_core_flows_and_accepts_production_options():
 
 def test_sync_mock_polling_and_analyze_signatures_match_production():
     methods = (
+        "remember",
+        "remember_async",
         "wait_for_remember_job",
         "remember_and_wait",
         "wait_for_remember_jobs",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @mysten-incubation/memwal
 
+## 0.1.2
+
+### Added
+
+- Added deterministic offline mock clients for credential-free tests.
+- Added idempotency keys to collapse retries onto one paid remember job.
+
+### Fixed
+
+- Isolated foreign manual-recall blobs and encoded large encrypted payloads safely.
+- Added Zod 3 and Zod 4 peer compatibility.
+
 ## 0.1.1
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -110,7 +110,8 @@ export class MemWalMock {
 
     async rememberAsync(
         text: string,
-        namespace?: string
+        namespace?: string,
+        _options: { idempotencyKey?: string } = {}
     ): Promise<RememberAcceptedResult> {
         const memory = this.store(text, namespace);
         return { job_id: memory.jobId, status: "done" };
@@ -118,9 +119,10 @@ export class MemWalMock {
 
     async remember(
         text: string,
-        namespace?: string
+        namespace?: string,
+        options: { idempotencyKey?: string } = {}
     ): Promise<RememberAcceptedResult> {
-        return this.rememberAsync(text, namespace);
+        return this.rememberAsync(text, namespace, options);
     }
 
     async getRememberStatus(jobId: string): Promise<RememberJobStatus> {
@@ -147,9 +149,11 @@ export class MemWalMock {
     async rememberAndWait(
         text: string,
         namespace?: string,
-        opts: { pollIntervalMs?: number; timeoutMs?: number } = {}
+        opts: { pollIntervalMs?: number; timeoutMs?: number; idempotencyKey?: string } = {}
     ): Promise<RememberResult> {
-        const accepted = await this.rememberAsync(text, namespace);
+        const accepted = await this.rememberAsync(text, namespace, {
+            idempotencyKey: opts.idempotencyKey,
+        });
         return this.waitForRememberJob(accepted.job_id, opts);
     }
 

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const releases = [
+    {
+        name: "TypeScript SDK",
+        version: "0.1.2",
+        manifests: [["packages/sdk/package.json", "version"]],
+        changelogs: ["packages/sdk/CHANGELOG.md", "docs/sdk/changelog.mdx"],
+    },
+    {
+        name: "Python SDK",
+        version: "0.1.7",
+        manifests: [
+            ["packages/python-sdk-memwal/pyproject.toml", "toml-version"],
+            ["packages/python-sdk-memwal/memwal/__init__.py", "python-version"],
+        ],
+        changelogs: [
+            "packages/python-sdk-memwal/CHANGELOG.md",
+            "docs/python-sdk/changelog.mdx",
+        ],
+    },
+    {
+        name: "MCP package",
+        version: "0.0.7",
+        manifests: [
+            ["packages/mcp/package.json", "version"],
+            [".claude-plugin/marketplace.json", "plugin-version"],
+            [".cursor-plugin/marketplace.json", "plugin-version"],
+            ["packages/mcp/plugin/.claude-plugin/plugin.json", "version"],
+            ["packages/mcp/plugin/.codex-plugin/plugin.json", "version"],
+            ["packages/mcp/plugin/.cursor-plugin/plugin.json", "version"],
+            ["packages/mcp/plugin/plugin.json", "version"],
+        ],
+        changelogs: ["packages/mcp/CHANGELOG.md", "docs/mcp/changelog.mdx"],
+    },
+];
+
+for (const release of releases) {
+    for (const [path, kind] of release.manifests) {
+        const content = readFileSync(path, "utf8");
+        const actual = readVersion(content, kind);
+        if (actual !== release.version) {
+            throw new Error(`${path}: expected ${release.version}, received ${actual}`);
+        }
+    }
+    for (const path of release.changelogs) {
+        const content = readFileSync(path, "utf8");
+        if (!content.includes(`## ${release.version}\n`)) {
+            throw new Error(`${path}: missing release ${release.version}`);
+        }
+    }
+    console.log(`${release.name} ${release.version}: manifests and changelogs synchronized`);
+}
+
+const openClaw = JSON.parse(
+    readFileSync("packages/openclaw-memory-memwal/package.json", "utf8"),
+);
+if (openClaw.version !== "0.0.5") {
+    throw new Error(`OpenClaw: expected unchanged 0.0.5, received ${openClaw.version}`);
+}
+console.log("OpenClaw 0.0.5: unchanged (no package changes in this promotion)");
+
+function readVersion(content, kind) {
+    if (kind === "version") return JSON.parse(content).version;
+    if (kind === "plugin-version") return JSON.parse(content).plugins[0].version;
+    if (kind === "toml-version") return match(content, /^version = "([^"]+)"$/m);
+    if (kind === "python-version") return match(content, /^__version__ = "([^"]+)"$/m);
+    throw new Error(`Unknown version reader: ${kind}`);
+}
+
+function match(content, pattern) {
+    const result = pattern.exec(content);
+    if (!result) throw new Error(`Could not read version with ${pattern}`);
+    return result[1];
+}


### PR DESCRIPTION
## Summary

Prepare every changed SDK package for the team's manual-version release flow before promoting `dev`.

- bump `@mysten-incubation/memwal` from `0.1.1` to `0.1.2`
- bump Python `memwal` from `0.1.6` to `0.1.7`, including `__version__`
- bump `@mysten-incubation/memwal-mcp` from `0.0.6` to `0.0.7`
- keep OpenClaw at `0.0.5` because it has no package changes in this promotion
- synchronize package changelogs, public docs changelogs, and existing monorepo plugin/marketplace version references
- stop future MCP npm tarballs from bundling a duplicate marketplace plugin; the plugin-only handoff lives in `CommandOSSLabs/walrus-memory-mcp-plugin`
- add a release consistency verifier

The release notes cover all package changes since `staging` while remaining intentionally concise: offline mocks, idempotent remember retries, manual recall/base64 fixes, Zod 3/4 compatibility, live MCP credential refresh/account isolation, and bounded restore truncation.

## Validation

- release consistency verifier passed
- TypeScript SDK typecheck/build and 31/31 tests passed
- MCP typecheck/build and 10/10 tests passed
- MCP dry-run tarball: 38 runtime files, no `plugin/` copy
- Python legacy suite: 95/95 passed
- Python focused client/mock suite: 47/47 passed
- Python 0.1.7 sdist/wheel built; wheel contains `memwal/mock.py`
- TypeScript SDK dry-run tarball reports 0.1.2
- `git diff --check` passed

## Release ordering

Merge this PR into `dev` before refreshing the `dev → staging` promotion. The promotion must rerun CI and receive exact-head approval after this commit is included.
