### PR TITLE
fix(mcp): disclose recall cleanup side effects

### DIFF
--- a/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
+++ b/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
@@ -34,7 +34,7 @@ test("tools/list publishes safe titles and behavior annotations for every remote
             },
             memwal_analyze: {
                 title: "Analyze and Remember",
-                annotations: { readOnlyHint: false, destructiveHint: false },
+                annotations: { readOnlyHint: false, destructiveHint: true },
             },
             memwal_restore: {
                 title: "Restore Memory Index",
@@ -42,7 +42,7 @@ test("tools/list publishes safe titles and behavior annotations for every remote
             },
             memwal_recall: {
                 title: "Recall Memories",
-                annotations: { readOnlyHint: true, destructiveHint: false },
+                annotations: { readOnlyHint: false, destructiveHint: true },
             },
             memwal_health: {
                 title: "Check Walrus Memory Health",

--- a/services/server/scripts/mcp/tools/annotations.ts
+++ b/services/server/scripts/mcp/tools/annotations.ts
@@ -17,7 +17,8 @@ export const TOOL_METADATA = {
     },
     memwal_analyze: {
         title: "Analyze and Remember",
-        annotations: { readOnlyHint: false, destructiveHint: false },
+        // Context recall may remove stale vector rows for blobs confirmed absent.
+        annotations: { readOnlyHint: false, destructiveHint: true },
     },
     memwal_restore: {
         title: "Restore Memory Index",
@@ -25,7 +26,8 @@ export const TOOL_METADATA = {
     },
     memwal_recall: {
         title: "Recall Memories",
-        annotations: { readOnlyHint: true, destructiveHint: false },
+        // Recall cleans stale index rows when Walrus confirms a blob is absent.
+        annotations: { readOnlyHint: false, destructiveHint: true },
     },
     memwal_health: {
         title: "Check Walrus Memory Health",


### PR DESCRIPTION
## Summary

- mark `memwal_recall` non-read-only and destructive because its hydration path deletes stale vector rows after a confirmed Walrus 404
- mark `memwal_analyze` destructive because pre-extraction context lookup uses the same cleanup path
- keep the exact `tools/list` contract test aligned with the real side effects

## Why

MCP annotations describe possible behavior, not only the primary intent of a tool. Although recall normally reads and analyze normally adds memories, both may invoke `WalrusSealEngine::cleanup_expired_blob` and delete stale index rows. Advertising recall as read-only or analyze as non-destructive is therefore unsafe for client confirmation policy and blocks the 0.0.8 release claim in #649.

## Validation

- `node --test --import tsx mcp/__tests__/tool-annotations.test.ts mcp/__tests__/restore.test.ts` (4/4)
- `git diff --check`

## Dependency

Merge this correction before #649 or any production claim that the annotations are Claude-review ready.
