### PR TITLE
fix(chatbot): fail loudly on a weak or missing AUTH_SECRET

### DIFF
--- a/apps/chatbot/app/(auth)/auth.ts
+++ b/apps/chatbot/app/(auth)/auth.ts
@@ -2,6 +2,7 @@ import { compare } from "bcrypt-ts";
 import NextAuth, { type DefaultSession } from "next-auth";
 import type { DefaultJWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
+import { getAuthSecret } from "@/lib/auth-secret";
 import { DUMMY_PASSWORD } from "@/lib/constants";
 import { createGuestUser, getUser } from "@/lib/db/queries";
 import { authConfig } from "./auth.config";
@@ -37,6 +38,7 @@ export const {
   signOut,
 } = NextAuth({
   ...authConfig,
+  secret: getAuthSecret(),
   providers: [
     Credentials({
       credentials: {},

--- a/apps/chatbot/lib/auth-secret.ts
+++ b/apps/chatbot/lib/auth-secret.ts
@@ -1,0 +1,16 @@
+const MIN_AUTH_SECRET_LENGTH = 32;
+
+/**
+ * Reads and validates AUTH_SECRET. NextAuth silently accepts any string
+ * (including a short placeholder), which weakly signs session/guest JWTs
+ * instead of failing — mirrors the guard in apps/researcher/lib/auth/enoki-challenge.ts.
+ */
+export function getAuthSecret(): string {
+  const value = process.env.AUTH_SECRET;
+  if (!value || value.length < MIN_AUTH_SECRET_LENGTH) {
+    throw new Error(
+      `AUTH_SECRET must contain at least ${MIN_AUTH_SECRET_LENGTH} characters`
+    );
+  }
+  return value;
+}

--- a/apps/chatbot/lib/session-token.ts
+++ b/apps/chatbot/lib/session-token.ts
@@ -1,11 +1,12 @@
 import { getToken } from "next-auth/jwt";
+import { getAuthSecret } from "@/lib/auth-secret";
 import { isDevelopmentEnvironment } from "@/lib/constants";
 
 export async function getSessionToken(request: Request) {
   try {
     return await getToken({
       req: request,
-      secret: process.env.AUTH_SECRET,
+      secret: getAuthSecret(),
       secureCookie: !isDevelopmentEnvironment,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- While debugging why Enoki sign-in was broken on `researcher-demo-staging`, found the root cause: staging's `researcher-frontend` has an `AUTH_SECRET` that's only 8 characters long. `apps/researcher/lib/auth/enoki-challenge.ts` correctly rejects it (`AUTH_SECRET must contain at least 32 characters`), which is what surfaces as the generic "Unable to verify wallet ownership" error in the UI.
- Checked the other two apps that touch staging auth for the same issue:
  - `noter-frontend` — not affected. Its Enoki challenge flow (`apps/noter/package/feature/auth/lib/enoki-challenge.ts`) is stateless via Redis nonces, no `AUTH_SECRET` dependency at all.
  - `chatbot-frontend` — **has the same 8-character `AUTH_SECRET` value as researcher-frontend**, but nothing validates it, so NextAuth just signs session/guest JWTs with a short HS256 key instead of erroring. Silent security weakness, not a visible bug — which is why it hadn't been caught.
- This PR adds the same defensive check chatbot is missing: `getAuthSecret()` (mirrors researcher's existing guard) throws if `AUTH_SECRET` is unset or under 32 chars, wired into the three places chatbot reads it directly (`auth.ts`, `guest/route.ts`, `proxy.ts`).

## Not included here (needs a separate ops action, not code)
The actual staging secrets still need to be rotated to real random values on Railway (in progress, separately — not via this PR):
- `researcher-frontend` (staging): currently broken (Enoki login 500s) until rotated
- `chatbot-frontend` (staging): currently "working" but weakly signed until rotated

Both are runtime config changes, not something this PR touches — flagging for a follow-up once this merges, so chatbot starts failing loudly the same way researcher already does if it's ever deployed with a weak value again.

## Test plan
- [ ] CI (lint/build/typecheck) passes
- [ ] Manually confirm chatbot boots normally on an environment with a proper `AUTH_SECRET`
- [ ] Confirm chatbot fails fast (clear error, not silent) if `AUTH_SECRET` is unset or short, e.g. locally with `AUTH_SECRET=short pnpm --filter chatbot dev`