### PR TITLE
fix(python-sdk): recall memories in sync LangChain calls inside a running loop

### DIFF
--- a/packages/python-sdk-memwal/memwal/middleware.py
+++ b/packages/python-sdk-memwal/memwal/middleware.py
@@ -403,24 +403,20 @@ def with_memwal_langchain(
 
         return result
 
+    def _run_memwal(coro_factory: Callable[[], Any]) -> Any:
+        # Keep httpx clients bound to the short-lived loop that uses them.
+        return _run_blocking(lambda: _with_fresh_http_client(memwal, coro_factory()))
+
     def patched_generate(
         messages: List[List[BaseMessage]], *args: Any, **kwargs: Any
     ) -> ChatResult:
-        # For sync generate, we inject memories synchronously via asyncio.run
-        import asyncio
-
+        # Inject via _run_blocking so recall still runs when a loop is already
+        # running (notebooks, async hosts) — the same helper the sync OpenAI
+        # wrapper uses. Passing the messages through untouched there made
+        # Walrus Memory look connected while recall silently never ran.
         enriched = []
         for msg_list in messages:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
-
-            if loop is not None and loop.is_running():
-                # Already in async context -- cannot use asyncio.run
-                enriched.append(msg_list)
-            else:
-                enriched.append(asyncio.run(_inject_memories(msg_list)))
+            enriched.append(_run_memwal(lambda: _inject_memories(msg_list)))
 
         result = original_generate(enriched, *args, **kwargs)
 

--- a/packages/python-sdk-memwal/tests/test_middleware.py
+++ b/packages/python-sdk-memwal/tests/test_middleware.py
@@ -447,6 +447,84 @@ class TestWithMemWalLangChain:
         await smart_llm._agenerate([[SystemMessage("only system")]])
         assert not recall_route.called
 
+    def _capturing_generate(self, captured: list):
+        """Replacement for llm._generate that records the batch it received."""
+        from langchain_core.messages import AIMessage
+        from langchain_core.outputs import ChatGeneration, ChatResult
+
+        def _generate(messages_batch, *a, **kw):
+            captured.extend(messages_batch)
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="ok"))]
+            )
+
+        return _generate
+
+    @respx.mock
+    def test_sync_generate_injects_memories(self) -> None:
+        """The plain sync path (no running loop) recalls and injects."""
+        _mock_seal_session_prereqs()
+        from langchain_core.messages import HumanMessage
+
+        llm = self._make_llm()
+        captured: list = []
+        llm._generate = self._capturing_generate(captured)
+
+        recall_route = respx.post(_RECALL_URL).mock(
+            return_value=_mock_recall([
+                {"blob_id": "b1", "text": "User loves coffee", "distance": 0.05}
+            ])
+        )
+
+        smart_llm = with_memwal_langchain(
+            llm, key=_KEY_HEX, account_id=_ACCOUNT_ID, server_url=_SERVER, auto_save=False
+        )
+        smart_llm._generate([[HumanMessage("What do I drink?")]])
+
+        assert recall_route.called
+        assert any("User loves coffee" in m.content for m in captured[0])
+
+    @respx.mock
+    async def test_sync_generate_injects_memories_inside_running_loop(self) -> None:
+        """GH #607: sync _generate must still recall when a loop is already
+        running (notebooks, async hosts).
+
+        It used to append the untouched msg_list in that branch, so callers got
+        a normal LLM answer with no memory context and no warning -- Walrus
+        Memory looked connected while recall never ran.
+        """
+        _mock_seal_session_prereqs()
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        llm = self._make_llm()
+        captured: list = []
+        llm._generate = self._capturing_generate(captured)
+
+        recall_route = respx.post(_RECALL_URL).mock(
+            return_value=_mock_recall([
+                {"blob_id": "b1", "text": "User loves coffee", "distance": 0.05}
+            ])
+        )
+
+        smart_llm = with_memwal_langchain(
+            llm, key=_KEY_HEX, account_id=_ACCOUNT_ID, server_url=_SERVER, auto_save=False
+        )
+
+        # An async test body is itself a running loop -- the exact condition
+        # that used to disable injection.
+        assert asyncio.get_running_loop().is_running()
+        smart_llm._generate([[HumanMessage("What do I drink?")]])
+
+        assert recall_route.called, "recall was skipped inside a running loop"
+        assert len(captured) == 1
+        injected = captured[0]
+        assert len(injected) == 3, "guard + memory message were not injected"
+        assert any(
+            isinstance(m, HumanMessage) and "User loves coffee" in m.content
+            for m in injected
+        )
+        assert any(isinstance(m, SystemMessage) for m in injected)
+
     def test_wraps_a_real_pydantic_backed_chat_model(self) -> None:
         """with_memwal_langchain must work on a real BaseChatModel, not just
         a MagicMock. LangChain chat models are Pydantic models that reject


### PR DESCRIPTION
## Ticket

Fixes #607

> Stacked on #606: `_run_memwal()` here calls `_with_fresh_http_client()`, which that PR introduces. Base is `fix/sync-http-client-lifecycle` so the diff below stays scoped to this change alone. Merge #606 first; GitHub then retargets this to `dev` automatically.

## What changed?

- `patched_generate()` now injects through the module's existing `_run_blocking()` helper, which runs the coroutine on a worker thread with its own loop.
- Added a local `_run_memwal()` mirroring the sync OpenAI wrapper, so both share one idiom for running memory work from sync code.

## Why is this needed?

The sync `_generate()` wrapper appended the untouched message list whenever an event loop was already running — the normal case in notebooks and async application hosts — and neither raised, warned, nor documented the skip. The LLM call still succeeded, so callers got an ordinary answer with no memory context and no signal that Walrus Memory had been bypassed.

`_run_blocking()` already solves this for the sync OpenAI wrapper; this brings LangChain to the same behaviour rather than inventing a new mechanism.

## Scope

Memory injection on the sync LangChain path (`_generate`). `patched_agenerate` already awaits injection on the caller's loop and is untouched.

### Out of scope

httpx client lifecycle leak (#606), the PR this is based on.

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

2 new tests in `TestWithMemWalLangChain`: the plain sync path, and the regression case inside a running loop — an async test body *is* a running loop, the exact condition that disabled injection. Verified to fail against the pre-fix wrapper. Suite: 121 passed, ruff clean.

## How can the reviewer verify it?

```bash
cd packages/python-sdk-memwal
python3 -m pytest tests/ -q -m "not integration"        # 121 passed
python3 -m ruff check memwal/ tests/test_middleware.py  # clean
```

To watch the test catch the bug, restore the old branch in `patched_generate()` (`if loop is not None and loop.is_running(): enriched.append(msg_list)`) and rerun with `-k sync_generate` → the running-loop test fails, the plain sync one still passes.

## Risks and dependencies

- **Depends on #606**, and the base branch enforces it — this cannot merge into `dev` before #606 lands.
- Sync `_generate()` inside a running loop now performs a blocking recall on a worker thread where it previously returned immediately — that is the fix, but those callers will see the recall latency they were silently skipping.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
