### PR TITLE
fix(server): make storage quota admission atomic with insertion

### DIFF
--- a/services/server/migrations/014_storage_quota_reservations.sql
+++ b/services/server/migrations/014_storage_quota_reservations.sql
@@ -1,0 +1,30 @@
+-- Walrus Memory — Atomic Storage Quota Admission (GH #532 / WALM-359)
+--
+-- Before this migration, quota admission read SUM(blob_size_bytes) under a
+-- per-owner advisory lock, then released the lock before the caller inserted.
+-- Concurrent requests from one owner all observed the same pre-insert total
+-- and all passed, collectively exceeding the quota.
+--
+-- A reservation row is claimed inside the same locked transaction as the
+-- usage read, so admission and commitment are atomic. Reserved bytes are
+-- counted alongside vector_entries during admission, released once the row
+-- lands (or the write fails), and expire on their own as a backstop so a
+-- missed release cannot strand an owner's quota permanently.
+
+CREATE TABLE IF NOT EXISTS storage_quota_reservations (
+    -- For enqueued writes this is the remember_jobs id, so the wallet worker
+    -- can release without extra plumbing. For inline writes it is a synthetic
+    -- id owned by the request handler.
+    id          TEXT PRIMARY KEY,
+    owner       TEXT NOT NULL,
+    bytes       BIGINT NOT NULL CHECK (bytes >= 0),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Backstop only. Normal releases are explicit; this bounds the damage of
+    -- a process that dies between admission and insertion.
+    expires_at  TIMESTAMPTZ NOT NULL
+);
+
+-- Admission sums live reservations for one owner; expiry sweeps use the same
+-- index from the other direction.
+CREATE INDEX IF NOT EXISTS idx_storage_quota_reservations_owner_expires
+    ON storage_quota_reservations (owner, expires_at);

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -175,6 +175,35 @@ pub(crate) async fn warm_blob_cache_after_upload(
     }
 }
 
+/// Release the storage-quota reservation held for `remember_job_id`.
+///
+/// Enqueued writes reserve quota keyed by job id at admission time
+/// (`routes/remember.rs`, `routes/analyze.rs`), because the row is inserted
+/// here in the wallet worker long after the request returned. Releasing on the
+/// same key closes the admission/insert window that GH #532 exploited without
+/// threading a reservation handle through `WalletOperation`.
+///
+/// Best-effort and idempotent: reservations also expire on their own, so a
+/// failed release costs the owner temporary headroom, never a stuck quota.
+/// Callers must invoke this only on TERMINAL outcomes — a retryable failure
+/// still needs its reservation for the next attempt.
+async fn release_job_storage_reservation(pool: &sqlx::PgPool, remember_job_id: Option<&str>) {
+    let Some(jid) = remember_job_id else {
+        return;
+    };
+    if let Err(e) = sqlx::query("DELETE FROM storage_quota_reservations WHERE id = $1")
+        .bind(jid)
+        .execute(pool)
+        .await
+    {
+        tracing::warn!(
+            "failed to release storage reservation job_id={} err={} (will expire via TTL)",
+            jid,
+            e
+        );
+    }
+}
+
 async fn update_remember_job_after_wallet_error(
     pool: &sqlx::PgPool,
     remember_job_id: Option<&str>,
@@ -217,6 +246,12 @@ async fn update_remember_job_after_wallet_error(
     .bind(jid)
     .execute(pool)
     .await;
+
+    // Only terminal failures release: a retryable error leaves the row
+    // 'running' and the next attempt still needs its reserved bytes.
+    if error.aborts_retries() {
+        release_job_storage_reservation(pool, remember_job_id).await;
+    }
 }
 
 async fn mark_remember_job_failed(
@@ -239,6 +274,8 @@ async fn mark_remember_job_failed(
     if result.rows_affected() == 0 {
         return Err(sqlx::Error::RowNotFound);
     }
+
+    release_job_storage_reservation(pool, remember_job_id).await;
 
     Ok(())
 }
@@ -832,6 +869,11 @@ async fn insert_vector_and_mark_remember_done(
         );
         return Err(classified);
     }
+
+    // The vector_entries row is committed, so its bytes now count via
+    // SUM(blob_size_bytes). Holding the reservation any longer would
+    // double-charge the owner for this write.
+    release_job_storage_reservation(state.db.pool(), remember_job_id).await;
 
     if let Some(jid) = remember_job_id {
         let _ = sqlx::query(

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -613,46 +613,68 @@ pub async fn rate_limit_middleware(
 // Storage Quota Check (called from routes, not middleware)
 // ============================================================
 
-/// Check if a user has enough storage quota for a new blob.
+/// How long a storage reservation survives without an explicit release.
 ///
-/// Storage tracking still uses PostgreSQL (it's per-row in vector_entries).
-/// Returns `Ok(())` if within quota, `Err(AppError::QuotaExceeded)` if not.
+/// Only a backstop for a process that dies between admission and insertion.
+/// Sized above the wallet-job upload ceiling described in `AppState`
+/// (`wallet_lock_pool`, up to ~5 minutes) so a slow-but-healthy upload is
+/// never charged twice, while a lost reservation still frees itself.
+const STORAGE_RESERVATION_TTL_SECONDS: i64 = 900;
+
+/// Reserve storage quota for one or more pending writes, atomically.
 ///
-/// Uses PostgreSQL advisory lock per-owner to prevent
-/// TOCTOU race where concurrent requests all pass quota check then
-/// all write, collectively exceeding the limit.
-pub async fn check_storage_quota(
+/// Replaces the former `check_storage_quota`, whose advisory lock covered only
+/// the usage read and was released before the caller inserted, letting
+/// concurrent requests from one owner collectively exceed the quota (GH #532).
+///
+/// Each entry in `items` is `(reservation_id, bytes)`. Admission is
+/// all-or-nothing, preserving the previous behavior where a bulk request
+/// either fully passes or is rejected with a single error.
+///
+/// The caller MUST release each reservation once the row lands or the write
+/// terminally fails, via `release_storage_quota`. Reservations expire on their
+/// own after `STORAGE_RESERVATION_TTL_SECONDS` as a backstop, so a missed
+/// release costs an owner temporary headroom rather than permanent quota.
+pub async fn reserve_storage_quota(
     state: &AppState,
     owner: &str,
-    additional_bytes: i64,
+    items: &[(String, i64)],
 ) -> Result<(), AppError> {
     let max_bytes = state.config.rate_limit.max_storage_bytes;
 
-    // 0 or negative means unlimited
+    // 0 or negative means unlimited. Skip reserving entirely so unlimited
+    // deployments do not accumulate rows they will never read.
     if max_bytes <= 0 {
         return Ok(());
     }
 
-    // Acquire a per-owner PostgreSQL advisory lock.
-    // This serializes concurrent quota checks for the same owner,
-    // preventing TOCTOU race conditions.
-    // We use a stable hash of the owner string as the lock key.
+    // Per-owner advisory lock key. Held across the usage read AND the
+    // reservation insert inside `try_reserve_storage`.
     let lock_key = stable_hash_i64(owner);
 
-    // Use the combined method which uses an explicit transaction and pg_advisory_xact_lock
-    let used = state.db.get_storage_used_with_lock(owner, lock_key).await?;
-    let projected = used + additional_bytes;
+    let outcome = state
+        .db
+        .try_reserve_storage(
+            owner,
+            lock_key,
+            items,
+            max_bytes,
+            STORAGE_RESERVATION_TTL_SECONDS,
+        )
+        .await?;
 
-    if projected > max_bytes {
+    if let Err(used) = outcome {
+        let additional: i64 = items.iter().map(|(_, bytes)| *bytes).sum();
         let used_mb = used as f64 / 1_048_576.0;
         let max_mb = max_bytes as f64 / 1_048_576.0;
         tracing::warn!(
             "storage quota exceeded: owner={} used={:.1}MB + {:.1}MB > max={:.1}MB",
             owner,
             used_mb,
-            additional_bytes as f64 / 1_048_576.0,
+            additional as f64 / 1_048_576.0,
             max_mb
         );
+        // Message shape unchanged so existing clients keep parsing it.
         return Err(AppError::QuotaExceeded(format!(
             "Storage quota exceeded: {:.1}MB used of {:.1}MB allowed",
             used_mb, max_mb
@@ -660,6 +682,39 @@ pub async fn check_storage_quota(
     }
 
     Ok(())
+}
+
+/// Convenience wrapper for the single-write paths.
+pub async fn reserve_storage_quota_one(
+    state: &AppState,
+    owner: &str,
+    reservation_id: &str,
+    additional_bytes: i64,
+) -> Result<(), AppError> {
+    reserve_storage_quota(
+        state,
+        owner,
+        &[(reservation_id.to_string(), additional_bytes)],
+    )
+    .await
+}
+
+/// Release a reservation after the row has landed or the write has failed.
+///
+/// Never propagates an error: a failed release is recoverable (the TTL
+/// backstop reclaims it) and must not turn a successful write into a failed
+/// request, nor mask the original error on a failure path.
+pub async fn release_storage_quota(state: &AppState, reservation_id: &str) {
+    if state.config.rate_limit.max_storage_bytes <= 0 {
+        return;
+    }
+    if let Err(e) = state.db.release_storage_reservation(reservation_id).await {
+        tracing::warn!(
+            "failed to release storage reservation id={} err={} (will expire via TTL)",
+            reservation_id,
+            e
+        );
+    }
 }
 
 /// Compute a stable i64 hash of a string for use as PG advisory lock key.

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -372,8 +372,16 @@ pub async fn analyze(
     if state.config.benchmark_mode {
         // Quota check on plaintext byte length (benchmark mode has no
         // ciphertext — plaintext is the closest analog).
-        let total_plaintext_bytes: i64 = facts.iter().map(|f| f.text.len() as i64).sum();
-        rate_limit::check_storage_quota(&state, owner, total_plaintext_bytes).await?;
+        let quota_items: Vec<(String, i64)> = facts
+            .iter()
+            .map(|f| {
+                (
+                    format!("bench-{}", uuid::Uuid::new_v4()),
+                    f.text.len() as i64,
+                )
+            })
+            .collect();
+        rate_limit::reserve_storage_quota(&state, owner, &quota_items).await?;
 
         let store_tasks: Vec<_> = facts
             .iter()
@@ -413,6 +421,12 @@ pub async fn analyze(
             .collect();
 
         let store_results = collect_bounded_results(store_tasks, ANALYZE_CONCURRENCY).await;
+        // Release before the `?` below: rows that landed now count on their own,
+        // and a partial failure must not leave the owner charged for facts that
+        // were never stored.
+        for (reservation_id, _) in &quota_items {
+            rate_limit::release_storage_quota(&state, reservation_id).await;
+        }
         let mut stored_facts: Vec<AnalyzeAcceptedFact> = Vec::with_capacity(store_results.len());
         for r in store_results {
             stored_facts.push(r?);
@@ -485,24 +499,33 @@ pub async fn analyze(
 
     let prep_results = collect_bounded_results(prep_tasks, ANALYZE_CONCURRENCY).await;
 
-    // Quota check on total ciphertext size
+    // Storage-quota admission on total ciphertext size
     let mut prepared: Vec<(String, f32, Vec<f32>, Vec<u8>)> =
         Vec::with_capacity(prep_results.len());
-    let mut total_encrypted_bytes: i64 = 0;
     for r in prep_results {
         let (fact_text, importance, vector, encrypted) = r?;
-        total_encrypted_bytes += encrypted.len() as i64;
         prepared.push((fact_text, importance, vector, encrypted));
     }
-    rate_limit::check_storage_quota(&state, owner, total_encrypted_bytes).await?;
+    // Job ids are generated up front so each reservation is keyed by the job
+    // whose wallet worker will release it after the row lands.
+    let pending_job_ids: Vec<String> = prepared
+        .iter()
+        .map(|_| uuid::Uuid::new_v4().to_string())
+        .collect();
+    let quota_items: Vec<(String, i64)> = prepared
+        .iter()
+        .zip(pending_job_ids.iter())
+        .map(|((_, _, _, encrypted), job_id)| (job_id.clone(), encrypted.len() as i64))
+        .collect();
+    rate_limit::reserve_storage_quota(&state, owner, &quota_items).await?;
 
     // Step 3: For each prepared fact — insert remember_jobs row + enqueue WalletJob.
     // Round-robin across wallet pool so facts upload in parallel.
     let mut job_ids: Vec<String> = Vec::with_capacity(prepared.len());
     let mut accepted_facts: Vec<AnalyzeAcceptedFact> = Vec::with_capacity(prepared.len());
-    for (fact_text, importance, vector, encrypted) in prepared {
-        let job_id = uuid::Uuid::new_v4().to_string();
-
+    for ((fact_text, importance, vector, encrypted), job_id) in
+        prepared.into_iter().zip(pending_job_ids.into_iter())
+    {
         // Insert status row
         sqlx::query(
             "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -81,6 +81,11 @@ async fn mark_remember_job_failed(
     .bind(prepare_claim_token)
     .execute(state.db.pool())
     .await;
+
+    // Preparation failed after admission, so the write will never land.
+    // Release the reservation now rather than leaving the owner charged for it
+    // until the TTL backstop expires.
+    rate_limit::release_storage_quota(state, job_id).await;
 }
 
 async fn mark_remember_jobs_failed(state: &AppState, job_ids: &[String], msg: &str) {
@@ -94,6 +99,11 @@ async fn mark_remember_jobs_failed(state: &AppState, job_ids: &[String], msg: &s
     .bind(job_ids)
     .execute(state.db.pool())
     .await;
+
+    // Same as the single-job path: nothing will be inserted for these ids.
+    for job_id in job_ids {
+        rate_limit::release_storage_quota(state, job_id).await;
+    }
 }
 
 // ============================================================
@@ -149,7 +159,15 @@ fn spawn_prepare_remember_job(
                 let vector = vector_result?;
                 let encrypted = encrypted_result?;
 
-                rate_limit::check_storage_quota(&state, &owner, encrypted.len() as i64).await?;
+                // Reservation is keyed by job_id: the wallet worker releases it
+                // once the row lands or the job terminally fails.
+                rate_limit::reserve_storage_quota_one(
+                    &state,
+                    &owner,
+                    &job_id,
+                    encrypted.len() as i64,
+                )
+                .await?;
 
                 let wallet_index = state.key_pool.next_index().ok_or_else(|| {
                     AppError::Internal(
@@ -305,14 +323,21 @@ fn spawn_prepare_bulk_remember_job(
 
                 let mut prepared: Vec<(String, String, Vec<f32>, Vec<u8>)> =
                     Vec::with_capacity(prep_results.len());
-                let mut total_encrypted_bytes: i64 = 0;
                 for result in prep_results {
                     let (job_id, namespace, vector, encrypted) = result?;
-                    total_encrypted_bytes += encrypted.len() as i64;
                     prepared.push((job_id, namespace, vector, encrypted));
                 }
 
-                rate_limit::check_storage_quota(&state, &owner, total_encrypted_bytes).await?;
+                // One reservation per item, admitted all-or-nothing in a single
+                // locked transaction, so bulk keeps its previous semantics while
+                // each item can be released independently by its wallet job.
+                let quota_items: Vec<(String, i64)> = prepared
+                    .iter()
+                    .map(|(job_id, _, _, encrypted)| (job_id.clone(), encrypted.len() as i64))
+                    .collect();
+                let total_encrypted_bytes: i64 =
+                    quota_items.iter().map(|(_, bytes)| *bytes).sum();
+                rate_limit::reserve_storage_quota(&state, &owner, &quota_items).await?;
 
                 let mut bulk_items: Vec<BulkRememberItem> = Vec::with_capacity(prepared.len());
                 for (job_id, namespace, vector, encrypted) in prepared {
@@ -1352,14 +1377,23 @@ pub async fn remember_manual(
         .decode(&body.encrypted_data)
         .map_err(|e| AppError::BadRequest(format!("encrypted_data is not valid base64: {}", e)))?;
 
-    // Check storage quota before upload (quota enforcement stays here —
-    // the engine owns persistence, not policy).
-    rate_limit::check_storage_quota(&state, owner, encrypted_bytes.len() as i64).await?;
+    // Reserve storage quota before upload (quota enforcement stays here —
+    // the engine owns persistence, not policy). This path inserts inline, so
+    // the handler holds the reservation across store_blob and releases it
+    // either way once the row has landed or the write has failed.
+    let reservation_id = format!("manual-{}", uuid::Uuid::new_v4());
+    rate_limit::reserve_storage_quota_one(
+        &state,
+        owner,
+        &reservation_id,
+        encrypted_bytes.len() as i64,
+    )
+    .await?;
 
     // Persist via the storage engine: Walrus upload (pool key pays gas,
     // configured storage epochs, immediate transfer to owner) -> Postgres index row.
     // Same logic as before, now in engine/walrus_seal.rs::store_blob.
-    let mref = state
+    let stored = state
         .engine
         .store_blob(
             owner,
@@ -1374,7 +1408,12 @@ pub async fn remember_manual(
             crate::services::extractor::IMPORTANCE_STANDARD,
             Some(&auth.public_key),
         )
-        .await?;
+        .await;
+    // Release before propagating: on success the row now counts on its own, and
+    // on failure nothing was stored, so holding the reservation would only
+    // charge the owner for a write that never happened.
+    rate_limit::release_storage_quota(&state, &reservation_id).await;
+    let mref = stored?;
     let id = mref.id;
     let blob_id = mref.blob_id;
 

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -46,6 +46,7 @@ mod tests {
             include_str!("../../migrations/008_benchmark_plaintext.sql"),
             include_str!("../../migrations/009_importance_signal.sql"),
             include_str!("../../migrations/010_restore_failed_blobs.sql"),
+            include_str!("../../migrations/014_storage_quota_reservations.sql"),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -344,6 +345,323 @@ mod tests {
             .await
             .unwrap();
     }
+
+    // ============================================================
+    // Storage quota admission atomicity (GH #532 / WALM-359)
+    //
+    // Before the fix these burst tests admitted 12 to 20 of 20 and the owner
+    // finished over quota; the delayed-insert case, which models the enqueued
+    // write paths, reached 20/20. They now assert exactly one admission.
+    // ============================================================
+
+    const QUOTA_TEST_MAX: i64 = 1_073_741_824; // rate_limit.rs default
+    const QUOTA_TEST_REQ: i64 = 1_557_504; // max manual ciphertext
+    const QUOTA_TEST_BURST: usize = 20; // 60 weighted/min ÷ weight 3
+    const QUOTA_TEST_TTL: i64 = 900;
+
+    /// Pool sized like production (`VectorDb::new` uses 10) so the burst is
+    /// genuinely concurrent rather than serialized by pool starvation.
+    async fn quota_test_db() -> Option<VectorDb> {
+        let database_url = test_database_url()?;
+        let pool = PgPoolOptions::new()
+            .max_connections(10)
+            .acquire_timeout(Duration::from_secs(20))
+            .connect(&database_url)
+            .await
+            .expect("test database should be available");
+        let _guard = VECTOR_SCHEMA_SETUP_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        for migration in [
+            include_str!("../../migrations/001_init.sql"),
+            include_str!("../../migrations/002_add_namespace.sql"),
+            include_str!("../../migrations/003_rate_limiter.sql"),
+            include_str!("../../migrations/008_benchmark_plaintext.sql"),
+            include_str!("../../migrations/009_importance_signal.sql"),
+            include_str!("../../migrations/010_restore_failed_blobs.sql"),
+            include_str!("../../migrations/014_storage_quota_reservations.sql"),
+        ] {
+            sqlx::raw_sql(migration).execute(&pool).await.unwrap();
+        }
+        Some(VectorDb { pool })
+    }
+
+    fn quota_lock_key(s: &str) -> i64 {
+        // Mirrors rate_limit::stable_hash_i64 (private to that module).
+        const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+        const FNV_PRIME: u64 = 1_099_511_628_211;
+        let mut hash = FNV_OFFSET;
+        for b in s.as_bytes() {
+            hash ^= *b as u64;
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        (hash & 0x7FFF_FFFF_FFFF_FFFF) as i64
+    }
+
+    /// Seed the owner so exactly ONE more request fits under the quota.
+    async fn quota_seed_one_slot(db: &VectorDb, owner: &str) {
+        sqlx::query(
+            "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, importance)
+             VALUES ($1, $2, 'default', $3, $4, $5, 0.5)",
+        )
+        .bind(format!("seed-{owner}"))
+        .bind(owner)
+        .bind(format!("seedblob-{owner}"))
+        .bind(pgvector::Vector::from(vec![0.05f32; 1536]))
+        .bind(QUOTA_TEST_MAX - QUOTA_TEST_REQ - 1024)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    }
+
+    async fn quota_total(db: &VectorDb, owner: &str) -> i64 {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(blob_size_bytes)::BIGINT, 0) FROM vector_entries WHERE owner = $1",
+        )
+        .bind(owner)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        row.0
+    }
+
+    async fn quota_cleanup(db: &VectorDb, owner: &str) {
+        sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
+            .bind(owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM storage_quota_reservations WHERE owner = $1")
+            .bind(owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    /// Run a concurrent burst. `gap_ms` models the enqueued paths, where the
+    /// insert happens in the wallet worker after a Walrus upload.
+    async fn quota_burst(gap_ms: u64) -> (usize, i64) {
+        let Some(db) = quota_test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return (usize::MAX, 0);
+        };
+        let db = std::sync::Arc::new(db);
+        let owner = format!("quota-burst-{}", uuid::Uuid::new_v4());
+        let lock_key = quota_lock_key(&owner);
+        quota_seed_one_slot(&db, &owner).await;
+
+        let mut handles = Vec::new();
+        for i in 0..QUOTA_TEST_BURST {
+            let db = std::sync::Arc::clone(&db);
+            let owner = owner.clone();
+            handles.push(tokio::spawn(async move {
+                let reservation_id = format!("{owner}-{i}");
+                let admitted = db
+                    .try_reserve_storage(
+                        &owner,
+                        lock_key,
+                        &[(reservation_id.clone(), QUOTA_TEST_REQ)],
+                        QUOTA_TEST_MAX,
+                        QUOTA_TEST_TTL,
+                    )
+                    .await
+                    .unwrap();
+                if admitted.is_err() {
+                    return false;
+                }
+                if gap_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(gap_ms)).await;
+                }
+                db.insert_vector(
+                    &reservation_id,
+                    &owner,
+                    "default",
+                    &format!("blob-{reservation_id}"),
+                    &vec![0.1f32; 1536],
+                    QUOTA_TEST_REQ,
+                    0.5,
+                )
+                .await
+                .unwrap();
+                db.release_storage_reservation(&reservation_id)
+                    .await
+                    .unwrap();
+                true
+            }));
+        }
+        let mut admitted = 0usize;
+        for h in handles {
+            if h.await.unwrap() {
+                admitted += 1;
+            }
+        }
+        let total = quota_total(&db, &owner).await;
+        quota_cleanup(&db, &owner).await;
+        (admitted, total)
+    }
+
+    /// Inline write paths (`remember_manual`, benchmark analyze).
+    #[tokio::test]
+    async fn storage_quota_burst_admits_exactly_one_inline() {
+        let (admitted, total) = quota_burst(0).await;
+        if admitted == usize::MAX {
+            return;
+        }
+        assert_eq!(
+            admitted, 1,
+            "expected exactly one admission, got {admitted}"
+        );
+        assert!(
+            total <= QUOTA_TEST_MAX,
+            "quota breached: total={total} max={QUOTA_TEST_MAX}"
+        );
+    }
+
+    /// Enqueued write paths: the insert lands long after admission returns.
+    /// This is the case that reached 20/20 bypass before the fix.
+    #[tokio::test]
+    async fn storage_quota_burst_admits_exactly_one_with_delayed_insert() {
+        let (admitted, total) = quota_burst(150).await;
+        if admitted == usize::MAX {
+            return;
+        }
+        assert_eq!(
+            admitted, 1,
+            "delayed insert must not widen the admission window, got {admitted}"
+        );
+        assert!(
+            total <= QUOTA_TEST_MAX,
+            "quota breached: total={total} max={QUOTA_TEST_MAX}"
+        );
+    }
+
+    /// A released reservation must return its bytes to the owner.
+    #[tokio::test]
+    async fn released_reservation_frees_quota() {
+        let Some(db) = quota_test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let owner = format!("quota-release-{}", uuid::Uuid::new_v4());
+        let lock_key = quota_lock_key(&owner);
+        quota_seed_one_slot(&db, &owner).await;
+        let items = vec![("rsv-a".to_string(), QUOTA_TEST_REQ)];
+
+        assert!(db
+            .try_reserve_storage(&owner, lock_key, &items, QUOTA_TEST_MAX, QUOTA_TEST_TTL)
+            .await
+            .unwrap()
+            .is_ok());
+        // Second attempt is refused while the first is outstanding.
+        assert!(db
+            .try_reserve_storage(
+                &owner,
+                lock_key,
+                &[("rsv-b".to_string(), QUOTA_TEST_REQ)],
+                QUOTA_TEST_MAX,
+                QUOTA_TEST_TTL
+            )
+            .await
+            .unwrap()
+            .is_err());
+
+        db.release_storage_reservation("rsv-a").await.unwrap();
+
+        // Freed again once released.
+        assert!(db
+            .try_reserve_storage(
+                &owner,
+                lock_key,
+                &[("rsv-b".to_string(), QUOTA_TEST_REQ)],
+                QUOTA_TEST_MAX,
+                QUOTA_TEST_TTL
+            )
+            .await
+            .unwrap()
+            .is_ok());
+
+        db.release_storage_reservation("rsv-b").await.unwrap();
+        quota_cleanup(&db, &owner).await;
+    }
+
+    /// A reservation whose release was lost must not strand quota forever.
+    #[tokio::test]
+    async fn expired_reservation_does_not_strand_quota() {
+        let Some(db) = quota_test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let owner = format!("quota-expiry-{}", uuid::Uuid::new_v4());
+        let lock_key = quota_lock_key(&owner);
+        quota_seed_one_slot(&db, &owner).await;
+
+        // TTL of 0 leaves an already-expired reservation, standing in for a
+        // worker that died between admission and insertion.
+        assert!(db
+            .try_reserve_storage(
+                &owner,
+                lock_key,
+                &[("rsv-stale".to_string(), QUOTA_TEST_REQ)],
+                QUOTA_TEST_MAX,
+                0
+            )
+            .await
+            .unwrap()
+            .is_ok());
+
+        // The next admission sweeps it and succeeds rather than being blocked.
+        assert!(db
+            .try_reserve_storage(
+                &owner,
+                lock_key,
+                &[("rsv-next".to_string(), QUOTA_TEST_REQ)],
+                QUOTA_TEST_MAX,
+                QUOTA_TEST_TTL
+            )
+            .await
+            .unwrap()
+            .is_ok());
+
+        db.release_storage_reservation("rsv-next").await.unwrap();
+        quota_cleanup(&db, &owner).await;
+    }
+
+    /// Bulk admission stays all-or-nothing: a batch that does not fit reserves
+    /// nothing, so a partial batch is never silently admitted.
+    #[tokio::test]
+    async fn bulk_admission_is_all_or_nothing() {
+        let Some(db) = quota_test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let owner = format!("quota-bulk-{}", uuid::Uuid::new_v4());
+        let lock_key = quota_lock_key(&owner);
+        quota_seed_one_slot(&db, &owner).await; // room for exactly one
+
+        let two = vec![
+            ("bulk-1".to_string(), QUOTA_TEST_REQ),
+            ("bulk-2".to_string(), QUOTA_TEST_REQ),
+        ];
+        assert!(
+            db.try_reserve_storage(&owner, lock_key, &two, QUOTA_TEST_MAX, QUOTA_TEST_TTL)
+                .await
+                .unwrap()
+                .is_err(),
+            "a batch exceeding the quota must be rejected as a whole"
+        );
+
+        let leaked: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)::BIGINT FROM storage_quota_reservations WHERE owner = $1",
+        )
+        .bind(&owner)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(leaked.0, 0, "rejected batch must not leave reservations");
+
+        quota_cleanup(&db, &owner).await;
+    }
 }
 
 fn db_status<T>(result: &Result<T, AppError>) -> &'static str {
@@ -457,6 +775,13 @@ impl VectorDb {
             .execute(&pool)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 013: {}", e)))?;
+
+        // Atomic storage-quota admission (GH #532).
+        let migration_014 = include_str!("../../migrations/014_storage_quota_reservations.sql");
+        sqlx::raw_sql(migration_014)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 014: {}", e)))?;
 
         tracing::info!("database connected and migrations applied");
 
@@ -939,16 +1264,32 @@ impl VectorDb {
     // Storage Quota (still PostgreSQL — tracks per-row blob sizes)
     // ============================================================
 
-    /// Acquire an advisory lock and get storage used within a single transaction.
+    /// Atomically admit `items` against `owner`'s storage quota.
     ///
-    /// Using `pg_advisory_lock` with a connection pool causes deadlocks
-    /// because it's session-level. We use `pg_advisory_xact_lock` inside an explicit
-    /// transaction so the lock is automatically released on commit/rollback.
-    pub async fn get_storage_used_with_lock(
+    /// Holds `pg_advisory_xact_lock` across BOTH the usage read and the
+    /// reservation insert, so concurrent callers for one owner serialize and
+    /// each sees the previous one's commitment. This is the property
+    /// `get_storage_used_with_lock` lacked: it committed (releasing the lock)
+    /// before its caller inserted, so every concurrent caller read the same
+    /// pre-insert total and all passed (GH #532).
+    ///
+    /// Mirrors the shape already used by `security_delete_store::claim_blobs`,
+    /// where `lock_and_check_cap` and `insert_batch` share one transaction.
+    ///
+    /// Admission is all-or-nothing across `items`, preserving the existing
+    /// behavior where a bulk request either fully passes or is rejected.
+    ///
+    /// Returns `Ok(Ok(()))` when admitted, or `Ok(Err(used_bytes))` when the
+    /// request would exceed `max_bytes`, where `used_bytes` is the owner's
+    /// current committed + reserved usage (for the error message).
+    pub async fn try_reserve_storage(
         &self,
         owner: &str,
         lock_key: i64,
-    ) -> Result<i64, AppError> {
+        items: &[(String, i64)],
+        max_bytes: i64,
+        ttl_seconds: i64,
+    ) -> Result<Result<(), i64>, AppError> {
         let started = std::time::Instant::now();
         let mut tx = self
             .pool
@@ -962,7 +1303,17 @@ impl VectorDb {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to acquire advisory lock: {}", e)))?;
 
-        let row: (i64,) = sqlx::query_as(
+        // Expired reservations must not count against the owner. Sweeping them
+        // inside the lock keeps the read below consistent with the insert.
+        sqlx::query(
+            "DELETE FROM storage_quota_reservations WHERE owner = $1 AND expires_at <= NOW()",
+        )
+        .bind(owner)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to sweep reservations: {}", e)))?;
+
+        let committed: (i64,) = sqlx::query_as(
             "SELECT COALESCE(SUM(blob_size_bytes)::BIGINT, 0) FROM vector_entries WHERE owner = $1",
         )
         .bind(owner)
@@ -970,12 +1321,75 @@ impl VectorDb {
         .await
         .map_err(|e| AppError::Internal(format!("Failed to get storage used: {}", e)))?;
 
+        let reserved: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(bytes)::BIGINT, 0) FROM storage_quota_reservations WHERE owner = $1",
+        )
+        .bind(owner)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to get reserved storage: {}", e)))?;
+
+        let used = committed.0 + reserved.0;
+        let additional: i64 = items.iter().map(|(_, bytes)| *bytes).sum();
+
+        if used + additional > max_bytes {
+            // Rollback rather than commit: the sweep above is not worth
+            // persisting on a rejected admission, and it will run again.
+            tx.rollback()
+                .await
+                .map_err(|e| AppError::Internal(format!("Failed to rollback tx: {}", e)))?;
+            crate::observability::observe_db(
+                "quota.try_reserve_storage",
+                "rejected",
+                started.elapsed(),
+            );
+            return Ok(Err(used));
+        }
+
+        for (id, bytes) in items {
+            sqlx::query(
+                "INSERT INTO storage_quota_reservations (id, owner, bytes, expires_at)
+                 VALUES ($1, $2, $3, NOW() + ($4 || ' seconds')::INTERVAL)
+                 ON CONFLICT (id) DO UPDATE SET
+                    owner = EXCLUDED.owner,
+                    bytes = EXCLUDED.bytes,
+                    expires_at = EXCLUDED.expires_at",
+            )
+            .bind(id)
+            .bind(owner)
+            .bind(bytes)
+            .bind(ttl_seconds.to_string())
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to reserve storage: {}", e)))?;
+        }
+
         tx.commit()
             .await
             .map_err(|e| AppError::Internal(format!("Failed to commit tx: {}", e)))?;
 
-        crate::observability::observe_db("quota.storage_used_with_lock", "ok", started.elapsed());
-        Ok(row.0)
+        crate::observability::observe_db("quota.try_reserve_storage", "ok", started.elapsed());
+        Ok(Ok(()))
+    }
+
+    /// Release a storage reservation once the row has landed, or once the
+    /// write has terminally failed. Idempotent: releasing an unknown or
+    /// already-released id is a no-op, so retries and duplicate terminal
+    /// transitions are safe.
+    pub async fn release_storage_reservation(&self, reservation_id: &str) -> Result<(), AppError> {
+        let started = std::time::Instant::now();
+        let result = sqlx::query("DELETE FROM storage_quota_reservations WHERE id = $1")
+            .bind(reservation_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to release reservation: {}", e)));
+        crate::observability::observe_db(
+            "quota.release_reservation",
+            db_status(&result),
+            started.elapsed(),
+        );
+        result?;
+        Ok(())
     }
 
     // ============================================================


### PR DESCRIPTION
Closes WALM-359. Fixes #532.

## The defect

`check_storage_quota` read `SUM(blob_size_bytes)` under a per-owner advisory lock, but `get_storage_used_with_lock` **committed** that transaction, releasing the lock, before the caller inserted anything. `pg_advisory_xact_lock` is transaction scoped, so the lock protected the read and nothing else. Concurrent requests from one owner all read the same pre-insert total, all passed a check that would have rejected them individually, and all wrote.

The comment claiming this closed a TOCTOU race was wrong, and is corrected here.

## Reproduced before fixing

Against the unmodified code on real Postgres 17.9 + pgvector, pool sized like production (`max_connections(10)`), 20 concurrent requests (the legal per-minute budget for `/api/remember/manual` at weight 3), real 1 GiB default quota, seeded so exactly one request fits:

| Scenario | Admitted | Overshoot |
|---|---|---|
| Inline path, no synchronization | 14 to 15 / 20 | +19 to +21 MiB |
| Enqueued path, 150 ms upload gap | 13 to 20 / 20 | +18 to +28 MiB |
| Staggered arrivals 25 ms apart | 7 / 20 | +8.9 MiB |
| Control: atomic check+insert | 1 / 20 | none |

Stable across 6 runs. No barrier or artificial synchronization: requests arriving 25 ms apart still overshoot, and the admitted count matches the predicted `floor(gap / stagger) + 1`. The control row differs only in holding the lock across both statements, which is what makes the harness credible rather than merely loud.

## The fix

Migration `014` adds `storage_quota_reservations`. `try_reserve_storage` holds the advisory lock across **both** the usage read and the reservation insert, so concurrent callers for one owner serialize and each sees the previous one's commitment.

This mirrors a pattern already shipped in this repo: `security_delete_store::claim_blobs` opens one transaction and calls `lock_and_check_cap` then `insert_batch` inside it. The difference was purely the signature, taking `&mut Transaction` rather than owning and committing one.

Reserved bytes count alongside committed rows at admission, and are released when the row lands or the write terminally fails.

**Why a reservation and not just one transaction.** A single transaction closes the inline paths, but three of the six write paths return from the request handler and insert later in the wallet worker, after a Walrus upload that `AppState` documents as taking up to five minutes. You cannot hold a Postgres transaction across that. The reservation covers both groups with one mechanism.

## Failure modes, deliberately

* **Lost release** (process dies between admission and insertion): reservations carry a 15 minute TTL and are swept at the next admission. The cost is temporary headroom, never permanently stranded quota. Covered by `expired_reservation_does_not_strand_quota`.
* **Retryable job failure**: keeps its reservation, because the next attempt still needs those bytes. Only terminal failures release.
* **Release fails**: logged and swallowed, never converted into a failed write, and never allowed to mask the original error on a failure path.
* **Rejected bulk batch**: reserves nothing, so a partial batch is never silently admitted. Covered by `bulk_admission_is_all_or_nothing`.

## Scope

Six call sites, not the three originally reported. `remember()` at `routes/remember.rs:152` was missing from the issue's list and has the same defect.

Inline (handler owns the reservation): `remember_manual`, analyze benchmark branch.
Enqueued (reservation keyed by job id, released by the wallet worker): `remember()`, `remember_bulk`, analyze main path.

Keying enqueued reservations by `remember_job_id` avoids threading a reservation handle through `WalletOperation`, since that id already reaches the insert site.

Releases are wired at every terminal outcome: success in `insert_vector_and_mark_remember_done`, terminal wallet failure in `update_remember_job_after_wallet_error`, `mark_remember_job_failed` in `jobs.rs`, and the two prepare-stage handlers in `routes/remember.rs`.

## Behavior preserved

* `402` status and the exact `"Storage quota exceeded: {used}MB used of {max}MB allowed"` message shape.
* Bulk admission stays all-or-nothing.
* `max_storage_bytes <= 0` still means unlimited, and now skips reserving entirely rather than accumulating rows nothing reads.
* Rate limiting is untouched.

## Verification

* `cargo test --bin memwal-server`: **552 passed, 0 failed**.
* 5 new real-Postgres regression tests, including the 20-way burst with a delayed insert, which is the case that previously reached 20/20 bypass and now admits exactly 1.
* `cargo clippy`: 0 errors.
* `cargo fmt`: clean on all touched files. Note `dev` has pre-existing formatting drift in `auth.rs`, `mcp_proxy.rs`, `routes/sponsor.rs`, and `types.rs`; I reverted those rather than bundling unrelated churn.
* Compiles clean under `cargo +1.88 build --release`, matching the Dockerfile's pinned toolchain.

**Not verified:** the Docker image build. It fails on this arm64 machine at the dependency stage (`qemu: uncaught target signal 11`, amd64 `rustc` segfaulting under emulation), and fails identically on unmodified `dev`, so it is environmental. That step consumes only `Cargo.toml`/`Cargo.lock`, neither of which this PR touches. CI should confirm.

## Deployment note

Migration `014` is additive (new table plus index, `IF NOT EXISTS`), with no change to existing tables and no backfill. Rollback is safe: reverting the code leaves an unused table.

No `RATE_LIMIT_STORAGE_BYTES` override exists in Railway `production`, `dev`, or `staging`, so all three run the 1 GiB default and are affected.
