### PR TITLE
fix(mcp): collapse duplicate results in memwal_recall

### DIFF
--- a/services/server/scripts/mcp/__tests__/recall-dedupe.test.ts
+++ b/services/server/scripts/mcp/__tests__/recall-dedupe.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `memwal_recall` collapses identical results before they reach the model.
+ *
+ * Observed on a real dev account: a `limit=5` recall returned the same fact
+ * five times, consuming the entire retrieval budget on one preference and
+ * crowding out every other memory the query should have surfaced.
+ *
+ * That is expected on the write side. Each remember is a distinct event with
+ * its own blob and timestamp, and there is no content-level uniqueness
+ * constraint by design (the only unique index is request idempotency on
+ * `remember_jobs (owner, idempotency_key)`, which guards retries, not content).
+ * So the fix belongs on the read side, and these tests pin that behavior.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { collapseDuplicates } from "../tools/recall.js";
+
+const row = (text: string, distance = 0.5) => ({ text, distance });
+
+test("collapses identical texts and reports the count", () => {
+    const { unique, collapsed } = collapseDuplicates([
+        row("User prefers dark roast coffee"),
+        row("User prefers dark roast coffee"),
+        row("User prefers dark roast coffee"),
+        row("User prefers dark roast coffee"),
+        row("User prefers dark roast coffee"),
+    ]);
+    assert.equal(unique.length, 1);
+    assert.equal(collapsed, 4);
+});
+
+test("keeps the highest scoring copy", () => {
+    // recall returns rows ranked best-first, so the survivor must be the first
+    // one seen, not an arbitrary map entry.
+    const { unique } = collapseDuplicates([
+        row("same fact", 0.1),
+        row("same fact", 0.9),
+    ]);
+    assert.equal(unique.length, 1);
+    assert.equal(unique[0].distance, 0.1);
+});
+
+test("normalizes whitespace and case before comparing", () => {
+    const { unique, collapsed } = collapseDuplicates([
+        row("User prefers dark roast coffee"),
+        row("  user prefers   DARK roast coffee  "),
+    ]);
+    assert.equal(unique.length, 1);
+    assert.equal(collapsed, 1);
+});
+
+test("preserves rank order of the survivors", () => {
+    const { unique } = collapseDuplicates([
+        row("first", 0.1),
+        row("second", 0.2),
+        row("first", 0.3),
+        row("third", 0.4),
+    ]);
+    assert.deepEqual(
+        unique.map((m) => m.text),
+        ["first", "second", "third"],
+    );
+});
+
+test("leaves distinct facts untouched", () => {
+    // The common case must not lose anything. A dedupe that is too eager is
+    // worse than the duplicates it removes.
+    const { unique, collapsed } = collapseDuplicates([
+        row("deploy region is ap-southeast-1"),
+        row("prefers dark roast coffee"),
+        row("uses pnpm, not npm"),
+    ]);
+    assert.equal(unique.length, 3);
+    assert.equal(collapsed, 0);
+});
+
+test("does not merely substring-match distinct facts", () => {
+    // "coffee" appearing in both must not collapse them: these are different
+    // statements and losing either would be a silent data loss bug.
+    const { unique, collapsed } = collapseDuplicates([
+        row("User prefers dark roast coffee"),
+        row("User prefers dark roast coffee in the morning only"),
+    ]);
+    assert.equal(unique.length, 2);
+    assert.equal(collapsed, 0);
+});
+
+test("handles an empty result set", () => {
+    const { unique, collapsed } = collapseDuplicates([]);
+    assert.equal(unique.length, 0);
+    assert.equal(collapsed, 0);
+});

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -24,6 +24,41 @@ const RECALL_INPUT = {
         ),
 } as const;
 
+/** Key deciding whether two results say the same thing: trimmed, internal
+ * whitespace collapsed, case-folded. Deliberately exact-after-normalization
+ * rather than fuzzy or embedding-based — collapsing two facts that merely
+ * resemble each other would silently hide real information. Near-duplicate
+ * merging, if ever wanted, belongs behind an explicit opt-in. */
+function dedupeKey(text: string): string {
+    return text.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/**
+ * Collapse results carrying identical text, keeping the first occurrence.
+ *
+ * `recall` returns rows ranked best-first, so the survivor is the highest
+ * scoring copy.
+ *
+ * Storing the same fact twice is legitimate: each write is a distinct event
+ * with its own blob and timestamp, and there is no content-level uniqueness
+ * constraint by design (the only unique index is request idempotency on
+ * `remember_jobs (owner, idempotency_key)`). So this does NOT touch the write
+ * path. But returning N identical lines spends the model's entire retrieval
+ * budget on one fact and crowds out everything else it asked for, which is a
+ * read-side problem worth fixing on the read side.
+ */
+export function collapseDuplicates<T extends { text: string }>(
+    results: T[],
+): { unique: T[]; collapsed: number } {
+    const seen = new Map<string, T>();
+    for (const item of results) {
+        const key = dedupeKey(item.text);
+        if (!seen.has(key)) seen.set(key, item);
+    }
+    const unique = [...seen.values()];
+    return { unique, collapsed: results.length - unique.length };
+}
+
 /**
  * memwal_recall — semantic search over the user's Walrus Memory memories.
  *
@@ -58,10 +93,19 @@ export function registerRecallTool(
                     ],
                 };
             }
-            const lines = result.results.map(
+            const { unique, collapsed } = collapseDuplicates(result.results);
+            const lines = unique.map(
                 (m, i) =>
                     `${i + 1}. [score=${(1 - m.distance).toFixed(3)}] ${m.text}`
             );
+            // Say what was folded away rather than quietly returning fewer rows
+            // than the caller asked for. It also surfaces that the same fact was
+            // stored repeatedly, which is usually worth knowing.
+            if (collapsed > 0) {
+                lines.push(
+                    `\n(${collapsed} duplicate ${collapsed === 1 ? "copy" : "copies"} of the above collapsed; the same fact is stored more than once.)`
+                );
+            }
             return {
                 content: [
                     {


### PR DESCRIPTION
## Problem

A `limit=5` recall on a real dev account returned this:

```
1. [score=0.224] User prefers dark roast coffee
2. [score=0.224] User prefers dark roast coffee
3. [score=0.224] User prefers dark roast coffee
4. [score=0.224] User prefers dark roast coffee
5. [score=0.224] User prefers dark roast coffee
```

One preference consumed the entire retrieval budget. Every other memory the query should have surfaced was crowded out, and the model burned context on five copies of one sentence.

## Why the fix is on the read side, not the write side

Storing the same fact repeatedly is legitimate. Each `remember` is a distinct event with its own blob and timestamp, and there is deliberately no content-level uniqueness constraint: the only unique index on the write path is

```sql
-- 013_remember_write_idempotency_index.sql
CREATE UNIQUE INDEX ... ON remember_jobs (owner, idempotency_key)
    WHERE idempotency_key IS NOT NULL;
```

which is **request** idempotency, guarding a retried request from being processed twice. It says nothing about content, and a repo-wide search finds no content dedup anywhere in the MCP tools, the SDK, or the relayer.

So this is not a regression, it is a gap. Deduping on write would silently discard a genuine re-statement of a fact, which is worse than the duplicates. Collapsing on read is safe and fixes the actual symptom.

## Approach

`collapseDuplicates` folds results whose text matches after trimming, whitespace collapsing, and case folding, keeping the first occurrence. Rows arrive ranked best-first, so the survivor is the highest scoring copy.

Matching is **exact-after-normalization**, not fuzzy or embedding-based. Merging facts that merely resemble each other would hide real information; near-duplicate merging, if ever wanted, belongs behind an explicit opt-in.

The reply reports what was folded rather than quietly returning fewer rows than requested:

```
1. [score=0.224] User prefers dark roast coffee

(4 duplicate copies of the above collapsed; the same fact is stored more than once.)
```

That also surfaces the underlying repetition, which is usually worth knowing.

## Tests

`mcp/__tests__/recall-dedupe.test.ts`, 7 cases, including the two that matter most for safety:

* **leaves distinct facts untouched** — an over-eager dedupe is worse than the duplicates it removes
* **does not merely substring-match** — `"prefers dark roast coffee"` and `"prefers dark roast coffee in the morning only"` must both survive, since losing either is silent data loss

Plus rank-order preservation, highest-scoring-survivor, whitespace/case normalization, and the empty set.

`npm test` in services/server/scripts: **202 pass, 0 fail**.

## Not included

Back-filling the retrieval budget after collapsing (over-fetching so `limit=5` still returns 5 *distinct* facts) would need either an over-sample on every call, which multiplies SEAL decryption cost for the common no-duplicate case, or an adaptive second round trip. Worth doing, but it is a separate performance tradeoff and does not belong in this fix.

Found while verifying WALM-324. Unrelated to that fix and deliberately kept out of #681.
