### PR TITLE
fix(remember,researcher): lock-contention backoff, error persistence, and same-origin check

### DIFF
--- a/apps/chatbot/app/(chat)/api/chat/route.ts
+++ b/apps/chatbot/app/(chat)/api/chat/route.ts
@@ -213,9 +213,21 @@ export async function POST(request: Request) {
         );
 
         if (titlePromise) {
-          const title = await titlePromise;
-          dataStream.write({ type: "data-chat-title", data: title });
-          updateChatTitleById({ chatId: id, title });
+          try {
+            const title = await titlePromise;
+            dataStream.write({ type: "data-chat-title", data: title });
+            updateChatTitleById({ chatId: id, title });
+          } catch (error) {
+            // Title generation is a non-fatal side effect of the response
+            // already being streamed below it (dataStream.merge above).
+            // Left unguarded, a title-model failure (bad slug, no credits,
+            // upstream 5xx) threw here and was caught by createUIMessageStream's
+            // own onError below, which turned an unrelated, recoverable
+            // title-gen failure into a fatal "error" part on the whole chat
+            // response — even though the real answer above continued to
+            // stream successfully. The chat still works without a title.
+            console.error("[chat] title generation failed:", error);
+          }
         }
       },
       generateId: generateUUID,
@@ -257,6 +269,7 @@ export async function POST(request: Request) {
         }
       },
       onError: (error) => {
+        console.error("[chat] stream execute() error:", error);
         if (
           error instanceof Error &&
           error.message?.includes(

--- a/apps/researcher/lib/auth/request-security.ts
+++ b/apps/researcher/lib/auth/request-security.ts
@@ -1,31 +1,27 @@
-/**
- * Reject cross-origin state-changing browser requests.
- *
- * Compares the `Origin` header's host against `Host`/`X-Forwarded-Host`
- * rather than `request.url`'s parsed origin. Behind a TLS-terminating proxy
- * (Railway) `request.url` reflects whatever internal host the app's server
- * constructed its request object from, which does not reliably match the
- * public origin the browser sent — that mismatch made this check reject
- * every same-origin request in production, including ones with a perfectly
- * matching `Origin` header. `Host`/`X-Forwarded-Host` are the two headers a
- * proxy is expected to forward, so they hold regardless of deployment
- * topology; this is the standard OWASP CSRF "verify Origin against Host"
- * pattern.
- */
+/** Reject cross-origin state-changing browser requests. */
 export function isSameOriginRequest(request: Request): boolean {
-  const origin = request.headers.get("origin");
-  if (!origin) {
-    return false;
-  }
-
-  const host =
-    request.headers.get("x-forwarded-host") ?? request.headers.get("host");
-  if (!host) {
+  const originHeader = request.headers.get("origin");
+  const host = request.headers.get("host");
+  if (!originHeader || !host) {
     return false;
   }
 
   try {
-    return new URL(origin).host === host;
+    const origin = new URL(originHeader);
+    if (origin.host !== host) {
+      return false;
+    }
+
+    // Production requests must originate from HTTPS. Keep HTTP available only
+    // for local development; forwarded headers are intentionally ignored here
+    // because they are client-spoofable without a trusted-proxy boundary.
+    return (
+      origin.protocol === "https:" ||
+      (origin.protocol === "http:" &&
+        (origin.hostname === "localhost" ||
+          origin.hostname === "127.0.0.1" ||
+          origin.hostname === "[::1]"))
+    );
   } catch {
     return false;
   }

--- a/apps/researcher/lib/auth/request-security.ts
+++ b/apps/researcher/lib/auth/request-security.ts
@@ -1,12 +1,31 @@
-/** Reject cross-origin state-changing browser requests. */
+/**
+ * Reject cross-origin state-changing browser requests.
+ *
+ * Compares the `Origin` header's host against `Host`/`X-Forwarded-Host`
+ * rather than `request.url`'s parsed origin. Behind a TLS-terminating proxy
+ * (Railway) `request.url` reflects whatever internal host the app's server
+ * constructed its request object from, which does not reliably match the
+ * public origin the browser sent — that mismatch made this check reject
+ * every same-origin request in production, including ones with a perfectly
+ * matching `Origin` header. `Host`/`X-Forwarded-Host` are the two headers a
+ * proxy is expected to forward, so they hold regardless of deployment
+ * topology; this is the standard OWASP CSRF "verify Origin against Host"
+ * pattern.
+ */
 export function isSameOriginRequest(request: Request): boolean {
   const origin = request.headers.get("origin");
   if (!origin) {
     return false;
   }
 
+  const host =
+    request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  if (!host) {
+    return false;
+  }
+
   try {
-    return new URL(origin).origin === new URL(request.url).origin;
+    return new URL(origin).host === host;
   } catch {
     return false;
   }

--- a/apps/researcher/lib/auth/request-security.unit.test.ts
+++ b/apps/researcher/lib/auth/request-security.unit.test.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { isSameOriginRequest } from "./request-security";
 
-test("Researcher state-changing auth requests require an exact Origin", () => {
+test("accepts an exact HTTPS Origin and Host", () => {
   assert.equal(
     isSameOriginRequest(
-      new Request("https://researcher.example/api/auth/key", {
+      new Request("http://internal.railway.internal:8080/api/auth/key", {
         headers: {
           origin: "https://researcher.example",
           host: "researcher.example",
@@ -14,6 +14,9 @@ test("Researcher state-changing auth requests require an exact Origin", () => {
     ),
     true
   );
+});
+
+test("fails closed for missing or mismatched origin headers", () => {
   assert.equal(
     isSameOriginRequest(
       new Request("https://researcher.example/api/auth/key", {
@@ -43,32 +46,39 @@ test("Researcher state-changing auth requests require an exact Origin", () => {
   );
 });
 
-test("matches against Host/X-Forwarded-Host, not request.url's own host — behind a reverse proxy request.url reflects the internal host, not the public one the Origin header names", () => {
-  // Same shape as the production bug: the app's internal request.url host
-  // ("internal.railway.internal") differs from the public origin the
-  // browser sent, but the Origin still matches what the proxy forwarded as
-  // Host/X-Forwarded-Host, so the request must be accepted.
+test("ignores a spoofed X-Forwarded-Host", () => {
   assert.equal(
     isSameOriginRequest(
-      new Request("http://internal.railway.internal:8080/api/auth/key", {
+      new Request("https://researcher.example/api/auth/key", {
         headers: {
-          origin: "https://researcher-demo-staging.memory.walrus.xyz",
-          host: "researcher-demo-staging.memory.walrus.xyz",
+          origin: "https://attacker.example",
+          host: "researcher.example",
+          "x-forwarded-host": "attacker.example",
         },
       })
     ),
-    true
+    false
   );
 });
 
-test("X-Forwarded-Host takes precedence over Host when a proxy sets both", () => {
+test("rejects HTTP origins outside loopback", () => {
   assert.equal(
     isSameOriginRequest(
-      new Request("https://internal.example/api/auth/key", {
+      new Request("https://researcher.example/api/auth/key", {
         headers: {
-          origin: "https://researcher.example",
-          host: "internal.example",
-          "x-forwarded-host": "researcher.example",
+          origin: "http://researcher.example",
+          host: "researcher.example",
+        },
+      })
+    ),
+    false
+  );
+  assert.equal(
+    isSameOriginRequest(
+      new Request("http://localhost:3000/api/auth/key", {
+        headers: {
+          origin: "http://localhost:3000",
+          host: "localhost:3000",
         },
       })
     ),

--- a/apps/researcher/lib/auth/request-security.unit.test.ts
+++ b/apps/researcher/lib/auth/request-security.unit.test.ts
@@ -6,7 +6,10 @@ test("Researcher state-changing auth requests require an exact Origin", () => {
   assert.equal(
     isSameOriginRequest(
       new Request("https://researcher.example/api/auth/key", {
-        headers: { origin: "https://researcher.example" },
+        headers: {
+          origin: "https://researcher.example",
+          host: "researcher.example",
+        },
       })
     ),
     true
@@ -14,15 +17,61 @@ test("Researcher state-changing auth requests require an exact Origin", () => {
   assert.equal(
     isSameOriginRequest(
       new Request("https://researcher.example/api/auth/key", {
-        headers: { origin: "https://attacker.example" },
+        headers: {
+          origin: "https://attacker.example",
+          host: "researcher.example",
+        },
       })
     ),
     false
   );
   assert.equal(
     isSameOriginRequest(
-      new Request("https://researcher.example/api/auth/key")
+      new Request("https://researcher.example/api/auth/key", {
+        headers: { host: "researcher.example" },
+      })
     ),
     false
+  );
+  assert.equal(
+    isSameOriginRequest(
+      new Request("https://researcher.example/api/auth/key", {
+        headers: { origin: "https://researcher.example" },
+      })
+    ),
+    false
+  );
+});
+
+test("matches against Host/X-Forwarded-Host, not request.url's own host — behind a reverse proxy request.url reflects the internal host, not the public one the Origin header names", () => {
+  // Same shape as the production bug: the app's internal request.url host
+  // ("internal.railway.internal") differs from the public origin the
+  // browser sent, but the Origin still matches what the proxy forwarded as
+  // Host/X-Forwarded-Host, so the request must be accepted.
+  assert.equal(
+    isSameOriginRequest(
+      new Request("http://internal.railway.internal:8080/api/auth/key", {
+        headers: {
+          origin: "https://researcher-demo-staging.memory.walrus.xyz",
+          host: "researcher-demo-staging.memory.walrus.xyz",
+        },
+      })
+    ),
+    true
+  );
+});
+
+test("X-Forwarded-Host takes precedence over Host when a proxy sets both", () => {
+  assert.equal(
+    isSameOriginRequest(
+      new Request("https://internal.example/api/auth/key", {
+        headers: {
+          origin: "https://researcher.example",
+          host: "internal.example",
+          "x-forwarded-host": "researcher.example",
+        },
+      })
+    ),
+    true
   );
 });

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -349,7 +349,6 @@ fn congestion_backoff_secs(requeues: u32) -> u64 {
 }
 
 /// Exponential back-off: attempt 1→2s, 2→4s, 3→8s, 4→16s, 5→32s.
-#[allow(dead_code)]
 pub fn backoff_duration(attempt: u32) -> std::time::Duration {
     std::time::Duration::from_secs(2u64.pow(attempt))
 }
@@ -1396,14 +1395,37 @@ async fn execute_upload_and_transfer(
         match lock_outcome(acquired, jid) {
             LockOutcome::Proceed(lock) => Some(lock),
             // Deferred or fail-closed: in BOTH cases we must NOT upload — return
-            // the retriable error so Apalis re-tries later (by which point the
-            // holder will have persisted `uploaded`, or the pool is reachable).
+            // the retriable error so Apalis re-tries later, by which point the
+            // holder should have persisted `uploaded`, or the pool should be
+            // reachable again.
+            //
+            // "Later" is not automatic: no WorkerBuilder in main.rs attaches a
+            // retry/backoff layer, so a bare `Err` here gets re-polled almost
+            // immediately (observed on staging: all 5 attempts of one job
+            // exhausted in ~124ms). That races the actual lock holder — a real
+            // upload can take seconds — and burns the whole attempt budget
+            // before the holder has any chance to finish, leaving the row
+            // silently `running` with no error_msg until the unrelated
+            // 10-minute staleness sweep force-fails it. Sleep with the
+            // existing (previously unused) exponential backoff before
+            // returning, and persist a visible error_msg immediately instead
+            // of leaving the row silent for the sweep to eventually catch.
             LockOutcome::Defer(err) => {
                 tracing::warn!(
-                    "[wallet-job:upload] job_id={} deferring upload: {}",
+                    "[wallet-job:upload] job_id={} deferring upload (attempt {}/{}): {}",
                     jid,
+                    attempt_info.current,
+                    attempt_info.max,
                     err,
                 );
+                update_remember_job_after_wallet_error(
+                    state,
+                    Some(jid.as_str()),
+                    &err,
+                    &err.to_string(),
+                )
+                .await;
+                tokio::time::sleep(backoff_duration(attempt_info.current as u32)).await;
                 return Err(err);
             }
         }
@@ -2356,9 +2378,13 @@ async fn maybe_alert_walrus_upload_exhausted(
 
 /// Failure classification for `WalletJob` handlers.
 ///
-/// Apalis re-queues with exponential backoff on `Transient`. `Permanent`
-/// errors are returned as-is so the job is marked Dead immediately and we
-/// don't burn retry budget on inputs that can never succeed.
+/// Apalis re-queues `Transient` for another attempt, up to `MAX_ATTEMPTS`.
+/// No WorkerBuilder attaches a retry/backoff layer, so that re-queue has no
+/// inherent delay — callers that need real spacing between attempts (lock
+/// contention, congestion) must enforce it themselves (see `backoff_duration`,
+/// `congestion_backoff_secs`). `Permanent` errors are returned as-is so the
+/// job is marked Dead immediately and we don't burn retry budget on inputs
+/// that can never succeed.
 ///
 /// Mapping rules (enforced at the point of error origination):
 /// - `MoveAbort(_)` → `Permanent` (deterministic Move-level failure)
@@ -2802,7 +2828,7 @@ mod tests {
     use sqlx::postgres::PgPoolOptions;
 
     use super::{
-        build_resume_transfer_job, classify_wallet_remember_handoff_failure,
+        backoff_duration, build_resume_transfer_job, classify_wallet_remember_handoff_failure,
         congestion_backoff_secs, consume_preparation_claim, escalate_if_gas_pool_exhausted,
         gas_pool_exhaustion_threshold, is_walrus_package_version_mismatch, load_upload_journal,
         lock_outcome, mark_remember_job_failed, parse_locked_object_info,
@@ -2948,6 +2974,19 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
             classified,
             WalletJobError::UploadSlotCongestion(_)
         ));
+    }
+
+    #[test]
+    fn lock_defer_backoff_matches_documented_schedule() {
+        // 1→2s, 2→4s, 3→8s, 4→16s, 5→32s — see backoff_duration's doc comment.
+        // Wired into the lock-contention Defer path so a job that repeatedly
+        // loses the per-job advisory lock gets real spacing between attempts
+        // instead of exhausting MAX_ATTEMPTS in milliseconds.
+        assert_eq!(backoff_duration(1), std::time::Duration::from_secs(2));
+        assert_eq!(backoff_duration(2), std::time::Duration::from_secs(4));
+        assert_eq!(backoff_duration(3), std::time::Duration::from_secs(8));
+        assert_eq!(backoff_duration(4), std::time::Duration::from_secs(16));
+        assert_eq!(backoff_duration(5), std::time::Duration::from_secs(32));
     }
 
     #[test]

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1698,7 +1698,7 @@ async fn execute_upload_and_transfer_locked(
     );
 
     if let Some(ref jid) = remember_job_id {
-        return execute_durable_upload(
+        return match execute_durable_upload(
             state,
             wallet_index,
             &encrypted,
@@ -1713,7 +1713,46 @@ async fn execute_upload_and_transfer_locked(
             jid,
             epochs,
         )
-        .await;
+        .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                // execute_durable_upload's own error path does not classify
+                // or persist to remember_jobs (see its doc comment) — do both
+                // here, mirroring the base64-decode-failure handling just
+                // above. Without this, a durable-upload failure was silently
+                // dropped: remember_jobs stayed at status='running' with no
+                // error_msg until the unrelated 10-minute staleness sweep in
+                // fail_stale_remember_jobs() eventually force-failed it,
+                // making every such failure look "stuck" for up to ~25
+                // minutes (MAX_ATTEMPTS retries at the 300s sidecar timeout)
+                // instead of surfacing immediately.
+                // execute_durable_upload only ever returns `Transient` today;
+                // unwrap its inner (unprefixed) message so classify_sidecar_error
+                // sees the raw sidecar/HTTP error text, not WalletJobError's
+                // Display-wrapped "wallet job error (transient): ..." form.
+                let msg = match &err {
+                    WalletJobError::Transient(m) => m.clone(),
+                    other => other.to_string(),
+                };
+                let classified = WalletJobError::classify_sidecar_error(&msg);
+                update_remember_job_after_wallet_error(
+                    state,
+                    Some(jid.as_str()),
+                    &classified,
+                    &msg,
+                )
+                .await;
+                tracing::error!(
+                    "[wallet-job:upload] job_id={} {} classification={} retryable={}",
+                    jid,
+                    msg,
+                    classified.kind(),
+                    !classified.aborts_retries()
+                );
+                Err(classified)
+            }
+        };
     }
 
     // Legacy untracked jobs retain the atomic sidecar route.

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -1305,7 +1305,7 @@ async fn execute_durable_upload(
             journal,
         )
         .await
-        .map_err(|e| WalletJobError::Transient(e.to_string()))?;
+        .map_err(|e| WalletJobError::classify_sidecar_error(&e.to_string()))?;
 
         match advanced {
             DurableUploadAdvance::Prepared(next) => {
@@ -1739,40 +1739,21 @@ async fn execute_upload_and_transfer_locked(
         {
             Ok(()) => Ok(()),
             Err(err) => {
-                // execute_durable_upload's own error path does not classify
-                // or persist to remember_jobs (see its doc comment) — do both
-                // here, mirroring the base64-decode-failure handling just
-                // above. Without this, a durable-upload failure was silently
-                // dropped: remember_jobs stayed at status='running' with no
-                // error_msg until the unrelated 10-minute staleness sweep in
-                // fail_stale_remember_jobs() eventually force-failed it,
-                // making every such failure look "stuck" for up to ~25
-                // minutes (MAX_ATTEMPTS retries at the 300s sidecar timeout)
-                // instead of surfacing immediately.
-                // execute_durable_upload only ever returns `Transient` today;
-                // unwrap its inner (unprefixed) message so classify_sidecar_error
-                // sees the raw sidecar/HTTP error text, not WalletJobError's
-                // Display-wrapped "wallet job error (transient): ..." form.
-                let msg = match &err {
-                    WalletJobError::Transient(m) => m.clone(),
-                    other => other.to_string(),
-                };
-                let classified = WalletJobError::classify_sidecar_error(&msg);
-                update_remember_job_after_wallet_error(
-                    state,
-                    Some(jid.as_str()),
-                    &classified,
-                    &msg,
-                )
-                .await;
+                // Sidecar failures are classified where they originate inside
+                // execute_durable_upload. Preserve that classification here:
+                // journal/state validation can already return Permanent, and
+                // reclassifying its display text would incorrectly make it
+                // retryable and leave the polling row running.
+                let msg = err.message().to_string();
+                update_remember_job_after_wallet_error(state, Some(jid.as_str()), &err, &msg).await;
                 tracing::error!(
                     "[wallet-job:upload] job_id={} {} classification={} retryable={}",
                     jid,
                     msg,
-                    classified.kind(),
-                    !classified.aborts_retries()
+                    err.kind(),
+                    !err.aborts_retries()
                 );
-                Err(classified)
+                Err(err)
             }
         };
     }
@@ -2441,6 +2422,17 @@ pub enum WalletJobError {
 }
 
 impl WalletJobError {
+    fn message(&self) -> &str {
+        match self {
+            WalletJobError::Transient(msg)
+            | WalletJobError::Permanent(msg)
+            | WalletJobError::WalrusBalanceLow(msg)
+            | WalletJobError::ObjectLockedUntilEpoch(msg)
+            | WalletJobError::GasPoolExhausted(msg)
+            | WalletJobError::UploadSlotCongestion(msg) => msg,
+        }
+    }
+
     pub fn kind(&self) -> &'static str {
         match self {
             WalletJobError::Transient(_) => "transient",
@@ -2829,14 +2821,14 @@ mod tests {
 
     use super::{
         backoff_duration, build_resume_transfer_job, classify_wallet_remember_handoff_failure,
-        congestion_backoff_secs, consume_preparation_claim, escalate_if_gas_pool_exhausted,
-        gas_pool_exhaustion_threshold, is_walrus_package_version_mismatch, load_upload_journal,
-        lock_outcome, mark_remember_job_failed, parse_locked_object_info,
-        parse_wal_balance_alert_info, persist_upload_journal, persist_uploaded_state,
-        recovery_seal_persistence, upload_resume_disposition, wallet_index_for_upload_attempt,
-        wallet_job_request, JobUploadLock, LockOutcome, UploadResume, WalletJob,
-        WalletJobAttemptInfo, WalletJobError, WalletOperation, MAX_ATTEMPTS,
-        MAX_CONGESTION_REQUEUES,
+        congestion_backoff_secs, consume_preparation_claim, durable_step_field,
+        escalate_if_gas_pool_exhausted, gas_pool_exhaustion_threshold,
+        is_walrus_package_version_mismatch, load_upload_journal, lock_outcome,
+        mark_remember_job_failed, parse_locked_object_info, parse_wal_balance_alert_info,
+        persist_upload_journal, persist_uploaded_state, recovery_seal_persistence,
+        upload_resume_disposition, wallet_index_for_upload_attempt, wallet_job_request,
+        JobUploadLock, LockOutcome, UploadResume, WalletJob, WalletJobAttemptInfo, WalletJobError,
+        WalletOperation, MAX_ATTEMPTS, MAX_CONGESTION_REQUEUES,
     };
     use crate::storage::walrus::{
         PreparedRegisterTransaction, UploadExecutionIdentity, UploadJournal,
@@ -2974,6 +2966,20 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
             classified,
             WalletJobError::UploadSlotCongestion(_)
         ));
+    }
+
+    #[test]
+    fn durable_upload_preserves_preclassified_errors() {
+        let permanent = durable_step_field(&serde_json::json!({}), "blobId").unwrap_err();
+        assert!(matches!(permanent, WalletJobError::Permanent(_)));
+        assert!(permanent.aborts_retries());
+        assert_eq!(
+            permanent.message(),
+            "durable upload step is missing required field blobId"
+        );
+
+        let sidecar = WalletJobError::classify_sidecar_error(PROD_CONGESTION_ERROR);
+        assert!(matches!(sidecar, WalletJobError::UploadSlotCongestion(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three fixes, bundled into one branch per review: two independent root causes for the same "remember() never completes" staging symptom, plus an unrelated auth bug (Researcher login 403) found during the same verification pass.

## Fix 1 — durable-upload error path never wrote to `remember_jobs`

`execute_durable_upload`'s error path returned an unclassified `WalletJobError::Transient` without ever writing to `remember_jobs`. Every other `WalletOperation` arm classifies its sidecar errors and updates the row on failure, but the `UploadAndTransfer` durable-upload path just propagated the bare error straight through, so no code path anywhere persisted a terminal (or even intermediate) state for it.

Routes the failure through `WalletJobError::classify_sidecar_error()` + `update_remember_job_after_wallet_error()` at the `execute_durable_upload` call site, mirroring the pattern already used for `SetMetadataAndTransfer` and the base64-decode-failure case immediately above this call site.

**Scope, as originally noted here:** this closes the "no DB write on failure, ever" gap for genuine upload failures. It does not force an immediate `failed` status on the final attempt for errors that classify as retryable — those still rely on the 10-minute staleness sweep as a backstop. Fix 2 below addresses one specific, dominant instance of that remaining gap.

## Fix 2 — lock-contention retries burned the whole attempt budget in ~124ms, and never went through Fix 1 at all

Re-investigated after finding a second, independent analysis of the same staging job (`355df946`) that pointed at a different mechanism than Fix 1. Verified it directly against source:

- `execute_upload_and_transfer` acquires a per-job Postgres advisory lock (`JobUploadLock`, guarding against Apalis's orphan-reenqueue racing two attempts of the same job). On contention or an unreachable lock pool, `lock_outcome` returns `LockOutcome::Defer(Transient(...))`, and this function returns that error **immediately** — before `execute_upload_and_transfer_locked` (where Fix 1 lives) is ever called. Fix 1 never engages on this path.
- The comment above that `return Err(err)` assumed "Apalis re-tries later" with backoff. No `WorkerBuilder` in `main.rs` attaches a retry/backoff layer — a bare `Err` gets re-polled almost immediately. Observed on staging: all 5 attempts of job `355df946` exhausted in **~124ms**, nowhere near enough time for the actual lock-holding attempt (a real Walrus upload) to finish. The row was left at `status='running'` with no `error_msg` until the unrelated 10-minute staleness sweep force-failed it.
- `backoff_duration()` — a documented exponential backoff helper (2s/4s/8s/16s/32s) — already existed in this file but was dead code (`#[allow(dead_code)]`), never called anywhere.

Wires `backoff_duration(attempt_info.current)` into the `LockOutcome::Defer` branch via `tokio::time::sleep` before returning, and persists an informative `error_msg` on every deferred attempt (previously none was ever written on this path) so the row isn't silently blank while it waits.

Compiled clean; 55/55 `jobs.rs` tests pass, including a new `lock_defer_backoff_matches_documented_schedule` regression test pinning the exact 2/4/8/16/32s schedule.

## Fix 3 — Researcher: `isSameOriginRequest` rejected every same-origin request in production

Found while verifying staging: all 4 Researcher auth routes (`enoki/challenge`, `enoki`, `key`, `signout`) returned 403 `"Invalid request origin"` for every login method. Reproduced directly against staging — `POST /api/auth/enoki/challenge` with `Origin: https://researcher-demo-staging.memory.walrus.xyz` (the exact, correctly-matching public origin) still returned 403.

`isSameOriginRequest` compared the `Origin` header against `new URL(request.url).origin`. Behind Railway's reverse proxy, `request.url` reflects whatever internal host the standalone Next.js server's request object was constructed from — not the public domain the browser's `Origin` header names. Fixed to compare `Origin`'s host against `Host`/`X-Forwarded-Host` instead — the two headers a reverse proxy is expected to forward, and the standard OWASP CSRF "verify Origin against Host" pattern, independent of deployment topology.

6/6 Researcher unit tests pass, including two new regression tests reproducing the exact bug pattern.

## Test plan

- [x] `cargo check` on `services/server` — compiles clean
- [x] `cargo test` on `services/server` jobs:: — 55/55 pass
- [x] `node --test` on `apps/researcher` lib/auth — 6/6 pass, `pnpm run test:unit` full suite green
- [x] Reproduced the Researcher 403 directly against staging before and confirmed the fix's logic against the actual failure headers
- [ ] Deploy to staging and reproduce the original stuck-`remember()` scenario end-to-end to confirm jobs now resolve (not just that the row gets a real `error_msg`)
- [ ] Confirm no behavior change for the already-passing legacy (`remember_job_id: None`) upload path


## Update — this is a live production incident, not just a staging blocker

Investigated why `researcher.demo.memwal.ai` (production) still logs in via delegate key while staging/dev reject every method with "Invalid request origin." Confirmed directly against `origin/main` and via curl:

- `origin/main`'s `apps/researcher/lib/auth/request-security.ts` has the **exact same broken `isSameOriginRequest`** as this branch's pre-fix state (`new URL(request.url).origin` comparison).
- On `main`, only `enoki/challenge`, `enoki`, and `signout` routes call it — `key/route.ts` (delegate-key login) does not yet. That check was added to `key/route.ts` on `dev`/staging only, as part of what this promotion is testing — so delegate-key login on production simply isn't gated by this bug yet.
- The other 3 routes **are** gated on `main`, and curling production directly with a perfectly-matching `Origin` confirms they're **currently 403ing in production right now**: `enoki/challenge` → 403, `enoki` → 403, `signout` → 403, `key` → 400 (different, unrelated validation error, not gated).
- The check was introduced on `main` in `cef97282` (2026-07-31) — so Google/Enoki sign-in and sign-out have been broken in production for roughly two weeks.

The fix in this PR is in the shared `request-security.ts` function, so it resolves this for all 4 routes, everywhere, once it reaches `main` through the normal `dev → staging → main` pipeline. Flagging because that pipeline may not be fast enough for an already-live incident — worth a call on whether this specific fix should also go directly to `main` ahead of the rest of this promotion.


## Fix 4 — chatbot: title-generation failure was crashing the whole chat response

Isolated via controlled A/B live reproduction on `chatbot-demo-staging` (not a guess, not a static-analysis hypothesis): a brand-new chat always produced a premature `error` part in the response stream right after `start`; the identical prompt in an existing chat never did. The only conditional code differing between the two cases is `titlePromise` (`route.ts:112-127`, only set for brand-new chats). Toggling Memory on/off made no difference either way, since title generation is unrelated to `useMemWal` — this is why the earlier report couldn't tie the crash to the memory layer.

`await titlePromise` (`route.ts:216`, sourcing `actions.ts`'s `generateTitleFromUserMessage` → `generateText({model: getTitleModel(), ...})`) was unguarded. A title-model failure threw straight into `createUIMessageStream`'s `onError`, which mislabeled a non-fatal, unrelated title-generation failure as a fatal chat error — even though the real answer kept streaming successfully underneath it. Wrapped the title block in its own try/catch: a title failure now just means the chat has no auto-generated title, not a crash. Also added `console.error` logging to `onError` itself, which previously logged nothing at all (the actual reason this needed live A/B reproduction instead of a one-line log read).

`tsc --noEmit` clean on the changed file.

Separately found, not yet acted on: staging's chatbot Railway var is named `MEMWAL_KEY`, not `MEMWAL_PRIVATE_KEY` (the name the code has read since commit `9758fc00`, "MEM-62 remove MEMWAL_KEY fallback") — a leftover from before that rename. Not fixing this: an earlier investigation in this same PR's history concluded the shared-key fallback is deliberately not meant to be wired into this public demo (BYOK-first design, avoids an operator-funded write sink open to any self-issued guest session) — renaming the var would just re-enable that. Flagging only for awareness.


## Operational fix (not in this diff) — dev's Researcher + Noter frontends pointed at the wrong on-chain package

Not a code change, so not part of this PR's diff — noting here for traceability since this PR is the running log for everything found in this review.

After the origin-check + Redis fixes above unblocked the auth pipeline on `researcher-frontend`/dev, real-account testing hit `"Object is not a configured MemWalAccount"` (`apps/researcher/lib/auth/delegate-account.ts`'s `assertDelegateAccountBinding`, which checks the on-chain account object's Move type against the app's configured package ID). Checked `MEMWAL_PACKAGE_ID`/`MEMWAL_REGISTRY_ID` across every `dev` service via Railway CLI: `relayer`, `indexer`, and `app` (the main dashboard) all agree on one pair of IDs; `researcher-frontend` and `noter-frontend` on `dev` both had a *different* pair — matching staging's values instead, not dev's own relayer's. Same mistake on both services, almost certainly copy-pasted from staging's config when dev was provisioned and never updated.

Fixed: set `NEXT_PUBLIC_MEMWAL_PACKAGE_ID` + `NEXT_PUBLIC_MEMWAL_REGISTRY_ID` on both services to match `relayer`/dev. Both redeployed, confirmed back online. Not yet confirmed with a real login (needs a human — see the standing note on private keys elsewhere in this PR's history). Staging/production not checked yet for the same drift.


## Both review blockers fixed — by the reviewer directly, on this branch

`ducnmm` (author of #601, and this PR's reviewer) pushed `520f4672` directly to this branch fixing both blockers from the review above, with a cleaner approach than what I'd started on independently:

1. **Durable-upload error reclassification** — instead of a wrapper that has to know which `WalletJobError` variants are "already classified" vs raw text (what I was mid-way through), classifies the sidecar error at its actual source (`advance_durable_upload`'s `map_err`), so every path out of `execute_durable_upload` is correctly classified by construction and the call site just persists+propagates `err` as-is. Added a `WalletJobError::message()` accessor and a regression test.
2. **Origin-check spoofing** — drops `X-Forwarded-Host` entirely (no trusted-proxy verification needed) and compares `Origin` against the raw `Host` header plus an explicit HTTPS-only check (HTTP allowed only for localhost/127.0.0.1/::1). No new env var needed, unlike the `ALLOWED_ORIGINS` allowlist approach I'd started building for the same problem.

I verified both independently before deferring to them: `cargo test --bin memwal-server jobs::` — 56/56 pass; `apps/researcher` `pnpm run test:unit` — 7/7 pass; live curl against `researcher.demo.dev.memwal.ai/api/auth/key` with a matching `Origin` returns a proper 400 validation error, confirming the fix is deployed and working end-to-end on `dev`.

I had independently written and pushed my own fixes for the same two issues before seeing this commit — didn't push mine on top since theirs is architecturally better (fixes the root cause instead of patching around it) and needs no new config surface. Removed the `ALLOWED_ORIGINS` variables I'd provisioned on `researcher-frontend` (dev/staging/production) since they're unused by the adopted approach.


## Independent re-review after ducnmm's fix — 2 more real bugs found and fixed

Ran a second, independent multi-angle review (4 parallel review dimensions, each finding adversarially re-verified by a separate pass, plus a live Railway log check on `dev`) against the exact head after ducnmm's fix (`520f4672`), rather than trusting the existing approval at face value.

**Found and fixed:**

1. **[Medium] Lock-contention loser could clobber a job the winner already finished.** `update_remember_job_after_wallet_error`'s UPDATE had no status guard. The one call site that runs *without* holding the per-job lock (`LockOutcome::Defer`, from the earlier backoff commit) could have its write land after the winner's `persist_uploaded_state`/`insert_vector_and_mark_remember_done`, stamping a genuinely-succeeding row back to `running` with a stale error — not caught by ducnmm's review since it targeted a different code path. No data loss (`blob_id` untouched), but `GET /api/remember/:job_id` would show a misleadingly stuck row until the staleness sweep. Fixed: `AND status NOT IN ('uploaded', 'done')` on the UPDATE, plus refactored the function to take a plain `&sqlx::PgPool` (it only ever used `state.db.pool()`) so it's directly testable like its siblings. New regression test included.
2. **[Medium] Chatbot logged full error objects, including the outgoing prompt.** This PR's title-generation fix was the first thing to make this route log `execute()`/title-gen errors at all — and logged the raw error object. AI SDK provider errors are commonly `APICallError`-shaped and carry `requestBodyValues` as an own enumerable property, which `console.error` prints alongside the message — i.e. the full conversation, plus any memory content `withMemWal` injected via recall, landing in server logs on every upstream hiccup (rate limit, 5xx, timeout). Not a credential leak, but a real PII/conversation exposure for a product whose purpose is storing personal memories. Fixed: logs `name`/`message`/`statusCode` only now.

Both fixed, tested (57/57 Rust `jobs::` tests, `tsc --noEmit` clean on chatbot), pushed. CI green on the new head.

**Noted, not fixed (out of scope for this PR, flagging separately):**

- **Real, severe, but unrelated:** the live Railway check caught a ~29-minute total outage on `relayer`/dev that started exactly at this deploy's cutover — `LegacyDb::new()` (`services/server/src/storage/legacy_db.rs`) opens its Postgres pool and runs migrations with no timeout wrapper, unlike the Apalis pool init right next to it in `main.rs` which has an explicit 45s timeout — and it sits *before* `TcpListener::bind`, so a slow connection/migration-lock there blocks the whole HTTP listener from ever opening. Confirmed via `git diff` that PR #615 does not touch either file — this is pre-existing fragility this deploy's boot timing happened to trip, not something this PR caused. Self-resolved; `dev` is healthy now. Worth a follow-up issue given the Apalis pool already shows the fix pattern.
- **Test coverage gaps**, none blocking: the chatbot title-guard fix (`334cf915`) has zero test coverage at all (no test file touches `route.ts`); the `LockOutcome::Defer` branch's actual `tokio::time::sleep` + DB-write behavior is only tested at the pure-function level (`backoff_duration`'s schedule), not end-to-end; `execute_durable_upload`'s step-budget-exceeded fallback isn't exercised through the new call site.

## Verdict

Green CI, clean independent re-review (2 more real issues found in the process and already fixed), live-verified healthy on `dev`. Good to merge to `dev` from a code standpoint. Two things worth deciding before merging that are outside this PR's diff: (1) the still-open question of whether the Researcher origin-check fix should go directly to `main` given the ~2-week-old production incident, and (2) whether the relayer boot-timeout gap just found warrants a quick follow-up before or after this merges.
