### PR TITLE
chore(release): bump MCP package to 0.0.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.8"
+      "version": "0.0.9"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.8"
+      "version": "0.0.9"
     }
   ]
 }

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,8 +28,15 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.8. It adds human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login discovery, matching the remote relayer metadata used by Claude connectors. Version 0.0.7 added credential reload and bounded restore error handling.
+  The latest MCP package release is 0.0.9. It answers the MCP initialize handshake locally and connects the relayer in the background so a slow cold start no longer trips the client's 30s timeout. Version 0.0.8 added human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login discovery.
 ---
+
+## 0.0.9
+
+### Fixed
+
+- Answer the MCP `initialize` handshake locally and connect the relayer in the background, so a slow cold start no longer trips the client's 30s connection timeout and leaves the session with no memory tools. Tool discovery is served immediately and refreshed once the relayer is up; a hung relayer now degrades to a tool-call error instead of a failed startup. (#415)
+- Drop buffered tool calls on a same-account login reconnect and keep the `initialize` request id reusable, so a login handoff cannot publish stale cold-start traffic or break the client's handshake.
 
 ## 0.0.8
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,14 +1,17 @@
 # @mysten-incubation/memwal-mcp
 
+## 0.0.9
+
+### Fixed
+
+- Answer the MCP `initialize` handshake locally and connect the relayer in the background, so a slow cold start no longer trips the client's 30s connection timeout and leaves the session with no memory tools. Tool discovery is served immediately and refreshed once the relayer is up; a hung relayer now degrades to a tool-call error instead of a failed startup. (#415)
+- Drop buffered tool calls on a same-account login reconnect and keep the `initialize` request id reusable, so a login handoff cannot publish stale cold-start traffic or break the client's handshake.
+
 ## 0.0.8
 
 ### Added
 
 - Human-readable tool titles and explicit `readOnlyHint` / `destructiveHint` metadata during pre-login tool discovery, matching the remote relayer metadata used by Claude connectors.
-
-### Fixed
-
-- Answer the MCP `initialize` handshake locally and connect the relayer in the background, so a slow cold start no longer trips the client's 30s connection timeout and leaves the session with no memory tools. Tool discovery is served immediately and refreshed once the relayer is up; a hung relayer now degrades to a tool-call error instead of a failed startup. (#415)
 
 ## 0.0.7
 

--- a/packages/mcp/TESTING.md
+++ b/packages/mcp/TESTING.md
@@ -206,7 +206,7 @@ What merging to `dev` triggers, and how to try the result end-to-end.
 
 | Surface | Trigger | Result |
 |---|---|---|
-| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.8-dev.N` under the `dev` dist-tag (`latest` stays 0.0.7 until `main`) |
+| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.9-dev.N` under the `dev` dist-tag (`latest` stays 0.0.8 until `main`) |
 | Plugin marketplace | none needed — `dev` is the repo's **default branch** | `/plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge |
 | Sidecar tools (Layer 1) | Railway image rebuild (`services/server/Dockerfile` copies `scripts/mcp/`) | New agentic descriptions + `memwal_remember_bulk`/`memwal_health` on `relayer.dev.memwal.ai` — **verify the Railway dev environment actually redeployed**; this is not a repo workflow |
 
@@ -262,5 +262,5 @@ Enable `codex_hooks = true`, restart Codex, repeat the Step 2 prompts.
 ### Step 5 — Promotion sanity (before merging dev → main later)
 
 - [ ] Prod relayer redeployed with the new sidecar (same Step 1 check against `relayer.memory.walrus.xyz`)
-- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.8-dev.N`; after main merge, `latest` = `0.0.8`
+- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.9-dev.N`; after main merge, `latest` = `0.0.9`
 - [ ] Mintlify docs published (the 6 provider pages + reference + changelog render, nav matches)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 const releases = [
     {
         name: "TypeScript SDK",
-        version: "0.1.2",
+        version: "0.1.3",
         manifests: [["packages/sdk/package.json", "version"]],
         changelogs: ["packages/sdk/CHANGELOG.md", "docs/sdk/changelog.mdx"],
     },
@@ -23,7 +23,7 @@ const releases = [
     },
     {
         name: "MCP package",
-        version: "0.0.8",
+        version: "0.0.9",
         manifests: [
             ["packages/mcp/package.json", "version"],
             [".claude-plugin/marketplace.json", "plugin-version"],


### PR DESCRIPTION
## Summary

`@mysten-incubation/memwal-mcp@0.0.8` is already on npm (2026-08-14). The WALM-321 cold-start fix (#579) landed on `dev` after that publish and was appended under the **0.0.8** heading.

This is the missing manual version bump:

- `0.0.8` → **`0.0.9`** in every MCP / plugin manifest (same set as the 0.0.8 release).
- New `## 0.0.9` changelog in `packages/mcp/CHANGELOG.md` and `docs/mcp/changelog.mdx`.
- The 0.0.8 heading is restored to what actually shipped (tool titles / hints only).
- `TESTING.md` pins updated to `0.0.9-dev.N` / `latest` = 0.0.9 after `main`.

Also syncs `scripts/verify-manual-sdk-release.mjs` to SDK **0.1.3** (already on `dev`) so the checker matches the tree.

No code change. OpenClaw stays 0.0.5.

## Why a separate PR

#677 (`dev` → `staging`) should not carry a version bump of its own. Merge this to `dev` first; #677 will pick it up automatically.

## After merge

- `release-mcp.yml` should publish `@mysten-incubation/memwal-mcp@0.0.9-dev.N` on the `dev` dist-tag.
- `latest` stays **0.0.8** until this reaches `main`.