### PR TITLE
Promote staging to main

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.7"
+      "version": "0.0.8"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.7"
+      "version": "0.0.8"
     }
   ]
 }

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,14 +28,14 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.8. It adds human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for Claude custom connector compliance, alongside 0.0.7 improvements to credential reload and bounded restore error handling.
+  The latest MCP package release is 0.0.8. It adds human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login discovery, matching the remote relayer metadata used by Claude connectors. Version 0.0.7 added credential reload and bounded restore error handling.
 ---
 
 ## 0.0.8
 
 ### Added
 
-- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
+- Human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login tool discovery, matching the remote relayer metadata used by Claude connectors.
 
 ## 0.0.7
 

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,8 +28,14 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.7. It reloads credentials after browser login, rejects stale credential handshakes and cross-account request replay, and reports bounded restore truncation explicitly.
+  The latest MCP package release is 0.0.8. It adds human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for Claude custom connector compliance, alongside 0.0.7 improvements to credential reload and bounded restore error handling.
 ---
+
+## 0.0.8
+
+### Added
+
+- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
 
 ## 0.0.7
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mysten-incubation/memwal-mcp
 
+## 0.0.8
+
+### Added
+
+- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
+
 ## 0.0.7
 
 ### Fixed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Human-readable tool titles and MCP behavior annotations (`readOnlyHint`, `destructiveHint`) for all remote Walrus Memory tools for Claude custom connector compliance.
+- Human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login tool discovery, matching the remote relayer metadata used by Claude connectors.
 
 ## 0.0.7
 

--- a/packages/mcp/TESTING.md
+++ b/packages/mcp/TESTING.md
@@ -206,7 +206,7 @@ What merging to `dev` triggers, and how to try the result end-to-end.
 
 | Surface | Trigger | Result |
 |---|---|---|
-| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.8-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
+| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.8-dev.N` under the `dev` dist-tag (`latest` stays 0.0.7 until `main`) |
 | Plugin marketplace | none needed — `dev` is the repo's **default branch** | `/plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge |
 | Sidecar tools (Layer 1) | Railway image rebuild (`services/server/Dockerfile` copies `scripts/mcp/`) | New agentic descriptions + `memwal_remember_bulk`/`memwal_health` on `relayer.dev.memwal.ai` — **verify the Railway dev environment actually redeployed**; this is not a repo workflow |
 

--- a/packages/mcp/TESTING.md
+++ b/packages/mcp/TESTING.md
@@ -206,7 +206,7 @@ What merging to `dev` triggers, and how to try the result end-to-end.
 
 | Surface | Trigger | Result |
 |---|---|---|
-| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.7-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
+| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.8-dev.N` under the `dev` dist-tag (`latest` stays 0.0.5 until `main`) |
 | Plugin marketplace | none needed — `dev` is the repo's **default branch** | `/plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge |
 | Sidecar tools (Layer 1) | Railway image rebuild (`services/server/Dockerfile` copies `scripts/mcp/`) | New agentic descriptions + `memwal_remember_bulk`/`memwal_health` on `relayer.dev.memwal.ai` — **verify the Railway dev environment actually redeployed**; this is not a repo workflow |
 
@@ -262,5 +262,5 @@ Enable `codex_hooks = true`, restart Codex, repeat the Step 2 prompts.
 ### Step 5 — Promotion sanity (before merging dev → main later)
 
 - [ ] Prod relayer redeployed with the new sidecar (same Step 1 check against `relayer.memory.walrus.xyz`)
-- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.7-dev.N`; after main merge, `latest` = `0.0.7`
+- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.8-dev.N`; after main merge, `latest` = `0.0.8`
 - [ ] Mintlify docs published (the 6 provider pages + reference + changelog render, nav matches)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -37,6 +37,8 @@ interface RpcMessage {
 const TOOL_DEFINITIONS = [
     {
         name: "memwal_remember",
+        title: "Remember a Fact",
+        annotations: { readOnlyHint: false, destructiveHint: false },
         description:
             "Save a fact to the user's Walrus Memory personal memory. Call ONLY when the user explicitly asks to remember/save something. Pass the full, detailed text — never summarize.",
         inputSchema: {
@@ -51,6 +53,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_recall",
+        title: "Recall Memories",
+        annotations: { readOnlyHint: false, destructiveHint: true },
         description:
             "Search the user's Walrus Memory for facts relevant to a query. Returns matching memories ranked by relevance.",
         inputSchema: {
@@ -66,6 +70,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_analyze",
+        title: "Analyze and Remember",
+        annotations: { readOnlyHint: false, destructiveHint: true },
         description:
             "Extract memorable facts from a passage of text (preferences, habits, biographical info, constraints) and save each as a separate Walrus Memory memory.",
         inputSchema: {
@@ -80,6 +86,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_restore",
+        title: "Restore Memory Index",
+        annotations: { readOnlyHint: false, destructiveHint: false },
         description:
             "Re-index a namespace from Walrus blobs back into the relayer's search index. Returns counts and truncated status; call again with a higher limit when truncated=true.",
         inputSchema: {
@@ -94,6 +102,8 @@ const TOOL_DEFINITIONS = [
     },
     {
         name: "memwal_login",
+        title: "Sign In to Walrus Memory",
+        annotations: { readOnlyHint: false, destructiveHint: false },
         description:
             "Sign this MCP client into your Walrus Memory account by opening a browser. Run once when the agent reports Walrus Memory is not signed in. Opens the dashboard in the default browser, waits for wallet approval, then writes credentials to ~/.memwal/credentials.json. Other memwal_* tools become usable on the next call after a successful login.",
         inputSchema: {

--- a/packages/mcp/test/login-handoff.test.mjs
+++ b/packages/mcp/test/login-handoff.test.mjs
@@ -167,6 +167,36 @@ test("auth-required mode picks up credentials mid-session without a restart", as
     const init = await waitFor((m) => m.id === 1 && m.result);
     assert.equal(init.result.serverInfo.name, "memwal");
 
+    // Pre-login discovery must expose the same safety metadata clients will
+    // receive after the bridge hands off to the remote relayer.
+    send({ jsonrpc: "2.0", id: 10, method: "tools/list", params: {} });
+    const listed = await waitFor((m) => m.id === 10 && m.result);
+    const metadata = Object.fromEntries(
+        listed.result.tools.map(({ name, title, annotations }) => [name, { title, annotations }]),
+    );
+    assert.deepEqual(metadata, {
+        memwal_remember: {
+            title: "Remember a Fact",
+            annotations: { readOnlyHint: false, destructiveHint: false },
+        },
+        memwal_recall: {
+            title: "Recall Memories",
+            annotations: { readOnlyHint: false, destructiveHint: true },
+        },
+        memwal_analyze: {
+            title: "Analyze and Remember",
+            annotations: { readOnlyHint: false, destructiveHint: true },
+        },
+        memwal_restore: {
+            title: "Restore Memory Index",
+            annotations: { readOnlyHint: false, destructiveHint: false },
+        },
+        memwal_login: {
+            title: "Sign In to Walrus Memory",
+            annotations: { readOnlyHint: false, destructiveHint: false },
+        },
+    });
+
     // 2. recall before login → not-signed-in instruction.
     send({
         jsonrpc: "2.0",

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -23,7 +23,7 @@ const releases = [
     },
     {
         name: "MCP package",
-        version: "0.0.7",
+        version: "0.0.8",
         manifests: [
             ["packages/mcp/package.json", "version"],
             [".claude-plugin/marketplace.json", "plugin-version"],

--- a/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
+++ b/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { MemWalSession } from "../auth.js";
+import { createMcpServer } from "../server.js";
+
+test("tools/list publishes safe titles and behavior annotations for every remote tool", async (t) => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createMcpServer({} as MemWalSession);
+    const client = new Client({ name: "annotations-test", version: "1.0.0" });
+
+    t.after(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const { tools } = await client.listTools();
+
+    assert.deepEqual(
+        Object.fromEntries(
+            tools.map(({ name, title, annotations }) => [name, { title, annotations }])
+        ),
+        {
+            memwal_remember: {
+                title: "Remember a Fact",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_remember_bulk: {
+                title: "Remember Multiple Facts",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_analyze: {
+                title: "Analyze and Remember",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_restore: {
+                title: "Restore Memory Index",
+                annotations: { readOnlyHint: false, destructiveHint: false },
+            },
+            memwal_recall: {
+                title: "Recall Memories",
+                annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+            memwal_health: {
+                title: "Check Walrus Memory Health",
+                annotations: { readOnlyHint: true, destructiveHint: false },
+            },
+        }
+    );
+});

--- a/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
+++ b/services/server/scripts/mcp/__tests__/tool-annotations.test.ts
@@ -34,7 +34,7 @@ test("tools/list publishes safe titles and behavior annotations for every remote
             },
             memwal_analyze: {
                 title: "Analyze and Remember",
-                annotations: { readOnlyHint: false, destructiveHint: false },
+                annotations: { readOnlyHint: false, destructiveHint: true },
             },
             memwal_restore: {
                 title: "Restore Memory Index",
@@ -42,7 +42,7 @@ test("tools/list publishes safe titles and behavior annotations for every remote
             },
             memwal_recall: {
                 title: "Recall Memories",
-                annotations: { readOnlyHint: true, destructiveHint: false },
+                annotations: { readOnlyHint: false, destructiveHint: true },
             },
             memwal_health: {
                 title: "Check Walrus Memory Health",

--- a/services/server/scripts/mcp/tools/analyze.ts
+++ b/services/server/scripts/mcp/tools/analyze.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool, explorerFooter } from "./util.js";
 
 const ANALYZE_INPUT = {
@@ -27,10 +28,14 @@ export function registerAnalyzeTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_analyze",
-        "Extract memorable facts from a longer passage of text (preferences, habits, biographical info, constraints) and save each as a separate Walrus Memory memory. Use this when you want MemWal's LLM to split the facts out of a transcript or notes for you; if you already know the exact facts, use memwal_remember or memwal_remember_bulk instead.",
-        ANALYZE_INPUT,
+        {
+            ...TOOL_METADATA.memwal_analyze,
+            description:
+                "Extract memorable facts from a longer passage of text (preferences, habits, biographical info, constraints) and save each as a separate Walrus Memory memory. Use this when you want MemWal's LLM to split the facts out of a transcript or notes for you; if you already know the exact facts, use memwal_remember or memwal_remember_bulk instead.",
+            inputSchema: ANALYZE_INPUT,
+        },
         wrapTool<{ text: string; namespace?: string }>(async ({ text, namespace }) => {
             const result = await session.memwal.analyzeAndWait(text, namespace, {
                 timeoutMs: 180_000,

--- a/services/server/scripts/mcp/tools/annotations.ts
+++ b/services/server/scripts/mcp/tools/annotations.ts
@@ -1,0 +1,34 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+interface RemoteToolMetadata {
+    title: string;
+    annotations: ToolAnnotations;
+}
+
+/** Metadata surfaced to MCP clients through `tools/list`. */
+export const TOOL_METADATA = {
+    memwal_remember: {
+        title: "Remember a Fact",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_remember_bulk: {
+        title: "Remember Multiple Facts",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_analyze: {
+        title: "Analyze and Remember",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_restore: {
+        title: "Restore Memory Index",
+        annotations: { readOnlyHint: false, destructiveHint: false },
+    },
+    memwal_recall: {
+        title: "Recall Memories",
+        annotations: { readOnlyHint: true, destructiveHint: false },
+    },
+    memwal_health: {
+        title: "Check Walrus Memory Health",
+        annotations: { readOnlyHint: true, destructiveHint: false },
+    },
+} as const satisfies Record<string, RemoteToolMetadata>;

--- a/services/server/scripts/mcp/tools/annotations.ts
+++ b/services/server/scripts/mcp/tools/annotations.ts
@@ -17,7 +17,8 @@ export const TOOL_METADATA = {
     },
     memwal_analyze: {
         title: "Analyze and Remember",
-        annotations: { readOnlyHint: false, destructiveHint: false },
+        // Context recall may remove stale vector rows for blobs confirmed absent.
+        annotations: { readOnlyHint: false, destructiveHint: true },
     },
     memwal_restore: {
         title: "Restore Memory Index",
@@ -25,7 +26,8 @@ export const TOOL_METADATA = {
     },
     memwal_recall: {
         title: "Recall Memories",
-        annotations: { readOnlyHint: true, destructiveHint: false },
+        // Recall cleans stale index rows when Walrus confirms a blob is absent.
+        annotations: { readOnlyHint: false, destructiveHint: true },
     },
     memwal_health: {
         title: "Check Walrus Memory Health",

--- a/services/server/scripts/mcp/tools/health.ts
+++ b/services/server/scripts/mcp/tools/health.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool } from "./util.js";
 
 /**
@@ -12,10 +13,14 @@ export function registerHealthTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_health",
-        "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
-        {},
+        {
+            ...TOOL_METADATA.memwal_health,
+            description:
+                "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
+            inputSchema: {},
+        },
         wrapTool<Record<string, never>>(async () => {
             const result = await session.memwal.health();
             return {

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool } from "./util.js";
 
 const RECALL_INPUT = {
@@ -37,10 +38,14 @@ export function registerRecallTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_recall",
-        "Search the user's Walrus Memory for relevant facts before responding. Call this PROACTIVELY at the start of a task, or whenever the user references past work, prior decisions, their preferences, or anything you may have stored earlier — don't wait to be asked. A single focused query is usually enough — recall is a real retrieval over encrypted storage, so do NOT fire multiple redundant searches for the same question. Returns matching memories ranked by relevance.",
-        RECALL_INPUT,
+        {
+            ...TOOL_METADATA.memwal_recall,
+            description:
+                "Search the user's Walrus Memory for relevant facts before responding. Call this PROACTIVELY at the start of a task, or whenever the user references past work, prior decisions, their preferences, or anything you may have stored earlier — don't wait to be asked. A single focused query is usually enough — recall is a real retrieval over encrypted storage, so do NOT fire multiple redundant searches for the same question. Returns matching memories ranked by relevance.",
+            inputSchema: RECALL_INPUT,
+        },
         wrapTool<{ query: string; limit: number; namespace?: string }>(async ({ query, limit, namespace }) => {
             const result = await session.memwal.recall(query, limit, namespace);
             if (result.results.length === 0) {

--- a/services/server/scripts/mcp/tools/remember-bulk.ts
+++ b/services/server/scripts/mcp/tools/remember-bulk.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool, explorerFooter } from "./util.js";
 
 const REMEMBER_BULK_INPUT = {
@@ -30,10 +31,14 @@ export function registerRememberBulkTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_remember_bulk",
-        "Save multiple durable facts in one call. Use when you learned several distinct facts at once (onboarding details, a list of preferences, decisions from a discussion). Pass an array of complete fact statements (max 20) — do not summarize. Prefer this over repeated memwal_remember calls.",
-        REMEMBER_BULK_INPUT,
+        {
+            ...TOOL_METADATA.memwal_remember_bulk,
+            description:
+                "Save multiple durable facts in one call. Use when you learned several distinct facts at once (onboarding details, a list of preferences, decisions from a discussion). Pass an array of complete fact statements (max 20) — do not summarize. Prefer this over repeated memwal_remember calls.",
+            inputSchema: REMEMBER_BULK_INPUT,
+        },
         wrapTool<{ facts: string[]; namespace?: string }>(async ({ facts, namespace }) => {
             const items = facts.map((text) => ({ text, namespace }));
             const result = await session.memwal.rememberBulkAndWait(items, {

--- a/services/server/scripts/mcp/tools/remember.ts
+++ b/services/server/scripts/mcp/tools/remember.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool, walruscanBlobUrl } from "./util.js";
 
 const REMEMBER_INPUT = {
@@ -31,10 +32,14 @@ export function registerRememberTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_remember",
-        "Save a durable fact about the user or project to their Walrus Memory. Call this PROACTIVELY whenever you learn something worth remembering across sessions — a stated preference, decision, constraint, correction, identity detail, or recurring workflow — even if the user did not explicitly say 'remember this'. Pass the full statement; do not summarize. To save several facts at once, use memwal_remember_bulk instead.",
-        REMEMBER_INPUT,
+        {
+            ...TOOL_METADATA.memwal_remember,
+            description:
+                "Save a durable fact about the user or project to their Walrus Memory. Call this PROACTIVELY whenever you learn something worth remembering across sessions — a stated preference, decision, constraint, correction, identity detail, or recurring workflow — even if the user did not explicitly say 'remember this'. Pass the full statement; do not summarize. To save several facts at once, use memwal_remember_bulk instead.",
+            inputSchema: REMEMBER_INPUT,
+        },
         wrapTool<{ text: string; namespace?: string }>(async ({ text, namespace }) => {
             const result = await session.memwal.rememberAndWait(
                 text,

--- a/services/server/scripts/mcp/tools/restore.ts
+++ b/services/server/scripts/mcp/tools/restore.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { MemWalSession } from "../auth.js";
+import { TOOL_METADATA } from "./annotations.js";
 import { wrapTool } from "./util.js";
 
 const RESTORE_INPUT = {
@@ -45,10 +46,14 @@ export function registerRestoreTool(
     server: McpServer,
     session: MemWalSession
 ): void {
-    server.tool(
+    server.registerTool(
         "memwal_restore",
-        "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. If truncated=true, increase limit and call again. Call memwal_recall afterwards to query the rebuilt index.",
-        RESTORE_INPUT,
+        {
+            ...TOOL_METADATA.memwal_restore,
+            description:
+                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. If truncated=true, increase limit and call again. Call memwal_recall afterwards to query the rebuilt index.",
+            inputSchema: RESTORE_INPUT,
+        },
         wrapTool<{ namespace: string; limit: number }>(async ({ namespace, limit }) => {
             const result = await session.memwal.restore(namespace, limit);
             return {


### PR DESCRIPTION
## Summary

Promote the current validated `staging` branch to `main`.

This promotion adds:
- human-readable top-level MCP tool titles for all six remote tools (#647)
- explicit `readOnlyHint` / `destructiveHint` behavior annotations
- corrected side-effect declarations for recall/analyze stale-index cleanup (#649)
- MCP npm/package and plugin version `0.0.8`, including equivalent pre-login tool metadata (#649)

## Promotion path

- MCP annotation implementation: #647
- MCP 0.0.8 release correction: #649
- dev → staging: #648
- staging head: `40b779469b0c1c644abeb3a7a638ec0f09cca137`

## Staging evidence

- Railway staging relayer deployed successfully from exact commit `40b779469b0c1c644abeb3a7a638ec0f09cca137`.
- `GET https://relayer-staging.memory.walrus.xyz/health` reports build commit `40b779469b0c1c644abeb3a7a638ec0f09cca137`.
- Staging OAuth protected-resource discovery is live and advertises `memwal:read`, `memwal:write`, and `offline_access`.
- The protocol-level MCP test uses `Client` + `InMemoryTransport` and verifies the exact `tools/list` title/annotation shape for all six remote tools.
- Published RC: `@mysten-incubation/memwal-mcp@0.0.8-rc.0`.
- The RC tarball contains pre-login top-level titles and explicit read/destructive annotations.

### Expected remote metadata

| Tool | Title | `readOnlyHint` | `destructiveHint` |
|---|---|---:|---:|
| `memwal_remember` | Remember a Fact | false | false |
| `memwal_remember_bulk` | Remember Multiple Facts | false | false |
| `memwal_analyze` | Analyze and Remember | false | true |
| `memwal_restore` | Restore Memory Index | false | false |
| `memwal_recall` | Recall Memories | false | true |
| `memwal_health` | Check Walrus Memory Health | true | false |

`recall` and `analyze` are marked potentially destructive because their hydration path may delete stale vector rows after a confirmed Walrus 404.

## Validation

- all checks on #647, #649, and #648 passed
- MCP package typecheck and 10/10 tests passed
- focused remote annotation tests: 4/4 passed
- release-manifest verification and RC tarball inspection passed
- `git diff --check origin/main...origin/staging` passed
- merge simulation reports no content conflicts

## Production gates

Do not merge until:
- required CI is green on the exact staging head
- an independent reviewer approves the exact staging head
- production deployment/rollback owner is confirmed

After merge:
- confirm stable npm `latest=0.0.8`
- verify production health/build commit and OAuth discovery
- run an authenticated production `tools/list` check and representative tool smoke test
- provide the dedicated reviewer test account to Kimberly through a private channel

## Verification limitation

The staging deployment commit and protocol-level `tools/list` output are verified. A live authenticated staging `tools/list` call was not repeated from this operator machine because it has no staging account/delegate credentials; production promotion should retain the authenticated smoke-test gate above.
