### PR TITLE
Promote dev to staging

### DIFF
--- a/apps/app/src/components/AdminConfig.tsx
+++ b/apps/app/src/components/AdminConfig.tsx
@@ -68,6 +68,13 @@ export function AdminConfig({ adminKey, onInvalidKey }: AdminConfigProps) {
         </div>
 
         <div className="admin-config-item">
+          <span className="admin-config-label">Uploader SUI Low Threshold</span>
+          <code className="admin-config-value" title={`${data.uploaderSuiLowThresholdMist} mist`}>
+            {formatTokenAmount(data.uploaderSuiLowThresholdMist)} SUI
+          </code>
+        </div>
+
+        <div className="admin-config-item">
           <span className="admin-config-label">Sponsor SUI Low Threshold</span>
           <code className="admin-config-value" title={`${data.sponsorSuiLowThresholdMist} mist`}>
             {formatTokenAmount(data.sponsorSuiLowThresholdMist)} SUI

--- a/apps/app/src/utils/admin-api.ts
+++ b/apps/app/src/utils/admin-api.ts
@@ -25,6 +25,7 @@ export interface UploadError {
 export interface AdminConfig {
   balanceMonitorIntervalSecs: number
   uploaderWalLowThresholdFrost: bigint
+  uploaderSuiLowThresholdMist: bigint
   sponsorSuiLowThresholdMist: bigint
 }
 
@@ -115,6 +116,7 @@ interface RawWalletsResponse {
   uploader_pool: {
     wallets: RawWalletBalance[]
     wal_threshold: string
+    sui_threshold: string
     last_updated: string
   }
   sponsor_wallet: {
@@ -145,6 +147,7 @@ interface RawUploadErrorsResponse {
 interface RawConfigResponse {
   balance_monitor_interval_secs: number
   wallet_wal_low_threshold_frost: string
+  wallet_sui_low_threshold_mist: string
   sponsor_sui_low_threshold_mist: string
 }
 
@@ -212,6 +215,7 @@ export async function fetchAdminConfig(
   return {
     balanceMonitorIntervalSecs: raw.balance_monitor_interval_secs,
     uploaderWalLowThresholdFrost: BigInt(raw.wallet_wal_low_threshold_frost),
+    uploaderSuiLowThresholdMist: BigInt(raw.wallet_sui_low_threshold_mist),
     sponsorSuiLowThresholdMist: BigInt(raw.sponsor_sui_low_threshold_mist),
   }
 }

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -225,9 +225,11 @@ ALLOWED_ORIGINS=http://localhost:3000
 # ADMIN_API_KEY=
 # Interval in seconds for checking wallet balances (default 900, minimum 30)
 # BALANCE_MONITOR_INTERVAL_SECS=900
-# Per-uploader-wallet WAL threshold in frost units (default 1M)
-# WALLET_BALANCE_LOW_THRESHOLD_WAL=1000000
-# Sponsor-wallet SUI threshold in mist units (default 100M)
-# SPONSOR_BALANCE_LOW_THRESHOLD_SUI=100000000
+# Per-uploader-wallet WAL threshold: 50 WAL in FROST units.
+# WALLET_BALANCE_LOW_THRESHOLD_WAL=50000000000
+# Per-uploader-wallet SUI threshold: 5 SUI in MIST units.
+# WALLET_BALANCE_LOW_THRESHOLD_SUI=5000000000
+# Sponsor-wallet SUI threshold: 5 SUI in MIST units.
+# SPONSOR_BALANCE_LOW_THRESHOLD_SUI=5000000000
 # Suppress duplicate low-balance alerts per wallet for this many seconds (default 12h)
 # WALLET_BALANCE_LOW_ALERT_DEDUP_SECS=43200

--- a/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
+++ b/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
@@ -132,10 +132,78 @@ test("legacy uploads preserve fallback behavior while using address balances", (
     });
 });
 
-test("durable register preparation honors the configured direct-sign fallback", () => {
+test("durable register never direct-signs when Enoki is configured", () => {
     assert.equal(durableRegisterDirectSigningAllowed(false, false), true);
     assert.equal(durableRegisterDirectSigningAllowed(true, false), false);
-    assert.equal(durableRegisterDirectSigningAllowed(true, true), true);
+    assert.equal(durableRegisterDirectSigningAllowed(true, true), false);
+});
+
+test("sponsored registration keeps WAL on the sender while assigning gas to the sponsor", async () => {
+    const signer = new Ed25519Keypair();
+    const sponsor = new Ed25519Keypair();
+    const walType = `0x${"2".repeat(64)}::wal::WAL`;
+    const transaction = new Transaction();
+    transaction.setSender(signer.toSuiAddress());
+    transaction.setGasOwner(sponsor.toSuiAddress());
+    transaction.setGasBudget(10_000_000n);
+    transaction.setGasPrice(1n);
+    transaction.setGasPayment([{
+        objectId: `0x${"1".repeat(64)}`,
+        version: "1",
+        digest: "11111111111111111111111111111111",
+    }]);
+    const withdrawal = transaction.withdrawal({ amount: 1n, type: walType });
+    const wal = transaction.moveCall({
+        target: "0x2::coin::redeem_funds",
+        typeArguments: [walType],
+        arguments: [withdrawal],
+    });
+    transaction.moveCall({
+        target: "0x2::coin::destroy_zero",
+        typeArguments: [walType],
+        arguments: [wal],
+    });
+    const bytes = await transaction.build();
+    const signed = await signer.signTransaction(bytes);
+    const digest = TransactionDataBuilder.getDigestFromBytes(bytes);
+    const prepared: PreparedRegisterTransaction = {
+        transactionBytes: signed.bytes,
+        signature: signed.signature,
+        digest,
+        sponsorDigest: digest,
+    };
+
+    const validated = await validatePreparedRegisterTransaction(prepared, signer.toSuiAddress());
+    assert.equal(validated.sponsorDigest, digest);
+
+    let submitted = false;
+    let directExecutions = 0;
+    const finalized = { Transaction: { digest } };
+    const client = {
+        async getTransaction() {
+            if (!submitted) throw Object.assign(new Error("not found"), { code: "NOT_FOUND" });
+            return finalized;
+        },
+        async executeTransaction() {
+            directExecutions += 1;
+            throw new Error("sponsored journal must not execute directly");
+        },
+    };
+    const result = await executePreparedRegisterTransaction(
+        validated,
+        client,
+        () => {},
+        async () => 1n,
+        false,
+        async (sponsorDigest, signature) => {
+            assert.equal(sponsorDigest, digest);
+            assert.equal(signature, signed.signature);
+            submitted = true;
+            return { digest };
+        },
+    );
+    assert.equal(result, finalized);
+    assert.equal(directExecutions, 0);
 });
 
 test("prepared registration rejects tampered digest, signature, and wallet", async () => {

--- a/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
+++ b/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
@@ -22,6 +22,7 @@ import {
     DURABLE_UPLOAD_PROTOCOL_VERSION,
     ENOKI_API_KEY,
     ENOKI_FALLBACK_TO_DIRECT_SIGN,
+    ENOKI_NETWORK,
     JSON_LIMIT_WALRUS_UPLOAD,
     MAX_WALRUS_EPOCHS,
     SERVER_SUI_PRIVATE_KEYS,
@@ -31,6 +32,7 @@ import {
     parseDurableWalrusEpochs,
 } from "../config.js";
 import {
+    getUploadRelayTipAddress,
     getWalrusClient,
     refreshWalrusClientIfStale,
     suiClient,
@@ -58,6 +60,11 @@ import {
 } from "./walrus-query.js";
 import { uploadWalrusBlobWithEffectsRetry } from "./walrus-upload.js";
 import { enforceAddressBalanceCoinIntents } from "../address-balance.js";
+import {
+    callEnoki,
+    type EnokiExecuteResponse,
+    type EnokiSponsorResponse,
+} from "../enoki.js";
 import {
     assertUploadExecutionIdentity,
     executionIdentity,
@@ -128,9 +135,12 @@ async function certifiedStep(
 
 export function durableRegisterDirectSigningAllowed(
     enokiConfigured: boolean,
-    fallbackToDirectSign: boolean,
+    _fallbackToDirectSign: boolean,
 ): boolean {
-    return !enokiConfigured || fallbackToDirectSign;
+    // When Enoki is configured, durable registration must fail closed rather
+    // than silently draining the upload wallet after a sponsor outage. Direct
+    // signing remains available only for deployments without Enoki (local/dev).
+    return !enokiConfigured;
 }
 
 export function createdBlobObjectIdFromTransaction(result: any): string {
@@ -186,6 +196,8 @@ export type PreparedRegisterTransaction = {
     transactionBytes: string;
     signature: string;
     digest: string;
+    /** Enoki's sponsorship handle. Absent on legacy/direct-signed journals. */
+    sponsorDigest?: string;
 };
 
 export type ValidatedPreparedRegisterTransaction = PreparedRegisterTransaction & {
@@ -205,25 +217,87 @@ type PreparedRegisterClient = {
     }): Promise<unknown>;
 };
 
+type PreparedRegisterSponsorExecutor = (
+    sponsorDigest: string,
+    signature: string,
+) => Promise<EnokiExecuteResponse>;
+
+async function executePreparedRegisterWithEnoki(
+    sponsorDigest: string,
+    signature: string,
+): Promise<EnokiExecuteResponse> {
+    return callEnoki<EnokiExecuteResponse>(
+        `/transaction-blocks/sponsor/${encodeURIComponent(sponsorDigest)}`,
+        { digest: sponsorDigest, signature },
+    );
+}
+
 function parsePreparedRegisterTransaction(raw: unknown): PreparedRegisterTransaction | null {
     if (raw === null || raw === undefined) return null;
     if (!raw || typeof raw !== "object") {
         throw new Error("registerTransaction must be an object");
     }
-    const { transactionBytes, signature, digest } = raw as Record<string, unknown>;
+    const { transactionBytes, signature, digest, sponsorDigest } = raw as Record<string, unknown>;
     if (typeof transactionBytes !== "string" || !transactionBytes
         || typeof signature !== "string" || !signature
         || typeof digest !== "string" || !digest) {
         throw new Error("registerTransaction requires transactionBytes, signature, and digest");
     }
-    return { transactionBytes, signature, digest };
+    if (sponsorDigest !== undefined && (typeof sponsorDigest !== "string" || !sponsorDigest)) {
+        throw new Error("registerTransaction.sponsorDigest must be a non-empty string");
+    }
+    return {
+        transactionBytes,
+        signature,
+        digest,
+        ...(typeof sponsorDigest === "string" ? { sponsorDigest } : {}),
+    };
 }
 
-async function prepareRegisterTransaction(
+export async function prepareRegisterTransaction(
     transaction: Transaction,
     signer: Ed25519Keypair,
+    allowedAddresses: string[] = [signer.toSuiAddress()],
 ): Promise<PreparedRegisterTransaction> {
-    transaction.setSenderIfNotSet(signer.toSuiAddress());
+    const signerAddress = signer.toSuiAddress();
+    transaction.setSenderIfNotSet(signerAddress);
+
+    if (ENOKI_API_KEY) {
+        // Journal the exact sponsored bytes before execution. Replays use the
+        // Enoki sponsorship handle below, so the upload remains idempotent
+        // without making the sender wallet the gas owner.
+        const transactionKind = await transaction.build({
+            client: suiClient as any,
+            onlyTransactionKind: true,
+        });
+        const sponsored = await callEnoki<EnokiSponsorResponse>(
+            "/transaction-blocks/sponsor",
+            {
+                network: ENOKI_NETWORK,
+                transactionBlockKindBytes: Buffer.from(transactionKind).toString("base64"),
+                sender: signerAddress,
+                ...(allowedAddresses.length ? { allowedAddresses } : {}),
+            },
+        );
+        const bytes = new Uint8Array(Buffer.from(sponsored.bytes, "base64"));
+        if (!bytes.length || Buffer.from(bytes).toString("base64") !== sponsored.bytes) {
+            throw new Error("Enoki returned non-canonical sponsored transaction bytes");
+        }
+        const transactionData = TransactionDataBuilder.fromBytes(bytes);
+        assertSponsoredRegisterTransaction(transactionData, signerAddress);
+        const digest = TransactionDataBuilder.getDigestFromBytes(bytes);
+        const signed = await signer.signTransaction(bytes);
+        return {
+            transactionBytes: signed.bytes,
+            signature: signed.signature,
+            digest,
+            sponsorDigest: sponsored.digest,
+        };
+    }
+
+    if (!durableRegisterDirectSigningAllowed(false, ENOKI_FALLBACK_TO_DIRECT_SIGN)) {
+        throw new Error("durable register requires Enoki sponsorship");
+    }
     transaction.setGasPayment([]);
     const bytes = await transaction.build({ client: suiClient });
     assertAddressBalanceRegisterTransaction(TransactionDataBuilder.fromBytes(bytes));
@@ -235,22 +309,9 @@ async function prepareRegisterTransaction(
     };
 }
 
-export function assertAddressBalanceRegisterTransaction(
+function assertRegisterTransactionUsesAddressBalanceWal(
     transactionData: TransactionDataBuilder,
-): bigint {
-    if (transactionData.gasData.payment?.length !== 0) {
-        throw new Error("registerTransaction must pay gas from the address balance");
-    }
-
-    const expiration = transactionData.expiration;
-    if (
-        expiration?.$kind !== "ValidDuring"
-        || expiration.ValidDuring.minTimestamp !== null
-        || expiration.ValidDuring.maxTimestamp !== null
-    ) {
-        throw new Error("registerTransaction must use a ValidDuring address-balance expiration");
-    }
-
+): void {
     let usesGasCoin = false;
     transactionData.mapArguments((argument) => {
         if (argument.$kind === "GasCoin") usesGasCoin = true;
@@ -274,7 +335,41 @@ export function assertAddressBalanceRegisterTransaction(
     if (!hasWalWithdrawal) {
         throw new Error("registerTransaction has no WAL address-balance withdrawal");
     }
+}
 
+export function assertSponsoredRegisterTransaction(
+    transactionData: TransactionDataBuilder,
+    expectedWalletAddress: string,
+): void {
+    const walletAddress = normalizeSuiAddress(expectedWalletAddress);
+    if (!transactionData.sender
+        || normalizeSuiAddress(transactionData.sender) !== walletAddress) {
+        throw new Error("sponsored registerTransaction sender does not match the wallet");
+    }
+    if (!transactionData.gasData.owner
+        || normalizeSuiAddress(transactionData.gasData.owner) === walletAddress) {
+        throw new Error("sponsored registerTransaction must use a distinct gas owner");
+    }
+    assertRegisterTransactionUsesAddressBalanceWal(transactionData);
+}
+
+export function assertAddressBalanceRegisterTransaction(
+    transactionData: TransactionDataBuilder,
+): bigint {
+    if (transactionData.gasData.payment?.length !== 0) {
+        throw new Error("registerTransaction must pay gas from the address balance");
+    }
+
+    const expiration = transactionData.expiration;
+    if (
+        expiration?.$kind !== "ValidDuring"
+        || expiration.ValidDuring.minTimestamp !== null
+        || expiration.ValidDuring.maxTimestamp !== null
+    ) {
+        throw new Error("registerTransaction must use a ValidDuring address-balance expiration");
+    }
+
+    assertRegisterTransactionUsesAddressBalanceWal(transactionData);
     return BigInt(expiration.ValidDuring.maxEpoch);
 }
 
@@ -302,7 +397,9 @@ export async function validatePreparedRegisterTransaction(
         || normalizeSuiAddress(transactionData.sender) !== walletAddress) {
         throw new Error("registerTransaction sender does not match the journaled wallet");
     }
-    if (!transactionData.gasData.owner
+    if (prepared.sponsorDigest) {
+        assertSponsoredRegisterTransaction(transactionData, walletAddress);
+    } else if (!transactionData.gasData.owner
         || normalizeSuiAddress(transactionData.gasData.owner) !== walletAddress) {
         throw new Error("registerTransaction gas owner does not match the journaled wallet");
     }
@@ -333,6 +430,7 @@ export async function executePreparedRegisterTransaction(
     onTransactionObservedOrSubmitted: () => void = () => {},
     getCurrentEpoch: () => Promise<bigint> = currentSuiEpoch,
     mayHaveBeenSubmitted = false,
+    executeSponsored: PreparedRegisterSponsorExecutor = executePreparedRegisterWithEnoki,
 ): Promise<unknown> {
     const include = { effects: true, objectTypes: true } as const;
     const assertExpectedDigest = (result: any): unknown => {
@@ -369,6 +467,30 @@ export async function executePreparedRegisterTransaction(
     // TransactionData bytes determine the Sui digest. Re-executing this exact
     // signed payload can only submit the already-journaled digest.
     onTransactionObservedOrSubmitted();
+    if (prepared.sponsorDigest) {
+        const executed = await trackWalletSubmission(() =>
+            executeSponsored(prepared.sponsorDigest!, prepared.signature),
+        );
+        if (executed.digest !== prepared.digest) {
+            throw new Error(
+                `Enoki executed unexpected register digest: expected ${prepared.digest}, got ${executed.digest}`,
+            );
+        }
+        // Enoki returns only a digest. Read the finalized transaction so the
+        // caller can validate the created Walrus Blob object exactly as it did
+        // for the legacy direct-execution path.
+        for (let attempt = 1; attempt <= 8; attempt += 1) {
+            try {
+                const finalized = await client.getTransaction({ digest: prepared.digest, include });
+                return assertExpectedDigest(finalized);
+            } catch (error: any) {
+                if (error?.code !== "NOT_FOUND" || attempt === 8) throw error;
+                await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+            }
+        }
+        throw new Error(`sponsored register transaction ${prepared.digest} was not found after execution`);
+    }
+
     const result = await trackWalletSubmission(() =>
         client.executeTransaction({
             transaction: prepared.bytes,
@@ -545,16 +667,6 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                                 blobId: encoded.blobId,
                             });
                         }
-                        if (!durableRegisterDirectSigningAllowed(
-                            !!ENOKI_API_KEY,
-                            ENOKI_FALLBACK_TO_DIRECT_SIGN,
-                        )) {
-                            return res.status(409).json({
-                                error: "durable register replay requires direct signing",
-                                code: "DURABLE_REGISTER_REPLAY_REQUIRES_DIRECT_SIGN",
-                                jobId,
-                            });
-                        }
                         const registerTx = flow.register({
                             epochs,
                             owner: signerAddress,
@@ -567,9 +679,17 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                             },
                         });
                         enforceAddressBalanceCoinIntents(registerTx);
+                        const tipRecipient = ENOKI_API_KEY
+                            ? await getUploadRelayTipAddress()
+                            : null;
+                        const allowedAddresses = [...new Set(
+                            [signerAddress, tipRecipient]
+                                .filter((address): address is string => typeof address === "string"),
+                        )];
                         const registerTransaction = await prepareRegisterTransaction(
                             registerTx,
                             signer,
+                            allowedAddresses,
                         );
                         console.log(`[walrus/upload-step-v3] [${traceId}] prepared ${JSON.stringify({
                             jobId,
@@ -577,6 +697,7 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                             step: "register_prepared",
                             blobId: encoded.blobId,
                             digest: registerTransaction.digest,
+                            sponsored: !!registerTransaction.sponsorDigest,
                         })}`);
                         return res.json({
                             registerTransaction,

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -94,9 +94,8 @@ pub struct AlertManager {
     /// and the monitor keeps polling every interval while the backlog lasts,
     /// so one notification per network per window is enough.
     walrus_queue_saturation_dedup: AlertDedup,
-    /// Suppresses wallet balance low spam. Keyed by `(wallet_type, address)`
-    /// so each wallet only alerts once per dedup window even if the monitor
-    /// runs many times.
+    /// Suppresses wallet balance low spam. Keyed by `(wallet_type:token, address)`
+    /// so WAL and SUI can each alert once for the same wallet per dedup window.
     wallet_balance_low_dedup: AlertDedup,
 }
 
@@ -259,7 +258,10 @@ impl AlertManager {
         };
         // Dedup by the full address; abbreviating here could make two distinct
         // wallets with the same prefix/suffix suppress each other's alerts.
-        let key = (alert.wallet_type.clone(), alert.address.clone());
+        let key = (
+            format!("{}:{}", alert.wallet_type, alert.token),
+            alert.address.clone(),
+        );
         if self.wallet_balance_low_dedup.should_suppress(key) {
             return Ok(());
         }
@@ -1219,12 +1221,14 @@ mod tests {
     #[test]
     fn wallet_balance_low_dedup_key_formation() {
         let dedup = AlertDedup::new(Duration::from_secs(600));
-        // First alert should fire
-        assert!(!dedup.should_suppress(("sponsor".to_string(), "0x1234...abcd".to_string())));
-        // Second alert with same key should be suppressed
-        assert!(dedup.should_suppress(("sponsor".to_string(), "0x1234...abcd".to_string())));
-        // Different wallet type should not be suppressed
-        assert!(!dedup.should_suppress(("uploader_pool".to_string(), "0x1234...abcd".to_string())));
+        let address = "0x1234...abcd".to_string();
+        // First WAL alert should fire, then repeat WAL should be suppressed.
+        assert!(!dedup.should_suppress(("uploader:WAL".to_string(), address.clone())));
+        assert!(dedup.should_suppress(("uploader:WAL".to_string(), address.clone())));
+        // SUI for the same uploader remains an independent actionable alert.
+        assert!(!dedup.should_suppress(("uploader:SUI".to_string(), address.clone())));
+        // Sponsor SUI is also independent.
+        assert!(!dedup.should_suppress(("sponsor:SUI".to_string(), address)));
     }
 
     #[test]

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -3690,6 +3690,7 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
                 transaction_bytes: "dHgtYnl0ZXM=".into(),
                 signature: "signature".into(),
                 digest: "digest-1".into(),
+                sponsor_digest: None,
             }),
         };
 

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -211,6 +211,17 @@ async fn balance_monitor_task(state: Arc<AppState>, interval_secs: u64) {
                                 );
                                     continue;
                                 };
+                                let Some(sui_balance) = wallet
+                                    .get("suiMist")
+                                    .and_then(|value| value.as_str())
+                                    .and_then(|value| value.parse::<u64>().ok())
+                                else {
+                                    tracing::warn!(
+                                        address,
+                                        "balance_monitor: wallet metrics entry has invalid suiMist"
+                                    );
+                                    continue;
+                                };
 
                                 if wal_balance < state.config.wallet_balance_low_threshold_wal {
                                     tracing::warn!(
@@ -240,6 +251,37 @@ async fn balance_monitor_task(state: Arc<AppState>, interval_secs: u64) {
                                         address,
                                         balance = wal_balance,
                                         "balance_monitor: uploader wallet WAL balance ok"
+                                    );
+                                }
+
+                                if sui_balance < state.config.wallet_balance_low_threshold_sui {
+                                    tracing::warn!(
+                                        address,
+                                        balance = sui_balance,
+                                        threshold = state.config.wallet_balance_low_threshold_sui,
+                                        "balance_monitor: uploader wallet SUI balance below threshold"
+                                    );
+                                    let alert = alerts::WalletBalanceLowAlert {
+                                        wallet_type: "uploader".to_string(),
+                                        address: address.to_string(),
+                                        balance: sui_balance,
+                                        threshold: state.config.wallet_balance_low_threshold_sui,
+                                        token: "SUI".to_string(),
+                                    };
+                                    if let Err(err) =
+                                        state.alerts.notify_wallet_balance_low(alert).await
+                                    {
+                                        tracing::warn!(
+                                            address,
+                                            "balance_monitor: failed to send uploader SUI alert: {}",
+                                            err
+                                        );
+                                    }
+                                } else {
+                                    tracing::debug!(
+                                        address,
+                                        balance = sui_balance,
+                                        "balance_monitor: uploader wallet SUI balance ok"
                                     );
                                 }
                             }
@@ -1177,9 +1219,10 @@ async fn main() {
         let balance_monitor_state = state.clone();
         let balance_monitor_interval_secs = config.balance_monitor_interval_secs;
         tracing::info!(
-            "  balance monitor: starting with interval={}s, wallet_threshold_wal={}, sponsor_threshold_sui={}",
+            "  balance monitor: starting with interval={}s, wallet_threshold_wal={}, wallet_threshold_sui={}, sponsor_threshold_sui={}",
             balance_monitor_interval_secs,
             config.wallet_balance_low_threshold_wal,
+            config.wallet_balance_low_threshold_sui,
             config.sponsor_balance_low_threshold_sui,
         );
         tokio::spawn(async move {

--- a/services/server/src/routes/admin_dashboard.rs
+++ b/services/server/src/routes/admin_dashboard.rs
@@ -25,6 +25,7 @@ pub struct WalletBalance {
 pub struct UploaderPool {
     pub wallets: Vec<WalletBalance>,
     pub wal_threshold: String,
+    pub sui_threshold: String,
     pub last_updated: String,
 }
 
@@ -65,6 +66,7 @@ pub struct UploadErrorsResponse {
 pub struct ConfigResponse {
     pub balance_monitor_interval_secs: u64,
     pub wallet_wal_low_threshold_frost: String,
+    pub wallet_sui_low_threshold_mist: String,
     pub sponsor_sui_low_threshold_mist: String,
 }
 
@@ -82,8 +84,13 @@ struct SidecarWalletMetrics {
     per_wallet: Vec<SidecarWalletBalance>,
 }
 
-fn wallet_status(wal_frost: u64, threshold: u64) -> &'static str {
-    if wal_frost < threshold {
+fn wallet_status(
+    wal_frost: u64,
+    wal_threshold: u64,
+    sui_mist: u64,
+    sui_threshold: u64,
+) -> &'static str {
+    if wal_frost < wal_threshold || sui_mist < sui_threshold {
         "low"
     } else {
         "ok"
@@ -118,6 +125,7 @@ pub async fn get_wallets(
         .map_err(|e| AppError::Internal(format!("Invalid sidecar wallet metrics: {}", e)))?;
 
     let wal_threshold = state.config.wallet_balance_low_threshold_wal;
+    let sui_threshold = state.config.wallet_balance_low_threshold_sui;
     let wallets: Vec<WalletBalance> = sidecar_data
         .per_wallet
         .into_iter()
@@ -141,7 +149,7 @@ pub async fn get_wallets(
                 address: entry.address,
                 sui: sui.to_string(),
                 wal: wal.to_string(),
-                status: wallet_status(wal, wal_threshold).to_string(),
+                status: wallet_status(wal, wal_threshold, sui, sui_threshold).to_string(),
             })
         })
         .collect::<Result<_, AppError>>()?;
@@ -176,6 +184,7 @@ pub async fn get_wallets(
         uploader_pool: UploaderPool {
             wallets,
             wal_threshold: wal_threshold.to_string(),
+            sui_threshold: sui_threshold.to_string(),
             last_updated: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         },
         sponsor_wallet: SponsorWallet {
@@ -245,6 +254,7 @@ pub async fn get_admin_config(
     Ok(Json(ConfigResponse {
         balance_monitor_interval_secs: state.config.balance_monitor_interval_secs,
         wallet_wal_low_threshold_frost: state.config.wallet_balance_low_threshold_wal.to_string(),
+        wallet_sui_low_threshold_mist: state.config.wallet_balance_low_threshold_sui.to_string(),
         sponsor_sui_low_threshold_mist: state.config.sponsor_balance_low_threshold_sui.to_string(),
     }))
 }
@@ -258,9 +268,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn wallet_status_respects_the_configured_threshold() {
-        assert_eq!(wallet_status(999, 1_000), "low");
-        assert_eq!(wallet_status(1_000, 1_000), "ok");
+    fn wallet_status_respects_the_50_wal_and_5_sui_thresholds() {
+        const WAL_50: u64 = 50_000_000_000;
+        const SUI_5: u64 = 5_000_000_000;
+        assert_eq!(wallet_status(WAL_50 - 1, WAL_50, SUI_5, SUI_5), "low");
+        assert_eq!(wallet_status(WAL_50, WAL_50, SUI_5 - 1, SUI_5), "low");
+        assert_eq!(wallet_status(WAL_50, WAL_50, SUI_5, SUI_5), "ok");
     }
 
     #[test]
@@ -317,20 +330,22 @@ mod tests {
                     wal: "2000000000".to_string(),
                     status: "ok".to_string(),
                 }],
-                wal_threshold: "1000000".to_string(),
+                wal_threshold: "50000000000".to_string(),
+                sui_threshold: "5000000000".to_string(),
                 last_updated: "2026-08-10T00:00:00Z".to_string(),
             },
             sponsor_wallet: SponsorWallet {
                 address: Some("0x456".to_string()),
                 sui: "3000000000".to_string(),
-                sui_threshold: "100000000".to_string(),
+                sui_threshold: "5000000000".to_string(),
                 status: "ok".to_string(),
             },
         };
 
         let json = serde_json::to_value(response).unwrap();
         assert_eq!(json["uploader_pool"]["wallets"][0]["wal"], "2000000000");
-        assert_eq!(json["sponsor_wallet"]["sui_threshold"], "100000000");
+        assert_eq!(json["uploader_pool"]["sui_threshold"], "5000000000");
+        assert_eq!(json["sponsor_wallet"]["sui_threshold"], "5000000000");
     }
 
     #[test]
@@ -362,12 +377,14 @@ mod tests {
         let response = ConfigResponse {
             balance_monitor_interval_secs: 900,
             wallet_wal_low_threshold_frost: u64::MAX.to_string(),
-            sponsor_sui_low_threshold_mist: "100000000".to_string(),
+            wallet_sui_low_threshold_mist: "5000000000".to_string(),
+            sponsor_sui_low_threshold_mist: "5000000000".to_string(),
         };
 
         let json = serde_json::to_value(response).unwrap();
         assert_eq!(json["wallet_wal_low_threshold_frost"], u64::MAX.to_string());
         assert!(json["wallet_wal_low_threshold_frost"].is_string());
+        assert!(json["wallet_sui_low_threshold_mist"].is_string());
         assert!(json["sponsor_sui_low_threshold_mist"].is_string());
     }
 }

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1997,8 +1997,9 @@ mod tests {
             walrus_system_object_id: String::new(),
             restore_requests_per_owner_per_minute: 10,
             balance_monitor_interval_secs: 900,
-            wallet_balance_low_threshold_wal: 1_000_000,
-            sponsor_balance_low_threshold_sui: 100_000_000,
+            wallet_balance_low_threshold_wal: 50_000_000_000,
+            wallet_balance_low_threshold_sui: 5_000_000_000,
+            sponsor_balance_low_threshold_sui: 5_000_000_000,
             mcp_oauth: None,
         }
     }

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -22,6 +22,9 @@ pub struct PreparedRegisterTransaction {
     pub transaction_bytes: String,
     pub signature: String,
     pub digest: String,
+    /// Enoki sponsorship handle. Absent for legacy/direct-signed journals.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sponsor_digest: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1043,6 +1046,7 @@ mod tests {
             transaction_bytes: "bytes".into(),
             signature: "signature".into(),
             digest: "digest".into(),
+            sponsor_digest: None,
         };
         let encoded = serde_json::json!({ "step": "encoded" });
         let registered = serde_json::json!({ "step": "registered" });

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -366,6 +366,7 @@ pub struct Config {
     /// Balance monitoring (proactive alerts)
     pub balance_monitor_interval_secs: u64,
     pub wallet_balance_low_threshold_wal: u64,
+    pub wallet_balance_low_threshold_sui: u64,
     pub sponsor_balance_low_threshold_sui: u64,
     /// MCP OAuth 2.1 support for Claude (and future) native custom
     /// connectors. `None` when required env vars are unset — routes still
@@ -533,8 +534,19 @@ impl Config {
                 "BALANCE_MONITOR_INTERVAL_SECS",
                 900,
             )),
-            wallet_balance_low_threshold_wal: env_number("WALLET_BALANCE_LOW_THRESHOLD_WAL", 1_000_000),
-            sponsor_balance_low_threshold_sui: env_number("SPONSOR_BALANCE_LOW_THRESHOLD_SUI", 100_000_000),
+            // Both WAL and SUI use 9 decimal places (FROST/MIST).
+            wallet_balance_low_threshold_wal: env_number(
+                "WALLET_BALANCE_LOW_THRESHOLD_WAL",
+                50_000_000_000,
+            ),
+            wallet_balance_low_threshold_sui: env_number(
+                "WALLET_BALANCE_LOW_THRESHOLD_SUI",
+                5_000_000_000,
+            ),
+            sponsor_balance_low_threshold_sui: env_number(
+                "SPONSOR_BALANCE_LOW_THRESHOLD_SUI",
+                5_000_000_000,
+            ),
             mcp_oauth: crate::oauth::McpOAuthConfig::from_env(),
         }
     }
@@ -1873,8 +1885,9 @@ mod tests {
             walrus_system_object_id: "0x4".into(),
             restore_requests_per_owner_per_minute: 10,
             balance_monitor_interval_secs: 900,
-            wallet_balance_low_threshold_wal: 1_000_000,
-            sponsor_balance_low_threshold_sui: 100_000_000,
+            wallet_balance_low_threshold_wal: 50_000_000_000,
+            wallet_balance_low_threshold_sui: 5_000_000_000,
+            sponsor_balance_low_threshold_sui: 5_000_000_000,
             mcp_oauth: None,
         }
     }


### PR DESCRIPTION
## Summary

Promote the latest `dev` changes to `staging`.

Includes #663:
- Enoki-sponsored durable Walrus registration.
- Balance monitoring background worker: alerts when WAL or SUI balances drop below configured thresholds before writes fail.
- Slack alert delivery integration for low-balance notifications.

## Validation

- PR #663 merged and verified.
- Sidecar and relayer verified healthy on `dev`.
- Balance monitor verified initializing with configured thresholds.