### PR TITLE
fix(sdk): actionable message on empty 401 without a session

### DIFF
--- a/.changeset/gh-696-empty-401-login-message.md
+++ b/.changeset/gh-696-empty-401-login-message.md
@@ -1,0 +1,7 @@
+---
+"@mysten-incubation/memwal": patch
+---
+
+Show an actionable `memwal_login` hint on empty 401s without a session (#696).
+
+Calling a `memwal_*` tool with no session used to surface `Walrus Memory server error (401): <no message>` when status was forwarded as a string and skipped the 401 special-case. Empty 401s now return the login instruction; WALM-318 AUTH_REJECTED (401 with a body) and clock-drift (`x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS`) are unchanged.

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -142,23 +142,59 @@ export function normalizeServerUrl(url: string): string {
 // ============================================================
 
 /**
+ * GH #696 — user-facing copy when a memwal_* tool is called without a session.
+ * Locked string: do not paraphrase.
+ */
+export const MEMWAL_LOGIN_REQUIRED_MESSAGE =
+    "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.";
+
+const AUTH_REJECTED_MESSAGE =
+    "401 from relayer: typically wrong private key, key not registered on this account, " +
+    "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
+    "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors";
+
+/**
+ * Relayer 401s are sometimes forwarded with status as a string (JSON-RPC /
+ * wrapTool / HTTP /api/mcp). Strict `=== 401` skipped the special-case and
+ * produced `Walrus Memory server error (401): <no message>`.
+ */
+function isUnauthorizedStatus(status: number | string): boolean {
+    return Number(status) === 401;
+}
+
+function isEmptyErrorBody(rawBody: string): boolean {
+    // eslint-disable-next-line no-control-regex
+    return !String(rawBody ?? "").replace(/[\u0000-\u001F\u007F]/g, " ").trim();
+}
+
+/**
  * LOW-26: Sanitize a raw server error body before surfacing it to callers.
  *
  * - Strips ASCII control characters.
  * - Truncates to at most 200 chars so stack traces / dumps don't leak.
  * - Leaves the untrimmed payload accessible via the returned `raw`
  *   field for debug logging (never included in the thrown message).
+ * - Empty 401 / string status "401" (no-session) returns
+ *   {@link MEMWAL_LOGIN_REQUIRED_MESSAGE} instead of `<no message>`.
  */
 export function sanitizeServerError(
-    status: number,
+    status: number | string,
     rawBody: string,
 ): { message: string; raw: string; serverCode?: string } {
-    if (status === 401) {
+    if (isUnauthorizedStatus(status)) {
+        // Empty 401 is the relayer's constant-time reject *and* the no-session
+        // case memwal_* callers hit. Distinguish AUTH_REJECTED when the body
+        // carries a rejection signal (WALM-318). Clock-drift 401s never reach
+        // here — signedRequest / manual.ts throw via clockDriftErrorFromResponse.
+        if (isEmptyErrorBody(rawBody)) {
+            return {
+                message: MEMWAL_LOGIN_REQUIRED_MESSAGE,
+                raw: rawBody,
+                serverCode: "UNAUTHENTICATED",
+            };
+        }
         return {
-            message:
-                "401 from relayer: typically wrong private key, key not registered on this account, " +
-                "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
-                "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",
+            message: AUTH_REJECTED_MESSAGE,
             raw: rawBody,
             serverCode: "AUTH_REJECTED",
         };

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -3,12 +3,36 @@ import test from "node:test";
 
 import { sanitizeServerError } from "../dist/utils.js";
 
-test("401 error message points to the troubleshooting guide", () => {
+const LOGIN_REQUIRED =
+    "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.";
+
+test("empty 401 / no-session is the memwal_login instruction, not <no message>", () => {
     const { message, serverCode } = sanitizeServerError(401, "");
+    assert.equal(message, LOGIN_REQUIRED);
+    assert.equal(serverCode, "UNAUTHENTICATED");
+    assert.doesNotMatch(message, /<no message>/);
+});
+
+test("string status \"401\" with an empty body also yields the login instruction", () => {
+    const { message, serverCode } = sanitizeServerError("401", "");
+    assert.equal(message, LOGIN_REQUIRED);
+    assert.equal(serverCode, "UNAUTHENTICATED");
+});
+
+test("401 error message points to the troubleshooting guide", () => {
+    const { message, serverCode } = sanitizeServerError(
+        401,
+        JSON.stringify({ error: "AUTH_REJECTED", message: "signature rejected" }),
+    );
     assert.equal(serverCode, "AUTH_REJECTED");
     assert.match(
         message,
         /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
         "401 message should point callers at the full AUTH_REJECTED triage table"
     );
+});
+
+test("non-401 empty bodies still use the <no message> placeholder", () => {
+    const { message } = sanitizeServerError(500, "");
+    assert.equal(message, "Walrus Memory server error (500): <no message>");
 });

--- a/services/server/scripts/mcp/__tests__/wrap-tool.test.ts
+++ b/services/server/scripts/mcp/__tests__/wrap-tool.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MEMWAL_LOGIN_REQUIRED_MESSAGE, wrapTool } from "../tools/util.js";
+
+const LOGIN_REQUIRED =
+    "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.";
+
+test("empty 401 / no-session surfaces the exact memwal_login instruction", async () => {
+    const handler = wrapTool(async () => {
+        const err = new Error("Walrus Memory server error (401): <no message>") as Error & {
+            status?: number | string;
+        };
+        err.status = 401;
+        throw err;
+    });
+
+    const result = await handler({});
+    assert.equal(result.isError, true);
+    assert.equal(result.content[0]?.text, LOGIN_REQUIRED);
+    assert.equal(result.content[0]?.text, MEMWAL_LOGIN_REQUIRED_MESSAGE);
+});
+
+test("string status 401 also surfaces the login instruction", async () => {
+    const handler = wrapTool(async () => {
+        const err = new Error("Walrus Memory server error (401): <no message>") as Error & {
+            status?: number | string;
+        };
+        err.status = "401";
+        throw err;
+    });
+
+    const result = await handler({});
+    assert.equal(result.content[0]?.text, LOGIN_REQUIRED);
+});
+
+test("clock-drift 401 is not rewritten into the login instruction", async () => {
+    const clockMsg =
+        "Request rejected: signed timestamp is outside the relayer's accepted clock-drift window. " +
+        "Synchronize this client's clock (NTP); if the deployment needs a wider tolerance, " +
+        "raise AUTH_MAX_CLOCK_DRIFT_SECS on the relayer.";
+    const handler = wrapTool(async () => {
+        const err = new Error(clockMsg) as Error & { status?: number; serverCode?: string };
+        err.status = 401;
+        err.serverCode = "ERR_TIMESTAMP_OUT_OF_BOUNDS";
+        throw err;
+    });
+
+    const result = await handler({});
+    assert.equal(result.isError, true);
+    assert.match(result.content[0]?.text ?? "", /clock-drift window/);
+    assert.doesNotMatch(result.content[0]?.text ?? "", /memwal_login/);
+});

--- a/services/server/scripts/mcp/tools/util.ts
+++ b/services/server/scripts/mcp/tools/util.ts
@@ -42,6 +42,29 @@ export function explorerFooter(): string {
     return `Explorer: ${walruscanBlobUrl("<blob_id>")} for any blob_id above.`;
 }
 
+/**
+ * GH #696 — same locked copy as SDK `MEMWAL_LOGIN_REQUIRED_MESSAGE`.
+ * wrapTool must return this *without* a "Tool error:" prefix so agents see
+ * the exact instruction.
+ */
+export const MEMWAL_LOGIN_REQUIRED_MESSAGE =
+    "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.";
+
+function isClockDriftError(err: any): boolean {
+    return err?.serverCode === "ERR_TIMESTAMP_OUT_OF_BOUNDS";
+}
+
+/** Empty / string-status 401, AUTH_REJECTED leftover, or `<no message>`. */
+function isLoginRequiredError(err: any): boolean {
+    if (isClockDriftError(err)) return false;
+    if (Number(err?.status) === 401) return true;
+    if (err?.serverCode === "UNAUTHENTICATED" || err?.serverCode === "AUTH_REJECTED") {
+        return true;
+    }
+    const msg = String(err?.message ?? "");
+    return msg.includes("<no message>") && (msg.includes("(401)") || msg.includes("401"));
+}
+
 export function wrapTool<Args>(
     handler: (args: Args) => Promise<ToolResultLike>
 ): (args: Args) => Promise<ToolResultLike> {
@@ -55,6 +78,13 @@ export function wrapTool<Args>(
             const causeStr = cause
                 ? ` | cause: ${cause?.message ?? String(cause)}`
                 : "";
+
+            if (isLoginRequiredError(err)) {
+                return {
+                    content: [{ type: "text", text: MEMWAL_LOGIN_REQUIRED_MESSAGE }],
+                    isError: true,
+                };
+            }
 
             // Operator-side diagnostic — full chain to sidecar stderr.
             console.error(


### PR DESCRIPTION
## Summary
- Calling `memwal_*` without a session surfaced `Walrus Memory server error (401): <no message>` because `sanitizeServerError` used strict `status === 401`. Relayer `auth.rs` returns a bare empty 401 (constant-time), and some MCP / HTTP `/api/mcp` / `wrapTool` paths forward status as the string `"401"`, so the special-case was skipped and the generic `<no message>` fallback won.
- Empty / string-status 401s now return exactly: `Walrus Memory isn't signed in. Call the memwal_login tool, then retry.` (`wrapTool` returns that line with no `Tool error:` prefix.)
- WALM-318 `AUTH_REJECTED` (401 **with** a body — wrong key / `.env.local` / troubleshooting URL) is unchanged. Clock-drift 401s (`x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS` via `clockDriftErrorFromResponse`) are unchanged. The stdio `LOGIN_INSTRUCTION` in `auth-required.ts` is unchanged.

Fixes #696

## Test plan
- [ ] `packages/sdk` unit test: empty-body 401 (number and string `"401"`) equals `Walrus Memory isn't signed in. Call the memwal_login tool, then retry.`
- [ ] Existing AUTH_REJECTED test still points at `docs.wal.app/walrus-memory/troubleshooting/overview` when the 401 body is non-empty
- [ ] Non-401 empty body still renders `Walrus Memory server error (500): <no message>`
- [ ] Sidecar `wrapTool` test: empty/`"401"` tool errors return the exact login string; clock-drift 401 is not rewritten
- [ ] Call a `memwal_*` tool without a session and confirm the text is the login instruction (no `<no message>`)
- [ ] After `memwal_login`, the same tool call succeeds or fails with a non-placeholder message
- [ ] Clock-drift 401 (`x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS`) still mentions synchronizing the client clock