### PR TITLE
fix(sdk): update default serverUrl to official mainnet relayer endpoint

### DIFF
--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -386,7 +386,8 @@ export default function Dashboard({
     const relayerLooksMismatched =
         (config.suiNetwork === 'mainnet' && normalizedRelayerUrl.includes('staging')) ||
         (config.suiNetwork !== 'mainnet' &&
-            normalizedRelayerUrl.includes('relayer.memwal.ai') &&
+            (normalizedRelayerUrl.includes('relayer.memory.walrus.xyz') ||
+                normalizedRelayerUrl.includes('relayer.memwal.ai')) &&
             !normalizedRelayerUrl.includes('staging') &&
             !normalizedRelayerUrl.includes('dev'))
     const dashboardSubtitle = delegateKey || previewReady

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -49,7 +49,7 @@ The TypeScript SDK (`MemWal.create()` and `withMemWal()`) and the Python SDK tak
 | `MEMWAL_PRIVATE_KEY` | `key` | none | Delegate private key in hex. The fundamentals and Python examples use this name |
 | `MEMWAL_KEY` | `key` | none | The same delegate private key under a shorter name used by the getting-started and SDK quick-starts. Pick one name per project |
 | `MEMWAL_ACCOUNT_ID` | `accountId` | none | `MemWalAccount` object ID on Sui |
-| `MEMWAL_SERVER_URL` | `serverUrl` | SDK-specific | Relayer base URL. The TypeScript SDK defaults to `https://relayer.memwal.ai`; the Python SDK defaults to `http://localhost:8000` unless `env="prod"` selects the hosted relayer |
+| `MEMWAL_SERVER_URL` | `serverUrl` | SDK-specific | Relayer base URL. The TypeScript SDK defaults to `https://relayer.memory.walrus.xyz`; the Python SDK defaults to `http://localhost:8000` unless `env="prod"` selects the hosted relayer |
 | `SUI_PRIVATE_KEY` | `suiPrivateKey` | none | Sui signer key for `MemWalManual` local signing, in `suiprivkey1...` format |
 | `OPENAI_API_KEY` | `embeddingApiKey` (manual client only) | none | Embedding and fact-extraction provider key. Only the `MemWalManual` client takes it as `embeddingApiKey`. The standard `MemWal` and Python SDKs let the relayer handle embeddings, so this is needed only for optional OpenAI middleware or demos |
 | `OPENAI_BASE_URL` | `embeddingApiBase` (manual client only) | `https://api.openai.com/v1` | Base URL for an OpenAI-compatible provider such as OpenRouter, in the same manual-client and optional-middleware contexts as `OPENAI_API_KEY` |

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -171,7 +171,7 @@ export class MemWalManual {
         this.delegatePrivateKey = typeof config.key === "string" ? hexToBytes(config.key) : config.key;
         // LOW-22: default to HTTPS; warn (do not throw) on plaintext HTTP
         // against non-localhost hosts.
-        this.serverUrl = normalizeServerUrl(config.serverUrl ?? "https://relayer.memwal.ai/");
+        this.serverUrl = normalizeServerUrl(config.serverUrl ?? "https://relayer.memory.walrus.xyz");
         this.walletSigner = config.walletSigner ?? null;
         this.config = config;
         this.namespace = config.namespace ?? "default";

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -203,7 +203,7 @@ export class MemWal {
         // LOW-22: default to HTTPS for production usage; normalizeServerUrl
         // warns (does not throw) if a user passes plain http:// for a
         // non-localhost host.
-        this.serverUrl = normalizeServerUrl(config.serverUrl ?? "https://relayer.memwal.ai/");
+        this.serverUrl = normalizeServerUrl(config.serverUrl ?? "https://relayer.memory.walrus.xyz");
         this.namespace = config.namespace ?? "default";
     }
 
@@ -211,7 +211,7 @@ export class MemWal {
      * Create a new Walrus Memory client instance.
      *
      * @param config.key - Ed25519 private key (hex string) — the delegate key
-     * @param config.serverUrl - Server URL (default: https://relayer.memwal.ai/)
+     * @param config.serverUrl - Server URL (default: https://relayer.memory.walrus.xyz)
      */
     static create(config: MemWalConfig): MemWal {
         return new MemWal(config);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -14,7 +14,7 @@ export interface MemWalConfig {
     key: string | Uint8Array;
     /** Walrus Memory account object ID on Sui (ensures correct account when delegate key exists in multiple accounts) */
     accountId: string;
-    /** Server URL (default: https://relayer.memwal.ai) */
+    /** Server URL (default: https://relayer.memory.walrus.xyz) */
     serverUrl?: string;
     /** Default namespace for memory isolation (default: "default") */
     namespace?: string;
@@ -339,7 +339,7 @@ export interface SealServerConfig {
 export interface MemWalManualConfig {
     /** Ed25519 delegate private key (hex or Uint8Array) for server auth */
     key: string | Uint8Array;
-    /** Server URL (default: https://relayer.memwal.ai) */
+    /** Server URL (default: https://relayer.memory.walrus.xyz) */
     serverUrl?: string;
     /**
      * Sui private key (bech32 suiprivkey1...) for SEAL + Walrus signing.

--- a/packages/sdk/test/default-server-url.test.mjs
+++ b/packages/sdk/test/default-server-url.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWal } from "../dist/memwal.js";
+import { MemWalManual } from "../dist/manual.js";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test("MemWal defaults serverUrl to official mainnet relayer URL", async () => {
+    let requestedUrl = null;
+    globalThis.fetch = async (url) => {
+        requestedUrl = String(url);
+        return Response.json({ status: "ok" });
+    };
+
+    const client = MemWal.create({
+        key: "01".repeat(32),
+        accountId: `0x${"02".repeat(32)}`,
+    });
+
+    await client.health();
+    assert.equal(requestedUrl, "https://relayer.memory.walrus.xyz/health");
+});
+
+test("MemWalManual defaults serverUrl to official mainnet relayer URL", async () => {
+    let requestedUrl = null;
+    globalThis.fetch = async (url) => {
+        requestedUrl = String(url);
+        return Response.json({
+            apiVersion: "1.0.0",
+            relayerVersion: "1.0.0",
+            minSupportedSdk: { typescript: "0.0.4" },
+        });
+    };
+
+    const manual = MemWalManual.create({
+        key: "01".repeat(32),
+        suiPrivateKey: "suiprivkey1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0g24m4",
+        embeddingApiKey: "test-openai-key",
+        packageId: `0x${"03".repeat(32)}`,
+        registryId: `0x${"04".repeat(32)}`,
+        accountId: `0x${"02".repeat(32)}`,
+    });
+
+    await manual.compatibility();
+    assert.equal(requestedUrl, "https://relayer.memory.walrus.xyz/version");
+});


### PR DESCRIPTION
Resolves #657

### Summary
Updates the default `serverUrl` in the TypeScript SDK (`MemWal` and `MemWalManual`) from legacy `https://relayer.memwal.ai/` to the official production endpoint `https://relayer.memory.walrus.xyz`.

### Changes
- Updated fallback `serverUrl` in `packages/sdk/src/memwal.ts` and `packages/sdk/src/manual.ts`.
- Updated TSDoc comments and type definitions in `packages/sdk/src/types.ts`.
- Updated environment variable documentation in `docs/reference/environment-variables.md`.
- Updated mismatch detection in `apps/app/src/pages/Dashboard.tsx`.
- Added unit test `packages/sdk/test/default-server-url.test.mjs` to assert default `serverUrl` behavior for `MemWal` and `MemWalManual`.

### Verification
- `pnpm --filter @mysten-incubation/memwal test` (33/33 tests pass)
- `node scripts/check-docs-freshness.mjs` (passes)