### PR TITLE
fix(server): stop leaking sqlx migration locks through the Neon pooler

### DIFF
--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -41,6 +41,7 @@ use jobs::{
 use services::{CompositeRanker, Embedder, Extractor, LlmExtractor, OpenAiEmbedder, Ranker};
 use storage::db::VectorDb;
 use storage::legacy_db::LegacyDb;
+use storage::postgres_url::direct_postgres_url;
 use types::{
     AppState, Config, KeyPool, DEFAULT_BLOB_CACHE_MAX_BYTES, DEFAULT_BLOB_CACHE_TTL_SECS,
     DEFAULT_EMBEDDING_CACHE_TTL_SECS,
@@ -471,33 +472,17 @@ async fn init_apalis_pool(
     database_url: &str,
     startup_timeout: std::time::Duration,
 ) -> Result<sqlx::PgPool, String> {
-    let statement_timeout = format!("{}ms", startup_timeout.as_millis().min(300_000));
-    let lock_timeout_ms = (startup_timeout.as_millis() / 3).clamp(1_000, 30_000);
-    let lock_timeout = format!("{}ms", lock_timeout_ms);
-
     tracing::info!(
         "  Apalis: connecting to PostgreSQL (startup_timeout={}s)",
         startup_timeout.as_secs()
     );
+    // Do not `set_config(..., false)` on this pool. Those are session GUCs;
+    // through a transaction-mode pooler they leak onto backends later reused
+    // by unrelated code (legacy sqlx migrate inherited lock_timeout=15s and
+    // panicked — WALM-378). Boot is still bounded by the tokio timeouts below.
     let pool_future = PgPoolOptions::new()
         .max_connections(10)
         .acquire_timeout(startup_timeout)
-        .after_connect(move |conn, _meta| {
-            let statement_timeout = statement_timeout.clone();
-            let lock_timeout = lock_timeout.clone();
-            Box::pin(async move {
-                sqlx::query(
-                    "SELECT set_config('statement_timeout', $1, false), \
-                            set_config('lock_timeout', $2, false), \
-                            set_config('idle_in_transaction_session_timeout', $1, false)",
-                )
-                .bind(statement_timeout)
-                .bind(lock_timeout)
-                .execute(conn)
-                .await?;
-                Ok(())
-            })
-        })
         .connect(database_url);
 
     let pool = match tokio::time::timeout(startup_timeout, pool_future).await {
@@ -529,7 +514,31 @@ async fn init_apalis_pool(
     }
 
     tracing::info!("  Apalis: running PostgreSQL migrations");
-    match tokio::time::timeout(startup_timeout, PostgresStorage::<()>::setup(&pool)).await {
+    let migrate_url = direct_postgres_url(database_url);
+    let setup_pool_future = PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(startup_timeout)
+        .connect(migrate_url.as_ref());
+    let setup_pool = match tokio::time::timeout(startup_timeout, setup_pool_future).await {
+        Ok(Ok(setup_pool)) => setup_pool,
+        Ok(Err(err)) => {
+            return Err(format!(
+                "connect to PostgreSQL for Apalis migrations: {err}"
+            ))
+        }
+        Err(_) => {
+            return Err(format!(
+                "timed out after {}s connecting to PostgreSQL for Apalis migrations",
+                startup_timeout.as_secs()
+            ))
+        }
+    };
+    let setup_result = match tokio::time::timeout(
+        startup_timeout,
+        PostgresStorage::<()>::setup(&setup_pool),
+    )
+    .await
+    {
         Ok(Ok(())) => {
             tracing::info!("  Apalis: PostgreSQL migrations applied");
             Ok(pool)
@@ -539,7 +548,9 @@ async fn init_apalis_pool(
             "timed out after {}s running Apalis PostgreSQL migrations",
             startup_timeout.as_secs()
         )),
-    }
+    };
+    setup_pool.close().await;
+    setup_result
 }
 
 async fn apalis_schema_ready(pool: &sqlx::PgPool) -> Result<bool, sqlx::Error> {

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -476,13 +476,38 @@ async fn init_apalis_pool(
         "  Apalis: connecting to PostgreSQL (startup_timeout={}s)",
         startup_timeout.as_secs()
     );
-    // Do not `set_config(..., false)` on this pool. Those are session GUCs;
-    // through a transaction-mode pooler they leak onto backends later reused
-    // by unrelated code (legacy sqlx migrate inherited lock_timeout=15s and
-    // panicked). Boot is still bounded by the tokio timeouts below.
+    // Runtime query bounds for this pool (job fetch/update, not migrate).
+    //
+    // `set_config(..., true)` (SET LOCAL) in after_connect is a no-op:
+    // after_connect runs under autocommit, so Postgres discards the GUC when
+    // that statement's implicit transaction ends — runtime queries would
+    // then be unbounded. Session-scoped (`false`) is the only after_connect
+    // form that actually sticks.
+    //
+    // `lock_timeout` is intentionally omitted. A leaked session lock_timeout
+    // on a transaction-mode pooler backend is what aborted sqlx migrate
+    // (15s wait → panic). Migrate now uses the direct host, but we still
+    // don't put lock_timeout on pooled backends. statement_timeout and
+    // idle_in_transaction_session_timeout bound queries without aborting
+    // lock waits; if they leak onto another pooler client they are still
+    // a bound, not a migrate-killer.
+    let statement_timeout = format!("{}ms", startup_timeout.as_millis().min(300_000));
     let pool_future = PgPoolOptions::new()
         .max_connections(10)
         .acquire_timeout(startup_timeout)
+        .after_connect(move |conn, _meta| {
+            let statement_timeout = statement_timeout.clone();
+            Box::pin(async move {
+                sqlx::query(
+                    "SELECT set_config('statement_timeout', $1, false), \
+                            set_config('idle_in_transaction_session_timeout', $1, false)",
+                )
+                .bind(statement_timeout)
+                .execute(conn)
+                .await?;
+                Ok(())
+            })
+        })
         .connect(database_url);
 
     let pool = match tokio::time::timeout(startup_timeout, pool_future).await {
@@ -549,7 +574,18 @@ async fn init_apalis_pool(
             startup_timeout.as_secs()
         )),
     };
-    setup_pool.close().await;
+    // If setup already timed out because the connection is wedged, a graceful
+    // close can block boot indefinitely. Keep the same outer bound as the rest
+    // of this function and surface `setup_result` either way.
+    if tokio::time::timeout(startup_timeout, setup_pool.close())
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            timeout_secs = startup_timeout.as_secs(),
+            "  Apalis: timed out closing the migration pool; continuing"
+        );
+    }
     setup_result
 }
 

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -479,7 +479,7 @@ async fn init_apalis_pool(
     // Do not `set_config(..., false)` on this pool. Those are session GUCs;
     // through a transaction-mode pooler they leak onto backends later reused
     // by unrelated code (legacy sqlx migrate inherited lock_timeout=15s and
-    // panicked — WALM-378). Boot is still bounded by the tokio timeouts below.
+    // panicked). Boot is still bounded by the tokio timeouts below.
     let pool_future = PgPoolOptions::new()
         .max_connections(10)
         .acquire_timeout(startup_timeout)

--- a/services/server/src/storage/legacy_db.rs
+++ b/services/server/src/storage/legacy_db.rs
@@ -69,24 +69,21 @@ async fn apply_legacy_migrations(
     for attempt in 1..=LEGACY_MIGRATION_MAX_ATTEMPTS {
         match apply_legacy_migrations_once(migrate_url.as_ref(), search_path).await {
             Ok(()) => return Ok(()),
-            Err(error)
-                if migration_error_is_lock_contention(&error)
-                    && attempt < LEGACY_MIGRATION_MAX_ATTEMPTS =>
-            {
+            Err(failure) if failure.lock_contention && attempt < LEGACY_MIGRATION_MAX_ATTEMPTS => {
                 let delay = Duration::from_millis(500 * (1u64 << (attempt - 1).min(4)));
                 tracing::warn!(
                     attempt,
                     max_attempts = LEGACY_MIGRATION_MAX_ATTEMPTS,
                     retry_in_ms = delay.as_millis() as u64,
-                    error = %error,
+                    error = %failure.error,
                     "legacy migration lock contention; retrying. \
                      If this persists, an orphaned sqlx advisory lock is held on a pooled backend. \
                      Release it with pg_terminate_backend on the pg_locks pid."
                 );
                 tokio::time::sleep(delay).await;
-                last_error = Some(error);
+                last_error = Some(failure.error);
             }
-            Err(error) => return Err(error),
+            Err(failure) => return Err(failure.error),
         }
     }
     Err(last_error.unwrap_or_else(|| {
@@ -94,10 +91,24 @@ async fn apply_legacy_migrations(
     }))
 }
 
+struct LegacyMigrationAttemptError {
+    error: AppError,
+    lock_contention: bool,
+}
+
+impl From<AppError> for LegacyMigrationAttemptError {
+    fn from(error: AppError) -> Self {
+        Self {
+            error,
+            lock_contention: false,
+        }
+    }
+}
+
 async fn apply_legacy_migrations_once(
     migrate_url: &str,
     search_path: Option<&str>,
-) -> Result<(), AppError> {
+) -> Result<(), LegacyMigrationAttemptError> {
     let mut options = PgConnectOptions::from_str(migrate_url)
         .map_err(|error| AppError::Internal(format!("legacy db URL invalid: {error}")))?;
     let mut gucs: Vec<(&str, &str)> = vec![("lock_timeout", LEGACY_MIGRATION_LOCK_TIMEOUT)];
@@ -119,19 +130,22 @@ async fn apply_legacy_migrations_once(
     // The old V1 database already contains migration history from Apalis.
     // Only validate and apply migrations owned by the security-delete subsystem.
     migrator.set_ignore_missing(true);
-    let result = migrator
-        .run(&mut conn)
-        .await
-        .map_err(|error| AppError::Internal(format!("legacy migration failed: {error}")));
-
-    if let Err(error) = &result {
-        if migration_error_is_lock_contention(error) {
-            // lock_timeout aborts the statement; if sqlx had a transaction open
-            // the connection is now unusable until ROLLBACK.
-            let _ = sqlx::query("ROLLBACK").execute(&mut conn).await;
-            release_orphaned_sqlx_migration_lock(&mut conn).await;
+    let result = match migrator.run(&mut conn).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let lock_contention = migrate_error_is_lock_contention(&error);
+            if lock_contention {
+                // lock_timeout aborts the statement; if sqlx had a transaction
+                // open the connection is now unusable until ROLLBACK.
+                let _ = sqlx::query("ROLLBACK").execute(&mut conn).await;
+                release_orphaned_sqlx_migration_lock(&mut conn).await;
+            }
+            Err(LegacyMigrationAttemptError {
+                error: AppError::Internal(format!("legacy migration failed: {error}")),
+                lock_contention,
+            })
         }
-    }
+    };
 
     // Direct connections drop session locks on close. Still unlock explicitly
     // so a cancelled run cannot leave the lock if the backend is reused.
@@ -233,12 +247,39 @@ async fn release_orphaned_sqlx_migration_lock(conn: &mut PgConnection) {
     }
 }
 
-fn migration_error_is_lock_contention(error: &AppError) -> bool {
-    let msg = error.to_string().to_ascii_lowercase();
-    msg.contains("lock timeout")
-        || msg.contains("deadlock detected")
-        || msg.contains("55p03")
-        || msg.contains("40p01")
+/// Postgres SQLSTATE for lock-wait failures.
+///
+/// `55P03` = lock_not_available (`canceling statement due to lock timeout`)
+/// `40P01` = deadlock_detected
+fn sqlstate_is_lock_contention(code: &str) -> bool {
+    code.eq_ignore_ascii_case("55P03") || code.eq_ignore_ascii_case("40P01")
+}
+
+fn sqlx_error_is_lock_contention(error: &sqlx::Error) -> bool {
+    let Some(db) = error.as_database_error() else {
+        return false;
+    };
+    match db.code() {
+        Some(code) => sqlstate_is_lock_contention(code.as_ref()),
+        // Driver dropped SQLSTATE: don't let a Display reword disable retries,
+        // but don't treat generic statement-timeout text as lock contention.
+        None => {
+            let msg = db.message().to_ascii_lowercase();
+            msg.contains("lock timeout") || msg.contains("deadlock detected")
+        }
+    }
+}
+
+fn migrate_error_sqlx_source(error: &sqlx::migrate::MigrateError) -> Option<&sqlx::Error> {
+    match error {
+        sqlx::migrate::MigrateError::Execute(source)
+        | sqlx::migrate::MigrateError::ExecuteMigration(source, _) => Some(source),
+        _ => None,
+    }
+}
+
+fn migrate_error_is_lock_contention(error: &sqlx::migrate::MigrateError) -> bool {
+    migrate_error_sqlx_source(error).is_some_and(sqlx_error_is_lock_contention)
 }
 
 #[cfg(test)]
@@ -294,18 +335,85 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn lock_timeout_errors_are_retryable() {
-        assert!(migration_error_is_lock_contention(&AppError::Internal(
-            "legacy migration failed: while executing migrations: \
-             error returned from database: canceling statement due to lock timeout"
-                .into()
-        )));
-        assert!(migration_error_is_lock_contention(&AppError::Internal(
-            "deadlock detected".into()
-        )));
-        assert!(!migration_error_is_lock_contention(&AppError::Internal(
-            "relation \"vector_entries\" does not exist".into()
-        )));
+    fn lock_timeout_sqlstates_are_retryable() {
+        assert!(sqlstate_is_lock_contention("55P03"));
+        assert!(sqlstate_is_lock_contention("40P01"));
+        assert!(sqlstate_is_lock_contention("55p03"));
+        assert!(!sqlstate_is_lock_contention("57014")); // statement_timeout
+        assert!(!sqlstate_is_lock_contention("42P01")); // undefined_table
+    }
+
+    #[test]
+    fn migrate_errors_classify_on_sqlstate_not_display_text() {
+        let lock_timeout = sqlx::Error::Database(Box::new(FakeDbError {
+            message: "the wording changed in a future postgres",
+            code: Some("55P03"),
+        }));
+        assert!(sqlx_error_is_lock_contention(&lock_timeout));
+        assert!(migrate_error_is_lock_contention(
+            &sqlx::migrate::MigrateError::Execute(lock_timeout)
+        ));
+
+        let statement_timeout = sqlx::Error::Database(Box::new(FakeDbError {
+            message: "canceling statement due to lock timeout",
+            code: Some("57014"),
+        }));
+        assert!(!sqlx_error_is_lock_contention(&statement_timeout));
+        assert!(!migrate_error_is_lock_contention(
+            &sqlx::migrate::MigrateError::Execute(statement_timeout)
+        ));
+
+        let missing_code_lock = sqlx::Error::Database(Box::new(FakeDbError {
+            message: "canceling statement due to lock timeout",
+            code: None,
+        }));
+        assert!(sqlx_error_is_lock_contention(&missing_code_lock));
+
+        let missing_code_other = sqlx::Error::Database(Box::new(FakeDbError {
+            message: "relation \"vector_entries\" does not exist",
+            code: None,
+        }));
+        assert!(!sqlx_error_is_lock_contention(&missing_code_other));
+    }
+
+    #[derive(Debug)]
+    struct FakeDbError {
+        message: &'static str,
+        code: Option<&'static str>,
+    }
+
+    impl std::fmt::Display for FakeDbError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.message)
+        }
+    }
+
+    impl std::error::Error for FakeDbError {}
+
+    impl sqlx::error::DatabaseError for FakeDbError {
+        fn message(&self) -> &str {
+            self.message
+        }
+
+        fn kind(&self) -> sqlx::error::ErrorKind {
+            sqlx::error::ErrorKind::Other
+        }
+
+        fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+            self.code.map(std::borrow::Cow::Borrowed)
+        }
+
+        fn as_error(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn std::error::Error + Send + Sync + 'static> {
+            self
+        }
     }
 
     #[tokio::test]

--- a/services/server/src/storage/legacy_db.rs
+++ b/services/server/src/storage/legacy_db.rs
@@ -3,7 +3,7 @@ use sqlx::{Connection, PgPool};
 use std::str::FromStr;
 use std::time::Duration;
 
-use super::postgres_url::{direct_postgres_url, is_transaction_pooler_url};
+use super::postgres_url::{direct_postgres_url, is_transaction_pooler_url, postgres_host};
 use crate::types::AppError;
 
 /// Bound how long a single migrate attempt waits on sqlx's session advisory
@@ -106,10 +106,13 @@ async fn apply_legacy_migrations_once(
     }
     options = options.options(gucs);
 
+    let host = postgres_host(migrate_url).unwrap_or_else(|| "unknown".into());
     let mut conn = PgConnection::connect_with(&options)
         .await
         .map_err(|error| {
-            AppError::Internal(format!("legacy db migrate connect failed: {error}"))
+            AppError::Internal(format!(
+                "legacy db migrate connect failed (host={host}): {error}"
+            ))
         })?;
 
     let mut migrator = sqlx::migrate!("./migrations_legacy");
@@ -121,6 +124,12 @@ async fn apply_legacy_migrations_once(
         .await
         .map_err(|error| AppError::Internal(format!("legacy migration failed: {error}")));
 
+    if let Err(error) = &result {
+        if migration_error_is_lock_contention(error) {
+            release_orphaned_sqlx_migration_lock(&mut conn).await;
+        }
+    }
+
     // Direct connections drop session locks on close. Still unlock explicitly
     // so a cancelled run cannot leave the lock if the backend is reused.
     let _ = sqlx::query("SELECT pg_advisory_unlock_all()")
@@ -128,6 +137,94 @@ async fn apply_legacy_migrations_once(
         .await;
     let _ = conn.close().await;
     result
+}
+
+/// sqlx's Postgres migrator lock: `0x3d32ad9e * crc32(database_name)`.
+/// Must match sqlx 0.8 so we can find (and drop) a leaked session lock.
+fn sqlx_migration_lock_id(database_name: &str) -> i64 {
+    0x3d32ad9e * (crc32_iso_hdlc(database_name.as_bytes()) as i64)
+}
+
+fn crc32_iso_hdlc(data: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffffu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            crc = if crc & 1 != 0 {
+                (crc >> 1) ^ 0xEDB8_8320
+            } else {
+                crc >> 1
+            };
+        }
+    }
+    !crc
+}
+
+/// Advisory locks are database-wide. A pooled backend that leaked sqlx's
+/// session lock will block even a direct migrator. If that holder is idle
+/// (the WALM-378 shape: pgbouncer backend now serving unrelated traffic),
+/// terminate it so the next attempt can proceed. Never kill a non-idle
+/// backend — that could be a live upload holding a different advisory lock.
+async fn release_orphaned_sqlx_migration_lock(conn: &mut PgConnection) {
+    let database_name: String = match sqlx::query_scalar("SELECT current_database()")
+        .fetch_one(&mut *conn)
+        .await
+    {
+        Ok(name) => name,
+        Err(error) => {
+            tracing::warn!(%error, "legacy migration: could not read current_database() after lock timeout");
+            return;
+        }
+    };
+    let lock_id = sqlx_migration_lock_id(&database_name);
+    let holders: Vec<(i32, Option<String>, Option<String>, Option<String>)> = match sqlx::query_as(
+        "SELECT a.pid, a.application_name, a.state, left(a.query, 120)
+         FROM pg_locks l
+         JOIN pg_stat_activity a ON a.pid = l.pid
+         WHERE l.locktype = 'advisory'
+           AND l.granted
+           AND l.objsubid = 1
+           AND l.pid <> pg_backend_pid()
+           AND ((l.classid::bigint << 32) | l.objid::bigint) = $1",
+    )
+    .bind(lock_id)
+    .fetch_all(&mut *conn)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            tracing::warn!(%error, "legacy migration: could not inspect pg_locks after lock timeout");
+            return;
+        }
+    };
+    for (pid, application_name, state, query) in holders {
+        tracing::warn!(
+            pid,
+            application_name = application_name.as_deref().unwrap_or(""),
+            state = state.as_deref().unwrap_or(""),
+            query = query.as_deref().unwrap_or(""),
+            "legacy migration: sqlx advisory lock is held by another backend (WALM-378)"
+        );
+        if state.as_deref() != Some("idle") {
+            continue;
+        }
+        match sqlx::query_scalar::<_, bool>("SELECT pg_terminate_backend($1)")
+            .bind(pid)
+            .fetch_one(&mut *conn)
+            .await
+        {
+            Ok(true) => tracing::warn!(
+                pid,
+                "legacy migration: terminated idle backend holding the leaked sqlx lock"
+            ),
+            Ok(false) => {
+                tracing::warn!(pid, "legacy migration: pg_terminate_backend returned false")
+            }
+            Err(error) => {
+                tracing::warn!(pid, %error, "legacy migration: pg_terminate_backend failed")
+            }
+        }
+    }
 }
 
 fn migration_error_is_lock_contention(error: &AppError) -> bool {
@@ -181,6 +278,13 @@ pub(crate) mod tests {
             .await
             .unwrap();
         Some((legacy, admin, schema))
+    }
+
+    #[test]
+    fn sqlx_lock_id_matches_walm378_neondb() {
+        // Values taken from the live incident (WALM-378).
+        assert_eq!(crc32_iso_hdlc(b"neondb"), 1_372_559_388);
+        assert_eq!(sqlx_migration_lock_id("neondb"), 1_409_249_852_220_689_736);
     }
 
     #[test]

--- a/services/server/src/storage/legacy_db.rs
+++ b/services/server/src/storage/legacy_db.rs
@@ -126,12 +126,16 @@ async fn apply_legacy_migrations_once(
 
     if let Err(error) = &result {
         if migration_error_is_lock_contention(error) {
+            // lock_timeout aborts the statement; if sqlx had a transaction open
+            // the connection is now unusable until ROLLBACK.
+            let _ = sqlx::query("ROLLBACK").execute(&mut conn).await;
             release_orphaned_sqlx_migration_lock(&mut conn).await;
         }
     }
 
     // Direct connections drop session locks on close. Still unlock explicitly
     // so a cancelled run cannot leave the lock if the backend is reused.
+    let _ = sqlx::query("ROLLBACK").execute(&mut conn).await;
     let _ = sqlx::query("SELECT pg_advisory_unlock_all()")
         .execute(&mut conn)
         .await;
@@ -205,7 +209,9 @@ async fn release_orphaned_sqlx_migration_lock(conn: &mut PgConnection) {
             query = query.as_deref().unwrap_or(""),
             "legacy migration: sqlx advisory lock is held by another backend (WALM-378)"
         );
-        if state.as_deref() != Some("idle") {
+        // Live migrators are `active`. The leaked pooler backend in WALM-378
+        // was `idle` (and would be `idle in transaction` if SET left a txn).
+        if !matches!(state.as_deref(), Some("idle") | Some("idle in transaction")) {
             continue;
         }
         match sqlx::query_scalar::<_, bool>("SELECT pg_terminate_backend($1)")

--- a/services/server/src/storage/legacy_db.rs
+++ b/services/server/src/storage/legacy_db.rs
@@ -1,8 +1,16 @@
-use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
-use sqlx::PgPool;
+use sqlx::postgres::{PgConnectOptions, PgConnection, PgPoolOptions};
+use sqlx::{Connection, PgPool};
 use std::str::FromStr;
+use std::time::Duration;
 
+use super::postgres_url::{direct_postgres_url, is_transaction_pooler_url};
 use crate::types::AppError;
+
+/// Bound how long a single migrate attempt waits on sqlx's session advisory
+/// lock. Combined with retries so a leaked pooler lock (WALM-378) is a
+/// transient boot delay, not a hard crash.
+const LEGACY_MIGRATION_LOCK_TIMEOUT: &str = "5s";
+const LEGACY_MIGRATION_MAX_ATTEMPTS: u32 = 6;
 
 pub struct LegacyDb {
     pool: PgPool,
@@ -17,6 +25,8 @@ impl LegacyDb {
         database_url: &str,
         search_path: Option<&str>,
     ) -> Result<Self, AppError> {
+        apply_legacy_migrations(database_url, search_path).await?;
+
         let mut options = PgConnectOptions::from_str(database_url)
             .map_err(|error| AppError::Internal(format!("legacy db URL invalid: {error}")))?;
         if let Some(search_path) = search_path {
@@ -27,14 +37,6 @@ impl LegacyDb {
             .connect_with(options)
             .await
             .map_err(|error| AppError::Internal(format!("legacy db connect failed: {error}")))?;
-        let mut migrator = sqlx::migrate!("./migrations_legacy");
-        // The old V1 database already contains migration history from Apalis.
-        // Only validate and apply migrations owned by the security-delete subsystem.
-        migrator.set_ignore_missing(true);
-        migrator
-            .run(&pool)
-            .await
-            .map_err(|error| AppError::Internal(format!("legacy migration failed: {error}")))?;
         tracing::info!("legacy db connected, security-delete migrations applied");
         Ok(Self { pool })
     }
@@ -42,6 +44,98 @@ impl LegacyDb {
     pub fn pool(&self) -> &PgPool {
         &self.pool
     }
+}
+
+async fn apply_legacy_migrations(
+    database_url: &str,
+    search_path: Option<&str>,
+) -> Result<(), AppError> {
+    let migrate_url = direct_postgres_url(database_url);
+    if is_transaction_pooler_url(database_url) {
+        let original_host = url::Url::parse(database_url)
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(str::to_owned));
+        let direct_host = url::Url::parse(migrate_url.as_ref())
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(str::to_owned));
+        tracing::info!(
+            original_host,
+            direct_host,
+            "legacy db: running sqlx migrations on the direct Postgres endpoint (WALM-378)"
+        );
+    }
+
+    let mut last_error: Option<AppError> = None;
+    for attempt in 1..=LEGACY_MIGRATION_MAX_ATTEMPTS {
+        match apply_legacy_migrations_once(migrate_url.as_ref(), search_path).await {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if migration_error_is_lock_contention(&error)
+                    && attempt < LEGACY_MIGRATION_MAX_ATTEMPTS =>
+            {
+                let delay = Duration::from_millis(500 * (1u64 << (attempt - 1).min(4)));
+                tracing::warn!(
+                    attempt,
+                    max_attempts = LEGACY_MIGRATION_MAX_ATTEMPTS,
+                    retry_in_ms = delay.as_millis() as u64,
+                    error = %error,
+                    "legacy migration lock contention; retrying. \
+                     If this persists, an orphaned sqlx advisory lock is held on a pooled backend \
+                     (WALM-378). Release it with pg_terminate_backend on the pg_locks pid."
+                );
+                tokio::time::sleep(delay).await;
+                last_error = Some(error);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| {
+        AppError::Internal("legacy migration failed: lock contention retries exhausted".into())
+    }))
+}
+
+async fn apply_legacy_migrations_once(
+    migrate_url: &str,
+    search_path: Option<&str>,
+) -> Result<(), AppError> {
+    let mut options = PgConnectOptions::from_str(migrate_url)
+        .map_err(|error| AppError::Internal(format!("legacy db URL invalid: {error}")))?;
+    let mut gucs: Vec<(&str, &str)> = vec![("lock_timeout", LEGACY_MIGRATION_LOCK_TIMEOUT)];
+    if let Some(search_path) = search_path {
+        gucs.push(("search_path", search_path));
+    }
+    options = options.options(gucs);
+
+    let mut conn = PgConnection::connect_with(&options)
+        .await
+        .map_err(|error| {
+            AppError::Internal(format!("legacy db migrate connect failed: {error}"))
+        })?;
+
+    let mut migrator = sqlx::migrate!("./migrations_legacy");
+    // The old V1 database already contains migration history from Apalis.
+    // Only validate and apply migrations owned by the security-delete subsystem.
+    migrator.set_ignore_missing(true);
+    let result = migrator
+        .run(&mut conn)
+        .await
+        .map_err(|error| AppError::Internal(format!("legacy migration failed: {error}")));
+
+    // Direct connections drop session locks on close. Still unlock explicitly
+    // so a cancelled run cannot leave the lock if the backend is reused.
+    let _ = sqlx::query("SELECT pg_advisory_unlock_all()")
+        .execute(&mut conn)
+        .await;
+    let _ = conn.close().await;
+    result
+}
+
+fn migration_error_is_lock_contention(error: &AppError) -> bool {
+    let msg = error.to_string().to_ascii_lowercase();
+    msg.contains("lock timeout")
+        || msg.contains("deadlock detected")
+        || msg.contains("55p03")
+        || msg.contains("40p01")
 }
 
 #[cfg(test)]
@@ -87,6 +181,21 @@ pub(crate) mod tests {
             .await
             .unwrap();
         Some((legacy, admin, schema))
+    }
+
+    #[test]
+    fn lock_timeout_errors_are_retryable() {
+        assert!(migration_error_is_lock_contention(&AppError::Internal(
+            "legacy migration failed: while executing migrations: \
+             error returned from database: canceling statement due to lock timeout"
+                .into()
+        )));
+        assert!(migration_error_is_lock_contention(&AppError::Internal(
+            "deadlock detected".into()
+        )));
+        assert!(!migration_error_is_lock_contention(&AppError::Internal(
+            "relation \"vector_entries\" does not exist".into()
+        )));
     }
 
     #[tokio::test]

--- a/services/server/src/storage/legacy_db.rs
+++ b/services/server/src/storage/legacy_db.rs
@@ -7,8 +7,8 @@ use super::postgres_url::{direct_postgres_url, is_transaction_pooler_url, postgr
 use crate::types::AppError;
 
 /// Bound how long a single migrate attempt waits on sqlx's session advisory
-/// lock. Combined with retries so a leaked pooler lock (WALM-378) is a
-/// transient boot delay, not a hard crash.
+/// lock. Combined with retries so a leaked pooler lock is a transient boot
+/// delay, not a hard crash.
 const LEGACY_MIGRATION_LOCK_TIMEOUT: &str = "5s";
 const LEGACY_MIGRATION_MAX_ATTEMPTS: u32 = 6;
 
@@ -61,7 +61,7 @@ async fn apply_legacy_migrations(
         tracing::info!(
             original_host,
             direct_host,
-            "legacy db: running sqlx migrations on the direct Postgres endpoint (WALM-378)"
+            "legacy db: running sqlx migrations on the direct Postgres endpoint"
         );
     }
 
@@ -80,8 +80,8 @@ async fn apply_legacy_migrations(
                     retry_in_ms = delay.as_millis() as u64,
                     error = %error,
                     "legacy migration lock contention; retrying. \
-                     If this persists, an orphaned sqlx advisory lock is held on a pooled backend \
-                     (WALM-378). Release it with pg_terminate_backend on the pg_locks pid."
+                     If this persists, an orphaned sqlx advisory lock is held on a pooled backend. \
+                     Release it with pg_terminate_backend on the pg_locks pid."
                 );
                 tokio::time::sleep(delay).await;
                 last_error = Some(error);
@@ -166,7 +166,7 @@ fn crc32_iso_hdlc(data: &[u8]) -> u32 {
 
 /// Advisory locks are database-wide. A pooled backend that leaked sqlx's
 /// session lock will block even a direct migrator. If that holder is idle
-/// (the WALM-378 shape: pgbouncer backend now serving unrelated traffic),
+/// (idle pgbouncer backend now serving unrelated traffic),
 /// terminate it so the next attempt can proceed. Never kill a non-idle
 /// backend — that could be a live upload holding a different advisory lock.
 async fn release_orphaned_sqlx_migration_lock(conn: &mut PgConnection) {
@@ -207,10 +207,10 @@ async fn release_orphaned_sqlx_migration_lock(conn: &mut PgConnection) {
             application_name = application_name.as_deref().unwrap_or(""),
             state = state.as_deref().unwrap_or(""),
             query = query.as_deref().unwrap_or(""),
-            "legacy migration: sqlx advisory lock is held by another backend (WALM-378)"
+            "legacy migration: sqlx advisory lock is held by another backend"
         );
-        // Live migrators are `active`. The leaked pooler backend in WALM-378
-        // was `idle` (and would be `idle in transaction` if SET left a txn).
+        // Live migrators are `active`. A leaked pooler backend is `idle`
+        // (or `idle in transaction` if SET left a txn).
         if !matches!(state.as_deref(), Some("idle") | Some("idle in transaction")) {
             continue;
         }
@@ -287,8 +287,8 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn sqlx_lock_id_matches_walm378_neondb() {
-        // Values taken from the live incident (WALM-378).
+    fn sqlx_lock_id_matches_known_neondb_dump() {
+        // Values taken from a live Neon/sqlx lock-id dump.
         assert_eq!(crc32_iso_hdlc(b"neondb"), 1_372_559_388);
         assert_eq!(sqlx_migration_lock_id("neondb"), 1_409_249_852_220_689_736);
     }

--- a/services/server/src/storage/mod.rs
+++ b/services/server/src/storage/mod.rs
@@ -18,6 +18,7 @@
 
 pub mod db;
 pub mod legacy_db;
+pub mod postgres_url;
 pub mod seal;
 pub mod security_delete_store;
 pub mod sui;

--- a/services/server/src/storage/postgres_url.rs
+++ b/services/server/src/storage/postgres_url.rs
@@ -39,7 +39,7 @@ pub fn direct_postgres_url(url: &str) -> Cow<'_, str> {
     Cow::Owned(parsed.to_string())
 }
 
-fn postgres_host(url: &str) -> Option<String> {
+pub(crate) fn postgres_host(url: &str) -> Option<String> {
     url::Url::parse(url)
         .ok()
         .and_then(|parsed| parsed.host_str().map(str::to_owned))

--- a/services/server/src/storage/postgres_url.rs
+++ b/services/server/src/storage/postgres_url.rs
@@ -1,4 +1,4 @@
-//! Postgres URL helpers for WALM-378.
+//! Postgres URL helpers for pooled vs direct endpoints.
 //!
 //! sqlx migrations take a **session-scoped** `pg_advisory_lock`. A
 //! transaction-mode pooler (Neon `-pooler`, PgBouncer) can route `LOCK` and

--- a/services/server/src/storage/postgres_url.rs
+++ b/services/server/src/storage/postgres_url.rs
@@ -1,0 +1,106 @@
+//! Postgres URL helpers for WALM-378.
+//!
+//! sqlx migrations take a **session-scoped** `pg_advisory_lock`. A
+//! transaction-mode pooler (Neon `-pooler`, PgBouncer) can route `LOCK` and
+//! `UNLOCK` to different backends, or return a backend to the pool with the
+//! lock still held after the client disconnects. The next boot then waits on
+//! that lock, inherits a leaked `lock_timeout`, and panics.
+//!
+//! Migrations must run against the direct compute endpoint. Runtime query
+//! pools may keep the pooled URL.
+
+use std::borrow::Cow;
+
+/// True when `url` points at a transaction-mode pooler hostname.
+///
+/// Neon names these `*-pooler.*` (e.g. `ep-foo-pooler.c-2.aws.neon.tech`).
+pub fn is_transaction_pooler_url(url: &str) -> bool {
+    postgres_host(url).is_some_and(|host| host.contains("-pooler."))
+}
+
+/// Rewrite a Neon/PgBouncer pooled URL to the direct compute hostname.
+///
+/// Leaves already-direct URLs, unparseable strings, and unix sockets
+/// unchanged. Credentials and query params are preserved.
+pub fn direct_postgres_url(url: &str) -> Cow<'_, str> {
+    let Ok(mut parsed) = url::Url::parse(url) else {
+        return Cow::Borrowed(url);
+    };
+    let Some(host) = parsed.host_str() else {
+        return Cow::Borrowed(url);
+    };
+    if !host.contains("-pooler.") {
+        return Cow::Borrowed(url);
+    }
+    let direct_host = host.replace("-pooler.", ".");
+    if parsed.set_host(Some(&direct_host)).is_err() {
+        return Cow::Borrowed(url);
+    }
+    Cow::Owned(parsed.to_string())
+}
+
+fn postgres_host(url: &str) -> Option<String> {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(str::to_owned))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn neon_pooler_host_rewrites_to_direct() {
+        let pooled = "postgresql://memwal:s3cret@ep-odd-cake-aorg5ujz-pooler.c-2.ap-southeast-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require";
+        let direct = direct_postgres_url(pooled);
+        assert_eq!(
+            url::Url::parse(&direct).unwrap().host_str(),
+            Some("ep-odd-cake-aorg5ujz.c-2.ap-southeast-1.aws.neon.tech")
+        );
+        assert!(direct.contains("sslmode=require"));
+        assert!(direct.contains("channel_binding=require"));
+        assert!(direct.contains("memwal:s3cret"));
+        assert!(
+            direct.ends_with("/neondb?sslmode=require&channel_binding=require")
+                || direct.contains("/neondb?")
+        );
+        assert!(is_transaction_pooler_url(pooled));
+        assert!(!is_transaction_pooler_url(&direct));
+    }
+
+    #[test]
+    fn already_direct_url_is_unchanged() {
+        let url = "postgresql://memwal:s3cret@ep-odd-cake-aorg5ujz.c-2.ap-southeast-1.aws.neon.tech/neondb";
+        assert!(matches!(direct_postgres_url(url), Cow::Borrowed(_)));
+        assert!(!is_transaction_pooler_url(url));
+    }
+
+    #[test]
+    fn pooler_in_user_or_db_name_is_not_rewritten() {
+        let url = "postgresql://pooler-user:x@localhost:5432/pooler";
+        assert!(matches!(direct_postgres_url(url), Cow::Borrowed(_)));
+        assert!(!is_transaction_pooler_url(url));
+    }
+
+    #[test]
+    fn percent_encoded_password_survives_rewrite() {
+        let pooled = "postgresql://memwal:p%40ss@ep-foo-pooler.us-east-2.aws.neon.tech/neondb";
+        let direct = direct_postgres_url(pooled);
+        let parsed = url::Url::parse(&direct).unwrap();
+        assert_eq!(parsed.password(), Some("p%40ss"));
+        assert_eq!(parsed.host_str(), Some("ep-foo.us-east-2.aws.neon.tech"));
+    }
+
+    #[test]
+    fn unparseable_or_socket_urls_pass_through() {
+        assert!(matches!(
+            direct_postgres_url("not a url"),
+            Cow::Borrowed("not a url")
+        ));
+        let socket = "postgresql://memwal@/neondb?host=/tmp";
+        // url crate may or may not treat this as host-less; either way we
+        // must not panic or invent a hostname.
+        let _ = direct_postgres_url(socket);
+        assert!(!is_transaction_pooler_url(socket));
+    }
+}


### PR DESCRIPTION
Fixes [WALM-378](https://linear.app/mysten-labs/issue/WALM-378/bugserver-orphaned-sqlx-migration-advisory-lock-leaks-through-the-neon).

## What happened

Dev relayer was hard down 07:30–07:44 UTC. It booted, applied main DB migrations, then panicked:

```
Failed to initialize legacy security-delete database:
  legacy migration failed: canceling statement due to lock timeout
```

Railway reported SUCCESS/RUNNING (no healthcheck). The process never bound :3001, so every request was 502.

## Why it looks random, and why staging/prod stayed up

sqlx migrations take a **session-scoped** `pg_advisory_lock`. `LEGACY_DB_URL` and `DATABASE_URL` both go through Neon’s **transaction-mode pooler**. `LOCK` and `UNLOCK` can land on different backends; a client disconnect returns the backend to the pool **with the lock still held**. Apalis then reused that backend for job-queue traffic, so the lock never cleared.

On the next boot the migrator waits on that lock. A leaked `set_config('lock_timeout', '15s', false)` from `init_apalis_pool` (session GUC, also pooler-leaked) cancels the wait after 15s, and `.expect()` takes the process down.

This only fires **on restart**, and only if a previous boot left the lock on a still-live pooled backend:

| Env | Why it looked fine |
|---|---|
| **staging / prod** | Same code path, same pooler. They just weren’t redeployed into a held lock. Staging is on an older SHA and has been up; prod likewise. The next restart can hit this. |
| **dev** | 9 deploys that day. Redeploy at 07:44 recovered because the lock happened to be free — then leaked again. |

Not caused by #711 (7 TypeScript files, not even merged) or #706.

## Fix

1. **Migrations run on the direct compute host** (`*-pooler.*` → `*.`). Runtime query pools keep the pooled URL.
2. **Retry lock contention** (5s `lock_timeout`, 6 attempts, backoff) instead of a single `.expect()`.
3. **Stop setting session GUCs** (`set_config(..., false)`) on the pooled Apalis connections. Boot is still bounded by tokio timeouts. Apalis schema setup, when needed, also uses the direct endpoint.

No Railway env change required — the pooler hostname is rewritten in code.

## Tests

- URL rewrite: Neon pooler → direct, credentials/query preserved, non-pooler URLs untouched
- Lock-timeout / deadlock errors classified as retryable