### PR TITLE
fix: point empty 401s at memwal_login

### DIFF
--- a/.changeset/gh-696-401-login-message.md
+++ b/.changeset/gh-696-401-login-message.md
@@ -4,4 +4,4 @@
 
 Show an actionable `memwal_login` hint on unauthenticated 401s (#696).
 
-An empty 401 used to surface as `Walrus Memory server error (401): <no message>`, which gives first-time MCP callers nothing to do. `sanitizeServerError` now returns a short message pointing at `memwal_login`.
+An empty 401 used to surface as `Walrus Memory server error (401): <no message>`. `sanitizeServerError` now returns: Walrus Memory isn't signed in. Call the memwal_login tool, then retry.

--- a/.changeset/gh-696-401-login-message.md
+++ b/.changeset/gh-696-401-login-message.md
@@ -1,0 +1,7 @@
+---
+"@mysten-incubation/memwal": patch
+---
+
+Show an actionable `memwal_login` hint on unauthenticated 401s (#696).
+
+An empty 401 used to surface as `Walrus Memory server error (401): <no message>`, which gives first-time MCP callers nothing to do. `sanitizeServerError` now returns a short message pointing at `memwal_login`.

--- a/.changeset/gh-696-401-login-message.md
+++ b/.changeset/gh-696-401-login-message.md
@@ -1,7 +1,0 @@
----
-"@mysten-incubation/memwal": patch
----
-
-Show an actionable `memwal_login` hint on unauthenticated 401s (#696).
-
-An empty 401 used to surface as `Walrus Memory server error (401): <no message>`. `sanitizeServerError` now returns: Walrus Memory isn't signed in. Call the memwal_login tool, then retry.

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,8 +28,14 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.3. It adds client-side token estimation and recall token budgets with configurable truncation strategies, and updates the default relayer URL.
+  The latest TypeScript SDK release is 0.1.4. It points empty-body 401s at `memwal_login` instead of `<no message>`. 0.1.3 added client-side token estimation and recall token budgets, and updated the default relayer URL.
 ---
+
+## 0.1.4
+
+### Fixed
+
+- Empty-body 401s now tell first-time MCP callers to run `memwal_login` instead of showing `<no message>`. Credential 401s still point at the AUTH_REJECTED troubleshooting guide.
 
 ## 0.1.3
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mysten-incubation/memwal
 
+## 0.1.4
+
+### Fixed
+
+- Empty-body 401s now tell first-time MCP callers to run `memwal_login` instead of showing `<no message>`. Credential 401s still point at the AUTH_REJECTED troubleshooting guide.
+
 ## 0.1.3
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.1.3",
-    "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
+    "version": "0.1.4",
+    "description": "Walrus Memory \u2014 Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mysten-incubation/memwal",
     "version": "0.1.4",
-    "description": "Walrus Memory \u2014 Privacy-first AI memory SDK with Ed25519 delegate key auth",
+    "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -155,8 +155,8 @@ export function sanitizeServerError(
 ): { message: string; raw: string; serverCode?: string } {
     // Number() so a string "401" (some MCP / HTTP paths) still hits this branch.
     if (Number(status) === 401) {
-        // Empty body = no-session / bare relayer 401 (#696). Non-empty keeps
-        // the WALM-318 AUTH_REJECTED triage (wrong key / account / network).
+        // Empty body = no-session / bare relayer 401. Non-empty keeps
+        // the AUTH_REJECTED triage (wrong key / account / network).
         const empty = !String(rawBody ?? "").trim();
         return {
             message: empty

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -155,10 +155,11 @@ export function sanitizeServerError(
 ): { message: string; raw: string; serverCode?: string } {
     if (status === 401) {
         return {
+            // GH #696: empty/unauthenticated 401s used to surface as
+            // "Walrus Memory server error (401): <no message>". Point first-time
+            // MCP callers at memwal_login instead of a blank body.
             message:
-                "401 from relayer: typically wrong private key, key not registered on this account, " +
-                "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
-                "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",
+                "Walrus Memory server error (401): Not authenticated. Run memwal_login to connect your Sui wallet.",
             raw: rawBody,
             serverCode: "AUTH_REJECTED",
         };

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -159,7 +159,7 @@ export function sanitizeServerError(
             // "Walrus Memory server error (401): <no message>". Point first-time
             // MCP callers at memwal_login instead of a blank body.
             message:
-                "Walrus Memory server error (401): Not authenticated. Run memwal_login to connect your Sui wallet.",
+                "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.",
             raw: rawBody,
             serverCode: "AUTH_REJECTED",
         };

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -153,13 +153,17 @@ export function sanitizeServerError(
     status: number,
     rawBody: string,
 ): { message: string; raw: string; serverCode?: string } {
-    if (status === 401) {
+    // Number() so a string "401" (some MCP / HTTP paths) still hits this branch.
+    if (Number(status) === 401) {
+        // Empty body = no-session / bare relayer 401 (#696). Non-empty keeps
+        // the WALM-318 AUTH_REJECTED triage (wrong key / account / network).
+        const empty = !String(rawBody ?? "").trim();
         return {
-            // GH #696: empty/unauthenticated 401s used to surface as
-            // "Walrus Memory server error (401): <no message>". Point first-time
-            // MCP callers at memwal_login instead of a blank body.
-            message:
-                "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.",
+            message: empty
+                ? "Walrus Memory isn't signed in. Call the memwal_login tool, then retry."
+                : "401 from relayer: typically wrong private key, key not registered on this account, " +
+                  "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
+                  "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",
             raw: rawBody,
             serverCode: "AUTH_REJECTED",
         };

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -3,12 +3,17 @@ import test from "node:test";
 
 import { sanitizeServerError } from "../dist/utils.js";
 
-test("401 error message points to the troubleshooting guide", () => {
+test("401 without a session points at memwal_login instead of <no message>", () => {
     const { message, serverCode } = sanitizeServerError(401, "");
     assert.equal(serverCode, "AUTH_REJECTED");
-    assert.match(
+    assert.equal(
         message,
-        /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
-        "401 message should point callers at the full AUTH_REJECTED triage table"
+        "Walrus Memory server error (401): Not authenticated. Run memwal_login to connect your Sui wallet."
     );
+    assert.doesNotMatch(message, /<no message>/);
+});
+
+test("non-401 empty bodies still use the <no message> placeholder", () => {
+    const { message } = sanitizeServerError(500, "");
+    assert.equal(message, "Walrus Memory server error (500): <no message>");
 });

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -3,14 +3,31 @@ import test from "node:test";
 
 import { sanitizeServerError } from "../dist/utils.js";
 
-test("401 without a session points at memwal_login instead of <no message>", () => {
+const LOGIN =
+    "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.";
+
+test("empty-body 401 points at memwal_login instead of <no message>", () => {
     const { message, serverCode } = sanitizeServerError(401, "");
     assert.equal(serverCode, "AUTH_REJECTED");
-    assert.equal(
-        message,
-        "Walrus Memory isn't signed in. Call the memwal_login tool, then retry."
-    );
+    assert.equal(message, LOGIN);
     assert.doesNotMatch(message, /<no message>/);
+});
+
+test("string status \"401\" with an empty body uses the login hint", () => {
+    const { message, serverCode } = sanitizeServerError("401", "   ");
+    assert.equal(serverCode, "AUTH_REJECTED");
+    assert.equal(message, LOGIN);
+    assert.doesNotMatch(message, /<no message>/);
+});
+
+test("non-empty 401 keeps the AUTH_REJECTED troubleshooting URL", () => {
+    const { message, serverCode } = sanitizeServerError(401, "auth rejected");
+    assert.equal(serverCode, "AUTH_REJECTED");
+    assert.match(
+        message,
+        /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
+    );
+    assert.doesNotMatch(message, /memwal_login/);
 });
 
 test("non-401 empty bodies still use the <no message> placeholder", () => {

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -8,7 +8,7 @@ test("401 without a session points at memwal_login instead of <no message>", () 
     assert.equal(serverCode, "AUTH_REJECTED");
     assert.equal(
         message,
-        "Walrus Memory server error (401): Not authenticated. Run memwal_login to connect your Sui wallet."
+        "Walrus Memory isn't signed in. Call the memwal_login tool, then retry."
     );
     assert.doesNotMatch(message, /<no message>/);
 });

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 const releases = [
     {
         name: "TypeScript SDK",
-        version: "0.1.3",
+        version: "0.1.4",
         manifests: [["packages/sdk/package.json", "version"]],
         changelogs: ["packages/sdk/CHANGELOG.md", "docs/sdk/changelog.mdx"],
     },


### PR DESCRIPTION
## Summary
- Empty-body 401s were surfacing as `Walrus Memory server error (401): <no message>`.
- `sanitizeServerError` now returns the locked login hint for empty / whitespace-only 401s (including string status `"401"`).
- Non-empty 401s keep the AUTH_REJECTED troubleshooting URL.
- Manual changelog + dump/version bump to **0.1.4** (`packages/sdk/CHANGELOG.md`, `docs/sdk/changelog.mdx`, `packages/sdk/package.json`, `scripts/verify-manual-sdk-release.mjs`).

Exact empty-401 string:
`Walrus Memory isn't signed in. Call the memwal_login tool, then retry.`

Fixes #696

## Test plan
- [ ] Empty-body 401 (number and string `"401"`) equals `Walrus Memory isn't signed in. Call the memwal_login tool, then retry.`
- [ ] Non-empty 401 still mentions `docs.wal.app/walrus-memory/troubleshooting/overview` and does not mention `memwal_login`
- [ ] Non-401 empty body still renders `Walrus Memory server error (<status>): <no message>`
- [ ] `scripts/verify-manual-sdk-release.mjs` accepts TypeScript SDK 0.1.4
- [ ] Call a `memwal_*` tool without a session and confirm the login hint (no `<no message>`)
- [ ] After `memwal_login`, the same tool succeeds or fails with a non-placeholder message