### PR TITLE
chore(release): bump MCP package to 0.0.8 & update changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.7"
+      "version": "0.0.8"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.7"
+      "version": "0.0.8"
     }
   ]
 }

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,14 +28,14 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.8. It adds human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for Claude custom connector compliance, alongside 0.0.7 improvements to credential reload and bounded restore error handling.
+  The latest MCP package release is 0.0.8. It adds human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login discovery, matching the remote relayer metadata used by Claude connectors. Version 0.0.7 added credential reload and bounded restore error handling.
 ---
 
 ## 0.0.8
 
 ### Added
 
-- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
+- Human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login tool discovery, matching the remote relayer metadata used by Claude connectors.
 
 ## 0.0.7
 

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,8 +28,14 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.7. It reloads credentials after browser login, rejects stale credential handshakes and cross-account request replay, and reports bounded restore truncation explicitly.
+  The latest MCP package release is 0.0.8. It adds human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for Claude custom connector compliance, alongside 0.0.7 improvements to credential reload and bounded restore error handling.
 ---
+
+## 0.0.8
+
+### Added
+
+- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
 
 ## 0.0.7
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mysten-incubation/memwal-mcp
 
+## 0.0.8
+
+### Added
+
+- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
+
 ## 0.0.7
 
 ### Fixed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
+- Human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login tool discovery, matching the remote relayer metadata used by Claude connectors.
 
 ## 0.0.7
 

--- a/packages/mcp/TESTING.md
+++ b/packages/mcp/TESTING.md
@@ -206,7 +206,7 @@ What merging to `dev` triggers, and how to try the result end-to-end.
 
 | Surface | Trigger | Result |
 |---|---|---|
-| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.8-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
+| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.8-dev.N` under the `dev` dist-tag (`latest` stays 0.0.7 until `main`) |
 | Plugin marketplace | none needed — `dev` is the repo's **default branch** | `/plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge |
 | Sidecar tools (Layer 1) | Railway image rebuild (`services/server/Dockerfile` copies `scripts/mcp/`) | New agentic descriptions + `memwal_remember_bulk`/`memwal_health` on `relayer.dev.memwal.ai` — **verify the Railway dev environment actually redeployed**; this is not a repo workflow |
 

--- a/packages/mcp/TESTING.md
+++ b/packages/mcp/TESTING.md
@@ -206,7 +206,7 @@ What merging to `dev` triggers, and how to try the result end-to-end.
 
 | Surface | Trigger | Result |
 |---|---|---|
-| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.7-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
+| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.8-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
 | Plugin marketplace | none needed — `dev` is the repo's **default branch** | `/plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge |
 | Sidecar tools (Layer 1) | Railway image rebuild (`services/server/Dockerfile` copies `scripts/mcp/`) | New agentic descriptions + `memwal_remember_bulk`/`memwal_health` on `relayer.dev.memwal.ai` — **verify the Railway dev environment actually redeployed**; this is not a repo workflow |
 
@@ -262,5 +262,5 @@ Enable `codex_hooks = true`, restart Codex, repeat the Step 2 prompts.
 ### Step 5 — Promotion sanity (before merging dev → main later)
 
 - [ ] Prod relayer redeployed with the new sidecar (same Step 1 check against `relayer.memory.walrus.xyz`)
-- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.7-dev.N`; after main merge, `latest` = `0.0.7`
+- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.8-dev.N`; after main merge, `latest` = `0.0.8`
 - [ ] Mintlify docs published (the 6 provider pages + reference + changelog render, nav matches)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -37,6 +37,8 @@ interface RpcMessage {
 const TOOL_DEFINITIONS = [
     {
         name: "memwal_remember",
+        title: "Remember a Fact",
+        annotations: { readOnlyHint: false, destructiveHint: false },
         description:
             "Save a fact to the user's Walrus Memory personal memory. Call ONLY when the user explicitly asks to remember/save something. Pass the full, detailed text — never summarize.",
         inputSchema: {
@@ -51,6 +53,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_recall",
+        title: "Recall Memories",
+        annotations: { readOnlyHint: false, destructiveHint: true },
         description:
             "Search the user's Walrus Memory for facts relevant to a query. Returns matching memories ranked by relevance.",
         inputSchema: {
@@ -66,6 +70,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_analyze",
+        title: "Analyze and Remember",
+        annotations: { readOnlyHint: false, destructiveHint: true },
         description:
             "Extract memorable facts from a passage of text (preferences, habits, biographical info, constraints) and save each as a separate Walrus Memory memory.",
         inputSchema: {
@@ -80,6 +86,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_restore",
+        title: "Restore Memory Index",
+        annotations: { readOnlyHint: false, destructiveHint: false },
         description:
             "Re-index a namespace from Walrus blobs back into the relayer's search index. Returns counts and truncated status; call again with a higher limit when truncated=true.",
         inputSchema: {
@@ -94,6 +102,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_login",
+        title: "Sign In to Walrus Memory",
+        annotations: { readOnlyHint: false, destructiveHint: false },
         description:
             "Sign this MCP client into your Walrus Memory account by opening a browser. Run once when the agent reports Walrus Memory is not signed in. Opens the dashboard in the default browser, waits for wallet approval, then writes credentials to ~/.memwal/credentials.json. Other memwal_* tools become usable on the next call after a successful login.",
         inputSchema: {

--- a/packages/mcp/test/login-handoff.test.mjs
+++ b/packages/mcp/test/login-handoff.test.mjs
@@ -167,6 +167,36 @@ test("auth-required mode picks up credentials mid-session without a restart", as
     const init = await waitFor((m) => m.id === 1 && m.result);
     assert.equal(init.result.serverInfo.name, "memwal");
 
+    // Pre-login discovery must expose the same safety metadata clients will
+    // receive after the bridge hands off to the remote relayer.
+    send({ jsonrpc: "2.0", id: 10, method: "tools/list", params: {} });
+    const listed = await waitFor((m) => m.id === 10 && m.result);
+    const metadata = Object.fromEntries(
+        listed.result.tools.map(({ name, title, annotations }) => [name, { title, annotations }]),
+    );
+    assert.deepEqual(metadata, {
+        memwal_remember: {
+            title: "Remember a Fact",
+            annotations: { readOnlyHint: false, destructiveHint: false },
+        },
+        memwal_recall: {
+            title: "Recall Memories",
+            annotations: { readOnlyHint: false, destructiveHint: true },
+        },
+        memwal_analyze: {
+            title: "Analyze and Remember",
+            annotations: { readOnlyHint: false, destructiveHint: true },
+        },
+        memwal_restore: {
+            title: "Restore Memory Index",
+            annotations: { readOnlyHint: false, destructiveHint: false },
+        },
+        memwal_login: {
+            title: "Sign In to Walrus Memory",
+            annotations: { readOnlyHint: false, destructiveHint: false },
+        },
+    });
+
     // 2. recall before login → not-signed-in instruction.
     send({
         jsonrpc: "2.0",

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -23,7 +23,7 @@ const releases = [
     },
     {
         name: "MCP package",
-        version: "0.0.7",
+        version: "0.0.8",
         manifests: [
             ["packages/mcp/package.json", "version"],
             [".claude-plugin/marketplace.json", "plugin-version"],

--- a/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
+++ b/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
@@ -34,7 +34,7 @@ test("tools/list publishes safe titles and behavior annotations for every remote
             },
             memwal_analyze: {
                 title: "Analyze and Remember",
-                annotations: { readOnlyHint: false, destructiveHint: false },
+                annotations: { readOnlyHint: false, destructiveHint: true },
             },
             memwal_restore: {
                 title: "Restore Memory Index",
@@ -42,7 +42,7 @@ test("tools/list publishes safe titles and behavior annotations for every remote
             },
             memwal_recall: {
                 title: "Recall Memories",
-                annotations: { readOnlyHint: true, destructiveHint: false },
+                annotations: { readOnlyHint: false, destructiveHint: true },
             },
             memwal_health: {
                 title: "Check Walrus Memory Health",

--- a/services/server/scripts/mcp/tools/annotations.ts
+++ b/services/server/scripts/mcp/tools/annotations.ts
@@ -17,7 +17,8 @@ export const TOOL_METADATA = {
     },
     memwal_analyze: {
         title: "Analyze and Remember",
-        annotations: { readOnlyHint: false, destructiveHint: false },
+        // Context recall may remove stale vector rows for blobs confirmed absent.
+        annotations: { readOnlyHint: false, destructiveHint: true },
     },
     memwal_restore: {
         title: "Restore Memory Index",
@@ -25,7 +26,8 @@ export const TOOL_METADATA = {
     },
     memwal_recall: {
         title: "Recall Memories",
-        annotations: { readOnlyHint: true, destructiveHint: false },
+        // Recall cleans stale index rows when Walrus confirms a blob is absent.
+        annotations: { readOnlyHint: false, destructiveHint: true },
     },
     memwal_health: {
         title: "Check Walrus Memory Health",


### PR DESCRIPTION
## Summary

- bump `@mysten-incubation/memwal-mcp` from `0.0.7` to `0.0.8`
- add human-readable tool titles and explicit behavior annotations to the npm client's pre-login `tools/list`
- include the remote relayer annotation correction: recall/analyze disclose their possible stale-index cleanup side effect
- synchronize Claude Code, Cursor, Codex, and Antigravity plugin manifests
- update package/docs changelogs and release validation expectations

## Annotation safety

- `memwal_recall`: non-read-only and potentially destructive because a confirmed Walrus 404 triggers stale vector-row cleanup
- `memwal_analyze`: potentially destructive because pre-extraction context lookup uses the same cleanup path
- `memwal_remember`, `memwal_restore`, and `memwal_login`: non-read-only, non-destructive
- remote `memwal_health`: read-only, non-destructive

## Validation

- `node scripts/verify-manual-sdk-release.mjs`
- `pnpm --filter @mysten-incubation/memwal-mcp typecheck`
- `pnpm --filter @mysten-incubation/memwal-mcp test` (10/10)
- remote `tools/list` annotation tests (4/4 focused tests)
- `git diff --check`

## Rollout

The npm release and relayer deployment are separate surfaces. After promotion, verify both pre-login npm discovery and authenticated production remote `tools/list` before connector submission.
