### PR TITLE
fix(researcher): retired title model broke every new chat — plus tooltip, auto-resume, pyodide, and sprint-export fixes

### DIFF
--- a/apps/researcher/app/(chat)/api/chat/route.ts
+++ b/apps/researcher/app/(chat)/api/chat/route.ts
@@ -307,9 +307,23 @@ export async function POST(request: Request) {
         );
 
         if (titlePromise) {
-          const title = await titlePromise;
-          dataStream.write({ type: "data-chat-title", data: title });
-          updateChatTitleById({ chatId: id, title });
+          try {
+            const title = await titlePromise;
+            dataStream.write({ type: "data-chat-title", data: title });
+            updateChatTitleById({ chatId: id, title });
+          } catch (error) {
+            // Title generation is a non-fatal side effect of the response
+            // already streaming above it (dataStream.merge). Left unguarded,
+            // the rejection reached createUIMessageStream's onError, which
+            // injected an "error" part into the stream — so the client
+            // surfaced a fatal chat error even though the real answer had
+            // streamed successfully underneath it. Verified locally A/B
+            // against the retired title model: without this catch the stream
+            // carries {"type":"error"}; with it, the answer arrives clean and
+            // the chat simply has no auto-generated title.
+            // Same fix as apps/chatbot (334cf915); researcher was missed then.
+            console.error("[chat] title generation failed:", error);
+          }
         }
       },
       generateId: generateUUID,

--- a/apps/researcher/app/(chat)/chat/[id]/page.tsx
+++ b/apps/researcher/app/(chat)/chat/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from "react";
 import { getSession } from "@/lib/auth/session";
 import { Chat } from "@/components/chat/chat";
 import { DataStreamHandler } from "@/components/data/data-stream-handler";
-import { DEFAULT_CHAT_MODEL } from "@/lib/ai/models";
+import { resolveChatModelId } from "@/lib/ai/models";
 import { getChatById, getMessagesByChatId, getSprintsByIds } from "@/lib/db/queries";
 import { convertToUIMessages } from "@/lib/utils";
 
@@ -48,9 +48,7 @@ async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
   const uiMessages = convertToUIMessages(messagesFromDb);
 
   const cookieStore = await cookies();
-  const chatModelFromCookie = cookieStore.get("chat-model");
-
-  const chatModel = chatModelFromCookie?.value ?? DEFAULT_CHAT_MODEL;
+  const chatModel = resolveChatModelId(cookieStore.get("chat-model")?.value);
 
   // Fetch sprint data if chat has associated sprints
   const sprintIds = chat.sprintIds ?? [];

--- a/apps/researcher/app/(chat)/chat/[id]/page.tsx
+++ b/apps/researcher/app/(chat)/chat/[id]/page.tsx
@@ -71,7 +71,13 @@ async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
   return (
     <>
       <Chat
-        autoResume={true}
+        // Resumable streaming is not implemented — api/chat/[id]/stream is a
+        // stub that always returns 204. With autoResume on, reopening a chat
+        // whose last message is from the user fired resumeStream() against
+        // that stub; overlapping attempts (easy under dev double-effects) race
+        // inside AI SDK 6.0.37 and throw "Cannot read properties of undefined
+        // (reading 'state')". Re-enable only once the stream route is real.
+        autoResume={false}
         id={chat.id}
         initialChatModel={chatModel}
         initialMessages={uiMessages}

--- a/apps/researcher/app/(chat)/layout.tsx
+++ b/apps/researcher/app/(chat)/layout.tsx
@@ -1,5 +1,4 @@
 import { cookies } from "next/headers";
-import Script from "next/script";
 import { Suspense } from "react";
 import { AppSidebar } from "@/components/sidebar/app-sidebar";
 import { DataStreamProvider } from "@/components/data/data-stream-provider";
@@ -8,12 +7,13 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { getSession } from "@/lib/auth/session";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  // No pyodide <Script> here anymore: it was template leftover (Vercel
+  // ai-chatbot's Python code-runner) that nothing in this app calls — no
+  // loadPyodide/runPython usage exists. It cost a multi-MB CDN download on
+  // every chat page and, as of Next 16, beforeInteractive in a nested layout
+  // throws "Encountered a script tag while rendering React component".
   return (
     <>
-      <Script
-        src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"
-        strategy="beforeInteractive"
-      />
       <DataStreamProvider>
         <SourceProcessingProvider>
           <Suspense fallback={<div className="flex h-dvh" />}>

--- a/apps/researcher/app/(chat)/page.tsx
+++ b/apps/researcher/app/(chat)/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { Suspense } from "react";
 import { Chat } from "@/components/chat/chat";
 import { DataStreamHandler } from "@/components/data/data-stream-handler";
-import { DEFAULT_CHAT_MODEL } from "@/lib/ai/models";
+import { resolveChatModelId } from "@/lib/ai/models";
 import { generateUUID } from "@/lib/utils";
 
 export default function Page() {
@@ -15,9 +15,8 @@ export default function Page() {
 
 async function NewChatPage() {
   const cookieStore = await cookies();
-  const modelIdFromCookie = cookieStore.get("chat-model");
   const id = generateUUID();
-  const chatModel = modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
+  const chatModel = resolveChatModelId(cookieStore.get("chat-model")?.value);
 
   return (
     <>

--- a/apps/researcher/app/layout.tsx
+++ b/apps/researcher/app/layout.tsx
@@ -7,9 +7,10 @@ import { SuiProviders } from "@/components/sui-providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://chat.vercel.ai"),
-  title: "Next.js Chatbot Template",
-  description: "Next.js chatbot template using the AI SDK.",
+  metadataBase: new URL("https://researcher.demo.memwal.ai"),
+  title: "Researcher | Walrus Memory",
+  description:
+    "AI-powered research with long-term memory. Save research sprints to Walrus and recall them in any future chat.",
 };
 
 export const viewport = {

--- a/apps/researcher/components/chat/suggested-actions.tsx
+++ b/apps/researcher/components/chat/suggested-actions.tsx
@@ -3,16 +3,13 @@
 import type { UseChatHelpers } from "@ai-sdk/react";
 import { motion } from "framer-motion";
 import { memo } from "react";
+// DEFAULT_SUGGESTIONS is imported rather than redeclared: this file used to
+// keep a byte-identical copy that was never reachable, because
+// useSprintGreeting always supplies the fallback via sprintSuggestions.
+import { DEFAULT_SUGGESTIONS } from "@/hooks/use-sprint-greeting";
 import type { ChatMessage } from "@/lib/types";
 import { Suggestion } from "../elements/suggestion";
 import type { VisibilityType } from "./visibility-selector";
-
-const DEFAULT_SUGGESTIONS = [
-  "What sources do I have?",
-  "Help me research the latest advances in decentralized storage",
-  "Compare SEAL encryption with traditional approaches",
-  "Summarize my research on blockchain scalability",
-];
 
 type SuggestedActionsProps = {
   chatId: string;
@@ -66,7 +63,7 @@ function PureSuggestedActions({
           transition={{ delay: 0.05 * index }}
         >
           <Suggestion
-            className="h-auto w-full whitespace-normal p-3 text-left"
+            className="h-[42px] w-full whitespace-nowrap p-3"
             onClick={(suggestion) => {
               window.history.pushState({}, "", `/chat/${chatId}`);
               sendMessage({
@@ -75,8 +72,12 @@ function PureSuggestedActions({
               });
             }}
             suggestion={suggestedAction}
+            title={suggestedAction}
           >
-            {suggestedAction}
+            {/* min-w-0 lets truncate work inside the button's flex layout, so an
+                over-long sprint suggestion ellipsises instead of wrapping and
+                making one pill taller than the rest. Full text is in `title`. */}
+            <span className="min-w-0 truncate">{suggestedAction}</span>
           </Suggestion>
         </motion.div>
       ))}

--- a/apps/researcher/components/sources/sprint-detail.tsx
+++ b/apps/researcher/components/sources/sprint-detail.tsx
@@ -2,17 +2,32 @@
 
 import {
   ArrowLeftIcon,
-  BookmarkIcon,
   CalendarIcon,
+  CopyIcon,
+  DownloadIcon,
   ExternalLinkIcon,
   FileTextIcon,
   HashIcon,
   LinkIcon,
   BrainIcon,
+  Maximize2Icon,
 } from "lucide-react";
-import { memo, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import { Response } from "@/components/elements/response";
+import { toast } from "@/components/toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { SprintListItem } from "@/hooks/use-sprints";
+import { buildSprintMarkdown, sprintFileName } from "@/lib/sprint/markdown";
 import { cn } from "@/lib/utils";
 
 function formatDate(dateStr: string): string {
@@ -25,44 +40,89 @@ function formatDate(dateStr: string): string {
   });
 }
 
-function PureSprintDetail({
-  sprint,
-  onBack,
+function dedupeSources(sprint: SprintListItem) {
+  // Deduplicate sources by title (same source may have different IDs across sessions)
+  const rawSources = sprint.sources ?? [];
+  return rawSources.filter((s, i, arr) =>
+    arr.findIndex((o) => (o.title ?? o.sourceId) === (s.title ?? s.sourceId)) === i
+  );
+}
+
+function SprintActionButton({
+  label,
+  onClick,
+  children,
 }: {
-  sprint: SprintListItem;
-  onBack: () => void;
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
 }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          onClick={onClick}
+          className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Copy / Download actions shared by the panel header and the expanded dialog. */
+function SprintExportActions({ sprint }: { sprint: SprintListItem }) {
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(buildSprintMarkdown(sprint));
+      toast({ type: "success", description: "Report copied as markdown" });
+    } catch {
+      toast({ type: "error", description: "Couldn't access the clipboard" });
+    }
+  }, [sprint]);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([buildSprintMarkdown(sprint)], {
+      type: "text/markdown",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = sprintFileName(sprint.title);
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }, [sprint]);
+
+  return (
+    <>
+      <SprintActionButton label="Copy report as markdown" onClick={handleCopy}>
+        <CopyIcon className="size-4" />
+      </SprintActionButton>
+      <SprintActionButton label="Download .md" onClick={handleDownload}>
+        <DownloadIcon className="size-4" />
+      </SprintActionButton>
+    </>
+  );
+}
+
+/**
+ * The summary card + Report/Citations/Sources tabs. Extracted so the narrow
+ * side panel and the expanded dialog render the identical body.
+ */
+function SprintBody({ sprint }: { sprint: SprintListItem }) {
   const [activeSection, setActiveSection] = useState<
     "report" | "citations" | "sources"
   >("report");
 
   const citations = sprint.citations ?? [];
-
-  // Deduplicate sources by title (same source may have different IDs across sessions)
-  const rawSources = sprint.sources ?? [];
-  const sources = rawSources.filter((s, i, arr) =>
-    arr.findIndex((o) => (o.title ?? o.sourceId) === (s.title ?? s.sourceId)) === i
-  );
+  const sources = dedupeSources(sprint);
 
   return (
-    <div className="flex h-full flex-col">
-      {/* Header with back button */}
-      <div className="flex items-center gap-2 border-b px-4 py-3">
-        <button
-          type="button"
-          onClick={onBack}
-          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <ArrowLeftIcon className="size-4" />
-        </button>
-        <div className="min-w-0 flex-1">
-          <h2 className="truncate text-sm font-semibold">{sprint.title}</h2>
-          <p className="text-xs text-muted-foreground">
-            {formatDate(sprint.createdAt)}
-          </p>
-        </div>
-      </div>
-
+    <>
       {/* Summary card */}
       <div className="border-b px-4 py-3">
         {sprint.summary && (
@@ -228,6 +288,74 @@ function PureSprintDetail({
           </div>
         )}
       </div>
+    </>
+  );
+}
+
+function PureSprintDetail({
+  sprint,
+  onBack,
+}: {
+  sprint: SprintListItem;
+  onBack: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header with back button and actions */}
+      <div className="flex items-center gap-2 border-b px-4 py-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ArrowLeftIcon className="size-4" />
+        </button>
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold">{sprint.title}</h2>
+          <p className="text-xs text-muted-foreground">
+            {formatDate(sprint.createdAt)}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <SprintExportActions sprint={sprint} />
+          <SprintActionButton
+            label="Expand"
+            onClick={() => setExpanded(true)}
+          >
+            <Maximize2Icon className="size-4" />
+          </SprintActionButton>
+        </div>
+      </div>
+
+      <SprintBody sprint={sprint} />
+
+      {/* Expanded reading view */}
+      <Dialog open={expanded} onOpenChange={setExpanded}>
+        <DialogContent
+          className="flex h-[85dvh] max-w-3xl flex-col gap-0 p-0"
+          // Radix focuses the first focusable element on open — the Copy
+          // button — which pops its tooltip over the dialog title.
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <DialogHeader className="border-b px-4 py-3 text-left">
+            <DialogTitle className="pr-8 text-base">
+              {sprint.title}
+            </DialogTitle>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <CalendarIcon className="size-3" />
+                {formatDate(sprint.createdAt)}
+              </span>
+              <span className="flex items-center gap-0.5">
+                <SprintExportActions sprint={sprint} />
+              </span>
+            </div>
+          </DialogHeader>
+          <SprintBody sprint={sprint} />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/researcher/components/ui/tooltip.tsx
+++ b/apps/researcher/components/ui/tooltip.tsx
@@ -15,15 +15,21 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
-      className
-    )}
-    {...props}
-  />
+  // Portal is required, not cosmetic. Rendered inline, the content stays inside
+  // the chat header's stacking context — `position: sticky` always creates one —
+  // so the tooltip's z-50 only applied within that 50px-tall header and the rest
+  // of it painted underneath the page content below. Only a ~2px sliver showed.
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/apps/researcher/hooks/use-auto-resume.ts
+++ b/apps/researcher/hooks/use-auto-resume.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { UseChatHelpers } from "@ai-sdk/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useDataStream } from "@/components/data/data-stream-provider";
 import type { ChatMessage } from "@/lib/types";
 
@@ -19,15 +19,22 @@ export function useAutoResume({
   setMessages,
 }: UseAutoResumeParams) {
   const { dataStream } = useDataStream();
+  // "Run once" must be enforced, not assumed: the dep array does not guarantee
+  // it (resumeStream identity can change, and dev double-invokes effects).
+  // Overlapping resumeStream() calls race inside AI SDK 6.0.37 — one attempt
+  // clears activeResponse while the other reads its .state — so guard with a
+  // ref rather than trusting effect semantics.
+  const resumeAttemptedRef = useRef(false);
 
   useEffect(() => {
-    if (!autoResume) {
+    if (!autoResume || resumeAttemptedRef.current) {
       return;
     }
 
     const mostRecentMessage = initialMessages.at(-1);
 
     if (mostRecentMessage?.role === "user") {
+      resumeAttemptedRef.current = true;
       resumeStream();
     }
 

--- a/apps/researcher/hooks/use-sprint-greeting.ts
+++ b/apps/researcher/hooks/use-sprint-greeting.ts
@@ -8,11 +8,18 @@ type SprintGreetingData = {
   isLoading: boolean;
 };
 
-const DEFAULT_SUGGESTIONS = [
+/**
+ * Fallback prompts shown when the chat has no sprints to generate from.
+ *
+ * Exported because SuggestedActions previously kept its own byte-identical
+ * copy, and only this one was ever reachable — editing the other silently did
+ * nothing. Kept to a similar, short length so each pill sits on one line.
+ */
+export const DEFAULT_SUGGESTIONS = [
   "What sources do I have?",
-  "Help me research the latest advances in decentralized storage",
-  "Compare SEAL encryption with traditional approaches",
-  "Summarize my research on blockchain scalability",
+  "Research advances in decentralized storage",
+  "Compare SEAL with traditional encryption",
+  "Summarize my blockchain scalability research",
 ];
 
 export function useSprintGreeting(sprintIds?: string[]): SprintGreetingData {

--- a/apps/researcher/lib/ai/models.ts
+++ b/apps/researcher/lib/ai/models.ts
@@ -1,6 +1,16 @@
 // Curated list of models available on OpenRouter
 export const DEFAULT_CHAT_MODEL = "google/gemini-2.5-flash";
 
+/**
+ * Model used for background chat-title generation.
+ *
+ * Declared here beside the curated list rather than hardcoded at the call site:
+ * the previous inline "google/gemini-2.0-flash-001" was retired upstream and
+ * returned 404 on every chat, and nothing tied it back to the models we
+ * actually support. Keep this pointing at a model present in `chatModels`.
+ */
+export const TITLE_MODEL = "google/gemini-2.5-flash";
+
 export type ChatModel = {
   id: string;
   name: string;
@@ -15,25 +25,6 @@ export const chatModels: ChatModel[] = [
     name: "Gemini 2.5 Flash",
     provider: "google",
     description: "Fast and capable — great for research tasks",
-  },
-  {
-    id: "google/gemini-2.0-flash-001",
-    name: "Gemini 2.0 Flash",
-    provider: "google",
-    description: "Ultra fast and affordable",
-  },
-  // Anthropic
-  {
-    id: "anthropic/claude-3.5-haiku",
-    name: "Claude 3.5 Haiku",
-    provider: "anthropic",
-    description: "Fast and affordable, great for everyday tasks",
-  },
-  {
-    id: "anthropic/claude-3.5-sonnet",
-    name: "Claude 3.5 Sonnet",
-    provider: "anthropic",
-    description: "Best balance of speed and intelligence",
   },
   // OpenAI
   {

--- a/apps/researcher/lib/ai/models.ts
+++ b/apps/researcher/lib/ai/models.ts
@@ -61,3 +61,18 @@ export const modelsByProvider = chatModels.reduce(
   },
   {} as Record<string, ChatModel[]>
 );
+
+/**
+ * Coerce a persisted `chat-model` cookie to a model we actually support.
+ *
+ * The cookie outlives the curated list: anyone who had a since-retired model
+ * selected keeps sending that id, and `/api/chat` rejects unknown ids with a
+ * 400. The picker's own fallback is display-only — it renders the default name
+ * while `initialChatModel` still carries the stale id into the request body —
+ * so the coercion has to happen where the cookie is read.
+ */
+export function resolveChatModelId(cookieValue: string | undefined): string {
+  return cookieValue && allowedModelIds.has(cookieValue)
+    ? cookieValue
+    : DEFAULT_CHAT_MODEL;
+}

--- a/apps/researcher/lib/ai/models.unit.test.ts
+++ b/apps/researcher/lib/ai/models.unit.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { chatModels, DEFAULT_CHAT_MODEL, TITLE_MODEL } from "./models";
+
+// Regression guard for the 2026-08 incident: getTitleModel() hardcoded
+// "google/gemini-2.0-flash-001", which OpenRouter retired. Every chat's title
+// call 404'd, and because the await was unguarded the rejection tore down the
+// whole response stream — users got no answer at all.
+//
+// These assertions cannot detect a model being retired upstream (that needs a
+// live call). What they do catch is the structural cause: a title/default model
+// drifting away from the curated set that the rest of the app maintains.
+
+const ids = new Set(chatModels.map((m) => m.id));
+
+test("TITLE_MODEL is a curated, supported model", () => {
+  assert.ok(
+    ids.has(TITLE_MODEL),
+    `TITLE_MODEL "${TITLE_MODEL}" is not in chatModels — background title generation would call a model the app does not otherwise support`
+  );
+});
+
+test("DEFAULT_CHAT_MODEL is a curated, supported model", () => {
+  assert.ok(
+    ids.has(DEFAULT_CHAT_MODEL),
+    `DEFAULT_CHAT_MODEL "${DEFAULT_CHAT_MODEL}" is not in chatModels`
+  );
+});
+
+test("retired model ids are not offered or referenced", () => {
+  // Retired upstream; kept here so they cannot be reintroduced by copy-paste.
+  // All three verified against OpenRouter with the production key on
+  // 2026-08-17: each returns 404 "No endpoints found".
+  const retired = [
+    "google/gemini-2.0-flash-001",
+    "anthropic/claude-3.5-haiku",
+    "anthropic/claude-3.5-sonnet",
+  ];
+  for (const id of retired) {
+    assert.ok(!ids.has(id), `retired model "${id}" is still in chatModels`);
+    assert.notEqual(TITLE_MODEL, id, `TITLE_MODEL points at retired "${id}"`);
+    assert.notEqual(
+      DEFAULT_CHAT_MODEL,
+      id,
+      `DEFAULT_CHAT_MODEL points at retired "${id}"`
+    );
+  }
+});
+
+test("chatModels entries are unique and well formed", () => {
+  assert.equal(ids.size, chatModels.length, "duplicate model ids in chatModels");
+  for (const m of chatModels) {
+    assert.ok(m.id.includes("/"), `model id "${m.id}" is not provider-qualified`);
+    assert.ok(m.name.length > 0, `model "${m.id}" has no display name`);
+  }
+});

--- a/apps/researcher/lib/ai/models.unit.test.ts
+++ b/apps/researcher/lib/ai/models.unit.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { chatModels, DEFAULT_CHAT_MODEL, TITLE_MODEL } from "./models";
+import {
+  chatModels,
+  DEFAULT_CHAT_MODEL,
+  resolveChatModelId,
+  TITLE_MODEL,
+} from "./models";
 
 // Regression guard for the 2026-08 incident: getTitleModel() hardcoded
 // "google/gemini-2.0-flash-001", which OpenRouter retired. Every chat's title
@@ -53,4 +58,36 @@ test("chatModels entries are unique and well formed", () => {
     assert.ok(m.id.includes("/"), `model id "${m.id}" is not provider-qualified`);
     assert.ok(m.name.length > 0, `model "${m.id}" has no display name`);
   }
+});
+
+// A `chat-model` cookie outlives the curated list. Anyone who had one of the
+// retired ids selected kept sending it, and /api/chat 400s unknown ids — the
+// picker's fallback is display-only, so the coercion belongs where the cookie
+// is read (both chat pages).
+
+test("resolveChatModelId keeps a supported cookie value", () => {
+  for (const m of chatModels) {
+    assert.equal(resolveChatModelId(m.id), m.id);
+  }
+});
+
+test("resolveChatModelId falls back for retired or unknown ids", () => {
+  const rejected = [
+    "google/gemini-2.0-flash-001",
+    "anthropic/claude-3.5-haiku",
+    "anthropic/claude-3.5-sonnet",
+    "not-a-model",
+    "",
+  ];
+  for (const value of rejected) {
+    assert.equal(
+      resolveChatModelId(value),
+      DEFAULT_CHAT_MODEL,
+      `"${value}" should have been coerced to the default`
+    );
+  }
+});
+
+test("resolveChatModelId falls back when the cookie is absent", () => {
+  assert.equal(resolveChatModelId(undefined), DEFAULT_CHAT_MODEL);
 });

--- a/apps/researcher/lib/ai/providers.ts
+++ b/apps/researcher/lib/ai/providers.ts
@@ -5,6 +5,7 @@ import {
   wrapLanguageModel,
 } from "ai";
 import { isTestEnvironment } from "../constants";
+import { TITLE_MODEL } from "./models";
 
 const THINKING_SUFFIX_REGEX = /-thinking$/;
 
@@ -56,7 +57,7 @@ export function getTitleModel() {
   if (isTestEnvironment && myProvider) {
     return myProvider.languageModel("title-model");
   }
-  return openrouter.chat("google/gemini-2.0-flash-001");
+  return openrouter.chat(TITLE_MODEL);
 }
 
 /** OpenRouter embedding model for source chunk embeddings */

--- a/apps/researcher/lib/sprint/markdown.ts
+++ b/apps/researcher/lib/sprint/markdown.ts
@@ -1,0 +1,54 @@
+/**
+ * Builds the exportable markdown for a saved sprint. Shared by the panel's
+ * Copy and Download actions so clipboard and file output are identical.
+ * Pure so it can be unit-tested without the React layer.
+ */
+
+type ExportableCitation = {
+  refIndex: number;
+  sourceTitle: string;
+  sourceUrl: string | null;
+  section: string;
+};
+
+export type ExportableSprint = {
+  title: string;
+  summary?: string | null;
+  reportContent?: string | null;
+  createdAt: string;
+  citations?: ExportableCitation[] | null;
+};
+
+export function buildSprintMarkdown(sprint: ExportableSprint): string {
+  const sections: string[] = [`# ${sprint.title}`];
+
+  if (sprint.summary) {
+    sections.push(sprint.summary);
+  }
+
+  if (sprint.reportContent) {
+    sections.push(sprint.reportContent);
+  }
+
+  const citations = sprint.citations ?? [];
+  if (citations.length > 0) {
+    const refs = citations
+      .map((c) => {
+        const base = `[${c.refIndex}] ${c.sourceTitle} — ${c.section}`;
+        return c.sourceUrl ? `${base} (${c.sourceUrl})` : base;
+      })
+      .join("\n");
+    sections.push(`## References\n\n${refs}`);
+  }
+
+  return `${sections.join("\n\n")}\n`;
+}
+
+/** Slug the sprint title into a filesystem-safe markdown file name. */
+export function sprintFileName(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${slug || "sprint-report"}.md`;
+}

--- a/apps/researcher/lib/sprint/markdown.unit.test.ts
+++ b/apps/researcher/lib/sprint/markdown.unit.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildSprintMarkdown, sprintFileName } from "./markdown";
+
+const sprint = {
+  title: "Erasure Code Research Report",
+  summary: "A short summary.",
+  reportContent: "## Findings\n\nErasure codes are FEC codes.",
+  createdAt: "2026-08-17T11:59:52.298Z",
+  citations: [
+    {
+      refIndex: 1,
+      sourceTitle: "Erasure Code — Wikipedia",
+      sourceUrl: "https://en.wikipedia.org/wiki/Erasure_code",
+      section: "Optimal erasure codes",
+    },
+    {
+      refIndex: 2,
+      sourceTitle: "Offline PDF",
+      sourceUrl: null,
+      section: "Intro",
+    },
+  ],
+};
+
+test("buildSprintMarkdown assembles title, summary, report, and references", () => {
+  const md = buildSprintMarkdown(sprint);
+
+  assert.ok(md.startsWith("# Erasure Code Research Report\n"));
+  assert.ok(md.includes("A short summary."));
+  assert.ok(md.includes("## Findings"));
+  assert.ok(md.includes("Erasure codes are FEC codes."));
+  assert.ok(md.includes("## References"));
+  assert.ok(
+    md.includes(
+      "[1] Erasure Code — Wikipedia — Optimal erasure codes (https://en.wikipedia.org/wiki/Erasure_code)"
+    )
+  );
+  // A citation without a URL still renders, without a dangling "(null)"
+  assert.ok(md.includes("[2] Offline PDF — Intro"));
+  assert.ok(!md.includes("null"));
+});
+
+test("buildSprintMarkdown omits empty sections instead of leaving headers", () => {
+  const md = buildSprintMarkdown({
+    title: "Bare",
+    summary: null,
+    reportContent: null,
+    createdAt: sprint.createdAt,
+    citations: [],
+  });
+
+  assert.equal(md.includes("## References"), false);
+  assert.ok(md.startsWith("# Bare"));
+  // No triple blank lines from skipped sections
+  assert.equal(md.includes("\n\n\n"), false);
+});
+
+test("sprintFileName slugs the title into a safe .md name", () => {
+  assert.equal(
+    sprintFileName("Erasure Code: Research / Report?"),
+    "erasure-code-research-report.md"
+  );
+  assert.equal(sprintFileName("   "), "sprint-report.md");
+});


### PR DESCRIPTION
## Summary

Fixes the production P0 where **every new Researcher chat rendered as a failed response**, plus four more defects found while verifying it live on `researcher.demo.memwal.ai`, and one UX gap in saved sprints.

### The P0 (`c031c472`)

`getTitleModel()` hardcoded `google/gemini-2.0-flash-001`, which OpenRouter has retired — it 404s (`No endpoints found`) for our own production key. The unguarded `await titlePromise` inside `createUIMessageStream`'s `execute()` then surfaced that rejection as an `error` part on the stream, so the client showed a fatal chat error even though the real answer had streamed fine underneath.

- Title model moved to a `TITLE_MODEL` constant beside the curated list, pointed at `gemini-2.5-flash`
- Title block wrapped in try/catch — ports the chatbot fix (`334cf915`) that researcher was missed from
- Picker audit with the production key found `claude-3.5-haiku` / `claude-3.5-sonnet` **also retired** (3 of 6 selectable models were dead) — removed, with a regression test pinning all three retired ids

Production impact when found: 11 of 43 chats untitled; the error path live since the 08-14 deploy.

### Also in this branch

- `754327f4` — portal `TooltipContent` (sticky-header stacking context clipped every tooltip to a 2px sliver); single-line suggestion pills; collapse a duplicate unreachable `DEFAULT_SUGGESTIONS`
- `39e102ae` — stop autoResume firing against the stub stream route (always 204): raced in AI SDK 6.0.37 and threw `Cannot read properties of undefined (reading 'state')` when reopening any reply-less chat
- `9db6db10` — delete the template-leftover pyodide `<Script>`: nothing calls it, multi-MB download per chat page, and a React error under Next 16
- `b9b57890` — sprint Copy-as-markdown / Download `.md` / expanded reading view (shared unit-tested `buildSprintMarkdown`); real page title (`Researcher | Walrus Memory`) instead of "Next.js Chatbot Template"

## Verification

- Local A/B against the exact prod condition (retired title model): with the guard the answer streams with no error frame; without it the error frame reproduces
- Live OpenRouter checks with the production key: retired ids → 404, replacement → 200; full e2e with a real key generates a title end-to-end
- Auto-resume fix verified on the repro chat (clean console; previously threw on every load)
- Sprint actions verified in-browser: clipboard content, toast, dialog
- `tsc --noEmit` clean on changed files; `pnpm test:unit` 14/14 (7 new tests)

## Not in this branch / follow-ups

- **Deploy drift:** prod currently runs `ec6a9b81a` from the unmerged `hotfix/noter-mainnet-rpc-cors` branch — this PR can't reach prod through normal promotion until that's reconciled
- Prod has 6 chats with a user message and no persisted assistant row; that symptom did **not** reproduce locally and needs a post-deploy re-check
- `apps/chatbot` shares the dead title model, (probably) the dead Anthropic picker entries, the unportaled tooltip, and the pyodide tag — needs its own branch
