### PR TITLE
feat(mcp): annotate remote tools for Claude review

### DIFF
--- a/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
+++ b/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { MemWalSession } from "../auth.js";
+import { createMcpServer } from "../server.js";
+
+test("tools/list publishes safe titles and behavior annotations for every remote tool", async (t) => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createMcpServer({} as MemWalSession);
+    const client = new Client({ name: "annotations-test", version: "1.0.0" });
+
+    t.after(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const { tools } = await client.listTools();
+
+    assert.deepEqual(
+        Object.fromEntries(
+            tools.map(({ name, title, annotations }) => [name, { title, annotations }])
+        ),
+        {
+            memwal_remember: {
+                title: "Remember a Fact",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_remember_bulk: {
+                title: "Remember Multiple Facts",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_analyze: {
+                title: "Analyze and Remember",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_restore: {
+                title: "Restore Memory Index",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_recall: {
+                title: "Recall Memories",
+                annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+            memwal_health: {
+                title: "Check Walrus Memory Health",
+                annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+        }
+    );
+});

--- a/services/server/scripts/mcp/tools/analyze.ts
+++ b/services/server/scripts/mcp/tools/analyze.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool, explorerFooter } from "./util.js";
 
 const ANALYZE_INPUT = {
@@ -27,10 +28,14 @@ export function registerAnalyzeTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_analyze",
-        "Extract memorable facts from a longer passage of text (preferences, habits, biographical info, constraints) and save each as a separate Walrus Memory memory. Use this when you want MemWal's LLM to split the facts out of a transcript or notes for you; if you already know the exact facts, use memwal_remember or memwal_remember_bulk instead.",
-        ANALYZE_INPUT,
+        {
+            ...TOOL_METADATA.memwal_analyze,
+            description:
+                "Extract memorable facts from a longer passage of text (preferences, habits, biographical info, constraints) and save each as a separate Walrus Memory memory. Use this when you want MemWal's LLM to split the facts out of a transcript or notes for you; if you already know the exact facts, use memwal_remember or memwal_remember_bulk instead.",
+            inputSchema: ANALYZE_INPUT,
+        },
         wrapTool<{ text: string; namespace?: string }>(async ({ text, namespace }) => {
             const result = await session.memwal.analyzeAndWait(text, namespace, {
                 timeoutMs: 180_000,

--- a/services/server/scripts/mcp/tools/annotations.ts
+++ b/services/server/scripts/mcp/tools/annotations.ts
@@ -1,0 +1,34 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+interface RemoteToolMetadata {
+    title: string;
+    annotations: ToolAnnotations;
+}
+
+/** Metadata surfaced to MCP clients through `tools/list`. */
+export const TOOL_METADATA = {
+    memwal_remember: {
+        title: "Remember a Fact",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_remember_bulk: {
+        title: "Remember Multiple Facts",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_analyze: {
+        title: "Analyze and Remember",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_restore: {
+        title: "Restore Memory Index",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_recall: {
+        title: "Recall Memories",
+        annotations: { readOnlyHint: true, destructiveHint: false },
+    },
+    memwal_health: {
+        title: "Check Walrus Memory Health",
+        annotations: { readOnlyHint: true, destructiveHint: false },
+    },
+} as const satisfies Record<string, RemoteToolMetadata>;

--- a/services/server/scripts/mcp/tools/health.ts
+++ b/services/server/scripts/mcp/tools/health.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool } from "./util.js";
 
 /**
@@ -12,10 +13,14 @@ export function registerHealthTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_health",
-        "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
-        {},
+        {
+            ...TOOL_METADATA.memwal_health,
+            description:
+                "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
+            inputSchema: {},
+        },
         wrapTool<Record<string, never>>(async () => {
             const result = await session.memwal.health();
             return {

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool } from "./util.js";
 
 const RECALL_INPUT = {
@@ -37,10 +38,14 @@ export function registerRecallTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_recall",
-        "Search the user's Walrus Memory for relevant facts before responding. Call this PROACTIVELY at the start of a task, or whenever the user references past work, prior decisions, their preferences, or anything you may have stored earlier — don't wait to be asked. A single focused query is usually enough — recall is a real retrieval over encrypted storage, so do NOT fire multiple redundant searches for the same question. Returns matching memories ranked by relevance.",
-        RECALL_INPUT,
+        {
+            ...TOOL_METADATA.memwal_recall,
+            description:
+                "Search the user's Walrus Memory for relevant facts before responding. Call this PROACTIVELY at the start of a task, or whenever the user references past work, prior decisions, their preferences, or anything you may have stored earlier — don't wait to be asked. A single focused query is usually enough — recall is a real retrieval over encrypted storage, so do NOT fire multiple redundant searches for the same question. Returns matching memories ranked by relevance.",
+            inputSchema: RECALL_INPUT,
+        },
         wrapTool<{ query: string; limit: number; namespace?: string }>(async ({ query, limit, namespace }) => {
             const result = await session.memwal.recall(query, limit, namespace);
             if (result.results.length === 0) {

--- a/services/server/scripts/mcp/tools/remember-bulk.ts
+++ b/services/server/scripts/mcp/tools/remember-bulk.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool, explorerFooter } from "./util.js";
 
 const REMEMBER_BULK_INPUT = {
@@ -30,10 +31,14 @@ export function registerRememberBulkTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_remember_bulk",
-        "Save multiple durable facts in one call. Use when you learned several distinct facts at once (onboarding details, a list of preferences, decisions from a discussion). Pass an array of complete fact statements (max 20) — do not summarize. Prefer this over repeated memwal_remember calls.",
-        REMEMBER_BULK_INPUT,
+        {
+            ...TOOL_METADATA.memwal_remember_bulk,
+            description:
+                "Save multiple durable facts in one call. Use when you learned several distinct facts at once (onboarding details, a list of preferences, decisions from a discussion). Pass an array of complete fact statements (max 20) — do not summarize. Prefer this over repeated memwal_remember calls.",
+            inputSchema: REMEMBER_BULK_INPUT,
+        },
         wrapTool<{ facts: string[]; namespace?: string }>(async ({ facts, namespace }) => {
             const items = facts.map((text) => ({ text, namespace }));
             const result = await session.memwal.rememberBulkAndWait(items, {

--- a/services/server/scripts/mcp/tools/remember.ts
+++ b/services/server/scripts/mcp/tools/remember.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool, walruscanBlobUrl } from "./util.js";
 
 const REMEMBER_INPUT = {
@@ -31,10 +32,14 @@ export function registerRememberTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_remember",
-        "Save a durable fact about the user or project to their Walrus Memory. Call this PROACTIVELY whenever you learn something worth remembering across sessions — a stated preference, decision, constraint, correction, identity detail, or recurring workflow — even if the user did not explicitly say 'remember this'. Pass the full statement; do not summarize. To save several facts at once, use memwal_remember_bulk instead.",
-        REMEMBER_INPUT,
+        {
+            ...TOOL_METADATA.memwal_remember,
+            description:
+                "Save a durable fact about the user or project to their Walrus Memory. Call this PROACTIVELY whenever you learn something worth remembering across sessions — a stated preference, decision, constraint, correction, identity detail, or recurring workflow — even if the user did not explicitly say 'remember this'. Pass the full statement; do not summarize. To save several facts at once, use memwal_remember_bulk instead.",
+            inputSchema: REMEMBER_INPUT,
+        },
         wrapTool<{ text: string; namespace?: string }>(async ({ text, namespace }) => {
             const result = await session.memwal.rememberAndWait(
                 text,

--- a/services/server/scripts/mcp/tools/restore.ts
+++ b/services/server/scripts/mcp/tools/restore.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool } from "./util.js";
 
 const RESTORE_INPUT = {
@@ -45,10 +46,14 @@ export function registerRestoreTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_restore",
-        "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. If truncated=true, increase limit and call again. Call memwal_recall afterwards to query the rebuilt index.",
-        RESTORE_INPUT,
+        {
+            ...TOOL_METADATA.memwal_restore,
+            description:
+                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. If truncated=true, increase limit and call again. Call memwal_recall afterwards to query the rebuilt index.",
+            inputSchema: RESTORE_INPUT,
+        },
         wrapTool<{ namespace: string; limit: number }>(async ({ namespace, limit }) => {
             const result = await session.memwal.restore(namespace, limit);
             return {


### PR DESCRIPTION
## Summary

- add human-readable top-level `title` metadata to all six remote Walrus Memory MCP tools
- classify `memwal_recall` and `memwal_health` as read-only
- classify write/re-index tools as non-read-only but non-destructive (additive updates)
- verify the exact metadata emitted by the MCP SDK through a real in-memory `tools/list` exchange

## Tool annotations

| Tool | Title | `readOnlyHint` | `destructiveHint` |
|---|---|---:|---:|
| `memwal_remember` | Remember a Fact | false | false |
| `memwal_remember_bulk` | Remember Multiple Facts | false | false |
| `memwal_analyze` | Analyze and Remember | false | false |
| `memwal_restore` | Restore Memory Index | false | false |
| `memwal_recall` | Recall Memories | true | false |
| `memwal_health` | Check Walrus Memory Health | true | false |

## Why

Claude's official custom-connector submission asks for tool titles and `readOnlyHint` / `destructiveHint` annotations. Without explicit values, the MCP defaults describe non-read-only tools as potentially destructive.

## Validation

- `node --test --import tsx mcp/__tests__/tool-annotations.test.ts`
- `git diff --check`

After deployment, verify the authenticated production `tools/list` response before sending the connector for review.
