### PR TITLE
fix(seal): preserve legacy decrypt committees

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -126,7 +126,9 @@ These are not all enforced at boot, but most real deployments need them.
 | `WALRUS_UPLOAD_RELAY_URL` | network default | Override the Walrus upload relay used by the sidecar |
 | `SEAL_SERVER_CONFIGS` | network default | Optional JSON SEAL server config override for independent or committee servers |
 | `SEAL_KEY_SERVERS` | network default | Legacy comma-separated independent SEAL key server override. Used only when `SEAL_SERVER_CONFIGS` is unset. Deprecated but supported through relayer API `1.x` |
-| `SEAL_THRESHOLD` | `min(2, total configured weight)` | Required configured server weight for SEAL encrypt/decrypt |
+| `SEAL_LEGACY_DECRYPT_KEY_SERVERS` | unset | Optional comma-separated independent SEAL servers retained only for decrypting ciphertexts created before a committee migration |
+| `SEAL_THRESHOLD` | `min(2, total configured weight)` | Required configured server weight for SEAL encryption |
+
 | `ENOKI_API_KEY` | none | Optional Enoki key for sponsored sidecar transactions |
 | `ENOKI_NETWORK` | `mainnet` | Network used for Enoki-sponsored flows |
 | `ENOKI_FALLBACK_TO_DIRECT_SIGN` | `false` | If true, sidecar pays gas directly with the server wallet when Enoki sponsorship fails or is not configured |
@@ -157,6 +159,7 @@ These are not all enforced at boot, but most real deployments need them.
 - `SEAL_KEY_SERVERS` is the legacy comma-separated independent key server list. It is only used when `SEAL_SERVER_CONFIGS` is unset, is advertised as deprecated in `/version`, and will not be removed before relayer API `2.0.0`.
 - If neither SEAL variable is set, the sidecar uses built-in defaults for `SUI_NETWORK`: the original Mysten independent key server pair on `testnet`, and the legacy independent key server pair on `mainnet` until an official mainnet committee aggregator is available.
 - Use `SEAL_SERVER_CONFIGS` to opt into a committee key server by providing `objectId`, `weight`, and `aggregatorUrl`. Mysten's testnet committee aggregator is `0xb012378c9f3799fb5b1a7083da74a4069e3c3f1c93de0b27212a5799ce1e1e98` with `https://seal-aggregator-testnet.mystenlabs.com`.
+- When migrating an existing deployment to a committee, keep the old independent server IDs in `SEAL_LEGACY_DECRYPT_KEY_SERVERS`. They are added to the decrypt-only client, while new encryption continues to use only `SEAL_SERVER_CONFIGS`; omit the variable after all legacy ciphertexts have been re-encrypted.
 - The Mysten testnet committee aggregator is a single logical server config from the SDK's point of view. Its 3-of-5 committee threshold is handled by the aggregator, so leave `SEAL_THRESHOLD` unset or set it to `1` when opting into that committee config.
 - Keep the independent testnet defaults, or pin `SEAL_KEY_SERVERS=0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8`, for deployments with existing memories encrypted by those key servers until the data is migrated or re-encrypted.
 - The sidecar `POST /walrus/upload` route defaults Walrus storage epochs by network: `50` on `testnet` (about 50 days) and `2` on `mainnet` (about 4 weeks), unless the request explicitly passes `epochs`.

--- a/services/server/scripts/__tests__/seal-config.test.ts
+++ b/services/server/scripts/__tests__/seal-config.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   getSealCommitteeIdentity,
+  getSealDecryptServerConfigsFromEnv,
   getSealServerConfigsFromEnv,
   getSealThresholdFromEnv,
   sealCommitteeIdentityMatches,
@@ -69,6 +70,30 @@ test("SEAL_KEY_SERVERS remains the legacy independent-server override", () => {
     { objectId: ID_ONE, weight: 1 },
     { objectId: ID_TWO, weight: 1 },
   ]);
+});
+
+test("legacy decrypt servers extend rather than replace the active committee", () => {
+  const active = [
+    {
+      objectId: ID_ONE,
+      weight: 1,
+      aggregatorUrl: "https://seal.example.com",
+      apiKeyName: "x-api-key",
+      apiKey: "secret",
+    },
+  ];
+
+  assert.deepEqual(
+    getSealDecryptServerConfigsFromEnv(active, {
+      SEAL_LEGACY_DECRYPT_KEY_SERVERS: "0x2,0x3,0x01",
+    }),
+    [
+      active[0],
+      { objectId: ID_TWO, weight: 1 },
+      { objectId: ID_THREE, weight: 1 },
+    ]
+  );
+  assert.deepEqual(getSealDecryptServerConfigsFromEnv(active, {}), active);
 });
 
 test("duplicate and aliased SEAL server object IDs are rejected", () => {

--- a/services/server/scripts/__tests__/sidecar-seal-routes.test.ts
+++ b/services/server/scripts/__tests__/sidecar-seal-routes.test.ts
@@ -65,14 +65,14 @@ const ACC = `0x${"3".repeat(64)}`;
 const REG = `0x${"9".repeat(64)}`;
 const PERSISTENCE_POLICY = { allowLegacySealAbi: false, policyPackageId: POLICY_PKG };
 
-function ciphertext(packageId: string): string {
+function ciphertext(packageId: string, threshold = 1): string {
     return Buffer.from(
         EncryptedObject.serialize({
             version: 0,
             packageId,
             id: "aabb",
             services: [[ACC, 1]],
-            threshold: 1,
+            threshold,
             encryptedShares: {
                 BonehFranklinBLS12381: {
                     nonce: new Uint8Array(96),
@@ -346,11 +346,13 @@ test("/seal/decrypt rejects a SessionKey from another immutable package", async 
 });
 
 test("batch parsing quarantines a foreign package and preserves the valid subset", () => {
-    const parsed = parseSealDecryptBatchItems([ciphertext(PKG), ciphertext(OTHER_PKG)], PKG);
+    const parsed = parseSealDecryptBatchItems([ciphertext(PKG, 2), ciphertext(OTHER_PKG)], PKG);
     assert.deepEqual(
         parsed.parsedItems.map((item: { index: number }) => item.index),
         [0]
     );
+    assert.equal(parsed.parsedItems[0].threshold, 2);
+    assert.deepEqual(parsed.parsedItems[0].serviceIds, [ACC]);
     assert.equal(parsed.errors.length, 1);
     assert.equal(parsed.errors[0].index, 1);
     assert.equal(parsed.errors[0].code, "CORRUPT_CIPHERTEXT");

--- a/services/server/scripts/seal-config.ts
+++ b/services/server/scripts/seal-config.ts
@@ -200,6 +200,25 @@ export function getSealServerConfigsFromEnv(
   return configs;
 }
 
+export function getSealDecryptServerConfigsFromEnv(
+  activeConfigs: SealServerConfig[],
+  env: Env = process.env
+): SealServerConfig[] {
+  const legacyConfigs = parseLegacyKeyServers(
+    env.SEAL_LEGACY_DECRYPT_KEY_SERVERS
+  );
+  const configs = [...activeConfigs];
+  const objectIds = new Set(configs.map(({ objectId }) => objectId));
+  for (const config of legacyConfigs) {
+    if (!objectIds.has(config.objectId)) {
+      configs.push(config);
+      objectIds.add(config.objectId);
+    }
+  }
+  sealTotalWeight(configs);
+  return configs;
+}
+
 export function getSealThresholdFromEnv(
   configs: SealServerConfig[],
   env: Env = process.env

--- a/services/server/scripts/sidecar/clients.ts
+++ b/services/server/scripts/sidecar/clients.ts
@@ -13,6 +13,7 @@ import { normalizeStructTag } from "@mysten/sui/utils";
 import { SealClient } from "@mysten/seal";
 import { WalrusClient, type WalrusClientConfig } from "@mysten/walrus";
 import {
+    SEAL_DECRYPT_SERVER_CONFIGS,
     SEAL_KEY_SERVER_TIMEOUT_MS,
     SEAL_SERVER_CONFIGS,
     SUI_GRAPHQL_URL,
@@ -48,13 +49,24 @@ export const suiGraphqlClient = new SuiGraphQLClient({
     fetch: archivalFetch,
 });
 
-export function createSealClient(): SealClient {
+function createSealClientWithConfigs(serverConfigs: typeof SEAL_SERVER_CONFIGS): SealClient {
     return new SealClient({
         suiClient: suiClient as any,
-        serverConfigs: SEAL_SERVER_CONFIGS,
+        serverConfigs,
         verifyKeyServers: true,
         timeout: SEAL_KEY_SERVER_TIMEOUT_MS,
     });
+}
+
+export function createSealClient(): SealClient {
+    return createSealClientWithConfigs(SEAL_SERVER_CONFIGS);
+}
+
+export function createSealDecryptClient(serviceIds: Iterable<string>): SealClient {
+    const requiredIds = new Set(serviceIds);
+    return createSealClientWithConfigs(
+        SEAL_DECRYPT_SERVER_CONFIGS.filter(({ objectId }) => requiredIds.has(objectId))
+    );
 }
 
 // Encryption caches public key-server metadata only. Decrypt routes must use a

--- a/services/server/scripts/sidecar/config.ts
+++ b/services/server/scripts/sidecar/config.ts
@@ -8,7 +8,12 @@
 
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { getSealCommitteeIdentity, getSealServerConfigsFromEnv, getSealThresholdFromEnv } from "../seal-config.js";
+import {
+    getSealCommitteeIdentity,
+    getSealDecryptServerConfigsFromEnv,
+    getSealServerConfigsFromEnv,
+    getSealThresholdFromEnv,
+} from "../seal-config.js";
 import { parseSuiNetwork } from "./sui-transport-policy.js";
 
 export function parsePositiveIntEnv(name: string, fallback: number, min: number, max: number): number {
@@ -52,6 +57,7 @@ export const SUI_TYPE = "0x2::sui::SUI";
 // ============================================================
 
 export const SEAL_SERVER_CONFIGS = getSealServerConfigsFromEnv();
+export const SEAL_DECRYPT_SERVER_CONFIGS = getSealDecryptServerConfigsFromEnv(SEAL_SERVER_CONFIGS);
 export const SEAL_THRESHOLD = getSealThresholdFromEnv(SEAL_SERVER_CONFIGS);
 export const SEAL_COMMITTEE_IDENTITY = getSealCommitteeIdentity(SEAL_SERVER_CONFIGS, SEAL_THRESHOLD);
 export const SEAL_KEY_SERVER_TIMEOUT_MS = parsePositiveIntEnv("SEAL_KEY_SERVER_TIMEOUT_MS", 25_000, 1_000, 120_000);

--- a/services/server/scripts/sidecar/routes/seal.ts
+++ b/services/server/scripts/sidecar/routes/seal.ts
@@ -30,7 +30,7 @@ import {
   SIDECAR_ENABLE_MIGRATION_SEAL_ROUTE,
 } from "../config.js";
 import { sealCommitteeIdentityMatches, type SealCommitteeIdentity } from "../../seal-config.js";
-import { createSealClient, sealEncryptClient, suiClient } from "../clients.js";
+import { createSealDecryptClient, sealEncryptClient, suiClient } from "../clients.js";
 import { buildSealEncryptId, fetchSealEncryptIdentity, type SealEncryptPurpose } from "../seal-identity.js";
 import {
   buildSealApproveTx,
@@ -181,6 +181,8 @@ export function parseSealDecryptBatchItems(items: unknown[], packageId: string) 
     index: number;
     encryptedData: Uint8Array;
     fullId: string;
+    threshold: number;
+    serviceIds: string[];
   }[] = [];
   const errors: { index: number; code: string; error: string }[] = [];
 
@@ -196,7 +198,13 @@ export function parseSealDecryptBatchItems(items: unknown[], packageId: string) 
         });
         continue;
       }
-      parsedItems.push({ index: i, encryptedData, fullId: parsed.id });
+      parsedItems.push({
+        index: i,
+        encryptedData,
+        fullId: parsed.id,
+        threshold: parsed.threshold,
+        serviceIds: parsed.services.map(([objectId]) => objectId),
+      });
     } catch (err: any) {
       errors.push({
         index: i,
@@ -330,13 +338,17 @@ export function registerSealRoutes(app: Express, policy = DEFAULT_SEAL_ROUTE_POL
             ]);
 
         phase = "fetch_keys";
-            const sealClient = createSealClient();
-        // Fetch keys from key servers
+            const sealClient = createSealDecryptClient(
+              parsed.services.map(([objectId]) => objectId)
+            );
+        // The ciphertext records both its key servers and threshold. Use only
+        // that committee so unrelated active servers cannot satisfy fetchKeys
+        // before enough matching legacy shares have arrived.
         await sealClient.fetchKeys({
           ids: [fullId],
           txBytes,
           sessionKey,
-          threshold: SEAL_THRESHOLD,
+          threshold: parsed.threshold,
         });
 
         phase = "decrypt";
@@ -419,57 +431,73 @@ export function registerSealRoutes(app: Express, policy = DEFAULT_SEAL_ROUTE_POL
         );
 
         phase = "fetch_keys";
-            const sealClient = createSealClient();
-        // ONE fetchKeys call for ALL IDs
-        try {
-          await sealClient.fetchKeys({
-            ids: allIds,
-            txBytes,
-            sessionKey,
-            threshold: SEAL_THRESHOLD,
-          });
-        } catch (err: any) {
-          const traceId = randomUUID();
-          const message = formattedError(err);
-          const error = `fetch_keys failed: ${message} (traceId=${traceId}, timeoutMs=${SEAL_KEY_SERVER_TIMEOUT_MS})`;
-          console.error(
-            `[seal/decrypt-batch] [${traceId}] phase=fetch_keys items=${parsedItems.length} uniqueIds=${allIds.length} timeoutMs=${SEAL_KEY_SERVER_TIMEOUT_MS} error: ${message}`,
-            err
-          );
-          return res.json({
-            results: [],
-            errors: [
-              ...errors,
-              ...parsedItems.map((item) => ({
+        // A batch can span ciphertexts from before and after a committee
+        // migration. Isolate each embedded committee and threshold so an
+        // unrelated active server cannot count toward a legacy threshold.
+        const committeeGroups = new Map<string, typeof parsedItems>();
+        for (const item of parsedItems) {
+          const key = JSON.stringify([item.threshold, item.serviceIds]);
+          const group = committeeGroups.get(key) ?? [];
+          group.push(item);
+          committeeGroups.set(key, group);
+        }
+        const readyGroups: Array<{
+          items: typeof parsedItems;
+          sealClient: ReturnType<typeof createSealDecryptClient>;
+        }> = [];
+        for (const group of committeeGroups.values()) {
+          const { threshold, serviceIds } = group[0];
+          const ids = [...new Set(group.map((item) => item.fullId))];
+          const sealClient = createSealDecryptClient(serviceIds);
+          try {
+            await sealClient.fetchKeys({
+              ids,
+              txBytes,
+              sessionKey,
+              threshold,
+            });
+            readyGroups.push({ items: group, sealClient });
+          } catch (err: any) {
+            const traceId = randomUUID();
+            const message = formattedError(err);
+            const error = `fetch_keys failed: ${message} (traceId=${traceId}, timeoutMs=${SEAL_KEY_SERVER_TIMEOUT_MS})`;
+            console.error(
+              `[seal/decrypt-batch] [${traceId}] phase=fetch_keys items=${group.length} uniqueIds=${ids.length} threshold=${threshold} timeoutMs=${SEAL_KEY_SERVER_TIMEOUT_MS} error: ${message}`,
+              err
+            );
+            errors.push(
+              ...group.map((item) => ({
                 index: item.index,
                 code: sealKeyFetchErrorCode(err),
                 error,
-              })),
-            ],
-          });
+              }))
+            );
+          }
         }
 
         phase = "decrypt";
-        // Decrypt each blob using the shared sessionKey
+        // Decrypt each blob with the client scoped to its embedded committee.
         const results: { index: number; decryptedData: string }[] = [];
 
-        for (const item of parsedItems) {
-          try {
-            const decrypted = await sealClient.decrypt({
-              data: item.encryptedData,
-              sessionKey,
-              txBytes,
-            });
-            results.push({
-              index: item.index,
-              decryptedData: Buffer.from(decrypted).toString("base64"),
-            });
-          } catch (err: any) {
-            errors.push({
-              index: item.index,
-              code: "DECRYPT_FAILED",
-              error: `decrypt failed: ${formattedError(err)}`,
-            });
+        for (const { items: group, sealClient } of readyGroups) {
+          for (const item of group) {
+            try {
+              const decrypted = await sealClient.decrypt({
+                data: item.encryptedData,
+                sessionKey,
+                txBytes,
+              });
+              results.push({
+                index: item.index,
+                decryptedData: Buffer.from(decrypted).toString("base64"),
+              });
+            } catch (err: any) {
+              errors.push({
+                index: item.index,
+                code: "DECRYPT_FAILED",
+                error: `decrypt failed: ${formattedError(err)}`,
+              });
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- keep encryption pinned to the active SEAL committee
- optionally extend only the decrypt client with legacy independent key servers
- derive decrypt thresholds from each ciphertext and isolate mixed-threshold batch failures

## Production incident
After production moved from the two independent mainnet key servers to the one logical committee aggregator, historical memories still carried threshold `2`. Recall found those memories but dropped every hit with `Invalid threshold 2 for 1 servers`.

Set `SEAL_LEGACY_DECRYPT_KEY_SERVERS` to the former independent server IDs during the migration window. New writes continue to use only `SEAL_SERVER_CONFIGS`.

## Validation
- focused SEAL config and route tests: 30/30
- live logs confirm recall reaches three hits and currently drops them only at SEAL decrypt
- `git diff --check`