### PR TITLE
chore(sdk): bump version to 0.1.3

### DIFF
--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,8 +28,18 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.2. It adds deterministic offline mocks and idempotent remember retries, isolates foreign manual-recall blobs, safely encodes large encrypted payloads, and supports Zod 3 and Zod 4.
+  The latest TypeScript SDK release is 0.1.3. It adds client-side token estimation and recall token budgets with configurable truncation strategies, and updates the default relayer URL.
 ---
+
+## 0.1.3
+
+### Added
+
+- Added client-side token estimation and recall token budgets with configurable truncation strategies.
+
+### Fixed
+
+- Updated the default SDK relayer URL to `https://relayer.memory.walrus.xyz`.
 
 ## 0.1.2
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @mysten-incubation/memwal
 
+## 0.1.3
+
+### Added
+
+- Added client-side token estimation and recall token budgets with configurable truncation strategies.
+
+### Fixed
+
+- Updated the default SDK relayer URL to `https://relayer.memory.walrus.xyz`.
+
 ## 0.1.2
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- bump `@mysten-incubation/memwal` from `0.1.2` to `0.1.3`
- add a short changelog entry for recall token budgeting and the default relayer URL fix

## Scope

Release metadata only: `packages/sdk/package.json` and `packages/sdk/CHANGELOG.md`.