### PR TITLE
test(sdk): e2e suite and CI workflow against the dev relayer

### DIFF
--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -14,6 +14,16 @@ on:
       - 'packages/sdk/**'
       - '.github/workflows/test-sdk.yml'
   workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Benchmark environment to run the authenticated e2e suite against
+        required: true
+        type: choice
+        default: dev
+        options:
+          - dev
+          - staging
+          - production
   schedule:
     # Catches relayer drift with no code change to trigger it. Offset 30
     # minutes from test-python-sdk.yml (17 9 * * 1) so the two weekly suites
@@ -59,33 +69,48 @@ jobs:
         run: pnpm --filter @mysten-incubation/memwal test
 
   e2e:
-    name: E2E / dev relayer
+    name: E2E / ${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }} relayer
     runs-on: ubuntu-latest
     needs: unit
     timeout-minutes: 30
 
-    # Dev only for now; staging and production follow once their credentials
-    # exist. Pull requests are excluded because environment secrets are
-    # withheld from fork PRs, and every authenticated run writes real memories.
+    # Each long-lived branch tests the deployment it corresponds to. Pull
+    # requests are excluded because environment secrets are withheld from fork
+    # PRs, and every authenticated run writes real memories.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref_name == 'dev')
+      (github.event_name == 'push' &&
+       (github.ref_name == 'dev' ||
+        github.ref_name == 'staging' ||
+        github.ref_name == 'main'))
 
     # Reuses the credentials benchmark-live.yml and test-python-sdk.yml already
     # rely on, so this needs no new secrets. Safe to share: the benchmark
     # writes to the `benchmark` namespace while these tests use a per-run
     # `sdk-e2e-<random>`.
-    environment: benchmark-dev
+    #
+    # main maps to benchmark-production, so a push to main writes real
+    # memories through the live Walrus pipeline on the production benchmark
+    # account. That is intentional, and the per-run namespace is what keeps it
+    # contained — never point this job at an account holding user data, and
+    # never relax the namespace isolation in live.e2e.mjs.
+    environment:
+      name: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
 
     env:
+      # Which deployment this run targets. Mirrors the `environment:` name
+      # above so error messages and the run summary can name it.
+      ENVIRONMENT_NAME: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
       # BENCH_DELEGATE_KEY is the delegate private key the SDK signs with,
       # which test/e2e/live.e2e.mjs reads as MEMWAL_PRIVATE_KEY.
       MEMWAL_PRIVATE_KEY: ${{ secrets.BENCH_DELEGATE_KEY }}
       MEMWAL_ACCOUNT_ID: ${{ secrets.BENCH_ACCOUNT_ID }}
-      # Public URL (docs/relayer/benchmark-ci-setup.md), defaulted so a missing
-      # variable cannot silently point the run at the wrong relayer.
-      MEMWAL_SERVER_URL: ${{ vars.BENCH_SERVER_URL || 'https://relayer.dev.memwal.ai' }}
+      # Public URL, set per environment (docs/relayer/benchmark-ci-setup.md).
+      # Deliberately NOT defaulted: with three environments in play, a literal
+      # fallback would silently run the production job against whichever
+      # relayer the default names. A missing variable fails the job instead.
+      MEMWAL_SERVER_URL: ${{ vars.BENCH_SERVER_URL }}
 
     steps:
       - name: Checkout
@@ -112,14 +137,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Without these the suite skips every authenticated test, and the
-          # job would report success having never exercised the relayer
-          # beyond /health. Fail instead of reporting a green run that
-          # proved nothing.
+          # Without the credentials the suite skips every authenticated test,
+          # and the job would report success having never exercised the
+          # relayer beyond /health. Without the URL there is no safe guess to
+          # fall back on. Fail instead of reporting a green run that proved
+          # nothing, or running the wrong deployment.
           missing=0
-          for name in MEMWAL_PRIVATE_KEY MEMWAL_ACCOUNT_ID; do
+          for name in MEMWAL_PRIVATE_KEY MEMWAL_ACCOUNT_ID MEMWAL_SERVER_URL; do
             if [ -z "${!name:-}" ]; then
-              echo "::error::${name} is empty — set BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID on the benchmark-dev environment."
+              echo "::error::${name} is empty — set BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID / BENCH_SERVER_URL on the ${ENVIRONMENT_NAME} environment."
               missing=1
             fi
           done
@@ -145,7 +171,8 @@ jobs:
             echo
             echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| Relayer | \`${MEMWAL_SERVER_URL}\` |"
+            echo "| Environment | \`${ENVIRONMENT_NAME}\` |"
+            echo "| Relayer | \`${MEMWAL_SERVER_URL:-<unset>}\` |"
             echo "| Authenticated | ${{ steps.config.outputs.authenticated }} |"
             echo "| Result | ${{ steps.e2e.outcome }} |"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -154,7 +181,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: js-sdk-e2e-${{ github.run_id }}
+          name: js-sdk-e2e-${{ env.ENVIRONMENT_NAME }}-${{ github.run_id }}
           path: packages/sdk/e2e-results.xml
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -1,0 +1,160 @@
+name: Test JS SDK
+
+on:
+  pull_request:
+    paths:
+      - 'packages/sdk/**'
+      - '.github/workflows/test-sdk.yml'
+  push:
+    branches:
+      - main
+      - staging
+      - dev
+    paths:
+      - 'packages/sdk/**'
+      - '.github/workflows/test-sdk.yml'
+  workflow_dispatch:
+  schedule:
+    # Catches relayer drift with no code change to trigger it. Offset 30
+    # minutes from test-python-sdk.yml (17 9 * * 1) so the two weekly suites
+    # don't write through the shared bench account at the same time.
+    - cron: '47 9 * * 1'
+
+concurrency:
+  group: test-sdk-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit / Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 22 is what the rest of CI runs on; 24 is the active LTS.
+        node-version: ['22', '24']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck, build and unit tests
+        run: pnpm --filter @mysten-incubation/memwal test
+
+  e2e:
+    name: E2E / dev relayer
+    runs-on: ubuntu-latest
+    needs: unit
+    timeout-minutes: 30
+
+    # Dev only for now; staging and production follow once their credentials
+    # exist. Pull requests are excluded because environment secrets are
+    # withheld from fork PRs, and every authenticated run writes real memories.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref_name == 'dev')
+
+    # Reuses the credentials benchmark-live.yml and test-python-sdk.yml already
+    # rely on, so this needs no new secrets. Safe to share: the benchmark
+    # writes to the `benchmark` namespace while these tests use a per-run
+    # `sdk-e2e-<random>`.
+    environment: benchmark-dev
+
+    env:
+      # BENCH_DELEGATE_KEY is the delegate private key the SDK signs with,
+      # which test/e2e/live.e2e.mjs reads as MEMWAL_PRIVATE_KEY.
+      MEMWAL_PRIVATE_KEY: ${{ secrets.BENCH_DELEGATE_KEY }}
+      MEMWAL_ACCOUNT_ID: ${{ secrets.BENCH_ACCOUNT_ID }}
+      # Public URL (docs/relayer/benchmark-ci-setup.md), defaulted so a missing
+      # variable cannot silently point the run at the wrong relayer.
+      MEMWAL_SERVER_URL: ${{ vars.BENCH_SERVER_URL || 'https://relayer.dev.memwal.ai' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter @mysten-incubation/memwal build
+
+      - name: Check credentials
+        id: config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Without these the suite skips every authenticated test, and the
+          # job would report success having never exercised the relayer
+          # beyond /health. Fail instead of reporting a green run that
+          # proved nothing.
+          missing=0
+          for name in MEMWAL_PRIVATE_KEY MEMWAL_ACCOUNT_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::${name} is empty — set BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID on the benchmark-dev environment."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+          echo "authenticated=true" >> "$GITHUB_OUTPUT"
+
+      - name: E2E tests
+        id: e2e
+        working-directory: packages/sdk
+        run: |
+          node --test \
+            --test-reporter=spec --test-reporter-destination=stdout \
+            --test-reporter=junit --test-reporter-destination=e2e-results.xml \
+            "test/e2e/live.e2e.mjs"
+
+      - name: Write run summary
+        if: always()
+        run: |
+          {
+            echo "## JS SDK e2e"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Relayer | \`${MEMWAL_SERVER_URL}\` |"
+            echo "| Authenticated | ${{ steps.config.outputs.authenticated }} |"
+            echo "| Result | ${{ steps.e2e.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload e2e results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-sdk-e2e-${{ github.run_id }}
+          path: packages/sdk/e2e-results.xml
+          if-no-files-found: warn
+          retention-days: 14

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -27,7 +27,8 @@
         "build": "tsc",
         "dev": "tsc --watch",
         "typecheck": "tsc --noEmit",
-        "test": "tsc && node --test \"test/**/*.test.mjs\""
+        "test": "tsc && node --test \"test/**/*.test.mjs\"",
+        "test:e2e": "tsc && node --test \"test/e2e/*.e2e.mjs\""
     },
     "dependencies": {
         "@noble/ed25519": "^2.3.0",

--- a/packages/sdk/test/e2e/live.e2e.mjs
+++ b/packages/sdk/test/e2e/live.e2e.mjs
@@ -20,7 +20,6 @@
  *   - recall()
  *   - analyze() / analyzeAndWait()
  *   - rememberBulkAndWait()
- *   - embed() + manual mode (rememberManual → recallManual)
  *   - restore()
  *   - Full e2e: remember → recall → verify
  *
@@ -55,7 +54,24 @@ const ACCOUNT_ID = process.env.MEMWAL_ACCOUNT_ID ?? "";
 // Measured around 44s against the dev relayer, so the SDK's 60s default leaves
 // too little headroom to be reliable in CI. 120s matches what the SDK already
 // uses for bulk pipelines.
-const REMEMBER_TIMEOUT_MS = Number(process.env.MEMWAL_REMEMBER_TIMEOUT_MS ?? "120000");
+function positiveIntEnv(name, fallback) {
+    const raw = process.env[name];
+    if (raw === undefined || raw === "") return fallback;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`${name} must be a positive number of milliseconds, got '${raw}'`);
+    }
+    return parsed;
+}
+
+const REMEMBER_TIMEOUT_MS = positiveIntEnv("MEMWAL_REMEMBER_TIMEOUT_MS", 120_000);
+
+// analyze() fans one input out into N facts, each its own full write pipeline.
+// They round-robin across relayer wallet slots and usually overlap, but the
+// bench account is shared, so a contended pool can push a 3-fact extraction
+// past the single-write budget. Give the fan-out twice the headroom rather
+// than letting a slow-but-healthy run report failed jobs.
+const ANALYZE_TIMEOUT_MS = REMEMBER_TIMEOUT_MS * 2;
 
 // Every authenticated test writes into a namespace unique to this run. The bench
 // account is shared, and `default` in particular is what real users get, so a
@@ -198,11 +214,15 @@ test("remember returns a job id and an accepted status", { skip: requiresKey }, 
     assert.ok(result.job_id.length > 0);
     assert.ok(["pending", "running"].includes(result.status), `unexpected status: ${result.status}`);
 
-    // One-shot status lookup on the accepted job (no polling).
+    // One-shot status lookup on the accepted job (no polling). This asserts the
+    // acceptance contract — the job is known to the relayer and reports a real
+    // state — so `failed` is tolerated here: whether the background pipeline
+    // succeeds is what rememberAndWait covers. `not_found` is the failure that
+    // matters, since it means the accepted job_id addresses nothing.
     const status = await mw.getRememberStatus(result.job_id);
     assert.equal(status.job_id, result.job_id);
     assert.ok(
-        ["pending", "running", "uploaded", "done"].includes(status.status),
+        ["pending", "running", "uploaded", "done", "failed"].includes(status.status),
         `unexpected job status: ${status.status}`,
     );
 });
@@ -274,7 +294,7 @@ test("analyzeAndWait stores every extracted fact", { skip: requiresKey }, async 
     const result = await mw.analyzeAndWait(
         "I moved to Lisbon last spring and I play tennis every Saturday.",
         undefined,
-        { timeoutMs: REMEMBER_TIMEOUT_MS },
+        { timeoutMs: ANALYZE_TIMEOUT_MS },
     );
     assert.equal(result.results.length, result.facts.length);
     assert.equal(result.failed, 0, `analyze facts failed to store: ${JSON.stringify(result.results)}`);
@@ -296,39 +316,19 @@ test("rememberBulkAndWait stores a batch", { skip: requiresKey }, async () => {
     for (const item of result.results) {
         assert.equal(item.status, "done");
         assert.ok(item.blob_id.length > 0);
+        // Client-side bookkeeping, not a server echo: the bulk status endpoint
+        // returns no namespace, so the SDK fills this in from the request.
         assert.equal(item.namespace, E2E_NAMESPACE);
     }
 });
 
-test("embed returns a numeric vector", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.embed("The quick brown fox jumps over the lazy dog");
-    assert.ok(Array.isArray(result.vector));
-    assert.ok(result.vector.length > 0);
-    assert.ok(result.vector.every((v) => Number.isFinite(v)));
-});
-
-test("manual mode round-trips a vector to its blob id", { skip: requiresKey }, async () => {
-    // Manual mode: the caller owns SEAL + Walrus, the relayer only stores the
-    // vector ↔ blob_id mapping — so a synthetic blob id round-trips fine and
-    // nothing is uploaded. Both requests transmit no SEAL credential.
-    const mw = client();
-    const marker = randomUUID().replaceAll("-", "").slice(0, 8);
-    const blobId = `manual-e2e-${marker}`;
-
-    const { vector } = await mw.embed(`Manual mode e2e test ${marker}`);
-    const stored = await mw.rememberManual({ blobId, vector });
-    assert.equal(stored.blob_id, blobId);
-    assert.ok(stored.owner.startsWith("0x"));
-    assert.equal(stored.namespace, E2E_NAMESPACE);
-
-    const hits = await mw.recallManual({ vector, limit: 5 });
-    assert.ok(hits.total >= 1, `Expected >= 1 manual hit, got ${hits.total}`);
-    assert.ok(
-        hits.results.some((hit) => hit.blob_id === blobId),
-        `Expected blob '${blobId}' in hits: ${JSON.stringify(hits.results)}`,
-    );
-});
+// `embed()` and the lightweight manual mode (`rememberManual` / `recallManual`)
+// are deliberately NOT covered here: both SDK methods target contracts this
+// relayer does not serve. `/api/embed` is absent from the protected route table
+// (services/server/src/main.rs), and `RememberManualRequest`
+// (services/server/src/types.rs) requires `encrypted_data` where the SDK sends
+// `blob_id`, so the call 422s before reaching the handler. Tests for them would
+// be guaranteed red on the first authenticated run. Tracked in WALM-371.
 
 test("restore reports counts for the run namespace", { skip: requiresKey }, async () => {
     // Everything this run stored is already indexed on the relayer, so restore

--- a/packages/sdk/test/e2e/live.e2e.mjs
+++ b/packages/sdk/test/e2e/live.e2e.mjs
@@ -1,0 +1,368 @@
+/**
+ * E2E tests for the Walrus Memory JS SDK against a live relayer.
+ *
+ * Targets MEMWAL_SERVER_URL (default: https://relayer-staging.memory.walrus.xyz).
+ * The structure mirrors the Python SDK's tests/test_integration.py so the two
+ * suites stay comparable; `ask()` has no JS equivalent (its analogue is the
+ * `ai/` integration, which needs a model provider and is out of scope here).
+ *
+ * No-auth tests (always run, no env vars needed):
+ *   - /health endpoint
+ *   - Compatibility contract (GET /version) accepts this SDK
+ *   - Unsigned request → 401
+ *   - Wrong signature → 401
+ *   - Expired timestamp → 401
+ *   - Future timestamp → 401
+ *   - Unregistered key → SDK error carrying the 401/403
+ *
+ * Authenticated tests (require MEMWAL_PRIVATE_KEY + MEMWAL_ACCOUNT_ID):
+ *   - remember() acceptance, rememberAndWait(), namespace handling
+ *   - recall()
+ *   - analyze() / analyzeAndWait()
+ *   - rememberBulkAndWait()
+ *   - embed() + manual mode (rememberManual → recallManual)
+ *   - restore()
+ *   - Full e2e: remember → recall → verify
+ *
+ * Usage:
+ *   # Run only no-auth tests (no keys needed)
+ *   pnpm --filter @mysten-incubation/memwal test:e2e
+ *
+ *   # Run full suite with real credentials
+ *   MEMWAL_PRIVATE_KEY=<hex> MEMWAL_ACCOUNT_ID=0x... \
+ *     pnpm --filter @mysten-incubation/memwal test:e2e
+ *
+ *   # Point at a specific relayer
+ *   MEMWAL_SERVER_URL=https://relayer.dev.memwal.ai ...
+ */
+
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+
+import * as ed from "@noble/ed25519";
+
+import { MemWal, MemWalCompatibilityError } from "../../dist/index.js";
+import { bytesToHex, sha256hex } from "../../dist/utils.js";
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+const SERVER_URL = (process.env.MEMWAL_SERVER_URL ?? "https://relayer-staging.memory.walrus.xyz").replace(/\/$/, "");
+const PRIVATE_KEY_HEX = process.env.MEMWAL_PRIVATE_KEY ?? "";
+const ACCOUNT_ID = process.env.MEMWAL_ACCOUNT_ID ?? "";
+
+// A live write runs embed -> SEAL encrypt -> Walrus upload -> on-chain metadata.
+// Measured around 44s against the dev relayer, so the SDK's 60s default leaves
+// too little headroom to be reliable in CI. 120s matches what the SDK already
+// uses for bulk pipelines.
+const REMEMBER_TIMEOUT_MS = Number(process.env.MEMWAL_REMEMBER_TIMEOUT_MS ?? "120000");
+
+// Every authenticated test writes into a namespace unique to this run. The bench
+// account is shared, and `default` in particular is what real users get, so a
+// recurring job must not leave live Walrus blobs there.
+const E2E_NAMESPACE = `sdk-e2e-${randomUUID().replaceAll("-", "").slice(0, 8)}`;
+const E2E_NAMESPACE_ALT = `${E2E_NAMESPACE}-alt`;
+
+const HAS_KEY = Boolean(PRIVATE_KEY_HEX && ACCOUNT_ID);
+
+// node:test skips the test (with this reason) when the value is a string.
+const requiresKey = HAS_KEY ? false : "MEMWAL_PRIVATE_KEY and MEMWAL_ACCOUNT_ID not set";
+
+function client(namespace = E2E_NAMESPACE) {
+    return MemWal.create({
+        key: PRIVATE_KEY_HEX,
+        accountId: ACCOUNT_ID,
+        serverUrl: SERVER_URL,
+        namespace,
+    });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Make a raw signed request without using the SDK (for auth rejection tests).
+ * Message format matches memwal.ts signedRequest():
+ *   "{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}"
+ */
+async function rawSignedRequest(method, path, body, privateKey, overrides = {}) {
+    const bodyStr = JSON.stringify(body);
+    const bodySha256 = await sha256hex(bodyStr);
+    const timestamp = overrides.timestamp ?? Math.floor(Date.now() / 1000).toString();
+    const nonce = randomUUID();
+    const accountId = ACCOUNT_ID || "0x0";
+    const message = `${timestamp}.${method}.${path}.${bodySha256}.${nonce}.${accountId}`;
+    const signature = await ed.signAsync(new TextEncoder().encode(message), privateKey);
+    const publicKeyHex = overrides.publicKeyHex ?? bytesToHex(await ed.getPublicKeyAsync(privateKey));
+
+    return fetch(`${SERVER_URL}${path}`, {
+        method,
+        headers: {
+            "Content-Type": "application/json",
+            "x-public-key": publicKeyHex,
+            "x-signature": bytesToHex(signature),
+            "x-timestamp": timestamp,
+            "x-nonce": nonce,
+            "x-account-id": accountId,
+        },
+        body: bodyStr,
+    });
+}
+
+const REJECTION_BODY = { text: "hello", namespace: "default" };
+
+// ── No-auth tests (always run) ───────────────────────────────────────────────
+
+test("health returns ok with a version string", async () => {
+    const mw = MemWal.create({ key: "aa".repeat(32), accountId: "0x0", serverUrl: SERVER_URL });
+    const result = await mw.health();
+    assert.equal(result.status, "ok", `Expected 'ok', got '${result.status}'`);
+    assert.equal(typeof result.version, "string");
+});
+
+test("compatibility contract accepts this SDK version", async () => {
+    // compatibility() both fetches GET /version and validates it against this
+    // SDK's compatibility version — a MemWalCompatibilityError here means the
+    // live relayer has dropped support for the SDK as released.
+    const mw = MemWal.create({ key: "aa".repeat(32), accountId: "0x0", serverUrl: SERVER_URL });
+    const result = await mw.compatibility();
+    assert.equal(typeof result.relayerVersion, "string");
+    assert.equal(typeof result.apiVersion, "string");
+    assert.equal(typeof result.minSupportedSdk.typescript, "string");
+});
+
+test("unsigned request is rejected with 401", async () => {
+    const res = await fetch(`${SERVER_URL}/api/remember`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(REJECTION_BODY),
+    });
+    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
+});
+
+test("wrong signature is rejected with 401", async () => {
+    // Sign with key A but claim key B's public key.
+    const keyA = ed.utils.randomPrivateKey();
+    const keyB = ed.utils.randomPrivateKey();
+    const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, keyA, {
+        publicKeyHex: bytesToHex(await ed.getPublicKeyAsync(keyB)),
+    });
+    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
+});
+
+test("expired timestamp is rejected with 401", async () => {
+    const key = ed.utils.randomPrivateKey();
+    const tenMinutesAgo = String(Math.floor(Date.now() / 1000) - 600);
+    const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, key, {
+        timestamp: tenMinutesAgo,
+    });
+    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
+});
+
+test("future timestamp is rejected with 401", async () => {
+    const key = ed.utils.randomPrivateKey();
+    const tenMinutesAhead = String(Math.floor(Date.now() / 1000) + 600);
+    const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, key, {
+        timestamp: tenMinutesAhead,
+    });
+    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
+});
+
+test("SDK surfaces an unregistered key as an auth error", async (t) => {
+    const mw = MemWal.create({
+        key: "bb".repeat(32), // random, not registered on-chain
+        accountId: "0x0",
+        serverUrl: SERVER_URL,
+    });
+    try {
+        await mw.remember("hello");
+        assert.fail("Expected remember() with an unregistered key to throw");
+    } catch (err) {
+        if (err instanceof MemWalCompatibilityError) {
+            t.skip("live relayer does not expose compatibility metadata yet");
+            return;
+        }
+        const status = err.status ?? 0;
+        assert.ok(
+            status === 401 || status === 403 || /\b40[13]\b/.test(String(err.message)),
+            `Expected a 401/403 auth rejection, got: ${err.message}`,
+        );
+    }
+});
+
+// ── Authenticated tests ──────────────────────────────────────────────────────
+
+test("remember returns a job id and an accepted status", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.remember("Integration test: the sky is blue");
+    assert.equal(typeof result.job_id, "string");
+    assert.ok(result.job_id.length > 0);
+    assert.ok(["pending", "running"].includes(result.status), `unexpected status: ${result.status}`);
+
+    // One-shot status lookup on the accepted job (no polling).
+    const status = await mw.getRememberStatus(result.job_id);
+    assert.equal(status.job_id, result.job_id);
+    assert.ok(
+        ["pending", "running", "uploaded", "done"].includes(status.status),
+        `unexpected job status: ${status.status}`,
+    );
+});
+
+test("rememberAndWait returns blob and owner", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.rememberAndWait("Integration test: the sky is blue", undefined, {
+        timeoutMs: REMEMBER_TIMEOUT_MS,
+    });
+    assert.equal(typeof result.id, "string");
+    assert.ok(result.id.length > 0);
+    assert.equal(typeof result.blob_id, "string");
+    assert.ok(result.blob_id.length > 0);
+    assert.ok(result.owner.startsWith("0x"));
+});
+
+test("remember uses the client namespace when none is passed", { skip: requiresKey }, async () => {
+    // Omitting `namespace` falls back to the one the client was built with.
+    // The literal `"default"` fallback is asserted in the mocked suite; proving
+    // it here would mean writing a live blob into the namespace real users get.
+    const mw = client();
+    const result = await mw.rememberAndWait("Integration test: namespace fallback", undefined, {
+        timeoutMs: REMEMBER_TIMEOUT_MS,
+    });
+    assert.equal(result.namespace, E2E_NAMESPACE);
+});
+
+test("remember honors a per-call namespace override", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.rememberAndWait(
+        "Integration test: custom namespace",
+        E2E_NAMESPACE_ALT,
+        { timeoutMs: REMEMBER_TIMEOUT_MS },
+    );
+    assert.equal(result.namespace, E2E_NAMESPACE_ALT);
+});
+
+test("recall returns results with the expected fields", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.recall({ query: "sky blue", limit: 5 });
+    assert.ok(Array.isArray(result.results));
+    assert.ok(result.total >= 0);
+    for (const memory of result.results) {
+        assert.equal(typeof memory.text, "string");
+        assert.equal(typeof memory.blob_id, "string");
+        assert.equal(typeof memory.distance, "number");
+    }
+});
+
+test("recall respects the limit", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.recall({ query: "test", limit: 2 });
+    assert.ok(result.results.length <= 2);
+});
+
+test("analyze extracts facts", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.analyze("I love hiking and my favorite food is pho.");
+    assert.ok(Array.isArray(result.facts));
+    assert.ok(result.fact_count >= 0);
+    assert.ok(result.owner.startsWith("0x"));
+    for (const fact of result.facts) {
+        assert.equal(typeof fact.text, "string");
+    }
+});
+
+test("analyzeAndWait stores every extracted fact", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.analyzeAndWait(
+        "I moved to Lisbon last spring and I play tennis every Saturday.",
+        undefined,
+        { timeoutMs: REMEMBER_TIMEOUT_MS },
+    );
+    assert.equal(result.results.length, result.facts.length);
+    assert.equal(result.failed, 0, `analyze facts failed to store: ${JSON.stringify(result.results)}`);
+    assert.equal(result.succeeded, result.facts.length);
+});
+
+test("rememberBulkAndWait stores a batch", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.rememberBulkAndWait(
+        [
+            { text: "Bulk e2e test: I drink oat-milk coffee" },
+            { text: "Bulk e2e test: my desk faces a window" },
+        ],
+        { timeoutMs: REMEMBER_TIMEOUT_MS },
+    );
+    assert.equal(result.total, 2);
+    assert.equal(result.failed, 0, `bulk items failed: ${JSON.stringify(result.results)}`);
+    assert.equal(result.succeeded, 2);
+    for (const item of result.results) {
+        assert.equal(item.status, "done");
+        assert.ok(item.blob_id.length > 0);
+        assert.equal(item.namespace, E2E_NAMESPACE);
+    }
+});
+
+test("embed returns a numeric vector", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.embed("The quick brown fox jumps over the lazy dog");
+    assert.ok(Array.isArray(result.vector));
+    assert.ok(result.vector.length > 0);
+    assert.ok(result.vector.every((v) => Number.isFinite(v)));
+});
+
+test("manual mode round-trips a vector to its blob id", { skip: requiresKey }, async () => {
+    // Manual mode: the caller owns SEAL + Walrus, the relayer only stores the
+    // vector ↔ blob_id mapping — so a synthetic blob id round-trips fine and
+    // nothing is uploaded. Both requests transmit no SEAL credential.
+    const mw = client();
+    const marker = randomUUID().replaceAll("-", "").slice(0, 8);
+    const blobId = `manual-e2e-${marker}`;
+
+    const { vector } = await mw.embed(`Manual mode e2e test ${marker}`);
+    const stored = await mw.rememberManual({ blobId, vector });
+    assert.equal(stored.blob_id, blobId);
+    assert.ok(stored.owner.startsWith("0x"));
+    assert.equal(stored.namespace, E2E_NAMESPACE);
+
+    const hits = await mw.recallManual({ vector, limit: 5 });
+    assert.ok(hits.total >= 1, `Expected >= 1 manual hit, got ${hits.total}`);
+    assert.ok(
+        hits.results.some((hit) => hit.blob_id === blobId),
+        `Expected blob '${blobId}' in hits: ${JSON.stringify(hits.results)}`,
+    );
+});
+
+test("restore reports counts for the run namespace", { skip: requiresKey }, async () => {
+    // Everything this run stored is already indexed on the relayer, so restore
+    // has no work to do — assert the response shape rather than exact counts:
+    // candidate discovery is capped per-owner across namespaces (WALM-319), so
+    // `total` for a fresh namespace on the shared bench account is not stable.
+    const mw = client();
+    const result = await mw.restore(E2E_NAMESPACE);
+    assert.equal(result.namespace, E2E_NAMESPACE);
+    assert.ok(Number.isInteger(result.restored) && result.restored >= 0);
+    assert.ok(Number.isInteger(result.skipped) && result.skipped >= 0);
+    assert.ok(Number.isInteger(result.total) && result.total >= 0);
+    assert.equal(typeof result.truncated, "boolean");
+    assert.ok(result.owner.startsWith("0x"));
+});
+
+// ── Full flow ────────────────────────────────────────────────────────────────
+
+test("full flow: remember then recall finds it", { skip: requiresKey }, async () => {
+    const unique = randomUUID().replaceAll("-", "").slice(0, 8);
+    const text = `SDK e2e test ${unique}: quantum entanglement in photonics`;
+    const namespace = `sdk-e2e-${unique}`;
+
+    const mw = client();
+
+    // Store a distinctive memory in an isolated namespace.
+    const memory = await mw.rememberAndWait(text, namespace, { timeoutMs: REMEMBER_TIMEOUT_MS });
+    assert.ok(memory.id.length > 0);
+
+    // Recall — should find the stored memory.
+    const result = await mw.recall({ query: `quantum photonics ${unique}`, limit: 5, namespace });
+    assert.ok(result.total >= 1, `Expected >= 1 result, got ${result.total}`);
+    assert.ok(
+        result.results.some((r) => r.text.includes(unique)),
+        `Expected unique marker '${unique}' in recalled texts: ${JSON.stringify(result.results.map((r) => r.text))}`,
+    );
+});


### PR DESCRIPTION
Closes WALM-353. Sibling of #661 (Python SDK e2e) — same structure, env contract and credentials, so the two suites stay comparable.

## What

**`packages/sdk/test/e2e/live.e2e.mjs`** (+ `test:e2e` script) — a live-relayer suite in two halves:

- **No-auth, always runs**: `/health`, the compatibility contract (`GET /version` accepts this SDK), unsigned → 401, wrong signature → 401, expired/future timestamp → 401, unregistered key surfaced as an auth error by the SDK.
- **Authenticated, skips without `MEMWAL_PRIVATE_KEY` / `MEMWAL_ACCOUNT_ID`**: remember acceptance + `getRememberStatus`, `rememberAndWait`, namespace fallback/override, `recall`, `analyze` / `analyzeAndWait`, `rememberBulkAndWait`, `restore`, and a full remember → recall → verify loop.

Hygiene mirrors the Python suite: every authenticated write lands in a per-run `sdk-e2e-<random>` namespace, and remember waits get 120s of headroom (a live write measures ~44s on dev), with the `analyze` fan-out given twice that since each extracted fact is its own write pipeline.

`ask()` has no JS-SDK equivalent — its analogue is the `ai/` integration, which needs a model provider and is out of scope here.

**Deliberately not covered — `embed()` and lightweight manual mode.** Both SDK methods target contracts this relayer does not serve: `/api/embed` is absent from the protected route table, and `rememberManual()` sends `blob_id` where `RememberManualRequest` requires `encrypted_data` (422 before the handler). Tests for them would be guaranteed red. Documented inline and tracked in WALM-371 — a real find this effort surfaced, since both methods are covered only by `MemWalMock` today.

**`.github/workflows/test-sdk.yml`** — sibling of `test-python-sdk.yml`:

- `unit`: the offline suite on Node 22 + 24 for every PR touching `packages/sdk/**`. This also closes a standing gap: the SDK's unit tests were not run by any CI workflow before this.
- `e2e`: **each long-lived branch tests the deployment it corresponds to** — `dev` → `benchmark-dev`, `staging` → `benchmark-staging`, `main` → `benchmark-production` — plus `workflow_dispatch` with an explicit environment choice, following the selection pattern `benchmark-live.yml` already uses. Scheduled runs stay on dev (cron fires on the default branch), so production is only reached by an explicit `main` push or a deliberate dispatch. PRs are excluded: fork PRs get no environment secrets, and every authenticated run writes real memories. No new secrets — all three environments already carry `BENCH_DELEGATE_KEY` / `BENCH_ACCOUNT_ID` / `BENCH_SERVER_URL`.

Two notes on the multi-environment setup:

- **No relayer-URL fallback.** With one environment a literal default guarded against an unset variable; with three it becomes the hazard it was meant to prevent, since a production run with a missing variable would silently exercise dev. The credential check now requires `MEMWAL_SERVER_URL` and fails the job without it.
- **Production safety rests on namespace isolation.** Every authenticated write is confined to the per-run `sdk-e2e-<random>` namespace; the only reference to `default` is the body of the 401-rejection tests, which never write. Don't relax that isolation, and don't point this job at an account holding user data.

One deliberate deviation from the Python workflow's matrix philosophy: Node 22/24 rather than reaching further back, because `node --test` only accepts glob arguments from Node 21.

## Test plan

- [x] Unit suite: 66 pass, 0 fail (glob untouched by the new `.e2e.mjs` files)
- [x] No-auth e2e slice against `https://relayer.dev.memwal.ai`: 7 pass, 11 skipped (credentials absent locally), 0 fail
- [x] Environment-selection expression simulated across all 8 trigger cases (push dev/staging/main, schedule, dispatch × 4)
- [ ] Authenticated e2e: `workflow_dispatch` after merge, as with #661. Worth one run by someone holding the `benchmark-dev` credentials before merge if we want it proven earlier — `MEMWAL_PRIVATE_KEY=… MEMWAL_ACCOUNT_ID=… MEMWAL_SERVER_URL=https://relayer.dev.memwal.ai pnpm --filter @mysten-incubation/memwal test:e2e`