### PR TITLE
fix(relayer): harden sponsored registration and balance alerts

### DIFF
--- a/apps/app/src/components/AdminWalletBalances.tsx
+++ b/apps/app/src/components/AdminWalletBalances.tsx
@@ -79,8 +79,8 @@ export function AdminWalletBalances({ adminKey, onInvalidKey }: AdminWalletBalan
             <thead>
               <tr>
                 <th scope="col">Address</th>
-                <th scope="col" style={{ textAlign: 'right' }}>SUI</th>
-                <th scope="col" style={{ textAlign: 'right' }}>WAL</th>
+                <th scope="col" style={{ textAlign: 'right' }}>SUI (spendable)</th>
+                <th scope="col" style={{ textAlign: 'right' }}>WAL (spendable)</th>
                 <th scope="col">Status</th>
               </tr>
             </thead>
@@ -96,11 +96,25 @@ export function AdminWalletBalances({ adminKey, onInvalidKey }: AdminWalletBalan
                   <td title={wallet.address} className="admin-table-monospace">
                     {abbreviateAddress(wallet.address)}
                   </td>
-                  <td style={{ textAlign: 'right' }} className="admin-table-monospace" title={`${wallet.suiBalance} mist`}>
+                  <td
+                    style={{ textAlign: 'right' }}
+                    className="admin-table-monospace"
+                    title={`spendable ${wallet.suiBalance} mist / total ${wallet.suiTotal} mist`}
+                  >
                     {formatBalance(wallet.suiBalance, 'SUI')}
+                    {wallet.suiTotal !== wallet.suiBalance ? (
+                      <div className="admin-balance-total">total {formatBalance(wallet.suiTotal, 'SUI')}</div>
+                    ) : null}
                   </td>
-                  <td style={{ textAlign: 'right' }} className="admin-table-monospace" title={`${wallet.walBalance} frost`}>
+                  <td
+                    style={{ textAlign: 'right' }}
+                    className="admin-table-monospace"
+                    title={`spendable ${wallet.walBalance} frost / total ${wallet.walTotal} frost`}
+                  >
                     {formatBalance(wallet.walBalance, 'WAL')}
+                    {wallet.walTotal !== wallet.walBalance ? (
+                      <div className="admin-balance-total">total {formatBalance(wallet.walTotal, 'WAL')}</div>
+                    ) : null}
                   </td>
                   <td>
                     <span className={`admin-status-badge admin-status-badge--${wallet.status}`}>

--- a/apps/app/src/utils/admin-api.ts
+++ b/apps/app/src/utils/admin-api.ts
@@ -4,6 +4,8 @@ export interface WalletBalance {
   address: string
   suiBalance: bigint
   walBalance: bigint
+  suiTotal: bigint
+  walTotal: bigint
   status: 'healthy' | 'warning' | 'critical'
 }
 
@@ -109,6 +111,8 @@ interface RawWalletBalance {
   address: string
   sui: string
   wal: string
+  sui_total?: string
+  wal_total?: string
   status: string
 }
 
@@ -167,6 +171,8 @@ export async function fetchAdminWallets(
       address: wallet.address,
       suiBalance: BigInt(wallet.sui || '0'),
       walBalance: BigInt(wallet.wal || '0'),
+      suiTotal: BigInt(wallet.sui_total || wallet.sui || '0'),
+      walTotal: BigInt(wallet.wal_total || wallet.wal || '0'),
       status: toBadgeStatus(wallet.status),
     })),
     sponsorWallet: {

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -129,7 +129,8 @@ These are not all enforced at boot, but most real deployments need them.
 | `SEAL_THRESHOLD` | `min(2, total configured weight)` | Required configured server weight for SEAL encrypt/decrypt |
 | `ENOKI_API_KEY` | none | Optional Enoki key for sponsored sidecar transactions |
 | `ENOKI_NETWORK` | `mainnet` | Network used for Enoki-sponsored flows |
-| `ENOKI_FALLBACK_TO_DIRECT_SIGN` | `false` | If true, sidecar pays gas directly with the server wallet when Enoki sponsorship fails or is not configured |
+| `DURABLE_ENOKI_REGISTER_ENABLED` | `false` | Enables Enoki sponsorship for durable Walrus registration. Deploy all replicas with this off first, then enable it after old replicas drain |
+| `ENOKI_FALLBACK_TO_DIRECT_SIGN` | `false` | If true, rebuildable Enoki flows may pay gas directly with the server wallet. Durable registration fails closed after `DURABLE_ENOKI_REGISTER_ENABLED=true` |
 | `ENOKI_TRANSIENT_MAX_ATTEMPTS` | `2` | Attempts for sidecar-level retries of transient Enoki failures (`429`, `5xx`, network errors) before failing the wallet job |
 | `ENOKI_TRANSIENT_BASE_DELAY_MS` | `5000` | Base delay for transient Enoki retries when the response does not include `Retry-After` or a retry hint |
 | `ENOKI_TRANSIENT_MAX_DELAY_MS` | `30000` | Maximum delay for one transient Enoki retry, including parsed retry hints such as “try again in 30 seconds” |
@@ -145,7 +146,8 @@ These are not all enforced at boot, but most real deployments need them.
 ### Notes
 
 - If both `SERVER_SUI_PRIVATE_KEYS` and `SERVER_SUI_PRIVATE_KEY` are set, the key pool takes priority for uploads. Upload jobs use the pool in round-robin order.
-- Keep `ENOKI_FALLBACK_TO_DIRECT_SIGN=false` in production if the server wallet should not pay gas when sponsorship is missing, expired, or rejected.
+- Roll out durable registration sponsorship in two phases: first deploy all replicas with `DURABLE_ENOKI_REGISTER_ENABLED=false`; after old replicas have drained, set it to `true`. This prevents mixed-version workers from rejecting persisted sponsored journals.
+- Keep `ENOKI_FALLBACK_TO_DIRECT_SIGN=false` in production if the server wallet should not pay gas for rebuildable Enoki flows when sponsorship is missing, expired, or rejected. Durable registration does not fall back after its rollout gate is enabled.
 - `OPENAI_API_KEY` and `OPENAI_API_BASE` control the embedding and fact-extraction provider used by `remember`, `recall`, `analyze`, `ask`, and restore re-indexing.
 - `WALRUS_AGGREGATOR_URLS` is only used after the Redis ciphertext cache misses. Put low-latency cache/proxy endpoints first after the primary and keep 404/5xx cache TTLs short in your proxy.
 - `WALRUS_SKIP_CONSISTENCY_CHECK=true` should only be used for trusted blobs written by the relayer. Restore keeps consistency checks enabled for on-chain-discovered blobs.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -137,6 +137,11 @@ These are not all enforced at boot, but most real deployments need them.
 | `ENOKI_INVALIDATED_MAX_ATTEMPTS` | `4` | Attempts for rebuildable sponsored transactions invalidated by Enoki `expired` responses or short Sui object visibility lag before failing the wallet job |
 | `ENOKI_INVALIDATED_BASE_DELAY_MS` | `1000` | Base delay for retrying rebuildable sponsored transactions after Enoki invalidation |
 | `ENOKI_INVALIDATED_MAX_DELAY_MS` | `8000` | Maximum delay for one rebuildable sponsored transaction invalidation retry |
+| `BALANCE_MONITOR_INTERVAL_SECS` | `900` | How often the relayer polls uploader and sponsor address balances for low-balance Slack alerts |
+| `WALLET_BALANCE_LOW_THRESHOLD_WAL` | `50000000000` | Uploader WAL address-balance threshold in FROST (50 WAL). Alerts independently of SUI |
+| `WALLET_BALANCE_LOW_THRESHOLD_SUI` | `5000000000` | Uploader SUI address-balance threshold in MIST (5 SUI). Load-bearing during phase 1, when durable register pays gas from the uploader wallet |
+| `SPONSOR_BALANCE_LOW_THRESHOLD_SUI` | `5000000000` | Sponsor wallet SUI address-balance threshold in MIST (5 SUI) |
+| `WALLET_BALANCE_LOW_ALERT_DEDUP_SECS` | `43200` | Dedup window for wallet low-balance Slack alerts, per `(network, wallet type, token, address)` |
 | `MEMWAL_RELAYER_URL` | `http://127.0.0.1:$PORT` | Relayer URL passed from the Rust server to the sidecar for MCP tool calls |
 | `MCP_MAX_TOTAL_SESSIONS` | `1000` | Maximum active MCP sessions across SSE and Streamable HTTP transports |
 | `MCP_MAX_SESSIONS_PER_IP` | `16` | Maximum active MCP sessions from one source IP |
@@ -146,7 +151,7 @@ These are not all enforced at boot, but most real deployments need them.
 ### Notes
 
 - If both `SERVER_SUI_PRIVATE_KEYS` and `SERVER_SUI_PRIVATE_KEY` are set, the key pool takes priority for uploads. Upload jobs use the pool in round-robin order.
-- Roll out durable registration sponsorship in two phases: first deploy all replicas with `DURABLE_ENOKI_REGISTER_ENABLED=false`; after old replicas have drained, set it to `true`. This prevents mixed-version workers from rejecting persisted sponsored journals.
+- Roll out durable registration sponsorship in two phases: first deploy all replicas with `DURABLE_ENOKI_REGISTER_ENABLED=false`; after old replicas have drained, set it to `true`. This prevents mixed-version workers from rejecting persisted sponsored journals. During phase 1, if `ENOKI_API_KEY` is set, durable register **direct-signs and pays gas from the uploader wallet** — the new SUI address-balance alert is load-bearing for that window. After phase 2, drain every replica before rolling the gate back to `false`; otherwise old replicas can 409 sponsored journals as `INVALID_PREPARED_REGISTER_TRANSACTION`.
 - Keep `ENOKI_FALLBACK_TO_DIRECT_SIGN=false` in production if the server wallet should not pay gas for rebuildable Enoki flows when sponsorship is missing, expired, or rejected. Durable registration does not fall back after its rollout gate is enabled.
 - `OPENAI_API_KEY` and `OPENAI_API_BASE` control the embedding and fact-extraction provider used by `remember`, `recall`, `analyze`, `ask`, and restore re-indexing.
 - `WALRUS_AGGREGATOR_URLS` is only used after the Redis ciphertext cache misses. Put low-latency cache/proxy endpoints first after the primary and keep 404/5xx cache TTLs short in your proxy.

--- a/docs/relayer/runbook-gas-pool.md
+++ b/docs/relayer/runbook-gas-pool.md
@@ -38,11 +38,20 @@ alert), or relayer logs show wallet jobs aborting with
 
 ## What it means
 
-The relayer sponsors Walrus register transactions through Enoki. Enoki's dry-run
-splits a SUI gas coin on the selected pool wallet to cover the sponsored budget.
-When that wallet has **no single SUI coin large enough** (its gas is fragmented
-into many small coins, or it is low on SUI), Sui aborts in `0x2::balance::split`
-with `ENotEnough`.
+Gas ownership depends on the durable-register rollout gate:
+
+- **Phase 1** (`DURABLE_ENOKI_REGISTER_ENABLED=false`, the current staging/prod
+  default): durable register **direct-signs**. The **uploader wallet** pays SUI
+  gas from its address balance. Top up that wallet; do not send SUI to an Enoki
+  pool wallet expecting it to sponsor this path.
+- **Phase 2** (`DURABLE_ENOKI_REGISTER_ENABLED=true`): durable register is
+  Enoki-sponsored. Enoki's dry-run splits a SUI gas coin on the selected pool
+  wallet. When that wallet has **no single SUI coin large enough** (fragmented
+  or low), Sui aborts in `0x2::balance::split` with `ENotEnough`.
+
+The rest of this runbook is the phase-2 / Enoki-sponsored path. Phase-1
+starvation is a low **uploader** SUI address balance — see the wallet-balance
+alert, not this gas-pool alert.
 
 The relayer now classifies this as `GasPoolExhausted` and **aborts the job
 immediately** instead of retrying across the whole pool (which would just
@@ -102,8 +111,12 @@ sui client pay-all-sui --input-coins <COIN_ID_1> <COIN_ID_2> ... --recipient <PO
 
 ### Top up
 
-Send SUI to the starved pool wallets so the largest coin comfortably exceeds
-the sponsored budget with headroom.
+**Phase 2 only.** Send SUI to the starved Enoki pool wallets so the largest
+coin comfortably exceeds the sponsored budget with headroom.
+
+**Phase 1:** send SUI to the **uploader** wallet address that fired the
+low-balance alert (`WALLET_BALANCE_LOW_THRESHOLD_SUI`). Pool-wallet top-ups do
+not pay durable-register gas while the gate is off.
 
 ## Verify
 

--- a/docs/relayer/runbook-gas-pool.md
+++ b/docs/relayer/runbook-gas-pool.md
@@ -28,7 +28,7 @@ questions:
   - "What causes Enoki dry_run_failed errors with balance split on MemWal?"
   - "How do I consolidate SUI gas coins on relayer pool wallets?"
 answer: >-
-  Gas-pool exhaustion occurs when relayer pool wallets have no single SUI coin large enough for Enoki-sponsored Walrus transactions, typically due to coin fragmentation. The fix is to consolidate fragmented coins using sui client merge-coin or pay-all-sui, or top up the wallet with additional SUI so the largest coin exceeds the sponsored budget.
+  Gas ownership depends on DURABLE_ENOKI_REGISTER_ENABLED. Phase 1 (flag false, current default) direct-signs durable register from the uploader wallet address balance — top up that uploader, not an Enoki pool wallet. Phase 2 (flag true) is Enoki-sponsored: exhaustion means a pool wallet has no single SUI coin large enough, typically from fragmentation; consolidate with sui client merge-coin or pay-all-sui, or top up the pool wallet so the largest coin exceeds the sponsored budget.
 ---
 
 When to use this: a **gas-pool alert** fires (the SUI gas pool maintenance

--- a/services/server/.env.example
+++ b/services/server/.env.example
@@ -159,6 +159,9 @@ MEMWAL_REGISTRY_ID=0x...
 # Enoki Sponsored Transactions (sidecar)
 ENOKI_API_KEY=
 ENOKI_NETWORK=mainnet
+# Two-phase rollout: deploy every replica with this false, then set true only
+# after old replicas have drained so persisted sponsored journals are compatible.
+DURABLE_ENOKI_REGISTER_ENABLED=false
 # Keep false in production so missing/expired/rejected sponsorship retries
 # through Apalis instead of making the server wallet pay gas directly.
 ENOKI_FALLBACK_TO_DIRECT_SIGN=false

--- a/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
+++ b/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
@@ -249,14 +249,18 @@ test("sponsored registration keeps WAL on the sender while assigning gas to the 
             },
             1,
         ),
-        /not_found/,
+        (error: unknown) => error instanceof Error
+            && (error as { code?: string }).code === "UNAVAILABLE"
+            && /ambiguous/.test(error.message),
     );
 
     let lookups = 0;
     const retryClient = {
         async getTransaction() {
             lookups += 1;
-            if (lookups < 2) throw Object.assign(new Error("not found"), { code: "NOT_FOUND" });
+            // 1 = pre-execute probe. 2 = first expired-path miss. 3 = hit.
+            // A helper that only looks up once would stop after #2 and fail.
+            if (lookups < 3) throw Object.assign(new Error("not found"), { code: "NOT_FOUND" });
             return finalized;
         },
         async executeTransaction() {
@@ -275,7 +279,7 @@ test("sponsored registration keeps WAL on the sender while assigning gas to the 
         2,
     );
     assert.equal(recovered, finalized);
-    assert.equal(lookups, 2);
+    assert.equal(lookups, 3);
 
     await assert.rejects(
         executePreparedRegisterTransaction(

--- a/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
+++ b/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../sidecar/config.js";
 import {
     assertAddressBalanceRegisterTransaction,
+    assertSponsoredRegisterTransactionKind,
     createdBlobObjectIdFromTransaction,
     durableRegisterDirectSigningAllowed,
     executePreparedRegisterTransaction,
@@ -132,9 +133,9 @@ test("legacy uploads preserve fallback behavior while using address balances", (
     });
 });
 
-test("durable register never direct-signs when Enoki is configured", () => {
+test("durable register sponsorship uses an explicit two-phase rollout gate", () => {
     assert.equal(durableRegisterDirectSigningAllowed(false, false), true);
-    assert.equal(durableRegisterDirectSigningAllowed(true, false), false);
+    assert.equal(durableRegisterDirectSigningAllowed(true, false), true);
     assert.equal(durableRegisterDirectSigningAllowed(true, true), false);
 });
 
@@ -175,6 +176,20 @@ test("sponsored registration keeps WAL on the sender while assigning gas to the 
 
     const validated = await validatePreparedRegisterTransaction(prepared, signer.toSuiAddress());
     assert.equal(validated.sponsorDigest, digest);
+    const expectedKind = TransactionDataBuilder.fromBytes(bytes).build({ onlyTransactionKind: true });
+    assert.doesNotThrow(() => assertSponsoredRegisterTransactionKind(
+        TransactionDataBuilder.fromBytes(bytes),
+        expectedKind,
+    ));
+    const tamperedKind = expectedKind.slice();
+    tamperedKind[tamperedKind.length - 1] ^= 1;
+    assert.throws(
+        () => assertSponsoredRegisterTransactionKind(
+            TransactionDataBuilder.fromBytes(bytes),
+            tamperedKind,
+        ),
+        /kind differs/,
+    );
 
     let submitted = false;
     let directExecutions = 0;
@@ -204,6 +219,21 @@ test("sponsored registration keeps WAL on the sender while assigning gas to the 
     );
     assert.equal(result, finalized);
     assert.equal(directExecutions, 0);
+
+    submitted = false;
+    await assert.rejects(
+        executePreparedRegisterTransaction(
+            validated,
+            client,
+            () => {},
+            async () => 1n,
+            false,
+            async () => {
+                throw new Error('Enoki API error (400): {"errors":[{"code":"expired"}]}');
+            },
+        ),
+        (error: unknown) => error instanceof NoSideEffectError && /rebuild sponsorship/.test(error.message),
+    );
 });
 
 test("prepared registration rejects tampered digest, signature, and wallet", async () => {

--- a/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
+++ b/services/server/scripts/__tests__/sidecar-query-helpers.test.ts
@@ -167,15 +167,16 @@ test("sponsored registration keeps WAL on the sender while assigning gas to the 
     const bytes = await transaction.build();
     const signed = await signer.signTransaction(bytes);
     const digest = TransactionDataBuilder.getDigestFromBytes(bytes);
+    const sponsorDigest = `sponsor-${digest}`;
     const prepared: PreparedRegisterTransaction = {
         transactionBytes: signed.bytes,
         signature: signed.signature,
         digest,
-        sponsorDigest: digest,
+        sponsorDigest,
     };
 
     const validated = await validatePreparedRegisterTransaction(prepared, signer.toSuiAddress());
-    assert.equal(validated.sponsorDigest, digest);
+    assert.equal(validated.sponsorDigest, sponsorDigest);
     const expectedKind = TransactionDataBuilder.fromBytes(bytes).build({ onlyTransactionKind: true });
     assert.doesNotThrow(() => assertSponsoredRegisterTransactionKind(
         TransactionDataBuilder.fromBytes(bytes),
@@ -210,8 +211,8 @@ test("sponsored registration keeps WAL on the sender while assigning gas to the 
         () => {},
         async () => 1n,
         false,
-        async (sponsorDigest, signature) => {
-            assert.equal(sponsorDigest, digest);
+        async (executedSponsorDigest, signature) => {
+            assert.equal(executedSponsorDigest, sponsorDigest);
             assert.equal(signature, signed.signature);
             submitted = true;
             return { digest };
@@ -231,8 +232,66 @@ test("sponsored registration keeps WAL on the sender while assigning gas to the 
             async () => {
                 throw new Error('Enoki API error (400): {"errors":[{"code":"expired"}]}');
             },
+            1,
         ),
         (error: unknown) => error instanceof NoSideEffectError && /rebuild sponsorship/.test(error.message),
+    );
+
+    await assert.rejects(
+        executePreparedRegisterTransaction(
+            validated,
+            client,
+            () => {},
+            async () => 1n,
+            false,
+            async () => {
+                throw new Error('Enoki API error (400): {"errors":[{"code":"not_found"}]}');
+            },
+            1,
+        ),
+        /not_found/,
+    );
+
+    let lookups = 0;
+    const retryClient = {
+        async getTransaction() {
+            lookups += 1;
+            if (lookups < 2) throw Object.assign(new Error("not found"), { code: "NOT_FOUND" });
+            return finalized;
+        },
+        async executeTransaction() {
+            throw new Error("sponsored journal must not execute directly");
+        },
+    };
+    const recovered = await executePreparedRegisterTransaction(
+        validated,
+        retryClient,
+        () => {},
+        async () => 1n,
+        false,
+        async () => {
+            throw new Error('Enoki API error (400): {"errors":[{"code":"expired"}]}');
+        },
+        2,
+    );
+    assert.equal(recovered, finalized);
+    assert.equal(lookups, 2);
+
+    await assert.rejects(
+        executePreparedRegisterTransaction(
+            validated,
+            client,
+            () => {},
+            async () => 1n,
+            true,
+            async () => {
+                throw new Error('Enoki API error (400): {"errors":[{"code":"expired"}]}');
+            },
+            1,
+        ),
+        (error: unknown) => error instanceof Error
+            && (error as { code?: string }).code === "UNAVAILABLE"
+            && /ambiguous/.test(error.message),
     );
 });
 

--- a/services/server/scripts/__tests__/sidecar-writer-mode.test.ts
+++ b/services/server/scripts/__tests__/sidecar-writer-mode.test.ts
@@ -150,8 +150,11 @@ test("writer mode exposes only durable writer and observability routes", async (
             perWallet: [
                 {
                     address: writerKey.toSuiAddress(),
+                    walletIndex: 0,
                     suiMist: "1230000000",
+                    suiAddressBalanceMist: "1200000000",
                     walFrost: "4560000000",
+                    walAddressBalanceFrost: "4500000000",
                 },
             ],
         });

--- a/services/server/scripts/sidecar/clients.ts
+++ b/services/server/scripts/sidecar/clients.ts
@@ -243,7 +243,14 @@ export type WalletBalanceSnapshot = {
     walletWalAddressBalanceFrost: string;
     walletWalCoinBalanceFrost: string;
     walletWalAddressFundedCount: number;
-    perWallet: Array<{ address: string; suiMist: string; walFrost: string }>;
+    perWallet: Array<{
+        address: string;
+        walletIndex: number;
+        suiMist: string;
+        suiAddressBalanceMist: string;
+        walFrost: string;
+        walAddressBalanceFrost: string;
+    }>;
 };
 
 const BALANCE_RPC_TIMEOUT_MS = 1_500;
@@ -300,7 +307,7 @@ async function loadWalletBalanceSnapshot(owners: string[]): Promise<WalletBalanc
     let suiAddressFundedCount = 0;
     let walAddressFundedCount = 0;
     const suiType = normalizeStructTag(SUI_TYPE);
-    const perWallet: Array<{ address: string; suiMist: string; walFrost: string }> = [];
+    const perWallet: WalletBalanceSnapshot["perWallet"] = [];
     balancesByOwner.forEach((balances, index) => {
         let ownerSuiAddressBalance = 0n;
         let ownerWalAddressBalance = 0n;
@@ -332,8 +339,11 @@ async function loadWalletBalanceSnapshot(owners: string[]): Promise<WalletBalanc
         if (ownerWalAddressBalance > 0n) walAddressFundedCount += 1;
         perWallet.push({
             address: owners[index],
+            walletIndex: index,
             suiMist: ownerSuiTotal.toString(),
+            suiAddressBalanceMist: ownerSuiAddressBalance.toString(),
             walFrost: ownerWalTotal.toString(),
+            walAddressBalanceFrost: ownerWalAddressBalance.toString(),
         });
     });
     return {

--- a/services/server/scripts/sidecar/config.ts
+++ b/services/server/scripts/sidecar/config.ts
@@ -249,6 +249,10 @@ export const ENOKI_NETWORK = (process.env.ENOKI_NETWORK || process.env.SUI_NETWO
     | "mainnet"
     | "testnet"
     | "devnet";
+// Roll out durable-register sponsorship in two phases: deploy this code with
+// the gate off so old and new replicas both understand persisted journals,
+// then enable it after the old replica set has drained.
+export const DURABLE_ENOKI_REGISTER_ENABLED = parseBooleanEnv("DURABLE_ENOKI_REGISTER_ENABLED", false);
 export const ENOKI_FALLBACK_TO_DIRECT_SIGN = (() => {
     const raw = (process.env.ENOKI_FALLBACK_TO_DIRECT_SIGN || "false").trim().toLowerCase();
     return raw !== "0" && raw !== "false" && raw !== "no";

--- a/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
+++ b/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
@@ -65,6 +65,7 @@ import {
     type EnokiExecuteResponse,
     type EnokiSponsorResponse,
 } from "../enoki.js";
+import { isSponsoredTransactionInvalidatedMessage } from "../../enoki-retry.js";
 import { isEnokiSponsoredTransactionExpired } from "../../walrus-error-detection.js";
 import {
     assertUploadExecutionIdentity,
@@ -511,9 +512,13 @@ export async function executePreparedRegisterTransaction(
                 executeSponsored(prepared.sponsorDigest!, prepared.signature),
             );
         } catch (error: unknown) {
-            // `expired` is the only invalidation that proves Enoki never
-            // submitted. `not_found` can mean the handle was already consumed.
-            if (!isEnokiSponsoredTransactionExpired(errorMessage(error))) throw error;
+            const message = errorMessage(error);
+            const expired = isEnokiSponsoredTransactionExpired(message);
+            const invalidated = isSponsoredTransactionInvalidatedMessage(message);
+            // `expired` proves Enoki never submitted. `not_found` can mean the
+            // handle was already consumed — look up the digest, then stay
+            // ambiguous instead of clearing the journal.
+            if (!invalidated) throw error;
 
             const finalized = await lookupPreparedRegisterTransaction(
                 client,
@@ -523,7 +528,7 @@ export async function executePreparedRegisterTransaction(
                 indexAttempts,
             );
             if (finalized !== undefined) return finalized;
-            if (mayHaveBeenSubmitted) {
+            if (!expired || mayHaveBeenSubmitted) {
                 throw Object.assign(
                     new Error(
                         `sponsored register transaction ${prepared.digest} was invalidated but remains ambiguous`,

--- a/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
+++ b/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
@@ -65,7 +65,7 @@ import {
     type EnokiExecuteResponse,
     type EnokiSponsorResponse,
 } from "../enoki.js";
-import { isSponsoredTransactionInvalidatedMessage } from "../../enoki-retry.js";
+import { isEnokiSponsoredTransactionExpired } from "../../walrus-error-detection.js";
 import {
     assertUploadExecutionIdentity,
     executionIdentity,
@@ -297,12 +297,8 @@ export async function prepareRegisterTransaction(
         };
     }
 
-    if (!durableRegisterDirectSigningAllowed(
-        !!ENOKI_API_KEY,
-        DURABLE_ENOKI_REGISTER_ENABLED,
-    )) {
-        throw new Error("durable register requires Enoki sponsorship");
-    }
+    // Fail-closed sponsorship already returned above. Remaining path is the
+    // explicit phase-1 / unconfigured-Enoki direct sign.
     transaction.setGasPayment([]);
     const bytes = await transaction.build({ client: suiClient });
     assertAddressBalanceRegisterTransaction(TransactionDataBuilder.fromBytes(bytes));
@@ -365,6 +361,9 @@ export function assertSponsoredRegisterTransaction(
         || normalizeSuiAddress(transactionData.gasData.owner) === walletAddress) {
         throw new Error("sponsored registerTransaction must use a distinct gas owner");
     }
+    // Enoki-sponsored journals do not carry a ValidDuring maxEpoch. They are
+    // intentionally unbounded and rebuild only via the expired-sponsorship
+    // path below, not the epoch-expiry guard used by direct-signed journals.
     assertRegisterTransactionUsesAddressBalanceWal(transactionData);
 }
 
@@ -439,6 +438,28 @@ async function currentSuiEpoch(): Promise<bigint> {
     return epoch;
 }
 
+async function lookupPreparedRegisterTransaction(
+    client: PreparedRegisterClient,
+    digest: string,
+    include: { effects: true; objectTypes: true },
+    assertExpectedDigest: (result: unknown) => unknown,
+    attempts: number,
+): Promise<unknown | undefined> {
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            return assertExpectedDigest(
+                await client.getTransaction({ digest, include }),
+            );
+        } catch (error: any) {
+            if (error?.code !== "NOT_FOUND") throw error;
+            if (attempt < attempts) {
+                await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+            }
+        }
+    }
+    return undefined;
+}
+
 export async function executePreparedRegisterTransaction(
     prepared: ValidatedPreparedRegisterTransaction,
     client: PreparedRegisterClient = suiClient,
@@ -446,6 +467,7 @@ export async function executePreparedRegisterTransaction(
     getCurrentEpoch: () => Promise<bigint> = currentSuiEpoch,
     mayHaveBeenSubmitted = false,
     executeSponsored: PreparedRegisterSponsorExecutor = executePreparedRegisterWithEnoki,
+    indexAttempts = 8,
 ): Promise<unknown> {
     const include = { effects: true, objectTypes: true } as const;
     const assertExpectedDigest = (result: any): unknown => {
@@ -489,20 +511,28 @@ export async function executePreparedRegisterTransaction(
                 executeSponsored(prepared.sponsorDigest!, prepared.signature),
             );
         } catch (error: unknown) {
-            if (!isSponsoredTransactionInvalidatedMessage(errorMessage(error))) throw error;
+            // `expired` is the only invalidation that proves Enoki never
+            // submitted. `not_found` can mean the handle was already consumed.
+            if (!isEnokiSponsoredTransactionExpired(errorMessage(error))) throw error;
 
-            // Enoki sponsorship handles are disposable. Only discard this one
-            // after a second digest lookup proves the journaled Sui transaction
-            // never landed; the Rust writer will then clear the prepared bytes
-            // and build a fresh sponsorship on its next checkpoint.
-            try {
-                const finalized = await client.getTransaction({ digest: prepared.digest, include });
-                return assertExpectedDigest(finalized);
-            } catch (lookupError: any) {
-                if (lookupError?.code !== "NOT_FOUND") throw lookupError;
+            const finalized = await lookupPreparedRegisterTransaction(
+                client,
+                prepared.digest,
+                include,
+                assertExpectedDigest,
+                indexAttempts,
+            );
+            if (finalized !== undefined) return finalized;
+            if (mayHaveBeenSubmitted) {
+                throw Object.assign(
+                    new Error(
+                        `sponsored register transaction ${prepared.digest} was invalidated but remains ambiguous`,
+                    ),
+                    { code: "UNAVAILABLE" },
+                );
             }
             throw new NoSideEffectError(
-                `sponsored register transaction ${prepared.digest} was invalidated and is not on chain; rebuild sponsorship`,
+                `sponsored register transaction ${prepared.digest} expired and is not on chain; rebuild sponsorship`,
             );
         }
         if (executed.digest !== prepared.digest) {
@@ -513,15 +543,14 @@ export async function executePreparedRegisterTransaction(
         // Enoki returns only a digest. Read the finalized transaction so the
         // caller can validate the created Walrus Blob object exactly as it did
         // for the legacy direct-execution path.
-        for (let attempt = 1; attempt <= 8; attempt += 1) {
-            try {
-                const finalized = await client.getTransaction({ digest: prepared.digest, include });
-                return assertExpectedDigest(finalized);
-            } catch (error: any) {
-                if (error?.code !== "NOT_FOUND" || attempt === 8) throw error;
-                await new Promise((resolve) => setTimeout(resolve, attempt * 250));
-            }
-        }
+        const finalized = await lookupPreparedRegisterTransaction(
+            client,
+            prepared.digest,
+            include,
+            assertExpectedDigest,
+            indexAttempts,
+        );
+        if (finalized !== undefined) return finalized;
         throw new Error(`sponsored register transaction ${prepared.digest} was not found after execution`);
     }
 

--- a/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
+++ b/services/server/scripts/sidecar/routes/walrus-upload-journal.ts
@@ -19,9 +19,9 @@ import { normalizeStructTag, normalizeSuiAddress } from "@mysten/sui/utils";
 import { verifyTransactionSignature } from "@mysten/sui/verify";
 import {
     DEFAULT_WALRUS_EPOCHS,
+    DURABLE_ENOKI_REGISTER_ENABLED,
     DURABLE_UPLOAD_PROTOCOL_VERSION,
     ENOKI_API_KEY,
-    ENOKI_FALLBACK_TO_DIRECT_SIGN,
     ENOKI_NETWORK,
     JSON_LIMIT_WALRUS_UPLOAD,
     MAX_WALRUS_EPOCHS,
@@ -65,6 +65,7 @@ import {
     type EnokiExecuteResponse,
     type EnokiSponsorResponse,
 } from "../enoki.js";
+import { isSponsoredTransactionInvalidatedMessage } from "../../enoki-retry.js";
 import {
     assertUploadExecutionIdentity,
     executionIdentity,
@@ -135,12 +136,12 @@ async function certifiedStep(
 
 export function durableRegisterDirectSigningAllowed(
     enokiConfigured: boolean,
-    _fallbackToDirectSign: boolean,
+    durableSponsorshipEnabled: boolean,
 ): boolean {
-    // When Enoki is configured, durable registration must fail closed rather
-    // than silently draining the upload wallet after a sponsor outage. Direct
-    // signing remains available only for deployments without Enoki (local/dev).
-    return !enokiConfigured;
+    // The explicit rollout gate keeps newly deployed replicas journal-compatible
+    // with pre-sponsorship replicas. Once enabled, an Enoki-configured service
+    // fails closed instead of silently draining the upload wallet on outage.
+    return !durableSponsorshipEnabled || !enokiConfigured;
 }
 
 export function createdBlobObjectIdFromTransaction(result: any): string {
@@ -262,7 +263,7 @@ export async function prepareRegisterTransaction(
     const signerAddress = signer.toSuiAddress();
     transaction.setSenderIfNotSet(signerAddress);
 
-    if (ENOKI_API_KEY) {
+    if (ENOKI_API_KEY && DURABLE_ENOKI_REGISTER_ENABLED) {
         // Journal the exact sponsored bytes before execution. Replays use the
         // Enoki sponsorship handle below, so the upload remains idempotent
         // without making the sender wallet the gas owner.
@@ -285,6 +286,7 @@ export async function prepareRegisterTransaction(
         }
         const transactionData = TransactionDataBuilder.fromBytes(bytes);
         assertSponsoredRegisterTransaction(transactionData, signerAddress);
+        assertSponsoredRegisterTransactionKind(transactionData, transactionKind);
         const digest = TransactionDataBuilder.getDigestFromBytes(bytes);
         const signed = await signer.signTransaction(bytes);
         return {
@@ -295,7 +297,10 @@ export async function prepareRegisterTransaction(
         };
     }
 
-    if (!durableRegisterDirectSigningAllowed(false, ENOKI_FALLBACK_TO_DIRECT_SIGN)) {
+    if (!durableRegisterDirectSigningAllowed(
+        !!ENOKI_API_KEY,
+        DURABLE_ENOKI_REGISTER_ENABLED,
+    )) {
         throw new Error("durable register requires Enoki sponsorship");
     }
     transaction.setGasPayment([]);
@@ -334,6 +339,16 @@ function assertRegisterTransactionUsesAddressBalanceWal(
     );
     if (!hasWalWithdrawal) {
         throw new Error("registerTransaction has no WAL address-balance withdrawal");
+    }
+}
+
+export function assertSponsoredRegisterTransactionKind(
+    transactionData: TransactionDataBuilder,
+    expectedKindBytes: Uint8Array,
+): void {
+    const returnedKindBytes = transactionData.build({ onlyTransactionKind: true });
+    if (!Buffer.from(returnedKindBytes).equals(Buffer.from(expectedKindBytes))) {
+        throw new Error("Enoki returned a sponsored transaction whose kind differs from the requested transaction");
     }
 }
 
@@ -468,9 +483,28 @@ export async function executePreparedRegisterTransaction(
     // signed payload can only submit the already-journaled digest.
     onTransactionObservedOrSubmitted();
     if (prepared.sponsorDigest) {
-        const executed = await trackWalletSubmission(() =>
-            executeSponsored(prepared.sponsorDigest!, prepared.signature),
-        );
+        let executed: EnokiExecuteResponse;
+        try {
+            executed = await trackWalletSubmission(() =>
+                executeSponsored(prepared.sponsorDigest!, prepared.signature),
+            );
+        } catch (error: unknown) {
+            if (!isSponsoredTransactionInvalidatedMessage(errorMessage(error))) throw error;
+
+            // Enoki sponsorship handles are disposable. Only discard this one
+            // after a second digest lookup proves the journaled Sui transaction
+            // never landed; the Rust writer will then clear the prepared bytes
+            // and build a fresh sponsorship on its next checkpoint.
+            try {
+                const finalized = await client.getTransaction({ digest: prepared.digest, include });
+                return assertExpectedDigest(finalized);
+            } catch (lookupError: any) {
+                if (lookupError?.code !== "NOT_FOUND") throw lookupError;
+            }
+            throw new NoSideEffectError(
+                `sponsored register transaction ${prepared.digest} was invalidated and is not on chain; rebuild sponsorship`,
+            );
+        }
         if (executed.digest !== prepared.digest) {
             throw new Error(
                 `Enoki executed unexpected register digest: expected ${prepared.digest}, got ${executed.digest}`,
@@ -679,7 +713,7 @@ export function registerWalrusUploadJournalRoute(app: Express): void {
                             },
                         });
                         enforceAddressBalanceCoinIntents(registerTx);
-                        const tipRecipient = ENOKI_API_KEY
+                        const tipRecipient = ENOKI_API_KEY && DURABLE_ENOKI_REGISTER_ENABLED
                             ? await getUploadRelayTipAddress()
                             : null;
                         const allowedAddresses = [...new Set(

--- a/services/server/scripts/sidecar/state.ts
+++ b/services/server/scripts/sidecar/state.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+    DURABLE_ENOKI_REGISTER_ENABLED,
     ENOKI_API_KEY,
     ENOKI_FALLBACK_TO_DIRECT_SIGN,
     ENOKI_INVALIDATED_MAX_ATTEMPTS,
@@ -74,6 +75,7 @@ export function sidecarStateSnapshot(): Record<string, unknown> {
         suiNetwork: SUI_NETWORK,
         enokiNetwork: ENOKI_NETWORK,
         enokiEnabled: !!ENOKI_API_KEY,
+        durableEnokiRegisterEnabled: DURABLE_ENOKI_REGISTER_ENABLED,
         fallbackToDirectSign: ENOKI_FALLBACK_TO_DIRECT_SIGN,
         enokiTransientMaxAttempts: ENOKI_TRANSIENT_MAX_ATTEMPTS,
         enokiInvalidatedMaxAttempts: ENOKI_INVALIDATED_MAX_ATTEMPTS,

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -259,7 +259,10 @@ impl AlertManager {
         // Dedup by the full address; abbreviating here could make two distinct
         // wallets with the same prefix/suffix suppress each other's alerts.
         let key = (
-            format!("{}:{}", alert.wallet_type, alert.token),
+            format!(
+                "{}:{}:{}",
+                alert.sui_network, alert.wallet_type, alert.token
+            ),
             alert.address.clone(),
         );
         if self.wallet_balance_low_dedup.should_suppress(key) {
@@ -435,6 +438,8 @@ pub struct WalletBalanceLowAlert {
     pub balance: u64,
     pub threshold: u64,
     pub token: String,
+    pub sui_network: String,
+    pub wallet_index: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -783,15 +788,21 @@ If the wallet is being topped up, rotate or temporarily remove that key from poo
         };
         let summary = format!(
             "Wallet balance alert on {}: {} balance is {} {}, below threshold of {} {} ({:.1}% remaining)",
-            alert.wallet_type, abbrev_address, balance_amount, alert.token, threshold_amount, alert.token, percent_remaining
+            alert.sui_network, abbrev_address, balance_amount, alert.token, threshold_amount, alert.token, percent_remaining
         );
         let action = format!(
             "*Action (ops):* Top up the {} wallet at {} with {} tokens.",
             alert.wallet_type, abbrev_address, alert.token
         );
+        let wallet_index = alert
+            .wallet_index
+            .map(|index| index.to_string())
+            .unwrap_or_else(|| "-".to_string());
         let details = format!(
-            "*Wallet type:* `{}`\n*Address:* `{}`\n*Balance:* {} {}\n*Threshold:* {} {}\n*Remaining:* {:.1}%",
+            "*Network:* `{}`\n*Wallet type:* `{}`\n*Wallet index:* `{}`\n*Address:* `{}`\n*Address balance:* {} {}\n*Threshold:* {} {}\n*Remaining:* {:.1}%",
+            alert.sui_network,
             alert.wallet_type,
+            wallet_index,
             alert.address,
             balance_amount,
             alert.token,
@@ -1176,6 +1187,8 @@ mod tests {
             balance: 500_000_000,
             threshold: 1_000_000_000,
             token: "SUI".to_string(),
+            sui_network: "mainnet".to_string(),
+            wallet_index: None,
         });
 
         let json = serde_json::to_string(&payload).unwrap();
@@ -1195,11 +1208,16 @@ mod tests {
             balance: 250_000_000,
             threshold: 1_000_000_000,
             token: "WAL".to_string(),
+            sui_network: "testnet".to_string(),
+            wallet_index: Some(2),
         });
 
         let json = serde_json::to_string(&payload).unwrap();
-        // 250M / 1B = 25%
+        // 250M / 1B = 25%; routing context is actionable in Slack.
         assert!(json.contains("25.0"));
+        assert!(json.contains("testnet"));
+        assert!(json.contains("Wallet index"));
+        assert!(json.contains("`2`"));
     }
 
     #[test]
@@ -1211,6 +1229,8 @@ mod tests {
             balance: 10_000_000,
             threshold: 100_000_000,
             token: "SUI".to_string(),
+            sui_network: "mainnet".to_string(),
+            wallet_index: None,
         });
 
         let json = serde_json::to_string(&payload).unwrap();
@@ -1223,12 +1243,13 @@ mod tests {
         let dedup = AlertDedup::new(Duration::from_secs(600));
         let address = "0x1234...abcd".to_string();
         // First WAL alert should fire, then repeat WAL should be suppressed.
-        assert!(!dedup.should_suppress(("uploader:WAL".to_string(), address.clone())));
-        assert!(dedup.should_suppress(("uploader:WAL".to_string(), address.clone())));
+        assert!(!dedup.should_suppress(("mainnet:uploader:WAL".to_string(), address.clone())));
+        assert!(dedup.should_suppress(("mainnet:uploader:WAL".to_string(), address.clone())));
         // SUI for the same uploader remains an independent actionable alert.
-        assert!(!dedup.should_suppress(("uploader:SUI".to_string(), address.clone())));
-        // Sponsor SUI is also independent.
-        assert!(!dedup.should_suppress(("sponsor:SUI".to_string(), address)));
+        assert!(!dedup.should_suppress(("mainnet:uploader:SUI".to_string(), address.clone())));
+        // Networks and sponsor SUI are also independent.
+        assert!(!dedup.should_suppress(("testnet:uploader:SUI".to_string(), address.clone())));
+        assert!(!dedup.should_suppress(("mainnet:sponsor:SUI".to_string(), address)));
     }
 
     #[test]

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -258,14 +258,16 @@ impl AlertManager {
         };
         // Dedup by the full address; abbreviating here could make two distinct
         // wallets with the same prefix/suffix suppress each other's alerts.
-        if self
-            .wallet_balance_low_dedup
-            .should_suppress(wallet_balance_low_dedup_key(&alert))
-        {
+        if self.should_suppress_wallet_balance_low(&alert) {
             return Ok(());
         }
         let payload = SlackPayload::for_wallet_balance_low(&alert);
         slack.send_payload(&payload).await
+    }
+
+    fn should_suppress_wallet_balance_low(&self, alert: &WalletBalanceLowAlert) -> bool {
+        self.wallet_balance_low_dedup
+            .should_suppress(wallet_balance_low_dedup_key(alert))
     }
 }
 
@@ -1288,15 +1290,9 @@ mod tests {
         );
 
         let manager = AlertManager::from_env(reqwest::Client::new());
-        let first = manager
-            .wallet_balance_low_dedup
-            .should_suppress(wallet_balance_low_dedup_key(&wal));
-        let repeat = manager
-            .wallet_balance_low_dedup
-            .should_suppress(wallet_balance_low_dedup_key(&wal));
-        let other_token = manager
-            .wallet_balance_low_dedup
-            .should_suppress(wallet_balance_low_dedup_key(&sui));
+        let first = manager.should_suppress_wallet_balance_low(&wal);
+        let repeat = manager.should_suppress_wallet_balance_low(&wal);
+        let other_token = manager.should_suppress_wallet_balance_low(&sui);
         assert!(!first);
         assert!(repeat);
         assert!(!other_token);

--- a/services/server/src/alerts.rs
+++ b/services/server/src/alerts.rs
@@ -258,19 +258,25 @@ impl AlertManager {
         };
         // Dedup by the full address; abbreviating here could make two distinct
         // wallets with the same prefix/suffix suppress each other's alerts.
-        let key = (
-            format!(
-                "{}:{}:{}",
-                alert.sui_network, alert.wallet_type, alert.token
-            ),
-            alert.address.clone(),
-        );
-        if self.wallet_balance_low_dedup.should_suppress(key) {
+        if self
+            .wallet_balance_low_dedup
+            .should_suppress(wallet_balance_low_dedup_key(&alert))
+        {
             return Ok(());
         }
         let payload = SlackPayload::for_wallet_balance_low(&alert);
         slack.send_payload(&payload).await
     }
+}
+
+fn wallet_balance_low_dedup_key(alert: &WalletBalanceLowAlert) -> (String, String) {
+    (
+        format!(
+            "{}:{}:{}",
+            alert.sui_network, alert.wallet_type, alert.token
+        ),
+        alert.address.clone(),
+    )
 }
 
 /// Read a dedup window (seconds) from `env_var`, falling back to `default`
@@ -1240,16 +1246,60 @@ mod tests {
 
     #[test]
     fn wallet_balance_low_dedup_key_formation() {
-        let dedup = AlertDedup::new(Duration::from_secs(600));
         let address = "0x1234...abcd".to_string();
-        // First WAL alert should fire, then repeat WAL should be suppressed.
-        assert!(!dedup.should_suppress(("mainnet:uploader:WAL".to_string(), address.clone())));
-        assert!(dedup.should_suppress(("mainnet:uploader:WAL".to_string(), address.clone())));
-        // SUI for the same uploader remains an independent actionable alert.
-        assert!(!dedup.should_suppress(("mainnet:uploader:SUI".to_string(), address.clone())));
-        // Networks and sponsor SUI are also independent.
-        assert!(!dedup.should_suppress(("testnet:uploader:SUI".to_string(), address.clone())));
-        assert!(!dedup.should_suppress(("mainnet:sponsor:SUI".to_string(), address)));
+        let wal = WalletBalanceLowAlert {
+            wallet_type: "uploader".to_string(),
+            address: address.clone(),
+            balance: 1,
+            threshold: 2,
+            token: "WAL".to_string(),
+            sui_network: "mainnet".to_string(),
+            wallet_index: Some(0),
+        };
+        let sui = WalletBalanceLowAlert {
+            token: "SUI".to_string(),
+            ..wal.clone()
+        };
+        let testnet = WalletBalanceLowAlert {
+            sui_network: "testnet".to_string(),
+            ..sui.clone()
+        };
+        let sponsor = WalletBalanceLowAlert {
+            wallet_type: "sponsor".to_string(),
+            wallet_index: None,
+            ..sui.clone()
+        };
+
+        assert_eq!(
+            wallet_balance_low_dedup_key(&wal),
+            ("mainnet:uploader:WAL".to_string(), address.clone())
+        );
+        assert_eq!(
+            wallet_balance_low_dedup_key(&sui),
+            ("mainnet:uploader:SUI".to_string(), address.clone())
+        );
+        assert_eq!(
+            wallet_balance_low_dedup_key(&testnet),
+            ("testnet:uploader:SUI".to_string(), address.clone())
+        );
+        assert_eq!(
+            wallet_balance_low_dedup_key(&sponsor),
+            ("mainnet:sponsor:SUI".to_string(), address)
+        );
+
+        let manager = AlertManager::from_env(reqwest::Client::new());
+        let first = manager
+            .wallet_balance_low_dedup
+            .should_suppress(wallet_balance_low_dedup_key(&wal));
+        let repeat = manager
+            .wallet_balance_low_dedup
+            .should_suppress(wallet_balance_low_dedup_key(&wal));
+        let other_token = manager
+            .wallet_balance_low_dedup
+            .should_suppress(wallet_balance_low_dedup_key(&sui));
+        assert!(!first);
+        assert!(repeat);
+        assert!(!other_token);
     }
 
     #[test]

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -200,89 +200,109 @@ async fn balance_monitor_task(state: Arc<AppState>, interval_secs: u64) {
                                     );
                                     continue;
                                 };
-                                let Some(wal_balance) = wallet
-                                    .get("walFrost")
-                                    .and_then(|value| value.as_str())
-                                    .and_then(|value| value.parse::<u64>().ok())
-                                else {
-                                    tracing::warn!(
-                                    address,
-                                    "balance_monitor: wallet metrics entry has invalid walFrost"
-                                );
-                                    continue;
-                                };
-                                let Some(sui_balance) = wallet
-                                    .get("suiMist")
-                                    .and_then(|value| value.as_str())
-                                    .and_then(|value| value.parse::<u64>().ok())
-                                else {
+                                let wallet_index = wallet
+                                    .get("walletIndex")
+                                    .and_then(|value| value.as_u64())
+                                    .and_then(|value| usize::try_from(value).ok());
+                                if wallet_index.is_none() {
                                     tracing::warn!(
                                         address,
-                                        "balance_monitor: wallet metrics entry has invalid suiMist"
-                                    );
-                                    continue;
-                                };
-
-                                if wal_balance < state.config.wallet_balance_low_threshold_wal {
-                                    tracing::warn!(
-                                    address,
-                                    balance = wal_balance,
-                                    threshold = state.config.wallet_balance_low_threshold_wal,
-                                    "balance_monitor: uploader wallet WAL balance below threshold"
-                                );
-                                    let alert = alerts::WalletBalanceLowAlert {
-                                        wallet_type: "uploader".to_string(),
-                                        address: address.to_string(),
-                                        balance: wal_balance,
-                                        threshold: state.config.wallet_balance_low_threshold_wal,
-                                        token: "WAL".to_string(),
-                                    };
-                                    if let Err(err) =
-                                        state.alerts.notify_wallet_balance_low(alert).await
-                                    {
-                                        tracing::warn!(
-                                            address,
-                                            "balance_monitor: failed to send uploader alert: {}",
-                                            err
-                                        );
-                                    }
-                                } else {
-                                    tracing::debug!(
-                                        address,
-                                        balance = wal_balance,
-                                        "balance_monitor: uploader wallet WAL balance ok"
+                                        "balance_monitor: wallet metrics entry has invalid walletIndex"
                                     );
                                 }
 
-                                if sui_balance < state.config.wallet_balance_low_threshold_sui {
-                                    tracing::warn!(
-                                        address,
-                                        balance = sui_balance,
-                                        threshold = state.config.wallet_balance_low_threshold_sui,
-                                        "balance_monitor: uploader wallet SUI balance below threshold"
-                                    );
-                                    let alert = alerts::WalletBalanceLowAlert {
-                                        wallet_type: "uploader".to_string(),
-                                        address: address.to_string(),
-                                        balance: sui_balance,
-                                        threshold: state.config.wallet_balance_low_threshold_sui,
-                                        token: "SUI".to_string(),
-                                    };
-                                    if let Err(err) =
-                                        state.alerts.notify_wallet_balance_low(alert).await
+                                // Durable registration withdraws both WAL and
+                                // its relay-tip SUI from address balances. Coin
+                                // object balances cannot prevent those writes
+                                // from failing, so alert on the spendable values.
+                                match wallet
+                                    .get("walAddressBalanceFrost")
+                                    .and_then(|value| value.as_str())
+                                    .and_then(|value| value.parse::<u64>().ok())
+                                {
+                                    Some(wal_balance)
+                                        if wal_balance
+                                            < state.config.wallet_balance_low_threshold_wal =>
                                     {
                                         tracing::warn!(
                                             address,
-                                            "balance_monitor: failed to send uploader SUI alert: {}",
-                                            err
+                                            balance = wal_balance,
+                                            threshold = state.config.wallet_balance_low_threshold_wal,
+                                            "balance_monitor: uploader wallet WAL address balance below threshold"
                                         );
+                                        let alert = alerts::WalletBalanceLowAlert {
+                                            wallet_type: "uploader".to_string(),
+                                            address: address.to_string(),
+                                            balance: wal_balance,
+                                            threshold: state.config.wallet_balance_low_threshold_wal,
+                                            token: "WAL".to_string(),
+                                            sui_network: state.config.sui_network.clone(),
+                                            wallet_index,
+                                        };
+                                        if let Err(err) =
+                                            state.alerts.notify_wallet_balance_low(alert).await
+                                        {
+                                            tracing::warn!(
+                                                address,
+                                                "balance_monitor: failed to send uploader WAL alert: {}",
+                                                err
+                                            );
+                                        }
                                     }
-                                } else {
-                                    tracing::debug!(
+                                    Some(wal_balance) => tracing::debug!(
+                                        address,
+                                        balance = wal_balance,
+                                        "balance_monitor: uploader wallet WAL address balance ok"
+                                    ),
+                                    None => tracing::warn!(
+                                        address,
+                                        "balance_monitor: wallet metrics entry has invalid walAddressBalanceFrost"
+                                    ),
+                                }
+
+                                match wallet
+                                    .get("suiAddressBalanceMist")
+                                    .and_then(|value| value.as_str())
+                                    .and_then(|value| value.parse::<u64>().ok())
+                                {
+                                    Some(sui_balance)
+                                        if sui_balance
+                                            < state.config.wallet_balance_low_threshold_sui =>
+                                    {
+                                        tracing::warn!(
+                                            address,
+                                            balance = sui_balance,
+                                            threshold = state.config.wallet_balance_low_threshold_sui,
+                                            "balance_monitor: uploader wallet SUI address balance below threshold"
+                                        );
+                                        let alert = alerts::WalletBalanceLowAlert {
+                                            wallet_type: "uploader".to_string(),
+                                            address: address.to_string(),
+                                            balance: sui_balance,
+                                            threshold: state.config.wallet_balance_low_threshold_sui,
+                                            token: "SUI".to_string(),
+                                            sui_network: state.config.sui_network.clone(),
+                                            wallet_index,
+                                        };
+                                        if let Err(err) =
+                                            state.alerts.notify_wallet_balance_low(alert).await
+                                        {
+                                            tracing::warn!(
+                                                address,
+                                                "balance_monitor: failed to send uploader SUI alert: {}",
+                                                err
+                                            );
+                                        }
+                                    }
+                                    Some(sui_balance) => tracing::debug!(
                                         address,
                                         balance = sui_balance,
-                                        "balance_monitor: uploader wallet SUI balance ok"
-                                    );
+                                        "balance_monitor: uploader wallet SUI address balance ok"
+                                    ),
+                                    None => tracing::warn!(
+                                        address,
+                                        "balance_monitor: wallet metrics entry has invalid suiAddressBalanceMist"
+                                    ),
                                 }
                             }
                         } else {
@@ -335,6 +355,8 @@ async fn balance_monitor_task(state: Arc<AppState>, interval_secs: u64) {
                                         balance: sponsor_balance,
                                         threshold: state.config.sponsor_balance_low_threshold_sui,
                                         token: "SUI".to_string(),
+                                        sui_network: state.config.sui_network.clone(),
+                                        wallet_index: None,
                                     };
                                     if let Err(err) =
                                         state.alerts.notify_wallet_balance_low(alert).await

--- a/services/server/src/routes/admin_dashboard.rs
+++ b/services/server/src/routes/admin_dashboard.rs
@@ -80,7 +80,9 @@ struct SidecarWalletBalance {
     address: String,
     sui_mist: String,
     wal_frost: String,
+    #[serde(default)]
     sui_address_balance_mist: String,
+    #[serde(default)]
     wal_address_balance_frost: String,
 }
 
@@ -88,6 +90,14 @@ struct SidecarWalletBalance {
 #[serde(rename_all = "camelCase")]
 struct SidecarWalletMetrics {
     per_wallet: Vec<SidecarWalletBalance>,
+}
+
+fn parse_address_or_total(raw: &str, total: u64, invalid: &str) -> Result<u64, AppError> {
+    if raw.is_empty() {
+        return Ok(total);
+    }
+    raw.parse::<u64>()
+        .map_err(|_| AppError::Internal(invalid.to_string()))
 }
 
 fn wallet_status(
@@ -151,19 +161,16 @@ pub async fn get_wallets(
                     "Sidecar wallet metrics contained invalid WAL balance".to_string(),
                 )
             })?;
-            let sui = entry.sui_address_balance_mist.parse::<u64>().map_err(|_| {
-                AppError::Internal(
-                    "Sidecar wallet metrics contained invalid SUI address balance".to_string(),
-                )
-            })?;
-            let wal = entry
-                .wal_address_balance_frost
-                .parse::<u64>()
-                .map_err(|_| {
-                    AppError::Internal(
-                        "Sidecar wallet metrics contained invalid WAL address balance".to_string(),
-                    )
-                })?;
+            let sui = parse_address_or_total(
+                &entry.sui_address_balance_mist,
+                sui_total,
+                "Sidecar wallet metrics contained invalid SUI address balance",
+            )?;
+            let wal = parse_address_or_total(
+                &entry.wal_address_balance_frost,
+                wal_total,
+                "Sidecar wallet metrics contained invalid WAL address balance",
+            )?;
             Ok(WalletBalance {
                 address: entry.address,
                 sui: sui.to_string(),
@@ -310,6 +317,26 @@ mod tests {
         });
         let parsed: SidecarWalletMetrics = serde_json::from_value(valid).unwrap();
         assert_eq!(parsed.per_wallet.len(), 1);
+        assert_eq!(parsed.per_wallet[0].wal_address_balance_frost, "500000000");
+
+        let legacy = serde_json::json!({
+            "perWallet": [{
+                "address": "0x123",
+                "suiMist": "1000000000",
+                "walFrost": "2000000000"
+            }]
+        });
+        let legacy_parsed: SidecarWalletMetrics = serde_json::from_value(legacy).unwrap();
+        assert_eq!(legacy_parsed.per_wallet[0].sui_address_balance_mist, "");
+        assert_eq!(
+            parse_address_or_total(
+                &legacy_parsed.per_wallet[0].wal_address_balance_frost,
+                2_000_000_000,
+                "invalid",
+            )
+            .unwrap(),
+            2_000_000_000
+        );
         assert!(
             serde_json::from_value::<SidecarWalletMetrics>(serde_json::json!({
                 "walletWalBalanceFrost": "2000000000"

--- a/services/server/src/routes/admin_dashboard.rs
+++ b/services/server/src/routes/admin_dashboard.rs
@@ -16,8 +16,12 @@ pub struct AdminQuery {
 #[derive(Debug, Serialize)]
 pub struct WalletBalance {
     pub address: String,
+    /// Spendable address balance (what durable registration can withdraw).
     pub sui: String,
     pub wal: String,
+    /// Address balance plus owned coins, for operator context.
+    pub sui_total: String,
+    pub wal_total: String,
     pub status: String,
 }
 
@@ -76,6 +80,8 @@ struct SidecarWalletBalance {
     address: String,
     sui_mist: String,
     wal_frost: String,
+    sui_address_balance_mist: String,
+    wal_address_balance_frost: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -135,20 +141,35 @@ pub async fn get_wallets(
                     "Sidecar wallet metrics contained an empty address".to_string(),
                 ));
             }
-            let sui = entry.sui_mist.parse::<u64>().map_err(|_| {
+            let sui_total = entry.sui_mist.parse::<u64>().map_err(|_| {
                 AppError::Internal(
                     "Sidecar wallet metrics contained invalid SUI balance".to_string(),
                 )
             })?;
-            let wal = entry.wal_frost.parse::<u64>().map_err(|_| {
+            let wal_total = entry.wal_frost.parse::<u64>().map_err(|_| {
                 AppError::Internal(
                     "Sidecar wallet metrics contained invalid WAL balance".to_string(),
                 )
             })?;
+            let sui = entry.sui_address_balance_mist.parse::<u64>().map_err(|_| {
+                AppError::Internal(
+                    "Sidecar wallet metrics contained invalid SUI address balance".to_string(),
+                )
+            })?;
+            let wal = entry
+                .wal_address_balance_frost
+                .parse::<u64>()
+                .map_err(|_| {
+                    AppError::Internal(
+                        "Sidecar wallet metrics contained invalid WAL address balance".to_string(),
+                    )
+                })?;
             Ok(WalletBalance {
                 address: entry.address,
                 sui: sui.to_string(),
                 wal: wal.to_string(),
+                sui_total: sui_total.to_string(),
+                wal_total: wal_total.to_string(),
                 status: wallet_status(wal, wal_threshold, sui, sui_threshold).to_string(),
             })
         })
@@ -282,7 +303,9 @@ mod tests {
             "perWallet": [{
                 "address": "0x123",
                 "suiMist": "1000000000",
-                "walFrost": "2000000000"
+                "suiAddressBalanceMist": "400000000",
+                "walFrost": "2000000000",
+                "walAddressBalanceFrost": "500000000"
             }]
         });
         let parsed: SidecarWalletMetrics = serde_json::from_value(valid).unwrap();
@@ -326,8 +349,10 @@ mod tests {
             uploader_pool: UploaderPool {
                 wallets: vec![WalletBalance {
                     address: "0x123".to_string(),
-                    sui: "1000000000".to_string(),
-                    wal: "2000000000".to_string(),
+                    sui: "400000000".to_string(),
+                    wal: "500000000".to_string(),
+                    sui_total: "1000000000".to_string(),
+                    wal_total: "2000000000".to_string(),
                     status: "ok".to_string(),
                 }],
                 wal_threshold: "50000000000".to_string(),
@@ -343,7 +368,11 @@ mod tests {
         };
 
         let json = serde_json::to_value(response).unwrap();
-        assert_eq!(json["uploader_pool"]["wallets"][0]["wal"], "2000000000");
+        assert_eq!(json["uploader_pool"]["wallets"][0]["wal"], "500000000");
+        assert_eq!(
+            json["uploader_pool"]["wallets"][0]["wal_total"],
+            "2000000000"
+        );
         assert_eq!(json["uploader_pool"]["sui_threshold"], "5000000000");
         assert_eq!(json["sponsor_wallet"]["sui_threshold"], "5000000000");
     }

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -531,8 +531,9 @@ pub async fn advance_durable_upload(
         );
         if reset_safe {
             // Reset-safe codes mean this replica must not execute the journaled
-            // bytes. Replacing them cannot duplicate a registration this replica
-            // submitted.
+            // bytes. NO_SIDE_EFFECT proved the digest absent. INVALID_PREPARED
+            // means this replica refused the bytes before execute (mixed-version
+            // or incompatible sponsorship) and can rebuild compatible ones.
             journal.register_transaction = None;
             return Ok(DurableUploadAdvance::Prepared(journal));
         }
@@ -1098,7 +1099,7 @@ mod tests {
     }
 
     #[test]
-    fn prepared_register_reset_requires_proof_of_no_effect() {
+    fn prepared_register_resets_on_no_side_effect_or_invalid_prepared() {
         let direct = PreparedRegisterTransaction {
             transaction_bytes: "bytes".into(),
             signature: "signature".into(),

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -44,6 +44,13 @@ pub struct UploadJournal {
 }
 
 pub enum DurableUploadAdvance {
+    /// Ready for another prepare/execute loop.
+    ///
+    /// Two producers:
+    /// - sidecar returned a prepared register (`register_transaction` is Some)
+    /// - a proven reset cleared the journal (`register_transaction` is None);
+    ///   the next loop iteration re-prepares. That reset consumes one of the
+    ///   six advance-loop slots; overflowing the loop is `WalletJobError::Transient`.
     Prepared(UploadJournal),
     Step {
         journal: UploadJournal,
@@ -464,7 +471,13 @@ fn should_reset_prepared_register(
     error_code: Option<&str>,
     prepared: Option<&PreparedRegisterTransaction>,
 ) -> bool {
-    matches!(error_code, Some("NO_SIDE_EFFECT")) && prepared.is_some()
+    // NO_SIDE_EFFECT: sidecar proved the digest absent. INVALID_PREPARED:
+    // this replica refused the journaled bytes before execute (mixed-version
+    // or incompatible sponsorship). Both are safe to rebuild.
+    matches!(
+        error_code,
+        Some("NO_SIDE_EFFECT") | Some("INVALID_PREPARED_REGISTER_TRANSACTION")
+    ) && prepared.is_some()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -517,9 +530,9 @@ pub async fn advance_durable_upload(
             journal.register_transaction.as_ref(),
         );
         if reset_safe {
-            // NO_SIDE_EFFECT means the sidecar proved the digest absent (for
-            // example after Enoki invalidated its sponsorship), so replacing
-            // these exact bytes cannot duplicate an on-chain registration.
+            // Reset-safe codes mean this replica must not execute the journaled
+            // bytes. Replacing them cannot duplicate a registration this replica
+            // submitted.
             journal.register_transaction = None;
             return Ok(DurableUploadAdvance::Prepared(journal));
         }
@@ -1101,7 +1114,7 @@ mod tests {
             Some("NO_SIDE_EFFECT"),
             Some(&direct)
         ));
-        assert!(!should_reset_prepared_register(
+        assert!(should_reset_prepared_register(
             Some("INVALID_PREPARED_REGISTER_TRANSACTION"),
             Some(&sponsored),
         ));

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -198,6 +198,13 @@ struct DurableUploadResponse {
     step: Option<serde_json::Value>,
 }
 
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DurableUploadErrorResponse {
+    #[serde(default)]
+    code: Option<String>,
+}
+
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetMetadataBatchEntry {
@@ -453,6 +460,13 @@ fn register_transaction_for_resume<'a>(
     is_encoded.then_some(register_transaction).flatten()
 }
 
+fn should_reset_prepared_register(
+    error_code: Option<&str>,
+    prepared: Option<&PreparedRegisterTransaction>,
+) -> bool {
+    matches!(error_code, Some("NO_SIDE_EFFECT")) && prepared.is_some()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn advance_durable_upload(
     client: &reqwest::Client,
@@ -464,7 +478,7 @@ pub async fn advance_durable_upload(
     namespace: &str,
     package_id: &str,
     job_id: &str,
-    journal: UploadJournal,
+    mut journal: UploadJournal,
 ) -> Result<DurableUploadAdvance, AppError> {
     let url = format!("{}/walrus/upload-step-v3", sidecar_url);
     let mut req = client.post(&url).json(&DurableUploadRequest {
@@ -495,6 +509,20 @@ pub async fn advance_durable_upload(
     let status = response.status();
     let body = response.text().await.unwrap_or_default();
     if !status.is_success() {
+        let error_code = serde_json::from_str::<DurableUploadErrorResponse>(&body)
+            .ok()
+            .and_then(|error| error.code);
+        let reset_safe = should_reset_prepared_register(
+            error_code.as_deref(),
+            journal.register_transaction.as_ref(),
+        );
+        if reset_safe {
+            // NO_SIDE_EFFECT means the sidecar proved the digest absent (for
+            // example after Enoki invalidated its sponsorship), so replacing
+            // these exact bytes cannot duplicate an on-chain registration.
+            journal.register_transaction = None;
+            return Ok(DurableUploadAdvance::Prepared(journal));
+        }
         return Err(AppError::Internal(format!(
             "durable Walrus upload failed ({}): {}",
             status, body
@@ -1036,7 +1064,7 @@ fn aggregate_download_errors(blob_id: &str, errors: &[(String, AppError)]) -> Ap
 mod tests {
     use super::{
         aggregate_download_errors, is_valid_blob_id, register_transaction_for_resume,
-        PreparedRegisterTransaction, QueryBlobsResponse,
+        should_reset_prepared_register, PreparedRegisterTransaction, QueryBlobsResponse,
     };
     use crate::types::AppError;
 
@@ -1054,6 +1082,33 @@ mod tests {
         assert!(register_transaction_for_resume(Some(&encoded), Some(&prepared)).is_some());
         assert!(register_transaction_for_resume(Some(&registered), Some(&prepared)).is_none());
         assert!(register_transaction_for_resume(None, Some(&prepared)).is_none());
+    }
+
+    #[test]
+    fn prepared_register_reset_requires_proof_of_no_effect() {
+        let direct = PreparedRegisterTransaction {
+            transaction_bytes: "bytes".into(),
+            signature: "signature".into(),
+            digest: "digest".into(),
+            sponsor_digest: None,
+        };
+        let sponsored = PreparedRegisterTransaction {
+            sponsor_digest: Some("sponsor".into()),
+            ..direct.clone()
+        };
+
+        assert!(should_reset_prepared_register(
+            Some("NO_SIDE_EFFECT"),
+            Some(&direct)
+        ));
+        assert!(!should_reset_prepared_register(
+            Some("INVALID_PREPARED_REGISTER_TRANSACTION"),
+            Some(&sponsored),
+        ));
+        assert!(!should_reset_prepared_register(
+            Some("DURABLE_SIDE_EFFECT_VERIFY_FAILED"),
+            Some(&sponsored),
+        ));
     }
 
     // ── QueryBlobsResponse.source_capped (WALM-319) ──────────────────────


### PR DESCRIPTION
## Summary

Follow-up hardening for #663 before promoting staging to main.

### Sponsored durable registration

- Compare Enoki's returned transaction kind byte-for-byte with the exact kind requested before signing it. This closes the blind-signing boundary.
- Recover an **expired** sponsorship only after a digest lookup (same 8-attempt index backoff as the success path) proves the transaction never landed. `not_found` is ambiguous and does not clear the journal. The sidecar returns `NO_SIDE_EFFECT`; Rust clears the prepared journal and creates a fresh sponsorship.
- Mixed-version `INVALID_PREPARED_REGISTER_TRANSACTION` also clears the journal so a current replica can rebuild instead of burning Transient retries.
- Add `DURABLE_ENOKI_REGISTER_ENABLED` (default `false`) for a two-phase rollout. Deploy all replicas with sponsorship disabled first, let old replicas drain, then enable it. Drain again before rolling the gate back.
- Keep durable registration fail-closed after the rollout gate is enabled.

### Proactive balance alerts

- Alert from per-wallet **address balances**, not address + owned coin totals, matching what durable registration can actually spend.
- Admin dashboard `status` uses the same address balances. Wire fields `sui`/`wal` are spendable; `sui_total`/`wal_total` keep combined totals.
- Evaluate WAL and SUI independently so a malformed metric cannot suppress the other alert.
- Include network and wallet index in Slack alerts and dedup keys.
- Expose per-wallet address-balance fields from the sidecar.

## Rollout

1. Merge and deploy with `DURABLE_ENOKI_REGISTER_ENABLED=false` (the default).
2. **Phase 1 note:** if `ENOKI_API_KEY` is set, durable register still **direct-signs and pays gas from the uploader wallet**. The SUI address-balance alert is load-bearing for this window. Do not top up Enoki pool wallets expecting them to sponsor this path.
3. Wait for all pre-fix replicas to drain.
4. Set `DURABLE_ENOKI_REGISTER_ENABLED=true` and redeploy/restart.
5. Drain every replica before rolling the gate back to `false`.
6. Verify one sponsored durable registration and a low-balance Slack alert before promoting to main.

## Validation

- Targeted sidecar tests: `sidecar-query-helpers.test.ts` (37/37)
- Targeted Rust tests: prepared-register reset, wallet low-balance dedup key, admin dashboard wire contract
- `cargo fmt --check`
- `git diff --check`

## Context

Addresses the blocking findings documented in the Notion task **Alert gas** for the #663 / #669 promotion path, and Harry's review on this PR.