### PR TITLE
fix(python-sdk): close the per-call httpx client instead of dropping it

### DIFF
--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import random
 import time
 import uuid
@@ -88,6 +89,9 @@ AUTH_REJECTED_MESSAGE = (
     "and dashboard credentials. Full troubleshooting: "
     "https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors"
 )
+
+
+logger = logging.getLogger("memwal")
 
 
 # ============================================================
@@ -1277,6 +1281,38 @@ class MemWalRememberJobTimeout(MemWalError):
         self.timeout_ms = timeout_ms
 
 
+async def _discard_http_client(memwal: MemWal) -> None:
+    """Close the cached httpx client, and drop it either way.
+
+    ``close()`` can fail when the client belongs to an event loop that has
+    already finished — the caller still needs ``_client`` cleared so the next
+    request builds one in a loop that is actually running.
+    """
+    try:
+        await memwal.close()
+    except Exception:
+        logger.debug("Closing the cached HTTP client failed", exc_info=True)
+    finally:
+        memwal._client = None
+
+
+async def _with_fresh_http_client(memwal: MemWal, coro: Any) -> Any:
+    """Run ``coro`` with an httpx client owned by the *current* event loop.
+
+    The sync entry points execute each coroutine in a throwaway ``asyncio.run()``
+    loop, and an ``httpx.AsyncClient`` is bound to the loop that created it, so
+    one can never be reused across calls. Both ends are closed rather than just
+    dropped (GH #606): on the way in for anything an earlier loop left behind —
+    e.g. a caller mixing ``await memwal.recall()`` with the sync wrapper — and in
+    ``finally`` for the client this call created, while its loop is still alive.
+    """
+    await _discard_http_client(memwal)
+    try:
+        return await coro
+    finally:
+        await _discard_http_client(memwal)
+
+
 class MemWalSync:
     """Synchronous wrapper around the async :class:`MemWal` client.
 
@@ -1326,11 +1362,10 @@ class MemWalSync:
         except RuntimeError:
             loop = None
 
-        # Reset the httpx client before every asyncio.run() path so it is
-        # recreated inside the loop that will use it. This matters in
-        # notebooks/Jupyter where the sync wrapper runs coroutines in worker
-        # threads with short-lived event loops.
-        self._inner._client = None
+        # The httpx client is created and closed inside the same short-lived
+        # loop that uses it. This matters in notebooks/Jupyter where the sync
+        # wrapper runs coroutines in worker threads with their own event loops.
+        wrapped = _with_fresh_http_client(self._inner, coro)
 
         if loop is not None and loop.is_running():
             # Already inside an event loop (e.g. Jupyter).
@@ -1338,9 +1373,9 @@ class MemWalSync:
             import concurrent.futures
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                return pool.submit(asyncio.run, coro).result()
+                return pool.submit(asyncio.run, wrapped).result()
         else:
-            return asyncio.run(coro)
+            return asyncio.run(wrapped)
 
     def remember(
         self,

--- a/packages/python-sdk-memwal/memwal/middleware.py
+++ b/packages/python-sdk-memwal/memwal/middleware.py
@@ -54,7 +54,7 @@ from typing import (
     Optional,
 )
 
-from .client import MemWal
+from .client import MemWal, _with_fresh_http_client
 from .types import RecallMemory
 
 if TYPE_CHECKING:
@@ -579,8 +579,7 @@ def _wrap_sync_openai(
 
     def _run_memwal(coro_factory: Callable[[], Any]) -> Any:
         # Keep httpx clients bound to the short-lived loop that uses them.
-        memwal._client = None
-        return _run_blocking(coro_factory)
+        return _run_blocking(lambda: _with_fresh_http_client(memwal, coro_factory()))
 
     def patched_create(*args: Any, **kwargs: Any) -> Any:
         messages = kwargs.get("messages") or (args[0] if args else None)

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -120,9 +120,26 @@ def memwal_client() -> MemWal:
 # ============================================================
 
 
-class _SyncRunInner:
+class _FakeHttpClient:
+    """Stand-in for httpx.AsyncClient, tracking whether it was closed."""
+
     def __init__(self) -> None:
-        self._client = object()
+        self.is_closed = False
+
+    async def aclose(self) -> None:
+        self.is_closed = True
+
+
+class _SyncRunInner:
+    """Minimal stand-in mirroring MemWal's httpx client lifecycle."""
+
+    def __init__(self) -> None:
+        self._client: Any = _FakeHttpClient()
+
+    async def close(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
 
 
 class TestMemWalSyncRun:
@@ -136,6 +153,57 @@ class TestMemWalSyncRun:
         result = sync._run(operation())
 
         assert result == "ok"
+        assert inner._client is None
+
+    async def test_closes_the_client_it_replaces(self) -> None:
+        """GH #606: _run() used to null out _client without closing it, leaking
+        the connection pool of every client an earlier event loop left behind."""
+        inner = _SyncRunInner()
+        orphan = inner._client
+        sync = MemWalSync(inner)  # type: ignore[arg-type]
+
+        async def operation() -> str:
+            return "ok"
+
+        assert not orphan.is_closed
+        assert sync._run(operation()) == "ok"
+
+        assert orphan.is_closed, "the replaced httpx client was never closed"
+        assert inner._client is None
+
+    async def test_closes_the_client_created_during_the_call(self) -> None:
+        """The per-call client is closed inside the loop that created it, so
+        repeated sync calls do not accumulate open pools."""
+        inner = _SyncRunInner()
+        await inner.close()
+        sync = MemWalSync(inner)  # type: ignore[arg-type]
+        created: list = []
+
+        async def operation() -> str:
+            # Stands in for the lazy `_http` property building a client inside
+            # whichever loop is currently running.
+            inner._client = _FakeHttpClient()
+            created.append(inner._client)
+            return "ok"
+
+        assert sync._run(operation()) == "ok"
+
+        assert len(created) == 1
+        assert created[0].is_closed, "the per-call httpx client was left open"
+        assert inner._client is None
+
+    async def test_closes_client_even_when_the_operation_raises(self) -> None:
+        inner = _SyncRunInner()
+        orphan = inner._client
+        sync = MemWalSync(inner)  # type: ignore[arg-type]
+
+        async def failing() -> str:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            sync._run(failing())
+
+        assert orphan.is_closed
         assert inner._client is None
 
 


### PR DESCRIPTION
## Ticket

Fixes #606

## What changed?

- New `_with_fresh_http_client()` in `client.py`: closes whatever is cached on entry, and closes the client this call created in `finally`, while the loop owning it is still alive.
- `_discard_http_client()` clears `_client` even when a cross-loop `aclose()` raises, so the next request can always build one in a live loop.
- Both drop sites route through it: `MemWalSync._run()` and `_wrap_sync_openai._run_memwal()`.
- `_SyncRunInner` test stand-in now mirrors `MemWal`'s real `close()` / `aclose()` contract.

## Why is this needed?

Both sync paths cleared `_client` before every `asyncio.run()` so a client is rebuilt inside the loop that uses it, but never closed the one they replaced. Every sync call therefore orphaned an open `httpx.AsyncClient` and its pool until GC — resource warnings, stale sockets and connection churn in notebooks and long-running scripts.

Worth flagging for review: closing on the way **out** is what removes the leak. Closing only on entry, as the issue suggests, still leaves an open client idle between every pair of calls.

## Scope

httpx client lifecycle on the sync entry points. Async paths are untouched — they already own their client for the caller's loop.

### Out of scope

Sync LangChain wrapper skipping recall (#607), branched off this PR.

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

3 new tests in `TestMemWalSyncRun`: replaced client closed, per-call client closed, and both when the coroutine raises. Each verified to fail against the pre-fix `_run()`. Suite: 119 passed, ruff clean.

## How can the reviewer verify it?

```bash
cd packages/python-sdk-memwal
python3 -m pytest tests/ -q -m "not integration"    # 119 passed
python3 -m ruff check memwal/ tests/test_client.py  # clean
```

To watch the tests catch the bug, restore the pre-fix body of `MemWalSync._run()` (`self._inner._client = None; wrapped = coro`) and rerun with `-k SyncRun` → 3 failures.

## Risks and dependencies

- **#607 branches off this one and must merge after it.**
- `_client` is now always `None` between sync calls. Nothing reads it across calls; `_http` rebuilds lazily.
- `aclose()` failures are swallowed by design — a client from a finished loop cannot always be closed, and cleanup must not mask the coroutine's result. Logged at debug.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
