### PR TITLE
fix: point empty/unauthenticated 401s at memwal_login (#696)

### DIFF
--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -167,6 +167,8 @@ const LOGIN_BG_TIMEOUT_MS = 5 * 60_000;
 const URL_READY_TIMEOUT_MS = 5_000;
 
 const LOGIN_INSTRUCTION = [
+    "Not authenticated. Run memwal_login to connect your Sui wallet.",
+    "",
     "❌ Walrus Memory isn't signed in yet.",
     "",
     "**Easiest fix — call the `memwal_login` tool from this client.** It opens a browser,",

--- a/packages/mcp/test/login-handoff.test.mjs
+++ b/packages/mcp/test/login-handoff.test.mjs
@@ -216,6 +216,11 @@ test("auth-required mode picks up credentials mid-session without a restart", as
     assert.equal(before.result.isError, true, "should be an error before login");
     assert.match(
         JSON.stringify(before.result),
+        /Not authenticated\. Run memwal_login to connect your Sui wallet\./,
+        "should return the exact unauthenticated memwal_login hint",
+    );
+    assert.match(
+        JSON.stringify(before.result),
         /isn't signed in|not signed in/i,
         "should nudge the user to log in",
     );

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -142,23 +142,50 @@ export function normalizeServerUrl(url: string): string {
 // ============================================================
 
 /**
+ * User-facing copy for a 401 with no session / empty body (GH #696).
+ * MCP tools should point first-time callers at `memwal_login`.
+ */
+export const UNAUTHENTICATED_LOGIN_MESSAGE =
+    "Not authenticated. Run memwal_login to connect your Sui wallet.";
+
+const AUTH_REJECTED_MESSAGE =
+    "401 from relayer: typically wrong private key, key not registered on this account, " +
+    "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
+    "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors";
+
+/**
  * LOW-26: Sanitize a raw server error body before surfacing it to callers.
  *
  * - Strips ASCII control characters.
  * - Truncates to at most 200 chars so stack traces / dumps don't leak.
  * - Leaves the untrimmed payload accessible via the returned `raw`
  *   field for debug logging (never included in the thrown message).
+ * - Empty 401s lead with {@link UNAUTHENTICATED_LOGIN_MESSAGE} so MCP
+ *   callers get a memwal_login hint, then the AUTH_REJECTED triage.
  */
 export function sanitizeServerError(
     status: number,
     rawBody: string,
 ): { message: string; raw: string; serverCode?: string } {
-    if (status === 401) {
+    // Number() so a string "401" still hits this branch — otherwise the
+    // generic path would print `Walrus Memory server error (401): <no message>`.
+    if (Number(status) === 401) {
+        const empty = !String(rawBody ?? "").trim();
+        if (empty) {
+            // Relayer AUTH_REJECTED is a bare 401 (empty body, constant-time).
+            // MCP no-session callers hit the same empty 401. Lead with the
+            // memwal_login hint; keep the WALM-318 key/docs copy so signed
+            // SDK callers still get the AUTH_REJECTED triage.
+            return {
+                message:
+                    `Walrus Memory server error (401): ${UNAUTHENTICATED_LOGIN_MESSAGE} ` +
+                    AUTH_REJECTED_MESSAGE,
+                raw: rawBody,
+                serverCode: "AUTH_REJECTED",
+            };
+        }
         return {
-            message:
-                "401 from relayer: typically wrong private key, key not registered on this account, " +
-                "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
-                "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",
+            message: AUTH_REJECTED_MESSAGE,
             raw: rawBody,
             serverCode: "AUTH_REJECTED",
         };

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -1,14 +1,40 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { sanitizeServerError } from "../dist/utils.js";
+import { sanitizeServerError, UNAUTHENTICATED_LOGIN_MESSAGE } from "../dist/utils.js";
 
-test("401 error message points to the troubleshooting guide", () => {
+const LOGIN_HINT = "Not authenticated. Run memwal_login to connect your Sui wallet.";
+
+test("empty 401 points at memwal_login and keeps AUTH_REJECTED triage", () => {
     const { message, serverCode } = sanitizeServerError(401, "");
+    assert.equal(serverCode, "AUTH_REJECTED");
+    assert.equal(UNAUTHENTICATED_LOGIN_MESSAGE, LOGIN_HINT);
+    assert.equal(
+        message.startsWith(`Walrus Memory server error (401): ${LOGIN_HINT}`),
+        true,
+        "empty 401 should use the Walrus Memory prefix plus the memwal_login hint",
+    );
+    assert.match(
+        message,
+        /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
+        "401 message should still point callers at the AUTH_REJECTED triage table",
+    );
+});
+
+test("string status 401 does not fall through to <no message>", () => {
+    const { message, serverCode } = sanitizeServerError(/** @type {any} */ ("401"), "");
+    assert.equal(serverCode, "AUTH_REJECTED");
+    assert.match(message, /memwal_login/);
+    assert.doesNotMatch(message, /<no message>/);
+});
+
+test("non-empty 401 keeps the AUTH_REJECTED key-mismatch copy", () => {
+    const { message, serverCode } = sanitizeServerError(401, '{"code":"AUTH_REJECTED"}');
     assert.equal(serverCode, "AUTH_REJECTED");
     assert.match(
         message,
         /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
-        "401 message should point callers at the full AUTH_REJECTED triage table"
+        "401 message should point callers at the full AUTH_REJECTED triage table",
     );
+    assert.match(message, /wrong private key/);
 });


### PR DESCRIPTION
## Summary
- Empty-body 401s (relayer AUTH_REJECTED is a bare 401; MCP no-session looks the same) now lead with `Walrus Memory server error (401): Not authenticated. Run memwal_login to connect your Sui wallet.` instead of a blank / `<no message>` string.
- WALM-318 AUTH_REJECTED triage (wrong key / docs.wal.app) is still appended on empty 401s and unchanged on non-empty 401s. Clock-drift (`x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS`) is untouched.
- MCP auth-required mode (no `~/.memwal/credentials.json`) returns the same memwal_login sentence on any `memwal_*` tool call.

Fixes #696

## Test plan
- [x] `packages/sdk/test/sanitize-server-error.test.mjs`: empty 401 uses the memwal_login prefix + keeps the troubleshooting URL; string `"401"` does not print `<no message>`; non-empty 401 keeps AUTH_REJECTED copy
- [x] `packages/mcp/test/login-handoff.test.mjs`: pre-login `memwal_recall` includes the exact `Not authenticated. Run memwal_login to connect your Sui wallet.` sentence