### PR TITLE
ci(python-sdk): build, unit test and e2e workflow against the dev relayer

### DIFF
--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -106,15 +106,24 @@ jobs:
 
       - name: Check credentials
         id: config
+        shell: bash
         run: |
-          # `requires_key` self-skips, so a half-configured environment still
-          # gets the unauthenticated coverage instead of nothing.
-          if [ -n "${MEMWAL_PRIVATE_KEY:-}" ] && [ -n "${MEMWAL_ACCOUNT_ID:-}" ]; then
-            echo "authenticated=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "authenticated=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID are not set on this environment — authenticated e2e tests will be skipped."
+          set -euo pipefail
+
+          # Without these the `requires_key` marker skips every authenticated
+          # test, and the job would report success having never called the
+          # relayer. Fail instead of reporting a green run that proved nothing.
+          missing=0
+          for name in MEMWAL_PRIVATE_KEY MEMWAL_ACCOUNT_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::${name} is empty — set BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID on the benchmark-dev environment."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
           fi
+          echo "authenticated=true" >> "$GITHUB_OUTPUT"
 
       - name: E2E tests
         id: e2e

--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -1,0 +1,145 @@
+name: Test Python SDK
+
+on:
+  pull_request:
+    paths:
+      - 'packages/python-sdk-memwal/**'
+      - '.github/workflows/test-python-sdk.yml'
+  push:
+    branches:
+      - main
+      - staging
+      - dev
+    paths:
+      - 'packages/python-sdk-memwal/**'
+      - '.github/workflows/test-python-sdk.yml'
+  workflow_dispatch:
+  schedule:
+    # Catches relayer drift with no code change to trigger it.
+    - cron: '17 9 * * 1'
+
+concurrency:
+  group: test-python-sdk-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: packages/python-sdk-memwal
+
+jobs:
+  unit:
+    name: Unit / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Tracks requires-python and the pyproject classifiers.
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build and install from source
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Lint
+        run: python -m ruff check memwal/ tests/
+
+      - name: Unit tests
+        run: python -m pytest tests/ -m "not integration" -q
+
+  e2e:
+    name: E2E / dev relayer
+    runs-on: ubuntu-latest
+    needs: unit
+    timeout-minutes: 30
+
+    # Dev only for now; staging and production follow once their credentials
+    # exist. Pull requests are excluded because environment secrets are
+    # withheld from fork PRs, and every authenticated run writes real memories.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref_name == 'dev')
+
+    # Reuses the credentials benchmark-live.yml already relies on, so this
+    # needs no new secrets. Safe to share: the benchmark writes to the
+    # `benchmark` namespace while these tests use `sdk-test`, `default` and a
+    # per-run `sdk-e2e-<uuid>`.
+    environment: benchmark-dev
+
+    env:
+      # BENCH_DELEGATE_KEY is the delegate private key the SDK signs with,
+      # which test_integration.py reads as MEMWAL_PRIVATE_KEY.
+      MEMWAL_PRIVATE_KEY: ${{ secrets.BENCH_DELEGATE_KEY }}
+      MEMWAL_ACCOUNT_ID: ${{ secrets.BENCH_ACCOUNT_ID }}
+      # Public URL (docs/relayer/benchmark-ci-setup.md), defaulted so a missing
+      # variable cannot silently point the run at the wrong relayer.
+      MEMWAL_SERVER_URL: ${{ vars.BENCH_SERVER_URL || 'https://relayer.dev.memwal.ai' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build and install from source
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Check credentials
+        id: config
+        run: |
+          # `requires_key` self-skips, so a half-configured environment still
+          # gets the unauthenticated coverage instead of nothing.
+          if [ -n "${MEMWAL_PRIVATE_KEY:-}" ] && [ -n "${MEMWAL_ACCOUNT_ID:-}" ]; then
+            echo "authenticated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authenticated=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID are not set on this environment — authenticated e2e tests will be skipped."
+          fi
+
+      - name: E2E tests
+        id: e2e
+        run: |
+          python -m pytest tests/test_integration.py -m integration \
+            -v --junit-xml=e2e-results.xml
+
+      - name: Write run summary
+        if: always()
+        run: |
+          {
+            echo "## Python SDK e2e"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Relayer | \`${MEMWAL_SERVER_URL}\` |"
+            echo "| Authenticated | ${{ steps.config.outputs.authenticated }} |"
+            echo "| Result | ${{ steps.e2e.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload e2e results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-sdk-e2e-${{ github.run_id }}
+          path: packages/python-sdk-memwal/e2e-results.xml
+          if-no-files-found: warn
+          retention-days: 14

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -73,6 +73,7 @@ from .utils import (
     bytes_to_hex,
     delegate_key_to_sui_address,
     encode_sui_private_key,
+    normalize_private_key,
     sha256_hex,
     sign_message,
     sign_sui_personal_message,
@@ -213,8 +214,8 @@ class MemWal:
     """
 
     def __init__(self, config: MemWalConfig) -> None:
-        self._signing_key = build_signing_key(config.key)
-        self._private_key_hex = config.key if not config.key.startswith("0x") else config.key[2:]
+        self._private_key_hex = normalize_private_key(config.key)
+        self._signing_key = build_signing_key(self._private_key_hex)
         self._account_id = config.account_id
         self._server_url = config.server_url.rstrip("/")
         self._namespace = config.namespace

--- a/packages/python-sdk-memwal/memwal/utils.py
+++ b/packages/python-sdk-memwal/memwal/utils.py
@@ -232,6 +232,58 @@ def bech32_encode(hrp: str, data: bytes) -> str:
     return hrp + "1" + "".join(_BECH32_CHARSET[d] for d in combined)
 
 
+def bech32_decode(bech: str) -> Tuple[str, bytes]:
+    """Decode a bech32 string into its human-readable part and 5-bit data."""
+    if bech != bech.lower() and bech != bech.upper():
+        raise ValueError("bech32 string is mixed case")
+    bech = bech.lower()
+    pos = bech.rfind("1")
+    if pos < 1 or pos + 7 > len(bech):
+        raise ValueError("bech32 string has no valid separator")
+
+    hrp = bech[:pos]
+    try:
+        data = bytes(_BECH32_CHARSET.index(c) for c in bech[pos + 1 :])
+    except ValueError as exc:
+        raise ValueError("bech32 string has a character outside the charset") from exc
+
+    if _bech32_polymod(_bech32_hrp_expand(hrp) + data) != 1:
+        raise ValueError("bech32 checksum mismatch")
+    return hrp, data[:-6]
+
+
+def decode_sui_private_key(encoded: str) -> bytes:
+    """Decode a Sui bech32 ``suiprivkey1...`` string to its 32-byte Ed25519 seed.
+
+    Inverse of :func:`encode_sui_private_key`. Mirrors ``decodeSuiPrivateKey``
+    from ``@mysten/sui``, which the TypeScript SDK uses.
+    """
+    hrp, data = bech32_decode(encoded)
+    if hrp != "suiprivkey":
+        raise ValueError(f"expected a suiprivkey string, got prefix {hrp!r}")
+
+    payload = _convertbits(data, 5, 8, pad=False)
+    if not payload or payload[0] != _SUI_ED25519_SCHEME_FLAG:
+        raise ValueError("only Ed25519 private keys are supported")
+
+    seed = payload[1:]
+    if len(seed) != 32:
+        raise ValueError(f"Ed25519 seed must be exactly 32 bytes, got {len(seed)}")
+    return seed
+
+
+def normalize_private_key(key: str) -> str:
+    """Accept either a hex seed or a Sui ``suiprivkey1...`` string, return hex.
+
+    The TypeScript SDK takes both, and the dashboard hands out the bech32 form,
+    so hex-only input would reject a key a user reasonably expects to work.
+    """
+    candidate = key.strip()
+    if candidate.lower().startswith("suiprivkey1"):
+        return bytes_to_hex(decode_sui_private_key(candidate))
+    return candidate[2:] if candidate.startswith("0x") else candidate
+
+
 def encode_sui_private_key(seed_bytes: bytes) -> str:
     """Encode a 32-byte Ed25519 seed to Sui bech32 `suiprivkey...` format."""
     if len(seed_bytes) != 32:

--- a/packages/python-sdk-memwal/tests/test_integration.py
+++ b/packages/python-sdk-memwal/tests/test_integration.py
@@ -58,6 +58,12 @@ SERVER_URL = os.environ.get("MEMWAL_SERVER_URL", "https://relayer-staging.memory
 PRIVATE_KEY_HEX = os.environ.get("MEMWAL_PRIVATE_KEY", "")
 ACCOUNT_ID = os.environ.get("MEMWAL_ACCOUNT_ID", "")
 
+# A live write runs embed -> SEAL encrypt -> Walrus upload -> on-chain metadata.
+# Measured around 44s against the dev relayer, so the SDK's 60s default leaves
+# too little headroom to be reliable in CI. 120s matches what the SDK already
+# uses for bulk pipelines.
+_REMEMBER_TIMEOUT_MS = int(os.environ.get("MEMWAL_REMEMBER_TIMEOUT_MS", "120000"))
+
 HAS_KEY = bool(PRIVATE_KEY_HEX and ACCOUNT_ID)
 
 requires_key = pytest.mark.skipif(
@@ -201,7 +207,11 @@ class TestRemember:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
-        result = mw.remember_and_wait("Integration test: the sky is blue", namespace="sdk-test")
+        result = mw.remember_and_wait(
+            "Integration test: the sky is blue",
+            namespace="sdk-test",
+            timeout_ms=_REMEMBER_TIMEOUT_MS,
+        )
         assert result.id is not None and isinstance(result.id, str)
         assert result.blob_id is not None and isinstance(result.blob_id, str)
         assert result.owner.startswith("0x")
@@ -211,14 +221,20 @@ class TestRemember:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
-        result = mw.remember_and_wait("Integration test: namespace default")
+        result = mw.remember_and_wait(
+            "Integration test: namespace default", timeout_ms=_REMEMBER_TIMEOUT_MS
+        )
         assert result.namespace == "default"
 
     def test_remember_custom_namespace(self) -> None:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
-        result = mw.remember_and_wait("Integration test: custom namespace", namespace="sdk-test")
+        result = mw.remember_and_wait(
+            "Integration test: custom namespace",
+            namespace="sdk-test",
+            timeout_ms=_REMEMBER_TIMEOUT_MS,
+        )
         assert result.namespace == "sdk-test"
 
 
@@ -306,7 +322,7 @@ class TestFullFlow:
         )
 
         # Store a distinctive memory in an isolated namespace
-        mem = mw.remember_and_wait(text, namespace=ns)
+        mem = mw.remember_and_wait(text, namespace=ns, timeout_ms=_REMEMBER_TIMEOUT_MS)
         assert mem.id is not None
 
         # Recall — should find the stored memory
@@ -323,7 +339,11 @@ class TestFullFlow:
         mw = MemWalSync.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         )
-        mw.remember_and_wait("I am allergic to shellfish", namespace="sdk-test")
+        mw.remember_and_wait(
+            "I am allergic to shellfish",
+            namespace="sdk-test",
+            timeout_ms=_REMEMBER_TIMEOUT_MS,
+        )
         result = mw.ask("What are my food allergies?", limit=3, namespace="sdk-test")
         assert isinstance(result.answer, str)
         assert len(result.answer) > 0
@@ -356,7 +376,9 @@ class TestAsync:
         async with MemWal.create(
             key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
         ) as mw:
-            await mw.remember_and_wait("Async SDK test: I enjoy reading")
+            await mw.remember_and_wait(
+                "Async SDK test: I enjoy reading", timeout_ms=_REMEMBER_TIMEOUT_MS
+            )
             result = await mw.recall("reading books", limit=3)
             assert isinstance(result.results, list)
 

--- a/packages/python-sdk-memwal/tests/test_integration.py
+++ b/packages/python-sdk-memwal/tests/test_integration.py
@@ -64,12 +64,36 @@ ACCOUNT_ID = os.environ.get("MEMWAL_ACCOUNT_ID", "")
 # uses for bulk pipelines.
 _REMEMBER_TIMEOUT_MS = int(os.environ.get("MEMWAL_REMEMBER_TIMEOUT_MS", "120000"))
 
+# Every authenticated test writes into a namespace unique to this run. The bench
+# account is shared, and `default` in particular is what real users get, so a
+# recurring job must not leave live Walrus blobs there.
+_E2E_NAMESPACE = f"sdk-e2e-{uuid.uuid4().hex[:8]}"
+_E2E_NAMESPACE_ALT = f"{_E2E_NAMESPACE}-alt"
+
 HAS_KEY = bool(PRIVATE_KEY_HEX and ACCOUNT_ID)
 
 requires_key = pytest.mark.skipif(
     not HAS_KEY,
     reason="MEMWAL_PRIVATE_KEY and MEMWAL_ACCOUNT_ID not set",
 )
+
+
+def _sync_client(namespace: str = _E2E_NAMESPACE) -> MemWalSync:
+    return MemWalSync.create(
+        key=PRIVATE_KEY_HEX,
+        account_id=ACCOUNT_ID,
+        server_url=SERVER_URL,
+        namespace=namespace,
+    )
+
+
+def _async_client(namespace: str = _E2E_NAMESPACE) -> MemWal:
+    return MemWal.create(
+        key=PRIVATE_KEY_HEX,
+        account_id=ACCOUNT_ID,
+        server_url=SERVER_URL,
+        namespace=namespace,
+    )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -195,47 +219,42 @@ class TestRemember:
     """remember() / remember_and_wait() against live server."""
 
     def test_remember_returns_job_id_and_status(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
-        result = mw.remember("Integration test: the sky is blue", namespace="sdk-test")
+        mw = _sync_client()
+        result = mw.remember("Integration test: the sky is blue")
         assert result.job_id is not None and isinstance(result.job_id, str)
         assert result.status in ("pending", "running")
         print(f"\n  accepted job={result.job_id[:8]}... status={result.status}")
 
     def test_remember_and_wait_returns_blob_and_owner(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
         result = mw.remember_and_wait(
-            "Integration test: the sky is blue",
-            namespace="sdk-test",
-            timeout_ms=_REMEMBER_TIMEOUT_MS,
+            "Integration test: the sky is blue", timeout_ms=_REMEMBER_TIMEOUT_MS
         )
         assert result.id is not None and isinstance(result.id, str)
         assert result.blob_id is not None and isinstance(result.blob_id, str)
         assert result.owner.startswith("0x")
         print(f"\n  done job={result.id[:8]}... blob={result.blob_id[:8]}...")
 
-    def test_remember_default_namespace(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+    def test_remember_uses_the_client_namespace(self) -> None:
+        """Omitting `namespace` falls back to the one the client was built with.
+
+        The literal `"default"` fallback is asserted in the mocked suite; proving
+        it here would mean writing a live blob into the namespace real users get.
+        """
+        mw = _sync_client()
         result = mw.remember_and_wait(
-            "Integration test: namespace default", timeout_ms=_REMEMBER_TIMEOUT_MS
+            "Integration test: namespace fallback", timeout_ms=_REMEMBER_TIMEOUT_MS
         )
-        assert result.namespace == "default"
+        assert result.namespace == _E2E_NAMESPACE
 
     def test_remember_custom_namespace(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
         result = mw.remember_and_wait(
             "Integration test: custom namespace",
-            namespace="sdk-test",
+            namespace=_E2E_NAMESPACE_ALT,
             timeout_ms=_REMEMBER_TIMEOUT_MS,
         )
-        assert result.namespace == "sdk-test"
+        assert result.namespace == _E2E_NAMESPACE_ALT
 
 
 @requires_key
@@ -243,25 +262,19 @@ class TestRecall:
     """recall() against live server."""
 
     def test_recall_returns_list(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
         result = mw.recall("sky blue", limit=5)
         assert isinstance(result.results, list)
         assert result.total >= 0
         print(f"\n  recall total={result.total}")
 
     def test_recall_respects_limit(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
         result = mw.recall("test", limit=2)
         assert len(result.results) <= 2
 
     def test_recall_result_has_expected_fields(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
         result = mw.recall("test", limit=3)
         for mem in result.results:
             assert isinstance(mem.text, str)
@@ -274,13 +287,8 @@ class TestAnalyze:
     """analyze() against live server."""
 
     def test_analyze_returns_facts(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
-        result = mw.analyze(
-            "I love hiking and my favorite food is pho.",
-            namespace="sdk-test",
-        )
+        mw = _sync_client()
+        result = mw.analyze("I love hiking and my favorite food is pho.")
         assert isinstance(result.facts, list)
         assert result.total >= 0
         assert result.owner.startswith("0x")
@@ -294,9 +302,7 @@ class TestAsk:
     """ask() against live server."""
 
     def test_ask_returns_string_answer(self) -> None:
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
         result = mw.ask("What outdoor activities do I enjoy?", limit=3)
         assert isinstance(result.answer, str)
         assert len(result.answer) > 0
@@ -317,9 +323,7 @@ class TestFullFlow:
         text = f"SDK e2e test {unique}: quantum entanglement in photonics"
         ns = f"sdk-e2e-{unique}"
 
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
 
         # Store a distinctive memory in an isolated namespace
         mem = mw.remember_and_wait(text, namespace=ns, timeout_ms=_REMEMBER_TIMEOUT_MS)
@@ -336,15 +340,11 @@ class TestFullFlow:
 
     def test_remember_then_ask_uses_memory(self) -> None:
         """remember → ask — answer should reference the stored fact."""
-        mw = MemWalSync.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        )
+        mw = _sync_client()
         mw.remember_and_wait(
-            "I am allergic to shellfish",
-            namespace="sdk-test",
-            timeout_ms=_REMEMBER_TIMEOUT_MS,
+            "I am allergic to shellfish", timeout_ms=_REMEMBER_TIMEOUT_MS
         )
-        result = mw.ask("What are my food allergies?", limit=3, namespace="sdk-test")
+        result = mw.ask("What are my food allergies?", limit=3)
         assert isinstance(result.answer, str)
         assert len(result.answer) > 0
         print(f"\n  ask answer: {result.answer[:100]}")
@@ -358,24 +358,18 @@ class TestAsync:
     """Async client variants."""
 
     async def test_async_health(self) -> None:
-        async with MemWal.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        ) as mw:
+        async with _async_client() as mw:
             result = await mw.health()
             assert result.status == "ok"
 
     async def test_async_remember(self) -> None:
-        async with MemWal.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        ) as mw:
+        async with _async_client() as mw:
             result = await mw.remember("Async SDK test: Paris is the capital of France")
             assert result.job_id is not None
             assert result.status in ("pending", "running")
 
     async def test_async_recall(self) -> None:
-        async with MemWal.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        ) as mw:
+        async with _async_client() as mw:
             await mw.remember_and_wait(
                 "Async SDK test: I enjoy reading", timeout_ms=_REMEMBER_TIMEOUT_MS
             )
@@ -383,15 +377,11 @@ class TestAsync:
             assert isinstance(result.results, list)
 
     async def test_async_analyze(self) -> None:
-        async with MemWal.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        ) as mw:
-            result = await mw.analyze("I drink tea every morning.", namespace="sdk-test")
+        async with _async_client() as mw:
+            result = await mw.analyze("I drink tea every morning.")
             assert isinstance(result.facts, list)
 
     async def test_async_ask(self) -> None:
-        async with MemWal.create(
-            key=PRIVATE_KEY_HEX, account_id=ACCOUNT_ID, server_url=SERVER_URL
-        ) as mw:
+        async with _async_client() as mw:
             result = await mw.ask("What do I drink?", limit=3)
             assert isinstance(result.answer, str)

--- a/packages/python-sdk-memwal/tests/test_signing.py
+++ b/packages/python-sdk-memwal/tests/test_signing.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 
 import nacl.signing
+import pytest
 
 from memwal.utils import (
     build_seal_session_personal_message,
@@ -278,3 +279,52 @@ class TestSealSessionUtils:
         raw = json.loads(json.dumps(signature))  # assert it's JSON-safe text
         assert isinstance(raw, str)
         assert len(base64.b64decode(signature)) == 97
+
+
+class TestPrivateKeyFormats:
+    """The dashboard hands out `suiprivkey1...`; the SDK must take both forms."""
+
+    _SEED_HEX = "17dc3c1eecfcdc014c0eba65c1f87897abbbd214fa32d4018f48669b5d37c413"
+
+    def test_decode_reverses_encode(self) -> None:
+        from memwal.utils import decode_sui_private_key, encode_sui_private_key
+
+        seed = bytes.fromhex(self._SEED_HEX)
+        assert decode_sui_private_key(encode_sui_private_key(seed)) == seed
+
+    def test_normalize_accepts_every_accepted_form(self) -> None:
+        from memwal.utils import encode_sui_private_key, normalize_private_key
+
+        seed = bytes.fromhex(self._SEED_HEX)
+        for form in (
+            self._SEED_HEX,
+            f"0x{self._SEED_HEX}",
+            encode_sui_private_key(seed),
+            f"  {encode_sui_private_key(seed)}  ",
+        ):
+            assert normalize_private_key(form) == self._SEED_HEX
+
+    def test_bech32_key_produces_the_same_client_identity(self) -> None:
+        from memwal.client import MemWal
+        from memwal.utils import encode_sui_private_key
+
+        bech32 = encode_sui_private_key(bytes.fromhex(self._SEED_HEX))
+        from_hex = MemWal.create(key=self._SEED_HEX, account_id="0xtest")
+        from_bech32 = MemWal.create(key=bech32, account_id="0xtest")
+        assert from_bech32._private_key_hex == from_hex._private_key_hex
+        assert bytes(from_bech32._signing_key) == bytes(from_hex._signing_key)
+
+    def test_rejects_a_non_ed25519_scheme(self) -> None:
+        from memwal.utils import _convertbits, bech32_encode, decode_sui_private_key
+
+        payload = bytes([1]) + bytes.fromhex(self._SEED_HEX)  # scheme flag 1 = secp256k1
+        with pytest.raises(ValueError, match="Ed25519"):
+            decode_sui_private_key(bech32_encode("suiprivkey", _convertbits(payload, 8, 5)))
+
+    def test_rejects_a_corrupted_checksum(self) -> None:
+        from memwal.utils import decode_sui_private_key, encode_sui_private_key
+
+        encoded = encode_sui_private_key(bytes.fromhex(self._SEED_HEX))
+        corrupted = encoded[:-1] + ("q" if encoded[-1] != "q" else "p")
+        with pytest.raises(ValueError, match="checksum"):
+            decode_sui_private_key(corrupted)

--- a/packages/python-sdk-memwal/tests/test_signing.py
+++ b/packages/python-sdk-memwal/tests/test_signing.py
@@ -144,7 +144,10 @@ class TestBuildSignatureMessage:
             nonce="550e8400-e29b-41d4-a716-446655440000",
             account_id="0xabc123",
         )
-        assert result == "1700000000.POST./api/remember.abc123.550e8400-e29b-41d4-a716-446655440000.0xabc123"
+        assert result == (
+            "1700000000.POST./api/remember.abc123"
+            ".550e8400-e29b-41d4-a716-446655440000.0xabc123"
+        )
 
     def test_get_method(self) -> None:
         result = build_signature_message(
@@ -175,7 +178,9 @@ class TestBuildSignatureMessage:
         nonce = "550e8400-e29b-41d4-a716-446655440000"
         account_id = "0xabc123"
 
-        message = build_signature_message(timestamp, method, path, body_hash, nonce=nonce, account_id=account_id)
+        message = build_signature_message(
+            timestamp, method, path, body_hash, nonce=nonce, account_id=account_id
+        )
         sig_hex, pub_hex = sign_message(message, signing_key)
 
         # Verify (as the server would)
@@ -239,8 +244,9 @@ class TestDelegateKeyUtils:
 
     def test_sui_address_matches_typescript_sdk(self):
         """Verify blake2b-256(0x00 || pubkey) matches TS delegateKeyToSuiAddress output."""
-        from memwal.utils import delegate_key_to_public_key, delegate_key_to_sui_address
         import hashlib
+
+        from memwal.utils import delegate_key_to_public_key, delegate_key_to_sui_address
 
         pub = delegate_key_to_public_key(self._KEY)
         scheme_input = bytes([0x00]) + pub


### PR DESCRIPTION
## Ticket

CI for the Python SDK: build from source, unit test, e2e against the dev relayer.

## What changed?

### Workflow

New `.github/workflows/test-python-sdk.yml`, named to sit alongside `release-python-sdk.yml`:

- **`unit`** — installs from source, runs `ruff`, then the mocked suite across Python 3.9–3.12. Every pull request touching the package.
- **`e2e`** — runs `tests/test_integration.py` against the dev relayer on pushes to `dev`, manual runs, and a weekly cron. Reuses the `benchmark-dev` environment, so no new secrets are needed, and fails if its credentials are missing rather than silently skipping every authenticated test.

### SDK — accept a Sui bech32 private key

> The only change outside CI and tests. Reviewable on its own; happy to split it into a separate PR if you would rather.

`memwal/utils.py` gains `bech32_decode` and `decode_sui_private_key`; `MemWal.__init__` normalises whatever it is handed into hex, so nothing downstream changes.

| | Accepts |
| --- | --- |
| TypeScript SDK | `suiprivkey1...` or hex, via `decodeSuiPrivateKey` |
| Python SDK, before | hex only — `bytes.fromhex()` |

Why it is in this PR: pointing the job at `BENCH_DELEGATE_KEY` failed all sixteen authenticated tests with `non-hexadecimal number found in fromhex() arg at position 0`. That secret is bech32 because its existing consumer, `bench-recall-latency.ts`, is TypeScript. E2E cannot pass without this.

It is worth fixing regardless of CI: the dashboard issues keys in the bech32 form, so the same credential worked in one SDK and not the other, and the error named nothing useful. `encode_sui_private_key` already existed with no inverse — the direction was simply missing. Verified against `@mysten/sui` on five generated keypairs: decode, encode, normalise and the derived Sui address all match.

### Tests

- Every authenticated test now runs in a per-run `sdk-e2e-<uuid>` namespace; `_sync_client` / `_async_client` replace sixteen identical constructions.
- The live `remember_and_wait` timeout goes from the SDK default of 60s to 120s (see Risks).
- Five cases cover the key formats, and the three pre-existing `ruff` offences in `tests/test_signing.py` are fixed — the new lint step would fail on arrival otherwise.

The reformatting in both test files is `ruff`, not a style pass. `line-length` is 100, and the extra `timeout_ms` argument pushes five calls to 106–130 characters; the sixth still fits and stays on one line.

## Why is this needed?

The Python SDK had no CI. `test.yml` only runs the relayer's own e2e script and `release-python-sdk.yml` just publishes, so nothing built the package or ran either suite on a push — 121 mocked and 23 integration tests sat unexecuted.

## What e2e covers

Unauthenticated, runs without any credential:

| Group | Cases |
| --- | --- |
| Health | `/health` returns ok; exposes a version string |
| Auth rejection | unsigned request; signature from a different key; expired timestamp; future timestamp; unregistered key surfaced as `MemWalError` |

Authenticated, needs the environment secrets:

| Group | Cases |
| --- | --- |
| Remember | job id and status; `remember_and_wait` returns blob and owner; default namespace; custom namespace |
| Recall | returns a list; respects `limit`; result field shape |
| Analyze | fact extraction; owner address |
| Ask | non-empty answer; `memories_used` |
| Full flow | remember then recall a unique marker in a per-run namespace; remember then ask |
| Async | health, remember, recall, analyze, ask via the async client |

The auth-rejection group builds its requests with `httpx` rather than through the SDK, so it checks the relayer's own contract: timestamp window and signature verification.

## Scope

The workflow. Both suites already exist and `tests/test_integration.py` already reads `MEMWAL_SERVER_URL` / `MEMWAL_PRIVATE_KEY` / `MEMWAL_ACCOUNT_ID` and self-skips its authenticated cases — this wires that up rather than adding tests.

### Out of scope

Staging and production environments.

## How was this tested?

- [x] Unit tests
- [x] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Ran what the `unit` job runs: `ruff` clean, 116 passed. Workflow validated with `actionlint`. All four matrix versions pass on this PR, and `e2e` correctly skips on pull requests.

Ran the full integration suite against `https://relayer.dev.memwal.ai` with a real delegate key: **23 passed**. An earlier run lost six tests to `MemWalRememberJobTimeout`, which is what the timeout change addresses.

Also ran `workflow_dispatch` on this branch end to end ([run 32098755482](https://github.com/MystenLabs/MemWal/actions/runs/32098755482)): **23 passed in 5m46s**, summary reports `Authenticated: true`, so the `BENCH_DELEGATE_KEY` → `MEMWAL_PRIVATE_KEY` mapping is confirmed against the real environment. The decode path is cross-checked against `@mysten/sui` on five generated keypairs — decode, encode, normalise and derived Sui address all match.

## How can the reviewer verify it?

```bash
cd packages/python-sdk-memwal
python -m pip install -e '.[dev]'
python -m ruff check memwal/ tests/
python -m pytest tests/ -m "not integration" -q

docker run --rm -v "$PWD/../..":/repo -w /repo rhysd/actionlint:latest \
  .github/workflows/test-python-sdk.yml
```

## Risks and dependencies

- **Reuses `benchmark-dev` rather than adding secrets.** `BENCH_DELEGATE_KEY` is the delegate private key the SDK signs with, which `test_integration.py` reads as `MEMWAL_PRIVATE_KEY`; `BENCH_ACCOUNT_ID` maps to `MEMWAL_ACCOUNT_ID`. Sharing the account is safe because the namespaces do not overlap. `BENCH_SERVER_URL` falls back to `https://relayer.dev.memwal.ai` so a missing variable cannot point a run at the wrong relayer. A missing credential fails the job rather than warning, so the run cannot go green having skipped every authenticated test.
- **A live write takes around 44s** on the dev relayer — embed, SEAL encrypt, Walrus upload, on-chain metadata. The SDK's 60s `remember_and_wait` default left ~16s of headroom, and runs failed on timing alone. The tests now pass 120s, matching the SDK's own bulk default, overridable via `MEMWAL_REMEMBER_TIMEOUT_MS`. The 30 min job timeout covers a full suite comfortably.
- **E2E is skipped on pull requests** — environment secrets are withheld from fork PRs, and each authenticated run writes real memories, costing embedding, Walrus storage and gas.
- **Every authenticated test writes into a `sdk-e2e-<uuid>` namespace unique to the run**, so a recurring job leaves nothing in `default` or `sdk-test` on the shared bench account.
- **The dev relayer's Node sidecar occasionally drops a request** (`Sidecar seal/encrypt request failed`), which surfaces as one failed write. It recovered on a rerun. No retry is wired in: a genuine relayer regression should stay visible.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [x] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.






