### PR TITLE
docs: add a multi-agent coordination guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,6 +59,7 @@
             "group": "Guides",
             "pages": [
               "guides/agent-runtimes",
+              "guides/multi-agent-coordination",
               "guides/delete-old-memories",
               "guides/delete-memories-programmatically"
             ]

--- a/docs/fundamentals/concepts/memory-space.md
+++ b/docs/fundamentals/concepts/memory-space.md
@@ -1,9 +1,9 @@
 ---
-title: "Memory Space"
+title: Memory Space
 description: >-
-  The isolated unit of storage in Walrus Memory. A memory space is uniquely identified by
-  owner address, namespace, and app ID, ensuring full isolation between users, apps, and
-  deployments.
+  The unit of storage scoping in Walrus Memory. A memory space is uniquely identified by
+  owner address, namespace, and app ID, which keeps storage and recall separate across users,
+  apps, and deployments.
 keywords:
   - Walrus Memory
   - MemWal
@@ -13,7 +13,7 @@ keywords:
   - isolation
   - scoping
 goal:
-  description: Use namespaces to scope agent memory within an account, prevent cross-namespace data leakage, and design a namespace strategy for multi-agent or multi-user deployments.
+  description: Use namespaces to scope agent memory within an account, understand why they scope queries rather than restrict decryption, and design a namespace strategy for multi-agent or multi-user deployments.
   requires:
     - has_frontmatter:
         - title
@@ -31,13 +31,15 @@ questions:
   - How are memories isolated between users and apps in MemWal?
   - What is a namespace in Walrus Memory?
 answer: >-
-  A memory space is the isolated unit of storage in Walrus Memory, uniquely identified by
+  A memory space is the unit of storage scoping in Walrus Memory, uniquely identified by
   three values: the owner address (Sui wallet), a developer-defined namespace, and the app ID
-  (Walrus Memory package ID). This triple ensures that no two memory spaces overlap, providing
-  full isolation between users, applications, and deployments.
+  (Walrus Memory package ID). This triple ensures that no two memory spaces overlap, so storage
+  and recall stay separate across users, applications, and deployments. Scoping is not access
+  control: encryption scopes by owner and app ID, so any delegate on an account can decrypt
+  every namespace it owns.
 ---
 
-A **memory space** is the isolated unit of storage in Walrus Memory. Think of it as a folder or bucket for your memories — you choose which memory space to store into and which to retrieve from.
+A **memory space** is the unit of storage scoping in Walrus Memory. Think of it as a folder or bucket for your memories, and you choose which memory space to store into and which to retrieve from.
 
 Each user can own as many memory spaces as they want.
 
@@ -45,22 +47,26 @@ Each user can own as many memory spaces as they want.
 
 Every memory space is uniquely identified by three values:
 
-| Component | What it is |
+| **Component** | **What it is** |
 |-----------|-----------|
 | **Owner address** | The Sui wallet address that owns the memory |
 | **Namespace** | A developer-defined label to group and organize memories |
-| **App ID** | The Walrus Memory package ID (`MEMWAL_PACKAGE_ID`) — unique per relayer deployment |
+| **App ID** | The Walrus Memory package ID (`MEMWAL_PACKAGE_ID`), unique per relayer deployment |
 
-Together, `owner + namespace + app_id` form the boundary — no two memory spaces can overlap.
+Together, `owner + namespace + app_id` form the boundary, so no two memory spaces can overlap.
+
+<Warning>
+A memory space scopes what a query returns, not what a key can decrypt. Encryption and blob discovery scope by `owner + app_id`, so any delegate the account authorizes can decrypt everything that account owns, across every namespace. Use namespaces to organize one account's memory. To separate two users, give them separate accounts. See [Coordinate Multiple Agents](/guides/multi-agent-coordination).
+</Warning>
 
 ## Namespace
 
 A namespace is simply a name you give to group related memories. One user can have multiple namespaces to separate different kinds of data.
 
 For example:
-- `personal` — store personal preferences, notes, and context
-- `work` — store work-related knowledge and conversations
-- `research` — store research findings and references
+- `personal`: store personal preferences, notes, and context
+- `work`: store work-related knowledge and conversations
+- `research`: store research findings and references
 
 Namespaces are set in the SDK when you create a client:
 
@@ -75,9 +81,9 @@ const memwal = MemWal.create({
 
 ## App ID
 
-The **app ID** is the Walrus Memory package ID deployed on Sui (`MEMWAL_PACKAGE_ID`). Each relayer deployment is tied to a single package ID, which is used for SEAL encryption key derivation and Walrus blob metadata.
+The **app ID** is the Walrus Memory package ID deployed on Sui (`MEMWAL_PACKAGE_ID`). Each relayer deployment is tied to a single package ID, which is used for Seal encryption key derivation and Walrus blob metadata.
 
-Two separate Walrus Memory deployments can each have a user with a `personal` namespace, and their memories will never mix — because the app ID (package ID) is different. This means the vector database scopes queries by `owner + namespace`, while the encryption and blob discovery layer provides an additional isolation boundary through the package ID.
+Two separate Walrus Memory deployments can each have a user with a `personal` namespace, and their memories never mix, because each deployment uses a different package ID. This means the vector database scopes queries by `owner + namespace`, while the encryption and blob discovery layer provides an additional isolation boundary through the package ID.
 
 ## How it works in practice
 
@@ -94,4 +100,4 @@ In this example, one user has three separate memory spaces:
 - **work** memories in **app-1**
 - **personal** memories in **app-2** (a completely different deployment)
 
-Each is fully isolated — storing into one never affects the others, and recall only searches within the specified memory space.
+Storing into one never affects the others, and recall only searches within the specified memory space.

--- a/docs/guides/multi-agent-coordination.md
+++ b/docs/guides/multi-agent-coordination.md
@@ -1,0 +1,126 @@
+---
+title: Coordinate Multiple Agents
+description: >-
+  Patterns for running several agents against one Walrus Memory account: give each agent its own
+  delegate key, use namespaces to decide what they share, and hand work from one agent to the next.
+keywords:
+  - multi-agent
+  - coordination
+  - shared memory
+  - delegate key
+  - namespace
+  - handoff
+  - MemWal
+  - Walrus
+goal:
+  description: Decide how several agents share or isolate memory, and implement a handoff between them
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 100
+      label: Needs enough content to cover the patterns
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I share memory between multiple agents?
+  - Can two agents use the same Walrus Memory account?
+  - How do I hand off context from one agent to another?
+  - Should each agent have its own delegate key?
+answer: >-
+  Give each agent its own delegate key on one account, then use namespaces to decide what they
+  share. Agents that read and write the same namespace share memory, because any delegate the
+  account authorizes can decrypt everything that account owns. Agents that use separate namespaces
+  never read each other's writes, because recall never crosses a namespace. A handoff is one agent writing to a
+  shared namespace and the next recalling from it.
+---
+
+Several agents can work against one Walrus Memory account. Two decisions shape everything else:
+
+1. How many delegate keys you issue.
+2. Which namespaces the agents read and write.
+
+## Give each agent its own delegate key
+
+An account has one owner and any number of delegates. A delegate is a keypair the owner authorizes onchain, and the relayer verifies that authorization against the contract on every request.
+
+Issue one delegate key per agent rather than sharing a single key. The keys grant identical access, so this is not an access-control boundary, but issuing one per agent gives you two things:
+
+1. The dashboard labels each key, so you can see which agent is running.
+2. You can revoke one agent without disturbing the others.
+
+<Warning>
+Any delegate the account authorizes can decrypt everything that account owns, across every namespace. Delegate keys separate identity, not data. If two agents must not read each other's memory, give them separate accounts, not separate namespaces.
+</Warning>
+
+## Decide what the agents share
+
+Namespaces decide what agents see, because recall and restore match a namespace exactly and never cross one.
+
+| **Pattern** | **Setup** | **Result** |
+| --- | --- | --- |
+| Shared memory | Every agent uses the same namespace | Each agent recalls what the others wrote |
+| Isolated memory | Each agent uses its own namespace | No agent recalls another's writes |
+| Shared plus private | A common namespace, plus one per agent | Agents pool findings and keep working notes apart |
+
+Shared plus private suits most multi-agent systems. A research agent writes conclusions to `findings` and keeps its own scratch work in `research-agent`, so a planner agent reading `findings` sees the conclusions without wading through intermediate steps.
+
+```ts
+const shared = MemWal.create({
+  key: process.env.RESEARCH_AGENT_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+  serverUrl: process.env.MEMWAL_SERVER_URL,
+  namespace: "findings",
+});
+
+const scratch = MemWal.create({
+  key: process.env.RESEARCH_AGENT_KEY!,
+  accountId: process.env.MEMWAL_ACCOUNT_ID!,
+  serverUrl: process.env.MEMWAL_SERVER_URL,
+  namespace: "research-agent",
+});
+```
+
+Both clients use the same delegate key and the same account. Only the namespace differs.
+
+## Hand off work between agents
+
+A handoff is a write followed by a recall. The first agent writes what the next one needs into a shared namespace, and the next agent recalls it when it starts.
+
+```ts
+// Research agent, finishing its turn.
+await shared.rememberAndWait(
+  "The customer runs Postgres 14 and cannot upgrade before Q3, so the migration plan must stay compatible with 14.",
+);
+
+// Planner agent, starting its turn against the same namespace.
+const context = await planner.recall({ query: "customer database constraints", limit: 10 });
+```
+
+Recall has two properties that change how you write for a handoff:
+
+1. It matches by meaning rather than by key, so the receiving agent finds a memory by describing what it needs instead of knowing an identifier.
+2. It returns whole memories, so write one complete, self-contained statement per fact rather than a fragment that only makes sense beside the one before it.
+
+<Tip>
+Use `rememberAndWait` for the last write before a handoff. `remember` returns as soon as the relayer creates the background job, and embedding, encryption, upload, and vector indexing continue afterwards, so you cannot recall it yet. `rememberAndWait` polls until that job finishes, which is the point the next agent can find it.
+</Tip>
+
+## Choose a boundary
+
+Match the boundary to what you actually need to separate:
+
+- Agents cooperating on one user's work: one account, one delegate key each, namespaces to divide the work.
+- Agents serving different users: one account per user, never one shared account split by namespace, because any delegate reads every namespace on the account.
+- Agents running against different deployments: separate app IDs already isolate them, because the package ID scopes encryption and blob discovery.
+
+## References
+
+- [Ownership and Delegates](/fundamentals/concepts/ownership-and-access)
+- [Memory Space](/fundamentals/concepts/memory-space)
+- [Use Walrus Memory From Any Agent Runtime](/guides/agent-runtimes)
+- [Headless SDK Setup](/sdk/headless-setup)

--- a/docs/guides/multi-agent-coordination.md
+++ b/docs/guides/multi-agent-coordination.md
@@ -39,14 +39,11 @@ answer: >-
   shared namespace and the next recalling from it.
 ---
 
-Several agents can work against one Walrus Memory account. Two decisions shape everything else:
-
-1. How many delegate keys you issue.
-2. Which namespaces the agents read and write.
+Several agents can work against one Walrus Memory account. Two things decide how they share memory: how many delegate keys you issue, and which namespaces each agent reads and writes.
 
 ## Give each agent its own delegate key
 
-An account has one owner and any number of delegates. A delegate is a keypair the owner authorizes onchain, and the relayer verifies that authorization against the contract on every request.
+An account has one owner and any number of [delegates](/fundamentals/concepts/ownership-and-access). A delegate is a keypair the owner authorizes onchain, and the relayer verifies that authorization against the contract on every request.
 
 Issue one delegate key per agent rather than sharing a single key. The keys grant identical access, so this is not an access-control boundary, but issuing one per agent gives you two things:
 
@@ -59,7 +56,7 @@ Any delegate the account authorizes can decrypt everything that account owns, ac
 
 ## Decide what the agents share
 
-Namespaces decide what agents see, because recall and restore match a namespace exactly and never cross one.
+[Namespaces](/fundamentals/concepts/memory-space) decide what agents see, because recall and restore match a namespace exactly and never cross one.
 
 | **Pattern** | **Setup** | **Result** |
 | --- | --- | --- |
@@ -117,10 +114,3 @@ Match the boundary to what you actually need to separate:
 - Agents cooperating on one user's work: one account, one delegate key each, namespaces to divide the work.
 - Agents serving different users: one account per user, never one shared account split by namespace, because any delegate reads every namespace on the account.
 - Agents running against different deployments: separate app IDs already isolate them, because the package ID scopes encryption and blob discovery.
-
-## References
-
-- [Ownership and Delegates](/fundamentals/concepts/ownership-and-access)
-- [Memory Space](/fundamentals/concepts/memory-space)
-- [Use Walrus Memory From Any Agent Runtime](/guides/agent-runtimes)
-- [Headless SDK Setup](/sdk/headless-setup)


### PR DESCRIPTION
Closes BEDU-1121. Eight builder questions asked how several agents share memory, and no page tied the pieces together.

## The gap

Delegates and namespaces are each documented well on their own concept page, but nothing says how they combine. That leaves the reader to infer which one is an identity boundary and which is a visibility boundary, and getting it backwards is expensive: **any delegate the account authorizes decrypts everything that account owns, across every namespace.** So namespaces organize an account's memory, and they cannot separate users. The guide states that outright, in a warning, rather than leaving it to be deduced from two pages.

## What the page covers

- **One delegate key per agent.** The keys grant identical access, so this is not an access-control boundary. It buys labelling in the dashboard and per-agent revocation.
- **Three sharing patterns**, as a table: shared namespace, per-agent namespace, and the common case of a shared namespace plus a private one per agent.
- **Handoff as a write followed by a recall**, with the two properties of recall that change how you write for one: it matches by meaning rather than by key, and it returns whole memories, so each fact needs to stand alone.
- **Choosing a boundary**, including the case that must not use namespaces: agents serving different users need separate accounts.

## Also fixes the concept page it contradicted

A review pass found that `fundamentals/concepts/memory-space.md` said the opposite of this guide, in the direction that gets people hurt. It called a memory space "the isolated unit of storage" offering "full isolation between users, apps, and deployments", its goal promised namespaces "prevent cross-namespace data leakage", and it closed with "each is fully isolated". A reader arriving there first would conclude namespaces separate users, which is exactly the mistake this guide exists to prevent.

Neither page stated a falsehood; they described different layers. That page's own App ID section already says the vector database scopes queries by `owner + namespace` while encryption and blob discovery scope by package ID, which is precisely why a delegate reads across namespaces. The isolation language just overstated what that buys you.

Reworded its description, goal, answer, and body to say scoping rather than isolation, and added a warning beside the boundary definition that states the decryption behaviour outright and links here. Fixing it inside this PR rather than filing a follow-up, so the contradiction never ships.

That page also carried twelve pre-existing style gate violations, which surface on push once the file is touched at all: eight em dashes, `SEAL` for `Seal`, a future tense, a quoted frontmatter title, and unbolded table headers. Cleared them in a separate commit. They are mechanical and unrelated to the wording change.

## Sources

| Claim | Source |
| --- | --- |
| An account has one owner and any number of delegates; a delegate is a keypair the owner authorizes | `docs/fundamentals/concepts/ownership-and-access.md`, "Delegates" |
| Delegate keys are registered onchain and verified on every request | same page, "Access Control Enforcement" |
| Only the owner and authorized delegates can access the encrypted content | same page, "Ownership" |
| Namespaces group memories within an account, and one user can hold several | `docs/fundamentals/concepts/memory-space.md`, "Namespace" |
| The vector database scopes queries by `owner + namespace`, while encryption and blob discovery scope by package ID | same page, "App ID" — this is what makes the delegate warning true |
| `MemWal.create` fields `key`, `accountId`, `serverUrl`, `namespace` | `MemWalConfig` in `packages/sdk/src/types.ts` |
| `recall({ query, limit })` | `RecallParams` and `RecallOptions` in the same file |
| `rememberAndWait` waits for the background job to complete | `packages/sdk/src/memwal.ts`, the method and its doc comment |
| `remember` returns once the relayer creates the job, with embedding, encryption, upload, and indexing continuing after | `docs/sdk/api-reference.md`, `remember` |

Prose written fresh. The code samples use only fields and methods verified above.

## Verification

Re-run against current `dev` rather than relying on the original checks, since the branch was 182 commits behind when this pass ran:

- The branch merges cleanly into `dev`; this push brings it up to date.
- Style gate passes on both changed pages.
- `node scripts/check-docs-freshness.mjs` passes: `docs freshness OK (94 pages, 44 routes, IDs, URLs, versions, limits)`, which covers the four reference links.
- Every SDK claim above re-checked against `packages/sdk/src` at current `dev`, not against the versions current when the page was drafted.