### PR TITLE
fix(read-api): deletions, metadata refill, docs CI on #554

### DIFF
--- a/docs/api/memory-read-api.md
+++ b/docs/api/memory-read-api.md
@@ -85,7 +85,7 @@ absence selects the Ed25519 path. A request cannot use both.
 | `x-signature` | Hex-encoded Ed25519 signature (64 bytes) over the canonical message below |
 | `x-timestamp` | Unix timestamp in seconds. Must be within ±300s (5 minutes) of server time |
 | `x-nonce` | UUID v4, used once for replay protection (tracked in Redis for 10 minutes) |
-| `x-account-id` | Walrus Memory account object ID. Effectively required: it is signed into the canonical message, so omitting it signs an empty string and will not match a real account on Testnet |
+| `x-account-id` | Walrus Memory account object ID. Effectively required: it is signed into the canonical message, so omitting it signs an empty string and does not match a real account on Testnet |
 
 ### Canonical signing string
 
@@ -97,9 +97,9 @@ sends the signature in `x-signature`:
 ```
 
 - `timestamp`: the exact value sent in `x-timestamp`.
-- `method`: HTTP method, e.g. `GET`.
+- `method`: HTTP method, for example `GET`.
 - `path_and_query`: the request's path plus query string exactly as sent,
-  e.g. `/v1/owners/0xabc.../memories?limit=50`. Mismatched query params
+  for example `/v1/owners/0xabc.../memories?limit=50`. Mismatched query params
   (including a tampered `updated_after` cursor) invalidate the signature.
 - `body_sha256`: hex-encoded SHA-256 of the request body. For these
   GET-only, bodyless endpoints this is the hash of an empty byte string.

--- a/docs/api/memory-read-api.md
+++ b/docs/api/memory-read-api.md
@@ -96,15 +96,15 @@ sends the signature in `x-signature`:
 {timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
 ```
 
-- `timestamp` ; the exact value sent in `x-timestamp`.
-- `method` ; HTTP method, e.g. `GET`.
-- `path_and_query` ; the request's path plus query string exactly as sent,
+- `timestamp`: the exact value sent in `x-timestamp`.
+- `method`: HTTP method, e.g. `GET`.
+- `path_and_query`: the request's path plus query string exactly as sent,
   e.g. `/v1/owners/0xabc.../memories?limit=50`. Mismatched query params
   (including a tampered `updated_after` cursor) invalidate the signature.
-- `body_sha256` ; hex-encoded SHA-256 of the request body. For these
+- `body_sha256`: hex-encoded SHA-256 of the request body. For these
   GET-only, bodyless endpoints this is the hash of an empty byte string.
-- `nonce` ; the `x-nonce` value.
-- `account_id` ; the `x-account-id` value (empty string if omitted, which
+- `nonce`: the `x-nonce` value.
+- `account_id`: the `x-account-id` value (empty string if omitted, which
   will not match a real signed request).
 
 Server-side verification flow (`auth.rs::verify_signature`): validate the
@@ -126,7 +126,7 @@ distinguishing failure reasons):
 - `x-timestamp` outside the ±300s window.
 - Ed25519 signature verification failure (including a tampered path, query
   string, or body).
-- Nonce already seen (replay) ; or the Redis nonce check itself failing
+- Nonce already seen (replay): or the Redis nonce check itself failing
   (fail-closed).
 - Public key not found among the resolved account's on-chain delegate keys,
   or the account is deactivated.
@@ -145,7 +145,7 @@ bare `401`, with no distinction in the response between causes, for:
 
 Once authenticated (either path), the three endpoints below additionally
 return `403` if the `{owner}` path segment does not equal the resolved
-identity, or ; bearer-token path only ; if the token's `permissions` don't
+identity, or, on the bearer-token path, if the token's `permissions` don't
 include `memories.read`.
 
 ## Rate limiting

--- a/docs/api/memory-read-api.md
+++ b/docs/api/memory-read-api.md
@@ -62,11 +62,11 @@ mechanisms, dispatched by `auth::verify_read_api_auth`
 (`services/server/src/auth.rs`) based on whether the request carries an
 `Authorization` header:
 
-1. **Ed25519 signed headers** ; the same `verify_signature` middleware
+1. **Ed25519 signed headers**, the same `verify_signature` middleware
    `/api/restore` and every other protected route use. This is the
    mechanism direct SDK/dashboard delegate-key callers use; see "Required
    headers" and "Canonical signing string" below.
-2. **Owner-scoped bearer token** (`Authorization: Bearer <token>`) ; the
+2. **Owner-scoped bearer token** (`Authorization: Bearer <token>`), the
    mechanism for Console, which structurally never holds a delegate key and
    so can never produce an Ed25519 signature. See `docs/api/owner-token-auth.md`
    for how Console obtains a token; once obtained, a request here is just
@@ -117,7 +117,7 @@ that account's on-chain `MemWalAccount.delegate_keys` (cached in
 
 ### 401 responses
 
-**Ed25519 path** (no `Authorization` header on the request) ; any of the
+**Ed25519 path** (no `Authorization` header on the request), any of the
 following returns a bare `401 Unauthorized` (no JSON body, constant ~100ms
 delay on signature/timestamp/nonce failures to prevent timing side-channels
 distinguishing failure reasons):
@@ -132,10 +132,10 @@ distinguishing failure reasons):
   or the account is deactivated.
 
 A request missing `x-nonce` entirely gets `426 Upgrade Required` instead of
-`401` ; signaling an unsupported legacy SDK version rather than an auth
+`401`, signaling an unsupported legacy SDK version rather than an auth
 failure.
 
-**Bearer-token path** (`Authorization: Bearer <token>` present) ; also a
+**Bearer-token path** (`Authorization: Bearer <token>` present), also a
 bare `401`, with no distinction in the response between causes, for:
 
 - An expired, tampered, wrongly-signed, or wrong-audience token.
@@ -154,14 +154,14 @@ These three endpoints run on their own router (`read_api_routes` in
 `main.rs`), separate from the write path's `protected_routes`, behind
 `read_api_rate_limit_middleware` (`services/server/src/rate_limit.rs`)
 instead of the write path's `rate_limit_middleware`. They do **not** share
-the write path's budget ; a routine pagination loop over this API can no
+the write path's budget, a routine pagination loop over this API can no
 longer trip, or contend with, the 30/min per-delegate-key budget that
 exists to bound the write path's spend-risk (Walrus upload, LLM calls,
 gas).
 
 There is a single sliding-window layer, keyed by delegate key under its
 own Redis prefix (`rate:read:dk:{public_key}`, distinct from the write
-path's `rate:dk:{public_key}`) ; no separate per-account burst/sustained
+path's `rate:dk:{public_key}`), no separate per-account burst/sustained
 tiers on top. Default limit is **200 weighted-requests/min per delegate
 key** (`ReadApiRateLimitConfig::per_delegate_key_per_minute`), overridable
 via the `READ_API_RATE_LIMIT_PER_MINUTE` env var. Weights for this API:
@@ -186,18 +186,18 @@ Exceeding the limit returns `429 Too Many Requests`:
 with a `Retry-After: 60` header. If the rate limiter itself is
 unavailable (Redis unreachable), requests fail closed with `503 Service
 Unavailable` and a `Retry-After: 30` header rather than being allowed
-through unmetered ; there is no in-memory fallback for this middleware,
+through unmetered, there is no in-memory fallback for this middleware,
 unlike the write path's deliberately-fallback-enabled limiter.
 
 ## `GET /v1/owners/:owner/namespaces`
 
-`updated_after` ; like `memories`' below ; must be the opaque `next_cursor`
+`updated_after`, like `memories`' below, must be the opaque `next_cursor`
 value returned by a previous call, not a raw timestamp or namespace name;
 omit it for the first page. It base64 (URL-safe, unpadded) encodes the
 JSON watermark `{"updated_at": ..., "namespace": ...}`: rows are ordered
 and filtered by the rollup's `(MAX(updated_at), namespace)`, mirroring
 `memories`' `(updated_at, id)` keyset. `limit` defaults to 100, max 500,
-`400` for non-positive/non-integer values ; same convention as `memories`.
+`400` for non-positive/non-integer values, same convention as `memories`.
 
 **Breaking change from an earlier version of this endpoint:** namespaces
 are now returned ordered by recency (`(MAX(updated_at), namespace)`), not
@@ -238,7 +238,7 @@ Response:
 }
 ```
 
-`updated_at` is `MAX(updated_at)` across the namespace's memories ; the same
+`updated_at` is `MAX(updated_at)` across the namespace's memories, the same
 value the cursor is built from.
 
 ## `GET /v1/owners/:owner/memories`
@@ -271,7 +271,7 @@ Response:
 }
 ```
 
-`updated_at` is the row's own last-modified time ; the same value this
+`updated_at` is the row's own last-modified time, the same value this
 page's cursor is built from.
 
 `status` is `"deleted"` for tombstoned rows, `"expired"` if `expires_at`
@@ -279,7 +279,7 @@ is in the past, and `"active"` otherwise (including when `end_epoch` /
 `expires_at` are still null because the expiry sweep has not run yet).
 
 The first time the sweep resolves a row's `end_epoch`/`expires_at` from
-`null` to a real value, that row's `updated_at` advances too ; so a client
+`null` to a real value, that row's `updated_at` advances too, so a client
 that already synced the row while it was still unsynced will see the
 populated values on its next incremental poll, rather than being stuck
 with `null` forever. A later routine re-verification that reconfirms an
@@ -289,29 +289,29 @@ anything changed); only a genuine change does.
 
 ### Cursor semantics (both paginated endpoints)
 
-`next_cursor` is **always** returned for a non-empty page ; including the
+`next_cursor` is **always** returned for a non-empty page, including the
 final page of a traversal and a result that fits entirely in one page. It
 is the watermark of the last row in that page, and it is what you pass as
 `updated_after` on your next poll.
 
 An empty page returns `next_cursor: null` in exactly one case: the very
 first page of a fresh walk (no `updated_after` on the request) that
-matches nothing at all ; there is no prior cursor and no row to build a
-watermark from. Every other empty page ; a continuation page reached with
+matches nothing at all, there is no prior cursor and no row to build a
+watermark from. Every other empty page, a continuation page reached with
 an incoming cursor, which can happen when every remaining row raced past
-the walk's snapshot boundary between pages ; still returns a non-null
+the walk's snapshot boundary between pages, still returns a non-null
 `next_cursor`: the same position as the incoming cursor, but with a fresh
 snapshot boundary. Use that new cursor rather than the one you already
-held; the one you held is now stale ; it's exactly what the reset exists
+held; the one you held is now stale, it's exactly what the reset exists
 to replace.
 
-So `next_cursor: null` does **not** mean "end of data" ; use the separate
+So `next_cursor: null` does **not** mean "end of data", use the separate
 `has_more` boolean for that instead. Keep paginating (pass back the latest
 `next_cursor`) while `has_more` is `true`; stop once you see `has_more:
 false`.
 
 **Do not infer end-of-data from page length.** `limit` is silently clamped
-to each endpoint's max (500) ; a request for `limit=1000` that happens to
+to each endpoint's max (500), a request for `limit=1000` that happens to
 match exactly 500 real rows returns a page exactly as long as the (clamped)
 `limit`, and a request for more than the actual remaining data returns a
 page shorter than `limit` while more data still exists elsewhere for that
@@ -336,13 +336,13 @@ Response:
 ## Errors
 
 All errors from these three endpoints (except the shared auth middleware's
-bare `401`/`426`, and the shared rate limiter's `429`/`503` ; see
+bare `401`/`426`, and the shared rate limiter's `429`/`503`, see
 Authentication and Rate limiting above) use the envelope
 `{ "error": "<message>" }`:
 
 | Status | Cause |
 |---|---|
-| `401` | Auth failed ; either an invalid/expired Ed25519 signature/nonce/timestamp, or (bearer-token path) an invalid/expired/unresolvable owner token (see Authentication) |
+| `401` | Auth failed, either an invalid/expired Ed25519 signature/nonce/timestamp, or (bearer-token path) an invalid/expired/unresolvable owner token (see Authentication) |
 | `403` | `{owner}` path segment does not match the authenticated identity, or (bearer-token path) the token's `permissions` lack `memories.read` |
 | `400` | Invalid/malformed cursor, or non-positive/non-integer `limit` |
 | `429` | Rate limit exceeded (see Rate limiting) |

--- a/docs/api/memory-read-api.md
+++ b/docs/api/memory-read-api.md
@@ -210,15 +210,15 @@ next poll if any of its memories were **created or updated** after that
 watermark, however early its name sorts. Namespaces untouched since the
 watermark are not re-sent.
 
-Hard deletes now advance a stored per-namespace watermark and write a
-`memory_tombstones` row, so incremental `/namespaces` polling resurfaces the
-namespace (with a smaller `memory_count`) and `/memories` returns
-`status: "deleted"` for the removed id. `snapshot_version` still only bumps
-when the wire format changes, not when data is deleted.
-
-Console should still run a periodic full (cursor-less) reconcile as a
-safety net. Size that interval around a 5 to 6 hour SLA if you only poll
-incrementally; a 5-minute `/namespaces` poll already sees the watermark bump.
+Hard deletes write a row to `memory_tombstones` and remove the live
+`vector_entries` row in one statement. Incremental `/namespaces` computes the
+watermark as GREATEST(live MAX(updated_at), tombstone MAX(deleted_at)), so a
+namespace whose last memory was deleted still resurfaces with a smaller
+`memory_count`. Incremental `/memories` never puts tombstones in `memories[]`.
+They arrive in the additive `deleted` array (`memory_id`, `namespace_id`,
+`deleted_at`). Old Console clients ignore that key. Tombstones are kept for
+30 days; a cursor older than that returns `must_resync: true`.
+`snapshot_version` stays 2.
 
 Response:
 ```json
@@ -234,7 +234,7 @@ Response:
   ],
   "next_cursor": "eyJ1cGRhdGVkX2F0IjouLi4sIm5hbWVzcGFjZSI6IndvcmsifQ",
   "has_more": false,
-  "snapshot_version": 3
+  "snapshot_version": 2
 }
 ```
 
@@ -265,9 +265,11 @@ Response:
       "importance": 0.5
     }
   ],
+  "deleted": [],
+  "must_resync": false,
   "next_cursor": "eyJ1cGRhdGVkX2F0IjouLi59",
   "has_more": false,
-  "snapshot_version": 3
+  "snapshot_version": 2
 }
 ```
 
@@ -329,7 +331,7 @@ Response:
   "agents": [
     { "label": "cli", "sui_address": "0xdelegate1" }
   ],
-  "snapshot_version": 3
+  "snapshot_version": 2
 }
 ```
 

--- a/docs/api/memory-read-api.md
+++ b/docs/api/memory-read-api.md
@@ -1,4 +1,50 @@
-# Memory Read API
+---
+title: Memory Read API
+description: >-
+  Owner-scoped, cursor-based, read-only listing of namespaces, memories, and
+  agents for Walrus Console. Covers authentication, pagination, expiry fields,
+  and deletion visibility.
+keywords:
+  - Walrus Memory
+  - MemWal
+  - Console
+  - read API
+  - namespaces
+  - memories
+goal:
+  description: List an owner's namespaces, memories, and agents through the owner-scoped read API.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 200
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What endpoints does the Memory Read API expose?
+  - How does incremental sync work on GET /v1/owners/:owner/memories?
+  - How does the read API surface deletions?
+answer: >-
+  GET /v1/owners/:owner/namespaces, /memories, and /agents list metadata only.
+  Pass next_cursor as updated_after for incremental sync. Hard deletes write a
+  tombstone and bump a namespace watermark so the next poll sees the change.
+  snapshot_version bumps only when the wire format changes.
+---
+
+## Overview
+
+Registered routes (colon form used by the docs freshness check):
+
+- `GET /v1/owners/:owner/namespaces`
+- `GET /v1/owners/:owner/memories`
+- `GET /v1/owners/:owner/agents`
+- `GET /v1/owners/:owner/_token_probe`
+
 
 Owner-scoped, cursor-based, read-only. All three endpoints accept either of
 two auth mechanisms (see Authentication below); either way, the `{owner}`
@@ -16,11 +62,11 @@ mechanisms, dispatched by `auth::verify_read_api_auth`
 (`services/server/src/auth.rs`) based on whether the request carries an
 `Authorization` header:
 
-1. **Ed25519 signed headers** — the same `verify_signature` middleware
+1. **Ed25519 signed headers** ; the same `verify_signature` middleware
    `/api/restore` and every other protected route use. This is the
    mechanism direct SDK/dashboard delegate-key callers use; see "Required
    headers" and "Canonical signing string" below.
-2. **Owner-scoped bearer token** (`Authorization: Bearer <token>`) — the
+2. **Owner-scoped bearer token** (`Authorization: Bearer <token>`) ; the
    mechanism for Console, which structurally never holds a delegate key and
    so can never produce an Ed25519 signature. See `docs/api/owner-token-auth.md`
    for how Console obtains a token; once obtained, a request here is just
@@ -39,7 +85,7 @@ absence selects the Ed25519 path. A request cannot use both.
 | `x-signature` | Hex-encoded Ed25519 signature (64 bytes) over the canonical message below |
 | `x-timestamp` | Unix timestamp in seconds. Must be within ±300s (5 minutes) of server time |
 | `x-nonce` | UUID v4, used once for replay protection (tracked in Redis for 10 minutes) |
-| `x-account-id` | Walrus Memory account object ID. Effectively required: it is signed into the canonical message, so omitting it signs an empty string and will not match a real account on testnet |
+| `x-account-id` | Walrus Memory account object ID. Effectively required: it is signed into the canonical message, so omitting it signs an empty string and will not match a real account on Testnet |
 
 ### Canonical signing string
 
@@ -50,15 +96,15 @@ sends the signature in `x-signature`:
 {timestamp}.{method}.{path_and_query}.{body_sha256}.{nonce}.{account_id}
 ```
 
-- `timestamp` — the exact value sent in `x-timestamp`.
-- `method` — HTTP method, e.g. `GET`.
-- `path_and_query` — the request's path plus query string exactly as sent,
+- `timestamp` ; the exact value sent in `x-timestamp`.
+- `method` ; HTTP method, e.g. `GET`.
+- `path_and_query` ; the request's path plus query string exactly as sent,
   e.g. `/v1/owners/0xabc.../memories?limit=50`. Mismatched query params
   (including a tampered `updated_after` cursor) invalidate the signature.
-- `body_sha256` — hex-encoded SHA-256 of the request body. For these
+- `body_sha256` ; hex-encoded SHA-256 of the request body. For these
   GET-only, bodyless endpoints this is the hash of an empty byte string.
-- `nonce` — the `x-nonce` value.
-- `account_id` — the `x-account-id` value (empty string if omitted, which
+- `nonce` ; the `x-nonce` value.
+- `account_id` ; the `x-account-id` value (empty string if omitted, which
   will not match a real signed request).
 
 Server-side verification flow (`auth.rs::verify_signature`): validate the
@@ -71,7 +117,7 @@ that account's on-chain `MemWalAccount.delegate_keys` (cached in
 
 ### 401 responses
 
-**Ed25519 path** (no `Authorization` header on the request) — any of the
+**Ed25519 path** (no `Authorization` header on the request) ; any of the
 following returns a bare `401 Unauthorized` (no JSON body, constant ~100ms
 delay on signature/timestamp/nonce failures to prevent timing side-channels
 distinguishing failure reasons):
@@ -80,16 +126,16 @@ distinguishing failure reasons):
 - `x-timestamp` outside the ±300s window.
 - Ed25519 signature verification failure (including a tampered path, query
   string, or body).
-- Nonce already seen (replay) — or the Redis nonce check itself failing
+- Nonce already seen (replay) ; or the Redis nonce check itself failing
   (fail-closed).
 - Public key not found among the resolved account's on-chain delegate keys,
   or the account is deactivated.
 
 A request missing `x-nonce` entirely gets `426 Upgrade Required` instead of
-`401` — signaling an unsupported legacy SDK version rather than an auth
+`401` ; signaling an unsupported legacy SDK version rather than an auth
 failure.
 
-**Bearer-token path** (`Authorization: Bearer <token>` present) — also a
+**Bearer-token path** (`Authorization: Bearer <token>` present) ; also a
 bare `401`, with no distinction in the response between causes, for:
 
 - An expired, tampered, wrongly-signed, or wrong-audience token.
@@ -99,7 +145,7 @@ bare `401`, with no distinction in the response between causes, for:
 
 Once authenticated (either path), the three endpoints below additionally
 return `403` if the `{owner}` path segment does not equal the resolved
-identity, or — bearer-token path only — if the token's `permissions` don't
+identity, or ; bearer-token path only ; if the token's `permissions` don't
 include `memories.read`.
 
 ## Rate limiting
@@ -108,14 +154,14 @@ These three endpoints run on their own router (`read_api_routes` in
 `main.rs`), separate from the write path's `protected_routes`, behind
 `read_api_rate_limit_middleware` (`services/server/src/rate_limit.rs`)
 instead of the write path's `rate_limit_middleware`. They do **not** share
-the write path's budget — a routine pagination loop over this API can no
+the write path's budget ; a routine pagination loop over this API can no
 longer trip, or contend with, the 30/min per-delegate-key budget that
 exists to bound the write path's spend-risk (Walrus upload, LLM calls,
 gas).
 
 There is a single sliding-window layer, keyed by delegate key under its
 own Redis prefix (`rate:read:dk:{public_key}`, distinct from the write
-path's `rate:dk:{public_key}`) — no separate per-account burst/sustained
+path's `rate:dk:{public_key}`) ; no separate per-account burst/sustained
 tiers on top. Default limit is **200 weighted-requests/min per delegate
 key** (`ReadApiRateLimitConfig::per_delegate_key_per_minute`), overridable
 via the `READ_API_RATE_LIMIT_PER_MINUTE` env var. Weights for this API:
@@ -140,18 +186,18 @@ Exceeding the limit returns `429 Too Many Requests`:
 with a `Retry-After: 60` header. If the rate limiter itself is
 unavailable (Redis unreachable), requests fail closed with `503 Service
 Unavailable` and a `Retry-After: 30` header rather than being allowed
-through unmetered — there is no in-memory fallback for this middleware,
+through unmetered ; there is no in-memory fallback for this middleware,
 unlike the write path's deliberately-fallback-enabled limiter.
 
-## GET /v1/owners/{owner}/namespaces?updated_after=<cursor>&limit=100
+## `GET /v1/owners/:owner/namespaces`
 
-`updated_after` — like `memories`' below — must be the opaque `next_cursor`
+`updated_after` ; like `memories`' below ; must be the opaque `next_cursor`
 value returned by a previous call, not a raw timestamp or namespace name;
 omit it for the first page. It base64 (URL-safe, unpadded) encodes the
 JSON watermark `{"updated_at": ..., "namespace": ...}`: rows are ordered
 and filtered by the rollup's `(MAX(updated_at), namespace)`, mirroring
 `memories`' `(updated_at, id)` keyset. `limit` defaults to 100, max 500,
-`400` for non-positive/non-integer values — same convention as `memories`.
+`400` for non-positive/non-integer values ; same convention as `memories`.
 
 **Breaking change from an earlier version of this endpoint:** namespaces
 are now returned ordered by recency (`(MAX(updated_at), namespace)`), not
@@ -164,14 +210,15 @@ next poll if any of its memories were **created or updated** after that
 watermark, however early its name sorts. Namespaces untouched since the
 watermark are not re-sent.
 
-**Deletions are not currently reflected.** Forgetting a memory (or its
-Walrus blob expiring/being cleaned up) removes its row outright — the
-namespace's rollup shrinks, but that shrink does not advance the
-namespace's `updated_at` watermark the way a create/update does, so a
-namespace whose only change since your last sync was a deletion will not
-be resurfaced. Until this is addressed, clients that need to detect
-deletions should periodically do a full (cursor-less) resync rather than
-relying on `updated_after` alone.
+Hard deletes now advance a stored per-namespace watermark and write a
+`memory_tombstones` row, so incremental `/namespaces` polling resurfaces the
+namespace (with a smaller `memory_count`) and `/memories` returns
+`status: "deleted"` for the removed id. `snapshot_version` still only bumps
+when the wire format changes, not when data is deleted.
+
+Console should still run a periodic full (cursor-less) reconcile as a
+safety net. Size that interval around a 5 to 6 hour SLA if you only poll
+incrementally; a 5-minute `/namespaces` poll already sees the watermark bump.
 
 Response:
 ```json
@@ -187,14 +234,14 @@ Response:
   ],
   "next_cursor": "eyJ1cGRhdGVkX2F0IjouLi4sIm5hbWVzcGFjZSI6IndvcmsifQ",
   "has_more": false,
-  "snapshot_version": 2
+  "snapshot_version": 3
 }
 ```
 
-`updated_at` is `MAX(updated_at)` across the namespace's memories — the same
+`updated_at` is `MAX(updated_at)` across the namespace's memories ; the same
 value the cursor is built from.
 
-## GET /v1/owners/{owner}/memories?updated_after=<cursor>&limit=100
+## `GET /v1/owners/:owner/memories`
 
 `updated_after` must be the opaque `next_cursor` value returned by a
 previous call, not a raw timestamp. `limit` defaults to 100, max 500.
@@ -214,25 +261,25 @@ Response:
       "package_id": "0xpkg",
       "status": "active",
       "end_epoch": 900,
-      "expires_at": "2026-09-15T00:00:00Z"
+      "expires_at": "2026-09-15T00:00:00Z",
+      "importance": 0.5
     }
   ],
   "next_cursor": "eyJ1cGRhdGVkX2F0IjouLi59",
   "has_more": false,
-  "snapshot_version": 2
+  "snapshot_version": 3
 }
 ```
 
-`updated_at` is the row's own last-modified time — the same value this
+`updated_at` is the row's own last-modified time ; the same value this
 page's cursor is built from.
 
-`status` is `"expired"` if `expires_at` is in the past, `"active"`
-otherwise — including when `end_epoch`/`expires_at` are still `null` (not
-yet synced; a background sweep populates them within roughly 5 minutes of
-a memory being written, sooner for the primary upload path).
+`status` is `"deleted"` for tombstoned rows, `"expired"` if `expires_at`
+is in the past, and `"active"` otherwise (including when `end_epoch` /
+`expires_at` are still null because the expiry sweep has not run yet).
 
 The first time the sweep resolves a row's `end_epoch`/`expires_at` from
-`null` to a real value, that row's `updated_at` advances too — so a client
+`null` to a real value, that row's `updated_at` advances too ; so a client
 that already synced the row while it was still unsynced will see the
 populated values on its next incremental poll, rather than being stuck
 with `null` forever. A later routine re-verification that reconfirms an
@@ -242,35 +289,35 @@ anything changed); only a genuine change does.
 
 ### Cursor semantics (both paginated endpoints)
 
-`next_cursor` is **always** returned for a non-empty page — including the
+`next_cursor` is **always** returned for a non-empty page ; including the
 final page of a traversal and a result that fits entirely in one page. It
 is the watermark of the last row in that page, and it is what you pass as
 `updated_after` on your next poll.
 
 An empty page returns `next_cursor: null` in exactly one case: the very
 first page of a fresh walk (no `updated_after` on the request) that
-matches nothing at all — there is no prior cursor and no row to build a
-watermark from. Every other empty page — a continuation page reached with
+matches nothing at all ; there is no prior cursor and no row to build a
+watermark from. Every other empty page ; a continuation page reached with
 an incoming cursor, which can happen when every remaining row raced past
-the walk's snapshot boundary between pages — still returns a non-null
+the walk's snapshot boundary between pages ; still returns a non-null
 `next_cursor`: the same position as the incoming cursor, but with a fresh
 snapshot boundary. Use that new cursor rather than the one you already
-held; the one you held is now stale — it's exactly what the reset exists
+held; the one you held is now stale ; it's exactly what the reset exists
 to replace.
 
-So `next_cursor: null` does **not** mean "end of data" — use the separate
+So `next_cursor: null` does **not** mean "end of data" ; use the separate
 `has_more` boolean for that instead. Keep paginating (pass back the latest
 `next_cursor`) while `has_more` is `true`; stop once you see `has_more:
 false`.
 
 **Do not infer end-of-data from page length.** `limit` is silently clamped
-to each endpoint's max (500) — a request for `limit=1000` that happens to
+to each endpoint's max (500) ; a request for `limit=1000` that happens to
 match exactly 500 real rows returns a page exactly as long as the (clamped)
 `limit`, and a request for more than the actual remaining data returns a
 page shorter than `limit` while more data still exists elsewhere for that
 owner. `has_more` is correct in both cases; page-length heuristics are not.
 
-## GET /v1/owners/{owner}/agents
+## `GET /v1/owners/:owner/agents`
 
 Live on-chain read of `MemWalAccount.delegate_keys`, short-TTL cached
 per-account (same 30s window `sui/client.rs::walrus_epoch()` uses) so
@@ -282,20 +329,20 @@ Response:
   "agents": [
     { "label": "cli", "sui_address": "0xdelegate1" }
   ],
-  "snapshot_version": 2
+  "snapshot_version": 3
 }
 ```
 
 ## Errors
 
 All errors from these three endpoints (except the shared auth middleware's
-bare `401`/`426`, and the shared rate limiter's `429`/`503` — see
+bare `401`/`426`, and the shared rate limiter's `429`/`503` ; see
 Authentication and Rate limiting above) use the envelope
 `{ "error": "<message>" }`:
 
 | Status | Cause |
 |---|---|
-| `401` | Auth failed — either an invalid/expired Ed25519 signature/nonce/timestamp, or (bearer-token path) an invalid/expired/unresolvable owner token (see Authentication) |
+| `401` | Auth failed ; either an invalid/expired Ed25519 signature/nonce/timestamp, or (bearer-token path) an invalid/expired/unresolvable owner token (see Authentication) |
 | `403` | `{owner}` path segment does not match the authenticated identity, or (bearer-token path) the token's `permissions` lack `memories.read` |
 | `400` | Invalid/malformed cursor, or non-positive/non-integer `limit` |
 | `429` | Rate limit exceeded (see Rate limiting) |

--- a/docs/api/owner-token-auth.md
+++ b/docs/api/owner-token-auth.md
@@ -101,7 +101,7 @@ cheapest handler-level check) → per-owner rate limit → `MemWalAccount`
 existence → mint. `owner` is canonicalized to lowercase before every
 downstream check and before it's embedded in the token's claims.
 
-Response ; `200 OK`:
+Response (`200 OK`):
 
 ```json
 {
@@ -133,8 +133,8 @@ existing token's lifetime.
 | `400` | `{"error": "owner has no MemWalAccount"}` | `owner` is a well-formed address but has never created a `MemWalAccount`. Use `GET /api/accounts/:owner/exists` first. |
 | `400` | `{"error": "Phase 1 only grants memories.read"}` | Request body included `scope` or `permissions` other than `memories.read`. |
 | `401` | *(bare, no body)* | Missing/wrong `x-service-credential`, or the credential is unconfigured on this deployment |
-| `429` | See "Rate limiting" ; **two different shapes**, do not assume one | Per-owner or per-credential budget exceeded |
-| `503` | See "Availability failures" ; **two different shapes**, do not assume one | `OWNER_TOKEN_SECRET` unconfigured, or the rate limiter's Redis backend is unreachable |
+| `429` | See "Rate limiting": **two different shapes**, do not assume one | Per-owner or per-credential budget exceeded |
+| `503` | See "Availability failures": **two different shapes**, do not assume one | `OWNER_TOKEN_SECRET` unconfigured, or the rate limiter's Redis backend is unreachable |
 
 ## Using a token
 

--- a/docs/api/owner-token-auth.md
+++ b/docs/api/owner-token-auth.md
@@ -1,8 +1,45 @@
-## Owner-Scoped Token Authentication
+---
+title: Owner-Scoped Token Authentication
+description: >-
+  How Walrus Console mints a short-lived memories.read bearer token and
+  presents it to the owner-scoped Memory Read API.
+keywords:
+  - Walrus Memory
+  - Console
+  - owner token
+  - authentication
+goal:
+  description: Mint and use an owner-scoped memories.read token.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 200
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How does Console authenticate to the Memory Read API?
+  - What does POST /v1/owner-tokens return?
+  - Which permission does a Phase 1 owner token grant?
+answer: >-
+  Console sends x-service-credential to POST /v1/owner-tokens with an owner
+  address and receives a short-lived bearer token whose only permission is
+  memories.read. Unknown scopes return 400. Present the token as
+  Authorization Bearer on GET /v1/owners/:owner/memories and related routes.
+---
+
+Issuance route: `POST /v1/owner-tokens`.
+
+## Overview
 
 Lets Console call WM's owner-scoped read API without ever holding
 a delegate key. Console proves control of a WM owner address `Y` entirely on
-its own side (its own identity-link flow — Enoki Connect or a wallet-signature
+its own side (its own identity-link flow ; Enoki Connect or a wallet-signature
 challenge; WM is never involved in that proof). It then calls `POST /v1/owner-tokens`,
 authenticating itself as a legitimate client via a single static **service
 credential** WM issues to Console out of band, to mint a short-lived bearer
@@ -12,7 +49,7 @@ token scoped to `Y`. Console presents that token as `Authorization: Bearer
 This is additive: it does not replace the existing Ed25519 signed-request
 scheme (`x-public-key`/`x-signature`/...) every other protected route and
 the owner-scoped read routes already use. The two schemes are separate, parallel
-auth mechanisms — mirroring how `security-delete.md`'s Bearer-token flow
+auth mechanisms ; mirroring how `security-delete.md`'s Bearer-token flow
 coexists with it today.
 
 **Phase 1 scope:** only the `memories.read` permission is ever granted. No
@@ -33,17 +70,17 @@ Content-Type: application/json
 
 Missing header, wrong value, or the secret being unconfigured on WM's side
 (`OWNER_TOKEN_SERVICE_CREDENTIAL` unset) all collapse to a bare `401` with no
-body — no detail is leaked about which of these it was.
+body ; no detail is leaked about which of these it was.
 
 **Trust boundary, stated explicitly:** this credential is the *only* thing
 gating who can request a token, and a request's `owner` is taken as a plain
 request parameter, trusted because the caller already proved it holds the
 credential. If the credential leaks, whoever holds it can mint a
-`memories.read` token for **any** owner address — there is no secondary check
+`memories.read` token for **any** owner address ; there is no secondary check
 tying a specific token request back to a specific proven identity-link event.
-This is an accepted Phase-1 trade-off — a deliberate choice of a shared
+This is an accepted Phase-1 trade-off ; a deliberate choice of a shared
 service credential over mTLS/signed-client-assertion for cost/complexity
-reasons — not an oversight. Treat the credential with the
+reasons ; not an oversight. Treat the credential with the
 same handling rigor as a database password: unique per environment, rotated
 if any Console-side compromise is suspected, never logged, never in a repo.
 
@@ -64,7 +101,7 @@ cheapest handler-level check) → per-owner rate limit → `MemWalAccount`
 existence → mint. `owner` is canonicalized to lowercase before every
 downstream check and before it's embedded in the token's claims.
 
-Response — `200 OK`:
+Response ; `200 OK`:
 
 ```json
 {
@@ -75,15 +112,15 @@ Response — `200 OK`:
 ```
 
 `token` is an opaque `base64url(claims json).base64url(HMAC-SHA256
-signature)` string — treat it as a black box, do not attempt to parse it
+signature)` string ; treat it as a black box, do not attempt to parse it
 client-side. Its claims (for WM's own reference, not something Console needs
 to decode): `subject` (constant `"console"`), `owner_address` (canonical
 lowercase), `audience` (constant `"memwal"`), `issued_at`/`expires_at` (Unix
-seconds), `nonce` (a UUID identifying this specific token — see "Replay and
+seconds), `nonce` (a UUID identifying this specific token ; see "Replay and
 revocation" below), `permissions` (`["memories.read"]` in Phase 1).
 
 TTL defaults to 900s (15 minutes), configurable via `OWNER_TOKEN_TTL_SECS`.
-**Refresh path:** there is no separate refresh/rotate endpoint in Phase 1 —
+**Refresh path:** there is no separate refresh/rotate endpoint in Phase 1 ; 
 when a token is at or near expiry, call `POST /v1/owner-tokens` again with
 the same `owner` to mint a fresh one. There is no reuse or extension of an
 existing token's lifetime.
@@ -93,10 +130,11 @@ existing token's lifetime.
 | Status | Body | Cause |
 |---|---|---|
 | `400` | `{"error": "owner must be a 0x-prefixed 32-byte Sui address (66 characters)"}` | Malformed `owner` |
-| `400` | `{"error": "owner has no MemWalAccount"}` | `owner` is a well-formed address but has never created a `MemWalAccount` — minting a token for it would be nonsensical (Console's own existence-check endpoint, `GET /api/accounts/{owner}/exists`, is the primitive it should use to avoid hitting this) |
+| `400` | `{"error": "owner has no MemWalAccount"}` | `owner` is a well-formed address but has never created a `MemWalAccount`. Use `GET /api/accounts/:owner/exists` first. |
+| `400` | `{"error": "Phase 1 only grants memories.read"}` | Request body included `scope` or `permissions` other than `memories.read`. |
 | `401` | *(bare, no body)* | Missing/wrong `x-service-credential`, or the credential is unconfigured on this deployment |
-| `429` | See "Rate limiting" — **two different shapes**, do not assume one | Per-owner or per-credential budget exceeded |
-| `503` | See "Availability failures" — **two different shapes**, do not assume one | `OWNER_TOKEN_SECRET` unconfigured, or the rate limiter's Redis backend is unreachable |
+| `429` | See "Rate limiting" ; **two different shapes**, do not assume one | Per-owner or per-credential budget exceeded |
+| `503` | See "Availability failures" ; **two different shapes**, do not assume one | `OWNER_TOKEN_SECRET` unconfigured, or the rate limiter's Redis backend is unreachable |
 
 ## Using a token
 
@@ -109,7 +147,7 @@ Authorization: Bearer <token>
 all accept this same bearer token via `auth::verify_read_api_auth`
 (`services/server/src/auth.rs`), which dispatches between it and the
 existing Ed25519 signed-request scheme based on whether the request carries
-an `Authorization` header — see `docs/api/memory-read-api.md`'s
+an `Authorization` header ; see `docs/api/memory-read-api.md`'s
 Authentication section for the combined contract. `GET
 /v1/owners/{owner}/_token_probe` still exists alongside them as the
 original dev-only smoke-test route this mechanism was proven against before
@@ -128,11 +166,11 @@ is rejected `401`, with no distinction in the response between those causes.
 Three **independent** budgets apply to `POST /v1/owner-tokens`, enforced by
 three different code paths that do **not** all share a response shape:
 
-**0. Per-IP** (outermost middleware — runs *before* the service-credential
+**0. Per-IP** (outermost middleware ; runs *before* the service-credential
 check, regardless of whether the credential is valid): default 30/min,
 300/hour per source IP (`OWNER_TOKEN_RATE_LIMIT_IP_PER_MINUTE`/`_PER_HOUR`).
 This is the layer that actually bounds someone guessing the shared service
-credential — the per-credential budget below is keyed by the *value* of the
+credential ; the per-credential budget below is keyed by the *value* of the
 supplied credential, so a wrong guess never accumulates against it, and a
 varying guess gets a fresh bucket every time; without a per-IP layer,
 credential-guessing had no throttling anywhere. Uses the same response shape
@@ -148,12 +186,12 @@ HTTP 429
 {"error": "too many owner-token requests for this owner; retry later"}
 ```
 
-No `Retry-After` header, no `layer`/`limit`/`retry_after_seconds` fields —
+No `Retry-After` header, no `layer`/`limit`/`retry_after_seconds` fields ; 
 this is the crate's plain `AppError` envelope, not the shared rate-limiter
 response builder.
 
 **2. Per-service-credential** (middleware, runs *before* the handler and
-before the per-owner check — a wrong credential never reaches the per-owner
+before the per-owner check ; a wrong credential never reaches the per-owner
 budget, confirmed by test): default 120/min, 3000/hour across all requests
 using this credential regardless of which owner they target
 (`OWNER_TOKEN_RATE_LIMIT_PER_MINUTE`/`_PER_HOUR`). Exceeding it:
@@ -172,7 +210,7 @@ Retry-After: 60
 (`layer` is `"owner_token_credential_sustained"` and `retry_after_seconds`/
 `Retry-After` are `300` for the hourly budget instead of the per-minute one.)
 This is the same response shape every other rate limiter in this crate uses
-(`rate_limit_response`) — **do not** confuse it with the per-owner shape
+(`rate_limit_response`) ; **do not** confuse it with the per-owner shape
 above; they are genuinely different envelopes from different limiters
 guarding the same endpoint.
 
@@ -181,7 +219,7 @@ guarding the same endpoint.
 Also two different shapes, both `503`, both meaning "try again later" but
 from different failure points:
 
-**Feature not configured** (`OWNER_TOKEN_SECRET` unset on this deployment —
+**Feature not configured** (`OWNER_TOKEN_SECRET` unset on this deployment ; 
 checked in the handler, before the per-owner rate-limit check runs):
 
 ```json
@@ -197,7 +235,7 @@ HTTP 503
 {"error": "Upstream temporarily unavailable (traceId: <uuid>)"}
 ```
 
-(Both of the above share one shape — the crate's generic `AppError`
+(Both of the above share one shape ; the crate's generic `AppError`
 envelope.)
 
 **Per-credential rate limiter's Redis backend unreachable** (the middleware,
@@ -209,7 +247,7 @@ Retry-After: 30
 {"error": "Rate limiter temporarily unavailable", "retry_after_seconds": 30}
 ```
 
-This third shape is distinct from the other two `503`s — it has a
+This third shape is distinct from the other two `503`s ; it has a
 `retry_after_seconds` field and a `Retry-After` header; they don't.
 Integrators should treat `503` generically (retry with backoff) rather than
 branching on these exact shapes, but the shapes are documented here precisely
@@ -234,10 +272,10 @@ other.
 
 Each token's `nonce` claim is a unique UUID generated at mint time. It is
 **not** a single-use, replay-preventing nonce the way the signed-request
-scheme's `x-nonce` is — a bearer token is meant to be reused across many read
+scheme's `x-nonce` is ; a bearer token is meant to be reused across many read
 requests during its TTL window, so per-request single-use tracking would
 break normal usage. Its purpose in Phase 1 is forward-compatibility
 (identifying a specific issued token, in case a revocation list is added
 later) and observability (logging which token served a given request). A
-stolen, unexpired token is fully usable for its entire remaining TTL — the
+stolen, unexpired token is fully usable for its entire remaining TTL ; the
 short default TTL (15 minutes) is the primary mitigation, not the nonce.

--- a/docs/api/owner-token-auth.md
+++ b/docs/api/owner-token-auth.md
@@ -39,7 +39,7 @@ Issuance route: `POST /v1/owner-tokens`.
 
 Lets Console call WM's owner-scoped read API without ever holding
 a delegate key. Console proves control of a WM owner address `Y` entirely on
-its own side (its own identity-link flow ; Enoki Connect or a wallet-signature
+its own side (its own identity-link flow, Enoki Connect or a wallet-signature
 challenge; WM is never involved in that proof). It then calls `POST /v1/owner-tokens`,
 authenticating itself as a legitimate client via a single static **service
 credential** WM issues to Console out of band, to mint a short-lived bearer
@@ -49,7 +49,7 @@ token scoped to `Y`. Console presents that token as `Authorization: Bearer
 This is additive: it does not replace the existing Ed25519 signed-request
 scheme (`x-public-key`/`x-signature`/...) every other protected route and
 the owner-scoped read routes already use. The two schemes are separate, parallel
-auth mechanisms ; mirroring how `security-delete.md`'s Bearer-token flow
+auth mechanisms, mirroring how `security-delete.md`'s Bearer-token flow
 coexists with it today.
 
 **Phase 1 scope:** only the `memories.read` permission is ever granted. No
@@ -70,17 +70,17 @@ Content-Type: application/json
 
 Missing header, wrong value, or the secret being unconfigured on WM's side
 (`OWNER_TOKEN_SERVICE_CREDENTIAL` unset) all collapse to a bare `401` with no
-body ; no detail is leaked about which of these it was.
+body, no detail is leaked about which of these it was.
 
 **Trust boundary, stated explicitly:** this credential is the *only* thing
 gating who can request a token, and a request's `owner` is taken as a plain
 request parameter, trusted because the caller already proved it holds the
 credential. If the credential leaks, whoever holds it can mint a
-`memories.read` token for **any** owner address ; there is no secondary check
+`memories.read` token for **any** owner address, there is no secondary check
 tying a specific token request back to a specific proven identity-link event.
-This is an accepted Phase-1 trade-off ; a deliberate choice of a shared
+This is an accepted Phase-1 trade-off, a deliberate choice of a shared
 service credential over mTLS/signed-client-assertion for cost/complexity
-reasons ; not an oversight. Treat the credential with the
+reasons, not an oversight. Treat the credential with the
 same handling rigor as a database password: unique per environment, rotated
 if any Console-side compromise is suspected, never logged, never in a repo.
 
@@ -112,15 +112,15 @@ Response (`200 OK`):
 ```
 
 `token` is an opaque `base64url(claims json).base64url(HMAC-SHA256
-signature)` string ; treat it as a black box, do not attempt to parse it
+signature)` string, treat it as a black box, do not attempt to parse it
 client-side. Its claims (for WM's own reference, not something Console needs
 to decode): `subject` (constant `"console"`), `owner_address` (canonical
 lowercase), `audience` (constant `"memwal"`), `issued_at`/`expires_at` (Unix
-seconds), `nonce` (a UUID identifying this specific token ; see "Replay and
+seconds), `nonce` (a UUID identifying this specific token, see "Replay and
 revocation" below), `permissions` (`["memories.read"]` in Phase 1).
 
 TTL defaults to 900s (15 minutes), configurable via `OWNER_TOKEN_TTL_SECS`.
-**Refresh path:** there is no separate refresh/rotate endpoint in Phase 1 ; 
+**Refresh path:** there is no separate refresh/rotate endpoint in Phase 1, 
 when a token is at or near expiry, call `POST /v1/owner-tokens` again with
 the same `owner` to mint a fresh one. There is no reuse or extension of an
 existing token's lifetime.
@@ -147,7 +147,7 @@ Authorization: Bearer <token>
 all accept this same bearer token via `auth::verify_read_api_auth`
 (`services/server/src/auth.rs`), which dispatches between it and the
 existing Ed25519 signed-request scheme based on whether the request carries
-an `Authorization` header ; see `docs/api/memory-read-api.md`'s
+an `Authorization` header, see `docs/api/memory-read-api.md`'s
 Authentication section for the combined contract. `GET
 /v1/owners/{owner}/_token_probe` still exists alongside them as the
 original dev-only smoke-test route this mechanism was proven against before
@@ -166,11 +166,11 @@ is rejected `401`, with no distinction in the response between those causes.
 Three **independent** budgets apply to `POST /v1/owner-tokens`, enforced by
 three different code paths that do **not** all share a response shape:
 
-**0. Per-IP** (outermost middleware ; runs *before* the service-credential
+**0. Per-IP** (outermost middleware, runs *before* the service-credential
 check, regardless of whether the credential is valid): default 30/min,
 300/hour per source IP (`OWNER_TOKEN_RATE_LIMIT_IP_PER_MINUTE`/`_PER_HOUR`).
 This is the layer that actually bounds someone guessing the shared service
-credential ; the per-credential budget below is keyed by the *value* of the
+credential, the per-credential budget below is keyed by the *value* of the
 supplied credential, so a wrong guess never accumulates against it, and a
 varying guess gets a fresh bucket every time; without a per-IP layer,
 credential-guessing had no throttling anywhere. Uses the same response shape
@@ -186,12 +186,12 @@ HTTP 429
 {"error": "too many owner-token requests for this owner; retry later"}
 ```
 
-No `Retry-After` header, no `layer`/`limit`/`retry_after_seconds` fields ; 
+No `Retry-After` header, no `layer`/`limit`/`retry_after_seconds` fields, 
 this is the crate's plain `AppError` envelope, not the shared rate-limiter
 response builder.
 
 **2. Per-service-credential** (middleware, runs *before* the handler and
-before the per-owner check ; a wrong credential never reaches the per-owner
+before the per-owner check, a wrong credential never reaches the per-owner
 budget, confirmed by test): default 120/min, 3000/hour across all requests
 using this credential regardless of which owner they target
 (`OWNER_TOKEN_RATE_LIMIT_PER_MINUTE`/`_PER_HOUR`). Exceeding it:
@@ -210,7 +210,7 @@ Retry-After: 60
 (`layer` is `"owner_token_credential_sustained"` and `retry_after_seconds`/
 `Retry-After` are `300` for the hourly budget instead of the per-minute one.)
 This is the same response shape every other rate limiter in this crate uses
-(`rate_limit_response`) ; **do not** confuse it with the per-owner shape
+(`rate_limit_response`), **do not** confuse it with the per-owner shape
 above; they are genuinely different envelopes from different limiters
 guarding the same endpoint.
 
@@ -219,7 +219,7 @@ guarding the same endpoint.
 Also two different shapes, both `503`, both meaning "try again later" but
 from different failure points:
 
-**Feature not configured** (`OWNER_TOKEN_SECRET` unset on this deployment ; 
+**Feature not configured** (`OWNER_TOKEN_SECRET` unset on this deployment, 
 checked in the handler, before the per-owner rate-limit check runs):
 
 ```json
@@ -235,7 +235,7 @@ HTTP 503
 {"error": "Upstream temporarily unavailable (traceId: <uuid>)"}
 ```
 
-(Both of the above share one shape ; the crate's generic `AppError`
+(Both of the above share one shape, the crate's generic `AppError`
 envelope.)
 
 **Per-credential rate limiter's Redis backend unreachable** (the middleware,
@@ -247,7 +247,7 @@ Retry-After: 30
 {"error": "Rate limiter temporarily unavailable", "retry_after_seconds": 30}
 ```
 
-This third shape is distinct from the other two `503`s ; it has a
+This third shape is distinct from the other two `503`s, it has a
 `retry_after_seconds` field and a `Retry-After` header; they don't.
 Integrators should treat `503` generically (retry with backoff) rather than
 branching on these exact shapes, but the shapes are documented here precisely
@@ -272,10 +272,10 @@ other.
 
 Each token's `nonce` claim is a unique UUID generated at mint time. It is
 **not** a single-use, replay-preventing nonce the way the signed-request
-scheme's `x-nonce` is ; a bearer token is meant to be reused across many read
+scheme's `x-nonce` is, a bearer token is meant to be reused across many read
 requests during its TTL window, so per-request single-use tracking would
 break normal usage. Its purpose in Phase 1 is forward-compatibility
 (identifying a specific issued token, in case a revocation list is added
 later) and observability (logging which token served a given request). A
-stolen, unexpired token is fully usable for its entire remaining TTL ; the
+stolen, unexpired token is fully usable for its entire remaining TTL, the
 short default TTL (15 minutes) is the primary mitigation, not the nonce.

--- a/docs/api/owner-token-auth.md
+++ b/docs/api/owner-token-auth.md
@@ -28,7 +28,7 @@ questions:
   - Which permission does a Phase 1 owner token grant?
 answer: >-
   Console sends x-service-credential to POST /v1/owner-tokens with an owner
-  address and receives a short-lived bearer token whose only permission is
+  address and gets a short-lived bearer token. The token's only permission is
   memories.read. Unknown scopes return 400. Present the token as
   Authorization Bearer on GET /v1/owners/:owner/memories and related routes.
 ---

--- a/services/server/docs/api/memory-read-api.openapi.yaml
+++ b/services/server/docs/api/memory-read-api.openapi.yaml
@@ -303,7 +303,7 @@ components:
             no more data remains.
         snapshot_version:
           type: integer
-          description: Wire-format version. Currently 3. Bumps only when fields or cursor encoding change, not when rows are deleted.
+          description: Wire-format version. Currently 2. Additive keys (deleted, must_resync) do not bump it.
 
     MemoryItem:
       type: object
@@ -340,11 +340,11 @@ components:
           nullable: true
         status:
           type: string
-          enum: [active, expired, deleted]
+          enum: [active, expired]
           description: >-
-            deleted for tombstoned rows, expired if expires_at is in the past,
-            active otherwise (including while end_epoch/expires_at are still
-            null).
+            expired if expires_at is in the past, active otherwise (including
+            while end_epoch/expires_at are still null). Tombstones are never
+            mixed into memories[]; they are listed in deleted[].
         importance:
           type: number
           format: float
@@ -368,14 +368,34 @@ components:
             Null until synced, independently of `end_epoch` —
             do not assume the two arrive together.
 
+    DeletedMemory:
+      type: object
+      required: [memory_id, namespace_id, deleted_at]
+      properties:
+        memory_id:
+          type: string
+        namespace_id:
+          type: string
+        deleted_at:
+          type: string
+          format: date-time
+
     MemoriesResponse:
       type: object
-      required: [memories, next_cursor, has_more, snapshot_version]
+      required: [memories, next_cursor, has_more, snapshot_version, deleted, must_resync]
       properties:
         memories:
           type: array
           items:
             $ref: '#/components/schemas/MemoryItem'
+        deleted:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeletedMemory'
+          description: Additive tombstone stream. Old clients ignore this key.
+        must_resync:
+          type: boolean
+          description: True when the cursor is older than the 30-day tombstone retention.
         next_cursor:
           type: string
           nullable: true

--- a/services/server/docs/api/memory-read-api.openapi.yaml
+++ b/services/server/docs/api/memory-read-api.openapi.yaml
@@ -303,10 +303,11 @@ components:
             no more data remains.
         snapshot_version:
           type: integer
+          description: Wire-format version. Currently 3. Bumps only when fields or cursor encoding change, not when rows are deleted.
 
     MemoryItem:
       type: object
-      required: [memory_id, namespace_id, blob_id, created_at, updated_at, size, agent_id, package_id, status, end_epoch, expires_at]
+      required: [memory_id, namespace_id, blob_id, created_at, updated_at, size, agent_id, package_id, status, end_epoch, expires_at, importance]
       properties:
         memory_id:
           type: string
@@ -339,11 +340,16 @@ components:
           nullable: true
         status:
           type: string
-          enum: [active, expired]
+          enum: [active, expired, deleted]
           description: >-
-            "expired" if `expires_at` is in the past, "active" otherwise —
-            including while `end_epoch`/`expires_at` are still null (not yet
-            synced).
+            deleted for tombstoned rows, expired if expires_at is in the past,
+            active otherwise (including while end_epoch/expires_at are still
+            null).
+        importance:
+          type: number
+          format: float
+          nullable: true
+          description: Extractor importance in 0.0-1.0.
         end_epoch:
           type: integer
           format: int32

--- a/services/server/migrations/020_read_api_followups.sql
+++ b/services/server/migrations/020_read_api_followups.sql
@@ -1,0 +1,41 @@
+-- Owner-scoped read API follow-ups (WALM-363 / WALM-364).
+--
+-- 1. namespace_watermarks: a stored recency timestamp that DELETE also
+--    advances. Incremental /namespaces polling used MAX(updated_at) over
+--    surviving rows, so deleting the row that held the max moved the
+--    watermark backwards and the namespace never resurfaced.
+-- 2. memory_tombstones: hard-deleted vector_entries rows still appear on
+--    /memories as status=deleted so an incremental consumer can drop them
+--    without a full resync.
+-- 3. metadata_synced_at: distinguishes "not yet backfilled" from "on-chain
+--    metadata genuinely had no memwal_agent_id". The refill script
+--    (services/server/scripts/backfill-read-api-metadata.sh) stamps this.
+
+CREATE TABLE IF NOT EXISTS namespace_watermarks (
+    owner TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    last_mutated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (owner, namespace)
+);
+
+CREATE TABLE IF NOT EXISTS memory_tombstones (
+    id TEXT PRIMARY KEY,
+    owner TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    blob_id TEXT NOT NULL,
+    deleted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_tombstones_owner_deleted_id
+    ON memory_tombstones (owner, deleted_at, id);
+
+ALTER TABLE vector_entries ADD COLUMN IF NOT EXISTS metadata_synced_at TIMESTAMPTZ NULL;
+
+-- Existing namespaces get a watermark equal to their current MAX(updated_at)
+-- so incremental cursors stay stable across this deploy.
+INSERT INTO namespace_watermarks (owner, namespace, last_mutated_at)
+SELECT owner, namespace, MAX(updated_at)
+FROM vector_entries
+WHERE updated_at IS NOT NULL
+GROUP BY owner, namespace
+ON CONFLICT (owner, namespace) DO NOTHING;

--- a/services/server/migrations/020_read_api_followups.sql
+++ b/services/server/migrations/020_read_api_followups.sql
@@ -1,41 +1,27 @@
--- Owner-scoped read API follow-ups (WALM-363 / WALM-364).
+-- WALM-363 / WALM-364 follow-ups for the owner-scoped read API.
 --
--- 1. namespace_watermarks: a stored recency timestamp that DELETE also
---    advances. Incremental /namespaces polling used MAX(updated_at) over
---    surviving rows, so deleting the row that held the max moved the
---    watermark backwards and the namespace never resurfaced.
--- 2. memory_tombstones: hard-deleted vector_entries rows still appear on
---    /memories as status=deleted so an incremental consumer can drop them
---    without a full resync.
--- 3. metadata_synced_at: distinguishes "not yet backfilled" from "on-chain
---    metadata genuinely had no memwal_agent_id". The refill script
---    (services/server/scripts/backfill-read-api-metadata.sh) stamps this.
-
-CREATE TABLE IF NOT EXISTS namespace_watermarks (
-    owner TEXT NOT NULL,
-    namespace TEXT NOT NULL,
-    last_mutated_at TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (owner, namespace)
-);
+-- WALM-363 (Linear, design approved 2026-08-18): separate tombstone table,
+-- not deleted_at on vector_entries. 21 production queries read that table;
+-- a missed soft-delete filter would leak content or over-count storage.
+-- Deletes are one atomic CTE (DELETE ... RETURNING + INSERT tombstone).
+--
+-- WALM-364: metadata_synced_at distinguishes "not yet backfilled" from
+-- "on-chain metadata had no memwal_agent_id".
 
 CREATE TABLE IF NOT EXISTS memory_tombstones (
-    id TEXT PRIMARY KEY,
-    owner TEXT NOT NULL,
-    namespace TEXT NOT NULL,
-    blob_id TEXT NOT NULL,
+    memory_id  TEXT PRIMARY KEY,
+    owner      TEXT NOT NULL,
+    namespace  TEXT NOT NULL,
+    blob_id    TEXT NOT NULL,
     deleted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_memory_tombstones_owner_deleted_id
-    ON memory_tombstones (owner, deleted_at, id);
+CREATE INDEX IF NOT EXISTS idx_memory_tombstones_owner_deleted
+    ON memory_tombstones (owner, deleted_at, memory_id);
 
 ALTER TABLE vector_entries ADD COLUMN IF NOT EXISTS metadata_synced_at TIMESTAMPTZ NULL;
 
--- Existing namespaces get a watermark equal to their current MAX(updated_at)
--- so incremental cursors stay stable across this deploy.
-INSERT INTO namespace_watermarks (owner, namespace, last_mutated_at)
-SELECT owner, namespace, MAX(updated_at)
-FROM vector_entries
-WHERE updated_at IS NOT NULL
-GROUP BY owner, namespace
-ON CONFLICT (owner, namespace) DO NOTHING;
+-- Previous draft of this migration created namespace_watermarks. The
+-- approved design computes the namespace watermark as GREATEST(live
+-- MAX(updated_at), tombstone MAX(deleted_at)) and does not need that table.
+DROP TABLE IF EXISTS namespace_watermarks;

--- a/services/server/scripts/backfill-read-api-metadata.sh
+++ b/services/server/scripts/backfill-read-api-metadata.sh
@@ -1,101 +1,148 @@
 #!/usr/bin/env bash
 # Refill agent_id / package_id on pre-migration vector_entries rows (WALM-364).
 #
-# New writes already dual-write those columns. Rows created before migration
-# 014 stay NULL forever unless this job runs. Batched, resumable, and never
-# on the read hot path.
-#
-# For each owner that still has unsynced rows, POST /walrus/query-blobs on the
-# sidecar (that payload already includes memwal_agent_id / memwal_package_id).
-# Matching blob_id stamps the columns and metadata_synced_at. Blobs with no
-# on-chain agent id stay NULL but still get metadata_synced_at so they are
-# not retried.
+# Safe for large mainnet sets (100k+ rows):
+#   - pages unsynced (owner, blob_id) from Postgres
+#   - asks the sidecar for THAT page only (blobIds), not the whole owner
+#   - stamps metadata_synced_at only on blob_ids requested in this page
+#   - never marks the rest of an owner "done"
+#   - HTTP / parse failures skip the page and leave rows NULL to retry
 #
 # Usage:
 #   DATABASE_URL=postgres://... \
-#   SIDECAR_URL=http://127.0.0.1:3001 \
+#   SIDECAR_URL=http://127.0.0.1:9000 \
 #   SIDECAR_SECRET=... \
 #     bash services/server/scripts/backfill-read-api-metadata.sh
 #
+# Optional: PAGE=100 SLEEP_SEC=0.25
 # Requires: psql, python3, curl.
 
 set -euo pipefail
+exec python3 - "$@" <<'PY'
+import json, os, subprocess, sys, time, urllib.error, urllib.request
 
-: "${DATABASE_URL:?set DATABASE_URL}"
-: "${SIDECAR_URL:?set SIDECAR_URL}"
-SIDECAR_SECRET="${SIDECAR_SECRET:-}"
-BATCH="${BATCH:-50}"
+db = os.environ.get("DATABASE_URL")
+sidecar = (os.environ.get("SIDECAR_URL") or "").rstrip("/")
+secret = os.environ.get("SIDECAR_SECRET") or ""
+if not db or not sidecar:
+    sys.exit("set DATABASE_URL and SIDECAR_URL")
 
-owners="$(psql "$DATABASE_URL" -Atqc "
-  SELECT DISTINCT owner
-  FROM vector_entries
-  WHERE metadata_synced_at IS NULL
-  ORDER BY owner
-  LIMIT ${BATCH};
-")"
+page = int(os.environ.get("PAGE") or "100")
+sleep_sec = float(os.environ.get("SLEEP_SEC") or "0.25")
+page = max(1, min(page, 200))
 
-if [ -z "$owners" ]; then
-  echo "nothing to backfill"
-  exit 0
-fi
-
-auth_args=()
-if [ -n "$SIDECAR_SECRET" ]; then
-  auth_args=(-H "X-Sidecar-Secret: ${SIDECAR_SECRET}")
-fi
-
-sql_escape() {
-  python3 -c 'import sys; print(sys.stdin.read().replace("'\''", "'\'\''"))' <<<"$1"
-}
-
-while IFS= read -r owner; do
-  [ -z "$owner" ] && continue
-  echo "owner ${owner}"
-  payload="$(python3 -c 'import json,sys; print(json.dumps({"owner": sys.argv[1]}))' "$owner")"
-  blobs_json="$(curl -sS "${SIDECAR_URL%/}/walrus/query-blobs" \
-    -H "content-type: application/json" \
-    "${auth_args[@]}" \
-    -d "$payload")"
-
-  python3 - "$DATABASE_URL" "$owner" "$blobs_json" <<'PY'
-import json, subprocess, sys
-
-db, owner, raw = sys.argv[1], sys.argv[2], sys.argv[3]
+def psql(sql: str) -> str:
+    r = subprocess.run(
+        ["psql", db, "-v", "ON_ERROR_STOP=1", "-At", "-c", sql],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout
 
 def lit(value):
     if value is None or value == "":
         return "NULL"
     return "'" + str(value).replace("'", "''") + "'"
 
-try:
-    data = json.loads(raw)
-except json.JSONDecodeError:
-    print("sidecar returned non-json, skipping", owner, file=sys.stderr)
-    sys.exit(0)
-
-blobs = data.get("blobs") or []
-stmts = []
-seen = 0
-for blob in blobs:
-    blob_id = blob.get("blobId") or blob.get("blob_id")
-    if not blob_id:
-        continue
-    seen += 1
-    agent = blob.get("agentId") or blob.get("agent_id")
-    package = blob.get("packageId") or blob.get("package_id")
-    stmts.append(
-        "UPDATE vector_entries SET "
-        f"agent_id = COALESCE(agent_id, {lit(agent)}), "
-        f"package_id = COALESCE(package_id, {lit(package)}), "
-        "metadata_synced_at = NOW() "
-        f"WHERE owner = {lit(owner)} AND blob_id = {lit(blob_id)} "
-        "AND metadata_synced_at IS NULL;"
+def fetch_blobs(owner, blob_ids):
+    body = json.dumps({"owner": owner, "blobIds": blob_ids}).encode()
+    headers = {"content-type": "application/json"}
+    if secret:
+        headers["authorization"] = f"Bearer {secret}"
+    req = urllib.request.Request(
+        f"{sidecar}/walrus/query-blobs",
+        data=body,
+        headers=headers,
+        method="POST",
     )
-stmts.append(
-    "UPDATE vector_entries SET metadata_synced_at = NOW() "
-    f"WHERE owner = {lit(owner)} AND metadata_synced_at IS NULL;"
-)
-subprocess.check_call(["psql", db, "-v", "ON_ERROR_STOP=1", "-c", "\n".join(stmts)])
-print(f"  applied {seen} on-chain blob rows")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            raw = resp.read().decode()
+            status = resp.status
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"sidecar HTTP {e.code}: {e.read()[:300]!r}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"sidecar transport: {e}") from e
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"sidecar HTTP {status}: {raw[:300]!r}")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"sidecar non-json: {raw[:300]!r}") from e
+    if not isinstance(data, dict) or "blobs" not in data:
+        raise RuntimeError(f"sidecar missing blobs: {raw[:300]!r}")
+    if data.get("sourceCapped") is True:
+        raise RuntimeError("sidecar sourceCapped=true; not stamping this page")
+    by_id = {}
+    for blob in data.get("blobs") or []:
+        blob_id = blob.get("blobId") or blob.get("blob_id")
+        if not blob_id:
+            continue
+        by_id[blob_id] = (
+            blob.get("agentId") or blob.get("agent_id") or None,
+            blob.get("packageId") or blob.get("package_id") or None,
+        )
+    return by_id
+
+updated = 0
+pages = 0
+errors = 0
+last_owner = ""
+last_blob = ""
+
+while True:
+    sql = (
+        "SELECT owner, blob_id FROM vector_entries "
+        "WHERE metadata_synced_at IS NULL "
+        f"AND (owner, blob_id) > ({lit(last_owner)}, {lit(last_blob)}) "
+        "ORDER BY owner, blob_id "
+        f"LIMIT {page}"
+    )
+    # First page: no cursor.
+    if pages == 0 and not last_owner:
+        sql = (
+            "SELECT owner, blob_id FROM vector_entries "
+            "WHERE metadata_synced_at IS NULL "
+            "ORDER BY owner, blob_id "
+            f"LIMIT {page}"
+        )
+    rows = [ln.split("|", 1) for ln in psql(sql).splitlines() if ln]
+    if not rows:
+        break
+    pages += 1
+    by_owner = {}
+    for owner, blob_id in rows:
+        by_owner.setdefault(owner, []).append(blob_id)
+    last_owner, last_blob = rows[-1]
+
+    for owner, blob_ids in by_owner.items():
+        try:
+            found = fetch_blobs(owner, blob_ids)
+        except Exception as e:
+            errors += 1
+            print(f"SKIP owner={owner} n={len(blob_ids)} err={e}", file=sys.stderr)
+            continue
+        stmts = ["BEGIN;"]
+        for blob_id in blob_ids:
+            agent, package = found.get(blob_id, (None, None))
+            stmts.append(
+                "UPDATE vector_entries SET "
+                f"agent_id = COALESCE(agent_id, {lit(agent)}), "
+                f"package_id = COALESCE(package_id, {lit(package)}), "
+                "metadata_synced_at = NOW() "
+                f"WHERE owner = {lit(owner)} AND blob_id = {lit(blob_id)} "
+                "AND metadata_synced_at IS NULL;"
+            )
+        stmts.append("COMMIT;")
+        psql("\n".join(stmts))
+        updated += len(blob_ids)
+        print(
+            f"page={pages} owner={owner} requested={len(blob_ids)} "
+            f"sidecar_hits={len(found)} total_stamped={updated}"
+        )
+        time.sleep(sleep_sec)
+
+print(f"done pages={pages} stamped={updated} skipped_pages={errors}")
+sys.exit(1 if errors else 0)
 PY
-done <<< "$owners"

--- a/services/server/scripts/backfill-read-api-metadata.sh
+++ b/services/server/scripts/backfill-read-api-metadata.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Refill agent_id / package_id on pre-migration vector_entries rows (WALM-364).
 #
-# Safe for large mainnet sets (100k+ rows):
-#   - pages unsynced (owner, blob_id) from Postgres
-#   - asks the sidecar for THAT page only (blobIds), not the whole owner
-#   - stamps metadata_synced_at only on blob_ids requested in this page
-#   - never marks the rest of an owner "done"
-#   - HTTP / parse failures skip the page and leave rows NULL to retry
+# Mainnet-sized (100k+ rows): one sidecar listing per owner, not per page of
+# blob ids. Passing blobIds still makes the sidecar walk every owned Blob
+# object, so paging by blob_id would re-scan the owner on every page.
+#
+# Stamping rules:
+#   - HTTP / parse / sourceCapped: stamp nothing for that owner, retry later
+#   - 200 with a complete listing: UPDATE matching blob_ids, then stamp the
+#     owner's leftover unsynced rows (looked, not on chain)
+#   - never stamps a different owner
 #
 # Usage:
 #   DATABASE_URL=postgres://... \
@@ -14,8 +17,8 @@
 #   SIDECAR_SECRET=... \
 #     bash services/server/scripts/backfill-read-api-metadata.sh
 #
-# Optional: PAGE=100 SLEEP_SEC=0.25
-# Requires: psql, python3, curl.
+# Optional: OWNER_BATCH=10 SLEEP_SEC=1 TIMEOUT_SEC=3600
+# Requires: psql, python3.
 
 set -euo pipefail
 exec python3 - "$@" <<'PY'
@@ -27,9 +30,9 @@ secret = os.environ.get("SIDECAR_SECRET") or ""
 if not db or not sidecar:
     sys.exit("set DATABASE_URL and SIDECAR_URL")
 
-page = int(os.environ.get("PAGE") or "100")
-sleep_sec = float(os.environ.get("SLEEP_SEC") or "0.25")
-page = max(1, min(page, 200))
+owner_batch = max(1, int(os.environ.get("OWNER_BATCH") or "10"))
+sleep_sec = float(os.environ.get("SLEEP_SEC") or "1")
+timeout_sec = int(os.environ.get("TIMEOUT_SEC") or "3600")
 
 def psql(sql: str) -> str:
     r = subprocess.run(
@@ -45,8 +48,8 @@ def lit(value):
         return "NULL"
     return "'" + str(value).replace("'", "''") + "'"
 
-def fetch_blobs(owner, blob_ids):
-    body = json.dumps({"owner": owner, "blobIds": blob_ids}).encode()
+def fetch_blobs(owner):
+    body = json.dumps({"owner": owner}).encode()
     headers = {"content-type": "application/json"}
     if secret:
         headers["authorization"] = f"Bearer {secret}"
@@ -57,7 +60,7 @@ def fetch_blobs(owner, blob_ids):
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with urllib.request.urlopen(req, timeout=timeout_sec) as resp:
             raw = resp.read().decode()
             status = resp.status
     except urllib.error.HTTPError as e:
@@ -71,9 +74,9 @@ def fetch_blobs(owner, blob_ids):
     except json.JSONDecodeError as e:
         raise RuntimeError(f"sidecar non-json: {raw[:300]!r}") from e
     if not isinstance(data, dict) or "blobs" not in data:
-        raise RuntimeError(f"sidecar missing blobs: {raw[:300]!r}")
+        raise RuntimeError(f"sidecar missing blobs key: {raw[:300]!r}")
     if data.get("sourceCapped") is True:
-        raise RuntimeError("sidecar sourceCapped=true; not stamping this page")
+        raise RuntimeError("sourceCapped=true; listing incomplete, not stamping leftovers")
     by_id = {}
     for blob in data.get("blobs") or []:
         blob_id = blob.get("blobId") or blob.get("blob_id")
@@ -85,47 +88,12 @@ def fetch_blobs(owner, blob_ids):
         )
     return by_id
 
-updated = 0
-pages = 0
-errors = 0
-last_owner = ""
-last_blob = ""
-
-while True:
-    sql = (
-        "SELECT owner, blob_id FROM vector_entries "
-        "WHERE metadata_synced_at IS NULL "
-        f"AND (owner, blob_id) > ({lit(last_owner)}, {lit(last_blob)}) "
-        "ORDER BY owner, blob_id "
-        f"LIMIT {page}"
-    )
-    # First page: no cursor.
-    if pages == 0 and not last_owner:
-        sql = (
-            "SELECT owner, blob_id FROM vector_entries "
-            "WHERE metadata_synced_at IS NULL "
-            "ORDER BY owner, blob_id "
-            f"LIMIT {page}"
-        )
-    rows = [ln.split("|", 1) for ln in psql(sql).splitlines() if ln]
-    if not rows:
-        break
-    pages += 1
-    by_owner = {}
-    for owner, blob_id in rows:
-        by_owner.setdefault(owner, []).append(blob_id)
-    last_owner, last_blob = rows[-1]
-
-    for owner, blob_ids in by_owner.items():
-        try:
-            found = fetch_blobs(owner, blob_ids)
-        except Exception as e:
-            errors += 1
-            print(f"SKIP owner={owner} n={len(blob_ids)} err={e}", file=sys.stderr)
-            continue
+def apply_owner(owner, found):
+    items = list(found.items())
+    for i in range(0, len(items), 200):
+        chunk = items[i:i+200]
         stmts = ["BEGIN;"]
-        for blob_id in blob_ids:
-            agent, package = found.get(blob_id, (None, None))
+        for blob_id, (agent, package) in chunk:
             stmts.append(
                 "UPDATE vector_entries SET "
                 f"agent_id = COALESCE(agent_id, {lit(agent)}), "
@@ -136,13 +104,46 @@ while True:
             )
         stmts.append("COMMIT;")
         psql("\n".join(stmts))
-        updated += len(blob_ids)
-        print(
-            f"page={pages} owner={owner} requested={len(blob_ids)} "
-            f"sidecar_hits={len(found)} total_stamped={updated}"
-        )
+        print(f"  applied {min(i+200, len(items))}/{len(items)} sidecar blobs", flush=True)
+    # Complete listing only: leftover unsynced rows were looked up and are
+    # not on chain (or have no memwal_* keys).
+    psql(
+        "UPDATE vector_entries SET metadata_synced_at = NOW() "
+        f"WHERE owner = {lit(owner)} AND metadata_synced_at IS NULL;"
+    )
+
+stamped_owners = 0
+errors = 0
+last_owner = ""
+
+while True:
+    sql = (
+        "SELECT DISTINCT owner FROM vector_entries "
+        "WHERE metadata_synced_at IS NULL "
+        + (f"AND owner > {lit(last_owner)} " if last_owner else "")
+        + "ORDER BY owner "
+        + f"LIMIT {owner_batch}"
+    )
+    owners = [ln for ln in psql(sql).splitlines() if ln]
+    if not owners:
+        break
+    last_owner = owners[-1]
+    for owner in owners:
+        leftover = psql(
+            "SELECT COUNT(*) FROM vector_entries "
+            f"WHERE owner = {lit(owner)} AND metadata_synced_at IS NULL"
+        ).strip()
+        print(f"owner={owner} unsynced={leftover}", flush=True)
+        try:
+            found = fetch_blobs(owner)
+            apply_owner(owner, found)
+            stamped_owners += 1
+            print(f"  sidecar_blobs={len(found)} ok", flush=True)
+        except Exception as e:
+            errors += 1
+            print(f"  SKIP {e}", file=sys.stderr, flush=True)
         time.sleep(sleep_sec)
 
-print(f"done pages={pages} stamped={updated} skipped_pages={errors}")
+print(f"done owners={stamped_owners} skipped={errors}")
 sys.exit(1 if errors else 0)
 PY

--- a/services/server/scripts/backfill-read-api-metadata.sh
+++ b/services/server/scripts/backfill-read-api-metadata.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Refill agent_id / package_id on pre-migration vector_entries rows (WALM-364).
+#
+# New writes already dual-write those columns. Rows created before migration
+# 014 stay NULL forever unless this job runs. Batched, resumable, and never
+# on the read hot path.
+#
+# For each owner that still has unsynced rows, POST /walrus/query-blobs on the
+# sidecar (that payload already includes memwal_agent_id / memwal_package_id).
+# Matching blob_id stamps the columns and metadata_synced_at. Blobs with no
+# on-chain agent id stay NULL but still get metadata_synced_at so they are
+# not retried.
+#
+# Usage:
+#   DATABASE_URL=postgres://... \
+#   SIDECAR_URL=http://127.0.0.1:3001 \
+#   SIDECAR_SECRET=... \
+#     bash services/server/scripts/backfill-read-api-metadata.sh
+#
+# Requires: psql, python3, curl.
+
+set -euo pipefail
+
+: "${DATABASE_URL:?set DATABASE_URL}"
+: "${SIDECAR_URL:?set SIDECAR_URL}"
+SIDECAR_SECRET="${SIDECAR_SECRET:-}"
+BATCH="${BATCH:-50}"
+
+owners="$(psql "$DATABASE_URL" -Atqc "
+  SELECT DISTINCT owner
+  FROM vector_entries
+  WHERE metadata_synced_at IS NULL
+  ORDER BY owner
+  LIMIT ${BATCH};
+")"
+
+if [ -z "$owners" ]; then
+  echo "nothing to backfill"
+  exit 0
+fi
+
+auth_args=()
+if [ -n "$SIDECAR_SECRET" ]; then
+  auth_args=(-H "X-Sidecar-Secret: ${SIDECAR_SECRET}")
+fi
+
+sql_escape() {
+  python3 -c 'import sys; print(sys.stdin.read().replace("'\''", "'\'\''"))' <<<"$1"
+}
+
+while IFS= read -r owner; do
+  [ -z "$owner" ] && continue
+  echo "owner ${owner}"
+  payload="$(python3 -c 'import json,sys; print(json.dumps({"owner": sys.argv[1]}))' "$owner")"
+  blobs_json="$(curl -sS "${SIDECAR_URL%/}/walrus/query-blobs" \
+    -H "content-type: application/json" \
+    "${auth_args[@]}" \
+    -d "$payload")"
+
+  python3 - "$DATABASE_URL" "$owner" "$blobs_json" <<'PY'
+import json, subprocess, sys
+
+db, owner, raw = sys.argv[1], sys.argv[2], sys.argv[3]
+
+def lit(value):
+    if value is None or value == "":
+        return "NULL"
+    return "'" + str(value).replace("'", "''") + "'"
+
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    print("sidecar returned non-json, skipping", owner, file=sys.stderr)
+    sys.exit(0)
+
+blobs = data.get("blobs") or []
+stmts = []
+seen = 0
+for blob in blobs:
+    blob_id = blob.get("blobId") or blob.get("blob_id")
+    if not blob_id:
+        continue
+    seen += 1
+    agent = blob.get("agentId") or blob.get("agent_id")
+    package = blob.get("packageId") or blob.get("package_id")
+    stmts.append(
+        "UPDATE vector_entries SET "
+        f"agent_id = COALESCE(agent_id, {lit(agent)}), "
+        f"package_id = COALESCE(package_id, {lit(package)}), "
+        "metadata_synced_at = NOW() "
+        f"WHERE owner = {lit(owner)} AND blob_id = {lit(blob_id)} "
+        "AND metadata_synced_at IS NULL;"
+    )
+stmts.append(
+    "UPDATE vector_entries SET metadata_synced_at = NOW() "
+    f"WHERE owner = {lit(owner)} AND metadata_synced_at IS NULL;"
+)
+subprocess.check_call(["psql", db, "-v", "ON_ERROR_STOP=1", "-c", "\n".join(stmts)])
+print(f"  applied {seen} on-chain blob rows")
+PY
+done <<< "$owners"

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1206,10 +1206,7 @@ async fn main() {
             if let Err(e) = evict_state.db.prune_unconsumed_oauth_clients().await {
                 tracing::error!("MCP OAuth client pruning failed: {}", e);
             }
-            if let Err(e) = evict_state
-                .db
-                .sweep_expired_tombstones(std::time::Duration::from_secs(30 * 24 * 3600))
-                .await
+            if let Err(e) = evict_state.db.sweep_expired_tombstones().await
             {
                 tracing::error!("tombstone retention sweep failed: {}", e);
             }

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1206,6 +1206,13 @@ async fn main() {
             if let Err(e) = evict_state.db.prune_unconsumed_oauth_clients().await {
                 tracing::error!("MCP OAuth client pruning failed: {}", e);
             }
+            if let Err(e) = evict_state
+                .db
+                .sweep_expired_tombstones(std::time::Duration::from_secs(30 * 24 * 3600))
+                .await
+            {
+                tracing::error!("tombstone retention sweep failed: {}", e);
+            }
         }
     });
 

--- a/services/server/src/routes/memory_read.rs
+++ b/services/server/src/routes/memory_read.rs
@@ -55,6 +55,9 @@ pub struct MemoryItem {
     pub status: String,
     pub end_epoch: Option<i32>,
     pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Extractor importance in 0.0–1.0. Already stored on `vector_entries`;
+    /// exposed so Console can sort or badge without a second query.
+    pub importance: Option<f32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -68,11 +71,14 @@ pub struct MemoriesResponse {
     pub snapshot_version: u32,
 }
 
-/// Bumped 1 -> 2: the `/namespaces` cursor changed wire format (bare
-/// namespace name -> `(updated_at, namespace)` watermark, so a v1 cursor is
-/// not decodable as a v2 one) and both `/namespaces` and `/memories` rows
-/// gained an `updated_at` field.
-pub const SNAPSHOT_VERSION: u32 = 2;
+/// Bumped on wire-format changes only (new fields or cursor encoding), not on
+/// ordinary source-data mutations. Phase 1 does not bump this on a source reset.
+///
+/// 1 -> 2: `/namespaces` cursor became `(updated_at, namespace)` and rows
+/// gained `updated_at`.
+/// 2 -> 3: `/memories` gained `importance` and `status=deleted` tombstones;
+/// `/namespaces` watermarks survive hard deletes.
+pub const SNAPSHOT_VERSION: u32 = 3;
 
 const DEFAULT_NAMESPACES_LIMIT: i64 = 100;
 const MAX_NAMESPACES_LIMIT: i64 = 500;
@@ -203,17 +209,42 @@ pub(crate) async fn query_owner_namespaces(
     // own, because `limit` is silently clamped to MAX_NAMESPACES_LIMIT: a
     // caller that asked for more than the cap and got exactly the cap back
     // would otherwise wrongly conclude it was done.
+    // Live rollup FULL OUTER JOIN stored watermarks so a namespace whose last
+    // row was deleted still resurfaces (WALM-363). Watermark-only rows have
+    // memory_count 0.
+    const NS_SQL_TAIL: &str = "
+        SELECT COALESCE(l.namespace, w.namespace) AS namespace,
+               COALESCE(l.memory_count, 0) AS memory_count,
+               COALESCE(l.storage_used, 0) AS storage_used,
+               GREATEST(
+                   COALESCE(l.last_updated_at, w.last_mutated_at),
+                   COALESCE(w.last_mutated_at, l.last_updated_at)
+               ) AS last_updated_at
+        FROM (
+            SELECT namespace,
+                   COUNT(*)::BIGINT AS memory_count,
+                   COALESCE(SUM(blob_size_bytes), 0)::BIGINT AS storage_used,
+                   MAX(updated_at) AS last_updated_at
+            FROM vector_entries
+            WHERE owner = $1
+            GROUP BY namespace
+        ) l
+        FULL OUTER JOIN (
+            SELECT namespace, last_mutated_at
+            FROM namespace_watermarks
+            WHERE owner = $1
+        ) w ON l.namespace = w.namespace
+    ";
+
     let mut rows: Vec<(String, i64, i64, chrono::DateTime<chrono::Utc>)> =
         if let Some((cursor_updated_at, cursor_namespace)) = after.clone() {
-            sqlx::query_as(
-                "SELECT namespace, COUNT(*) AS memory_count, COALESCE(SUM(blob_size_bytes), 0)::BIGINT AS storage_used, MAX(updated_at) AS last_updated_at
-                 FROM vector_entries
-                 WHERE owner = $1
-                 GROUP BY namespace
-                 HAVING (MAX(updated_at), namespace) > ($2, $3) AND MAX(updated_at) <= $4
-                 ORDER BY MAX(updated_at), namespace
+            let sql = format!(
+                "SELECT namespace, memory_count, storage_used, last_updated_at FROM ({NS_SQL_TAIL}) s
+                 WHERE (last_updated_at, namespace) > ($2, $3) AND last_updated_at <= $4
+                 ORDER BY last_updated_at, namespace
                  LIMIT $5",
-            )
+            );
+            sqlx::query_as(&sql)
             .bind(owner)
             .bind(cursor_updated_at)
             .bind(cursor_namespace)
@@ -222,15 +253,13 @@ pub(crate) async fn query_owner_namespaces(
             .fetch_all(pool)
             .await
         } else {
-            sqlx::query_as(
-                "SELECT namespace, COUNT(*) AS memory_count, COALESCE(SUM(blob_size_bytes), 0)::BIGINT AS storage_used, MAX(updated_at) AS last_updated_at
-                 FROM vector_entries
-                 WHERE owner = $1
-                 GROUP BY namespace
-                 HAVING MAX(updated_at) <= $2
-                 ORDER BY MAX(updated_at), namespace
+            let sql = format!(
+                "SELECT namespace, memory_count, storage_used, last_updated_at FROM ({NS_SQL_TAIL}) s
+                 WHERE last_updated_at <= $2
+                 ORDER BY last_updated_at, namespace
                  LIMIT $3",
-            )
+            );
+            sqlx::query_as(&sql)
             .bind(owner)
             .bind(snapshot_at)
             .bind(limit + 1)
@@ -405,6 +434,22 @@ pub(crate) async fn query_owner_memories(
     // Peek one row past `limit` for an explicit has_more signal — see
     // query_owner_namespaces's identical comment on why page-length alone
     // (vs. the clamped limit) isn't a reliable end-of-data signal.
+    const MEM_SQL: &str = "
+        SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes,
+               agent_id, package_id, end_epoch, expires_at, importance, is_deleted
+        FROM (
+            SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes,
+                   agent_id, package_id, end_epoch, expires_at, importance, FALSE AS is_deleted
+            FROM vector_entries
+            WHERE owner = $1
+            UNION ALL
+            SELECT id, namespace, blob_id, deleted_at, deleted_at, 0::BIGINT,
+                   NULL::TEXT, NULL::TEXT, NULL::INT, NULL::TIMESTAMPTZ, NULL::REAL, TRUE
+            FROM memory_tombstones
+            WHERE owner = $1
+        ) u
+    ";
+
     #[allow(clippy::type_complexity)]
     let mut rows: Vec<(
         String,
@@ -417,14 +462,16 @@ pub(crate) async fn query_owner_memories(
         Option<String>,
         Option<i32>,
         Option<chrono::DateTime<chrono::Utc>>,
+        Option<f32>,
+        bool,
     )> = if let Some((cursor_updated_at, cursor_id)) = after.clone() {
-        sqlx::query_as(
-            "SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes, agent_id, package_id, end_epoch, expires_at
-             FROM vector_entries
-             WHERE owner = $1 AND (updated_at, id) > ($2, $3) AND updated_at <= $4
+        let sql = format!(
+            "{MEM_SQL}
+             WHERE (updated_at, id) > ($2, $3) AND updated_at <= $4
              ORDER BY updated_at, id
-             LIMIT $5",
-        )
+             LIMIT $5"
+        );
+        sqlx::query_as(&sql)
         .bind(owner)
         .bind(cursor_updated_at)
         .bind(cursor_id)
@@ -433,13 +480,13 @@ pub(crate) async fn query_owner_memories(
         .fetch_all(pool)
         .await
     } else {
-        sqlx::query_as(
-            "SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes, agent_id, package_id, end_epoch, expires_at
-             FROM vector_entries
-             WHERE owner = $1 AND updated_at <= $2
+        let sql = format!(
+            "{MEM_SQL}
+             WHERE updated_at <= $2
              ORDER BY updated_at, id
-             LIMIT $3",
-        )
+             LIMIT $3"
+        );
+        sqlx::query_as(&sql)
         .bind(owner)
         .bind(snapshot_at)
         .bind(limit + 1)
@@ -480,6 +527,8 @@ pub(crate) async fn query_owner_memories(
                 package_id,
                 end_epoch,
                 expires_at,
+                importance,
+                is_deleted,
             )| {
                 MemoryItem {
                     memory_id: id,
@@ -490,12 +539,17 @@ pub(crate) async fn query_owner_memories(
                     size,
                     agent_id,
                     package_id,
-                    status: match expires_at {
-                        Some(exp) if exp < chrono::Utc::now() => "expired".to_string(),
-                        _ => "active".to_string(), // includes NULL (not yet synced) — optimistic default
+                    status: if is_deleted {
+                        "deleted".to_string()
+                    } else {
+                        match expires_at {
+                            Some(exp) if exp < chrono::Utc::now() => "expired".to_string(),
+                            _ => "active".to_string(),
+                        }
                     },
                     end_epoch,
                     expires_at,
+                    importance,
                 }
             },
         )
@@ -651,6 +705,8 @@ mod tests {
             include_str!("../../migrations/016_memory_read_api_index.sql"),
             include_str!("../../migrations/017_memory_expiry_columns.sql"),
             include_str!("../../migrations/018_memory_expiry_synced_at_index.sql"),
+            include_str!("../../migrations/019_memory_read_api_updated_at_set_not_null.sql"),
+            include_str!("../../migrations/020_read_api_followups.sql"),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -746,6 +802,14 @@ mod tests {
     }
 
     async fn cleanup(pool: &PgPool, owner: &str) {
+        let _ = sqlx::query("DELETE FROM memory_tombstones WHERE owner = $1")
+            .bind(owner)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM namespace_watermarks WHERE owner = $1")
+            .bind(owner)
+            .execute(pool)
+            .await;
         let _ = sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
             .bind(owner)
             .execute(pool)
@@ -806,6 +870,69 @@ mod tests {
         let decoded = decode_namespaces_cursor(&cursor).unwrap();
         assert_eq!(decoded.namespace, "work");
         assert_eq!(decoded.updated_at, ts(120));
+
+        cleanup(&pool, &owner).await;
+    }
+
+    #[tokio::test]
+    async fn deleting_the_watermark_row_still_resurfaces_the_namespace() {
+        let pool = test_pool().await;
+        let owner = format!("0xtest-{}", uuid::Uuid::new_v4());
+        seed_entry(&pool, &owner, "keep", "notes", 100, ts(0)).await;
+        seed_entry(&pool, &owner, "gone", "notes", 200, ts(120)).await;
+
+        let before = query_owner_namespaces(&pool, &owner, None, 100)
+            .await
+            .unwrap();
+        assert_eq!(before.namespaces[0].memory_count, 2);
+        let cursor = before.next_cursor.clone().unwrap();
+
+        sqlx::query(
+            "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
+             SELECT id, owner, namespace, blob_id, NOW()
+             FROM vector_entries WHERE owner = $1 AND id = $2",
+        )
+        .bind(&owner)
+        .bind(format!("{}-gone", owner))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("DELETE FROM vector_entries WHERE owner = $1 AND id = $2")
+            .bind(&owner)
+            .bind(format!("{}-gone", owner))
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO namespace_watermarks (owner, namespace, last_mutated_at)
+             VALUES ($1, 'notes', $2)
+             ON CONFLICT (owner, namespace) DO UPDATE SET last_mutated_at = EXCLUDED.last_mutated_at",
+        )
+        .bind(&owner)
+        .bind(ts(180))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let after = query_owner_namespaces(&pool, &owner, Some(cursor), 100)
+            .await
+            .unwrap();
+        assert_eq!(after.namespaces.len(), 1, "deleted watermark must still resurface");
+        assert_eq!(after.namespaces[0].memory_count, 1);
+        assert_eq!(after.namespaces[0].updated_at, ts(180));
+
+        let memories = query_owner_memories(&pool, &owner, None, 100)
+            .await
+            .unwrap();
+        let statuses: Vec<_> = memories
+            .memories
+            .iter()
+            .map(|m| (m.memory_id.rsplit('-').next().unwrap_or(""), m.status.as_str()))
+            .collect();
+        assert!(
+            statuses.iter().any(|(id, status)| *id == "gone" && *status == "deleted"),
+            "tombstone missing: {statuses:?}",
+        );
 
         cleanup(&pool, &owner).await;
     }

--- a/services/server/src/routes/memory_read.rs
+++ b/services/server/src/routes/memory_read.rs
@@ -445,8 +445,9 @@ pub(crate) async fn query_owner_memories(
             UNION ALL
             SELECT id, namespace, blob_id, deleted_at, deleted_at, 0::BIGINT,
                    NULL::TEXT, NULL::TEXT, NULL::INT, NULL::TIMESTAMPTZ, NULL::REAL, TRUE
-            FROM memory_tombstones
+            FROM memory_tombstones t
             WHERE owner = $1
+              AND NOT EXISTS (SELECT 1 FROM vector_entries v WHERE v.id = t.id)
         ) u
     ";
 
@@ -666,6 +667,7 @@ pub async fn list_owner_agents(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::db::VectorDb;
     use sqlx::postgres::PgPoolOptions;
     use std::sync::OnceLock;
 
@@ -887,39 +889,18 @@ mod tests {
         assert_eq!(before.namespaces[0].memory_count, 2);
         let cursor = before.next_cursor.clone().unwrap();
 
-        sqlx::query(
-            "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
-             SELECT id, owner, namespace, blob_id, NOW()
-             FROM vector_entries WHERE owner = $1 AND id = $2",
-        )
-        .bind(&owner)
-        .bind(format!("{}-gone", owner))
-        .execute(&pool)
-        .await
-        .unwrap();
-        sqlx::query("DELETE FROM vector_entries WHERE owner = $1 AND id = $2")
-            .bind(&owner)
-            .bind(format!("{}-gone", owner))
-            .execute(&pool)
+        let deleted = VectorDb::from_pool(pool.clone())
+            .delete_by_blob_id(&format!("blob-gone"), &owner, "notes")
             .await
             .unwrap();
-        sqlx::query(
-            "INSERT INTO namespace_watermarks (owner, namespace, last_mutated_at)
-             VALUES ($1, 'notes', $2)
-             ON CONFLICT (owner, namespace) DO UPDATE SET last_mutated_at = EXCLUDED.last_mutated_at",
-        )
-        .bind(&owner)
-        .bind(ts(180))
-        .execute(&pool)
-        .await
-        .unwrap();
+        assert_eq!(deleted, 1);
 
         let after = query_owner_namespaces(&pool, &owner, Some(cursor), 100)
             .await
             .unwrap();
         assert_eq!(after.namespaces.len(), 1, "deleted watermark must still resurface");
         assert_eq!(after.namespaces[0].memory_count, 1);
-        assert_eq!(after.namespaces[0].updated_at, ts(180));
+        assert!(after.namespaces[0].updated_at > ts(120));
 
         let memories = query_owner_memories(&pool, &owner, None, 100)
             .await

--- a/services/server/src/routes/memory_read.rs
+++ b/services/server/src/routes/memory_read.rs
@@ -55,9 +55,16 @@ pub struct MemoryItem {
     pub status: String,
     pub end_epoch: Option<i32>,
     pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
-    /// Extractor importance in 0.0–1.0. Already stored on `vector_entries`;
-    /// exposed so Console can sort or badge without a second query.
     pub importance: Option<f32>,
+}
+
+/// Additive tombstone for Console incremental sync (WALM-363). Ignored by
+/// clients that do not read `deleted`. Never mixed into `memories[]`.
+#[derive(Debug, Serialize)]
+pub struct DeletedMemory {
+    pub memory_id: String,
+    pub namespace_id: String,
+    pub deleted_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, Serialize)]
@@ -69,16 +76,16 @@ pub struct MemoriesResponse {
     /// `MAX_MEMORIES_LIMIT`).
     pub has_more: bool,
     pub snapshot_version: u32,
+    pub deleted: Vec<DeletedMemory>,
+    pub must_resync: bool,
 }
 
-/// Bumped on wire-format changes only (new fields or cursor encoding), not on
-/// ordinary source-data mutations. Phase 1 does not bump this on a source reset.
-///
-/// 1 -> 2: `/namespaces` cursor became `(updated_at, namespace)` and rows
-/// gained `updated_at`.
-/// 2 -> 3: `/memories` gained `importance` and `status=deleted` tombstones;
-/// `/namespaces` watermarks survive hard deletes.
-pub const SNAPSHOT_VERSION: u32 = 3;
+/// Additive fields only (`deleted`, `must_resync`). Keep at 2 so the shipped
+/// Console client (COMG-568) ignores the new keys and never treats tombstones
+/// as live memories.
+pub const SNAPSHOT_VERSION: u32 = 2;
+
+const TOMBSTONE_RETENTION: chrono::Duration = chrono::Duration::days(30);
 
 const DEFAULT_NAMESPACES_LIMIT: i64 = 100;
 const MAX_NAMESPACES_LIMIT: i64 = 500;
@@ -230,9 +237,10 @@ pub(crate) async fn query_owner_namespaces(
             GROUP BY namespace
         ) l
         FULL OUTER JOIN (
-            SELECT namespace, last_mutated_at
-            FROM namespace_watermarks
+            SELECT namespace, MAX(deleted_at) AS last_mutated_at
+            FROM memory_tombstones
             WHERE owner = $1
+            GROUP BY namespace
         ) w ON l.namespace = w.namespace
     ";
 
@@ -376,6 +384,12 @@ struct MemoriesCursor {
     id: String,
     #[serde(default)]
     snapshot_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Second keyset for the additive `deleted[]` stream. Absent on v1
+    /// cursors: replay up to 30 days of tombstones once.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    deleted_id: Option<String>,
 }
 
 /// `snapshot_at: None` resets the walk boundary — see
@@ -389,10 +403,22 @@ fn encode_cursor(
     id: &str,
     snapshot_at: Option<chrono::DateTime<chrono::Utc>>,
 ) -> String {
+    encode_cursor_ex(updated_at, id, snapshot_at, None, None)
+}
+
+fn encode_cursor_ex(
+    updated_at: chrono::DateTime<chrono::Utc>,
+    id: &str,
+    snapshot_at: Option<chrono::DateTime<chrono::Utc>>,
+    deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+    deleted_id: Option<String>,
+) -> String {
     let json = serde_json::to_vec(&MemoriesCursor {
         updated_at,
         id: id.to_string(),
         snapshot_at,
+        deleted_at,
+        deleted_id,
     })
     .expect("cursor serializes");
     // URL_SAFE_NO_PAD (not STANDARD): next_cursor is used verbatim in a URL
@@ -418,40 +444,40 @@ pub(crate) async fn query_owner_memories(
     limit: i64,
 ) -> Result<MemoriesResponse, AppError> {
     let limit = limit.clamp(1, MAX_MEMORIES_LIMIT);
+    let now = chrono::Utc::now();
+    let retention_cut = now - TOMBSTONE_RETENTION;
 
-    // See the doc comment on `MemoriesCursor::snapshot_at`: bind this whole
-    // walk to one boundary, captured now on the first page and threaded
-    // forward unchanged from the incoming cursor on every later page.
-    let (after, snapshot_at) = match cursor {
-        Some(raw_cursor) => {
-            let c = decode_cursor(&raw_cursor)?;
-            let snapshot_at = c.snapshot_at.unwrap_or_else(chrono::Utc::now);
-            (Some((c.updated_at, c.id)), snapshot_at)
-        }
-        None => (None, chrono::Utc::now()),
+    let decoded = match cursor.as_deref() {
+        Some(raw) => Some(decode_cursor(raw)?),
+        None => None,
     };
 
-    // Peek one row past `limit` for an explicit has_more signal — see
-    // query_owner_namespaces's identical comment on why page-length alone
-    // (vs. the clamped limit) isn't a reliable end-of-data signal.
-    const MEM_SQL: &str = "
-        SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes,
-               agent_id, package_id, end_epoch, expires_at, importance, is_deleted
-        FROM (
-            SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes,
-                   agent_id, package_id, end_epoch, expires_at, importance, FALSE AS is_deleted
-            FROM vector_entries
-            WHERE owner = $1
-            UNION ALL
-            SELECT id, namespace, blob_id, deleted_at, deleted_at, 0::BIGINT,
-                   NULL::TEXT, NULL::TEXT, NULL::INT, NULL::TIMESTAMPTZ, NULL::REAL, TRUE
-            FROM memory_tombstones t
-            WHERE owner = $1
-              AND NOT EXISTS (SELECT 1 FROM vector_entries v WHERE v.id = t.id)
-        ) u
-    ";
+    if let Some(c) = decoded.as_ref() {
+        let oldest = c.deleted_at.or(c.snapshot_at).unwrap_or(c.updated_at);
+        if oldest < retention_cut {
+            return Ok(MemoriesResponse {
+                memories: Vec::new(),
+                next_cursor: None,
+                has_more: false,
+                snapshot_version: SNAPSHOT_VERSION,
+                deleted: Vec::new(),
+                must_resync: true,
+            });
+        }
+    }
 
-    #[allow(clippy::type_complexity)]
+    let (after, snapshot_at, deleted_after) = match decoded {
+        Some(c) => {
+            let snapshot_at = c.snapshot_at.unwrap_or(now);
+            let deleted_after = match (c.deleted_at, c.deleted_id) {
+                (Some(t), Some(id)) => Some((t, id)),
+                _ => None,
+            };
+            (Some((c.updated_at, c.id)), snapshot_at, deleted_after)
+        }
+        None => (None, now, None),
+    };
+
     let mut rows: Vec<(
         String,
         String,
@@ -464,15 +490,15 @@ pub(crate) async fn query_owner_memories(
         Option<i32>,
         Option<chrono::DateTime<chrono::Utc>>,
         Option<f32>,
-        bool,
     )> = if let Some((cursor_updated_at, cursor_id)) = after.clone() {
-        let sql = format!(
-            "{MEM_SQL}
-             WHERE (updated_at, id) > ($2, $3) AND updated_at <= $4
+        sqlx::query_as(
+            "SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes,
+                    agent_id, package_id, end_epoch, expires_at, importance
+             FROM vector_entries
+             WHERE owner = $1 AND (updated_at, id) > ($2, $3) AND updated_at <= $4
              ORDER BY updated_at, id
-             LIMIT $5"
-        );
-        sqlx::query_as(&sql)
+             LIMIT $5",
+        )
         .bind(owner)
         .bind(cursor_updated_at)
         .bind(cursor_id)
@@ -481,13 +507,14 @@ pub(crate) async fn query_owner_memories(
         .fetch_all(pool)
         .await
     } else {
-        let sql = format!(
-            "{MEM_SQL}
-             WHERE updated_at <= $2
+        sqlx::query_as(
+            "SELECT id, namespace, blob_id, created_at, updated_at, blob_size_bytes,
+                    agent_id, package_id, end_epoch, expires_at, importance
+             FROM vector_entries
+             WHERE owner = $1 AND updated_at <= $2
              ORDER BY updated_at, id
-             LIMIT $3"
-        );
-        sqlx::query_as(&sql)
+             LIMIT $3",
+        )
         .bind(owner)
         .bind(snapshot_at)
         .bind(limit + 1)
@@ -496,22 +523,77 @@ pub(crate) async fn query_owner_memories(
     }
     .map_err(|e| AppError::Internal(format!("Failed to query memories: {}", e)))?;
 
-    let has_more = rows.len() as i64 > limit;
+    let live_has_more = rows.len() as i64 > limit;
     rows.truncate(limit as usize);
 
-    // Same watermark rule as `query_owner_namespaces`: the cursor always
-    // comes from the last row emitted (never the peeked extra row above), so
-    // the final (or only) page still checkpoints the client for its next
-    // incremental poll.
-    // `Some(snapshot_at)` while the walk continues, `None` on the terminal
-    // page — see `encode_cursor`'s doc comment. An empty continuation page
-    // needs the same reset — see the identical branch and its full
-    // rationale in `query_owner_namespaces`.
-    let next_cursor = match rows.last() {
-        Some(r) => Some(encode_cursor(r.4, &r.0, has_more.then_some(snapshot_at))),
-        None => after.map(|(cursor_updated_at, cursor_id)| {
-            encode_cursor(cursor_updated_at, &cursor_id, None)
-        }),
+    let tombstone_start = deleted_after
+        .as_ref()
+        .map(|(t, _)| *t)
+        .unwrap_or(retention_cut);
+
+    let mut deleted_rows: Vec<(String, String, chrono::DateTime<chrono::Utc>)> =
+        if let Some((d_at, d_id)) = deleted_after.clone() {
+            sqlx::query_as(
+                "SELECT memory_id, namespace, deleted_at
+                 FROM memory_tombstones
+                 WHERE owner = $1
+                   AND deleted_at >= $2
+                   AND (deleted_at, memory_id) > ($3, $4)
+                   AND deleted_at <= $5
+                 ORDER BY deleted_at, memory_id
+                 LIMIT $6",
+            )
+            .bind(owner)
+            .bind(retention_cut)
+            .bind(d_at)
+            .bind(d_id)
+            .bind(snapshot_at)
+            .bind(limit + 1)
+            .fetch_all(pool)
+            .await
+        } else {
+            sqlx::query_as(
+                "SELECT memory_id, namespace, deleted_at
+                 FROM memory_tombstones
+                 WHERE owner = $1
+                   AND deleted_at >= $2
+                   AND deleted_at <= $3
+                 ORDER BY deleted_at, memory_id
+                 LIMIT $4",
+            )
+            .bind(owner)
+            .bind(tombstone_start)
+            .bind(snapshot_at)
+            .bind(limit + 1)
+            .fetch_all(pool)
+            .await
+        }
+        .map_err(|e| AppError::Internal(format!("Failed to query tombstones: {}", e)))?;
+
+    let deleted_has_more = deleted_rows.len() as i64 > limit;
+    deleted_rows.truncate(limit as usize);
+    let has_more = live_has_more || deleted_has_more;
+
+    let next_deleted = deleted_rows
+        .last()
+        .map(|(id, _, t)| (*t, id.clone()))
+        .or(deleted_after.clone());
+
+    let live_mark = rows
+        .last()
+        .map(|r| (r.4, r.0.clone()))
+        .or(after.clone())
+        .unwrap_or((snapshot_at, String::new()));
+    let next_cursor = if rows.is_empty() && deleted_rows.is_empty() && after.is_none() {
+        None
+    } else {
+        Some(encode_cursor_ex(
+            live_mark.0,
+            &live_mark.1,
+            has_more.then_some(snapshot_at),
+            next_deleted.as_ref().map(|(t, _)| *t),
+            next_deleted.as_ref().map(|(_, id)| id.clone()),
+        ))
     };
 
     let memories = rows
@@ -529,31 +611,33 @@ pub(crate) async fn query_owner_memories(
                 end_epoch,
                 expires_at,
                 importance,
-                is_deleted,
-            )| {
-                MemoryItem {
-                    memory_id: id,
-                    namespace_id: namespace,
-                    blob_id,
-                    created_at,
-                    updated_at,
-                    size,
-                    agent_id,
-                    package_id,
-                    status: if is_deleted {
-                        "deleted".to_string()
-                    } else {
-                        match expires_at {
-                            Some(exp) if exp < chrono::Utc::now() => "expired".to_string(),
-                            _ => "active".to_string(),
-                        }
-                    },
-                    end_epoch,
-                    expires_at,
-                    importance,
-                }
+            )| MemoryItem {
+                memory_id: id,
+                namespace_id: namespace,
+                blob_id,
+                created_at,
+                updated_at,
+                size,
+                agent_id,
+                package_id,
+                status: match expires_at {
+                    Some(exp) if exp < chrono::Utc::now() => "expired".to_string(),
+                    _ => "active".to_string(),
+                },
+                end_epoch,
+                expires_at,
+                importance,
             },
         )
+        .collect();
+
+    let deleted = deleted_rows
+        .into_iter()
+        .map(|(memory_id, namespace_id, deleted_at)| DeletedMemory {
+            memory_id,
+            namespace_id,
+            deleted_at,
+        })
         .collect();
 
     Ok(MemoriesResponse {
@@ -561,6 +645,8 @@ pub(crate) async fn query_owner_memories(
         next_cursor,
         has_more,
         snapshot_version: SNAPSHOT_VERSION,
+        deleted,
+        must_resync: false,
     })
 }
 
@@ -742,6 +828,8 @@ mod tests {
                 updated_at,
                 id: id.clone(),
                 snapshot_at: Some(snapshot_at),
+                deleted_at: None,
+                deleted_id: None,
             })
             .expect("cursor serializes");
             let standard_encoded = base64::engine::general_purpose::STANDARD.encode(&json);
@@ -805,10 +893,6 @@ mod tests {
 
     async fn cleanup(pool: &PgPool, owner: &str) {
         let _ = sqlx::query("DELETE FROM memory_tombstones WHERE owner = $1")
-            .bind(owner)
-            .execute(pool)
-            .await;
-        let _ = sqlx::query("DELETE FROM namespace_watermarks WHERE owner = $1")
             .bind(owner)
             .execute(pool)
             .await;
@@ -905,15 +989,19 @@ mod tests {
         let memories = query_owner_memories(&pool, &owner, None, 100)
             .await
             .unwrap();
-        let statuses: Vec<_> = memories
-            .memories
-            .iter()
-            .map(|m| (m.memory_id.rsplit('-').next().unwrap_or(""), m.status.as_str()))
-            .collect();
         assert!(
-            statuses.iter().any(|(id, status)| *id == "gone" && *status == "deleted"),
-            "tombstone missing: {statuses:?}",
+            memories.memories.iter().all(|m| !m.memory_id.ends_with("-gone")),
+            "deleted row must not appear in memories[]",
         );
+        assert!(
+            memories
+                .deleted
+                .iter()
+                .any(|d| d.memory_id.ends_with("-gone")),
+            "deleted[] missing tombstone: {:?}",
+            memories.deleted,
+        );
+        assert!(!memories.must_resync);
 
         cleanup(&pool, &owner).await;
     }

--- a/services/server/src/routes/memory_read.rs
+++ b/services/server/src/routes/memory_read.rs
@@ -9,6 +9,7 @@ use sqlx::PgPool;
 use std::sync::Arc;
 
 use crate::security_delete_auth::same_owner;
+use crate::storage::db::TOMBSTONE_RETENTION;
 use crate::types::*;
 
 #[derive(Debug, Serialize)]
@@ -84,8 +85,6 @@ pub struct MemoriesResponse {
 /// Console client (COMG-568) ignores the new keys and never treats tombstones
 /// as live memories.
 pub const SNAPSHOT_VERSION: u32 = 2;
-
-const TOMBSTONE_RETENTION: chrono::Duration = chrono::Duration::days(30);
 
 const DEFAULT_NAMESPACES_LIMIT: i64 = 100;
 const MAX_NAMESPACES_LIMIT: i64 = 500;
@@ -223,10 +222,7 @@ pub(crate) async fn query_owner_namespaces(
         SELECT COALESCE(l.namespace, w.namespace) AS namespace,
                COALESCE(l.memory_count, 0) AS memory_count,
                COALESCE(l.storage_used, 0) AS storage_used,
-               GREATEST(
-                   COALESCE(l.last_updated_at, w.last_mutated_at),
-                   COALESCE(w.last_mutated_at, l.last_updated_at)
-               ) AS last_updated_at
+               GREATEST(l.last_updated_at, w.last_mutated_at) AS last_updated_at
         FROM (
             SELECT namespace,
                    COUNT(*)::BIGINT AS memory_count,
@@ -390,6 +386,9 @@ struct MemoriesCursor {
     deleted_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     deleted_id: Option<String>,
+    /// When this cursor was minted. v1 cursors lack it and must_resync.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    minted_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// `snapshot_at: None` resets the walk boundary — see
@@ -419,6 +418,7 @@ fn encode_cursor_ex(
         snapshot_at,
         deleted_at,
         deleted_id,
+        minted_at: Some(chrono::Utc::now()),
     })
     .expect("cursor serializes");
     // URL_SAFE_NO_PAD (not STANDARD): next_cursor is used verbatim in a URL
@@ -452,23 +452,24 @@ pub(crate) async fn query_owner_memories(
         None => None,
     };
 
-    // must_resync only when the tombstone cursor itself is older than
-    // retention: those tombstones have been swept. A v1 cursor (no
-    // deleted_at) replays 30 days instead. Do not use live updated_at;
-    // a quiet account's last live row can be months old while the client
-    // polled 5 minutes ago.
+    // minted_at is the last-sync clock. v1 cursors lack it and must_resync
+    // once. Do not use live updated_at: a quiet account's last live row can
+    // be months old while the client polled 5 minutes ago.
     if let Some(c) = decoded.as_ref() {
-        if let Some(deleted_at) = c.deleted_at {
-            if deleted_at < retention_cut {
-                return Ok(MemoriesResponse {
-                    memories: Vec::new(),
-                    next_cursor: None,
-                    has_more: false,
-                    snapshot_version: SNAPSHOT_VERSION,
-                    deleted: Vec::new(),
-                    must_resync: true,
-                });
-            }
+        let stale_mint = match c.minted_at {
+            Some(t) => t < retention_cut,
+            None => true,
+        };
+        let stale_tombstone = c.deleted_at.is_some_and(|t| t < retention_cut);
+        if stale_mint || stale_tombstone {
+            return Ok(MemoriesResponse {
+                memories: Vec::new(),
+                next_cursor: None,
+                has_more: false,
+                snapshot_version: SNAPSHOT_VERSION,
+                deleted: Vec::new(),
+                must_resync: true,
+            });
         }
     }
 
@@ -585,21 +586,28 @@ pub(crate) async fn query_owner_memories(
         .map(|(id, _, t)| (*t, id.clone()))
         .or(deleted_after.clone());
 
+    // Never pin a missing live watermark to snapshot_at: a tombstone-only
+    // first page would skip in-flight inserts with updated_at < snapshot_at.
     let live_mark = rows
         .last()
         .map(|r| (r.4, r.0.clone()))
-        .or(after.clone())
-        .unwrap_or((snapshot_at, String::new()));
-    let next_cursor = if rows.is_empty() && deleted_rows.is_empty() && after.is_none() {
-        None
-    } else {
-        Some(encode_cursor_ex(
-            live_mark.0,
-            &live_mark.1,
+        .or(after.clone());
+    let next_cursor = match live_mark {
+        Some((ts, id)) => Some(encode_cursor_ex(
+            ts,
+            &id,
             has_more.then_some(snapshot_at),
             next_deleted.as_ref().map(|(t, _)| *t),
             next_deleted.as_ref().map(|(_, id)| id.clone()),
-        ))
+        )),
+        None if deleted_has_more => Some(encode_cursor_ex(
+            chrono::DateTime::<chrono::Utc>::UNIX_EPOCH,
+            "",
+            Some(snapshot_at),
+            next_deleted.as_ref().map(|(t, _)| *t),
+            next_deleted.as_ref().map(|(_, id)| id.clone()),
+        )),
+        None => None,
     };
 
     let memories = rows
@@ -836,6 +844,7 @@ mod tests {
                 snapshot_at: Some(snapshot_at),
                 deleted_at: None,
                 deleted_id: None,
+                minted_at: None,
             })
             .expect("cursor serializes");
             let standard_encoded = base64::engine::general_purpose::STANDARD.encode(&json);

--- a/services/server/src/routes/memory_read.rs
+++ b/services/server/src/routes/memory_read.rs
@@ -452,17 +452,23 @@ pub(crate) async fn query_owner_memories(
         None => None,
     };
 
+    // must_resync only when the tombstone cursor itself is older than
+    // retention: those tombstones have been swept. A v1 cursor (no
+    // deleted_at) replays 30 days instead. Do not use live updated_at;
+    // a quiet account's last live row can be months old while the client
+    // polled 5 minutes ago.
     if let Some(c) = decoded.as_ref() {
-        let oldest = c.deleted_at.or(c.snapshot_at).unwrap_or(c.updated_at);
-        if oldest < retention_cut {
-            return Ok(MemoriesResponse {
-                memories: Vec::new(),
-                next_cursor: None,
-                has_more: false,
-                snapshot_version: SNAPSHOT_VERSION,
-                deleted: Vec::new(),
-                must_resync: true,
-            });
+        if let Some(deleted_at) = c.deleted_at {
+            if deleted_at < retention_cut {
+                return Ok(MemoriesResponse {
+                    memories: Vec::new(),
+                    next_cursor: None,
+                    has_more: false,
+                    snapshot_version: SNAPSHOT_VERSION,
+                    deleted: Vec::new(),
+                    must_resync: true,
+                });
+            }
         }
     }
 
@@ -1002,6 +1008,16 @@ mod tests {
             memories.deleted,
         );
         assert!(!memories.must_resync);
+
+        VectorDb::from_pool(pool.clone())
+            .delete_by_blob_id(&format!("blob-keep"), &owner, "notes")
+            .await
+            .unwrap();
+        let empty = query_owner_namespaces(&pool, &owner, Some(cursor), 100)
+            .await
+            .unwrap();
+        assert_eq!(empty.namespaces.len(), 1);
+        assert_eq!(empty.namespaces[0].memory_count, 0);
 
         cleanup(&pool, &owner).await;
     }

--- a/services/server/src/routes/owner_token.rs
+++ b/services/server/src/routes/owner_token.rs
@@ -106,6 +106,13 @@ pub async fn service_credential_gate(
 #[derive(Debug, Deserialize)]
 pub struct IssueOwnerTokenRequest {
     pub owner: String,
+    /// Optional. Phase 1 only mints `memories.read`. Unknown values are 400
+    /// so a caller cannot think they received a broader grant.
+    #[serde(default)]
+    pub permissions: Option<Vec<String>>,
+    /// Alias some clients send instead of `permissions`.
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -136,6 +143,20 @@ pub async fn issue_token(
         return Err(AppError::BadRequest(
             "owner must be a 0x-prefixed 32-byte Sui address (66 characters)".into(),
         ));
+    }
+    if let Some(ref permissions) = request.permissions {
+        if permissions != &[PERMISSION_MEMORIES_READ.to_string()] {
+            return Err(AppError::BadRequest(
+                "Phase 1 only grants memories.read".into(),
+            ));
+        }
+    }
+    if let Some(ref scope) = request.scope {
+        if scope != PERMISSION_MEMORIES_READ {
+            return Err(AppError::BadRequest(
+                "Phase 1 only grants memories.read".into(),
+            ));
+        }
     }
     // Same case-normalization rationale as `routes::accounts::account_exists`:
     // the indexed `accounts.owner` column is always lowercase hex (populated

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -880,27 +880,6 @@ const PAGINATION_INDEX_NAME: &str = "idx_vector_entries_owner_updated_id";
 /// nullable `updated_at` column) and before migration 015 (which
 /// requires no NULL rows remain before it can validate its NOT NULL
 /// constraint).
-async fn bump_namespace_watermark<'e, E>(
-    exec: E,
-    owner: &str,
-    namespace: &str,
-) -> Result<(), AppError>
-where
-    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
-{
-    sqlx::query(
-        "INSERT INTO namespace_watermarks (owner, namespace, last_mutated_at)
-         VALUES ($1, $2, NOW())
-         ON CONFLICT (owner, namespace) DO UPDATE SET last_mutated_at = NOW()",
-    )
-    .bind(owner)
-    .bind(namespace)
-    .execute(exec)
-    .await
-    .map_err(|e| AppError::Internal(format!("Failed to bump namespace watermark: {}", e)))?;
-    Ok(())
-}
-
 async fn backfill_updated_at(pool: &PgPool) -> Result<(), AppError> {
     const BATCH_SIZE: i64 = 5000;
     let mut total_rows: u64 = 0;
@@ -1235,8 +1214,7 @@ impl VectorDb {
         .map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)));
         crate::observability::observe_db("vector.insert", db_status(&result), started.elapsed());
         result?;
-        bump_namespace_watermark(&mut *tx, owner, namespace).await?;
-        sqlx::query("DELETE FROM memory_tombstones WHERE id = $1")
+        sqlx::query("DELETE FROM memory_tombstones WHERE memory_id = $1")
             .bind(id)
             .execute(&mut *tx)
             .await
@@ -1307,8 +1285,7 @@ impl VectorDb {
             started.elapsed(),
         );
         result?;
-        bump_namespace_watermark(&self.pool, owner, namespace).await?;
-        sqlx::query("DELETE FROM memory_tombstones WHERE id = $1")
+        sqlx::query("DELETE FROM memory_tombstones WHERE memory_id = $1")
             .bind(id)
             .execute(&self.pool)
             .await
@@ -1479,30 +1456,21 @@ impl VectorDb {
     /// `POST /api/forget` — authed, owner-scoped.
     pub async fn delete_by_namespace(&self, owner: &str, namespace: &str) -> Result<u64, AppError> {
         let started = std::time::Instant::now();
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to begin forget tx: {}", e)))?;
-        sqlx::query(
-            "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
-             SELECT id, owner, namespace, blob_id, NOW()
-             FROM vector_entries
-             WHERE owner = $1 AND namespace = $2
-             ON CONFLICT (id) DO UPDATE SET deleted_at = NOW()",
+        let result = sqlx::query(
+            "WITH removed AS (
+                DELETE FROM vector_entries
+                WHERE owner = $1 AND namespace = $2
+                RETURNING id, owner, namespace, blob_id
+             )
+             INSERT INTO memory_tombstones (memory_id, owner, namespace, blob_id)
+             SELECT id, owner, namespace, blob_id FROM removed
+             ON CONFLICT (memory_id) DO UPDATE SET deleted_at = NOW()",
         )
         .bind(owner)
         .bind(namespace)
-        .execute(&mut *tx)
+        .execute(&self.pool)
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to tombstone namespace: {}", e)))?;
-        bump_namespace_watermark(&mut *tx, owner, namespace).await?;
-        let result = sqlx::query("DELETE FROM vector_entries WHERE owner = $1 AND namespace = $2")
-            .bind(owner)
-            .bind(namespace)
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)));
+        .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)));
         crate::observability::observe_db(
             "vector.delete_by_namespace",
             db_status(&result),
@@ -1510,9 +1478,6 @@ impl VectorDb {
         );
         let result = result?;
         let rows = result.rows_affected();
-        tx.commit()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to commit forget tx: {}", e)))?;
         tracing::info!(
             "deleted {} entries for owner={}, ns={}",
             rows,
@@ -1533,35 +1498,20 @@ impl VectorDb {
         namespace: &str,
     ) -> Result<u64, AppError> {
         let started = std::time::Instant::now();
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to begin blob-delete tx: {}", e)))?;
-        let tombstoned = sqlx::query(
-            "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
-             SELECT id, owner, namespace, blob_id, NOW()
-             FROM vector_entries
-             WHERE blob_id = $1 AND owner = $2 AND namespace = $3
-             ON CONFLICT (id) DO UPDATE SET deleted_at = NOW()",
-        )
-        .bind(blob_id)
-        .bind(owner)
-        .bind(namespace)
-        .execute(&mut *tx)
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to tombstone blob: {}", e)))?;
-        if tombstoned.rows_affected() > 0 {
-            bump_namespace_watermark(&mut *tx, owner, namespace).await?;
-        }
         let result = sqlx::query(
-            "DELETE FROM vector_entries
-             WHERE blob_id = $1 AND owner = $2 AND namespace = $3",
+            "WITH removed AS (
+                DELETE FROM vector_entries
+                WHERE blob_id = $1 AND owner = $2 AND namespace = $3
+                RETURNING id, owner, namespace, blob_id
+             )
+             INSERT INTO memory_tombstones (memory_id, owner, namespace, blob_id)
+             SELECT id, owner, namespace, blob_id FROM removed
+             ON CONFLICT (memory_id) DO UPDATE SET deleted_at = NOW()",
         )
         .bind(blob_id)
         .bind(owner)
         .bind(namespace)
-        .execute(&mut *tx)
+        .execute(&self.pool)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to delete vector by blob_id: {}", e)));
         crate::observability::observe_db(
@@ -1571,9 +1521,6 @@ impl VectorDb {
         );
         let result = result?;
         let rows = result.rows_affected();
-        tx.commit()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to commit blob-delete tx: {}", e)))?;
         if rows > 0 {
             tracing::info!(
                 "deleted expired blob from DB: blob_id={}, owner={}, namespace={}, rows={}",
@@ -1584,6 +1531,33 @@ impl VectorDb {
             );
         }
         Ok(rows)
+    }
+
+    /// Drop tombstones older than `retention`. Batched so a large backlog
+    /// cannot lock the table for one giant delete.
+    pub async fn sweep_expired_tombstones(&self, retention: std::time::Duration) -> Result<u64, AppError> {
+        let secs = retention.as_secs() as i64;
+        let mut total = 0u64;
+        loop {
+            let result = sqlx::query(
+                "DELETE FROM memory_tombstones
+                 WHERE memory_id IN (
+                    SELECT memory_id FROM memory_tombstones
+                    WHERE deleted_at < NOW() - make_interval(secs => $1)
+                    LIMIT 1000
+                 )",
+            )
+            .bind(secs)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to sweep tombstones: {}", e)))?;
+            let n = result.rows_affected();
+            total += n;
+            if n < 1000 {
+                break;
+            }
+        }
+        Ok(total)
     }
 
     // ============================================================

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -4,6 +4,10 @@ use sqlx::PgPool;
 
 use crate::types::{AppError, SearchHit};
 
+/// Tombstone retention for both the read-API `must_resync` clock and the
+/// background sweep. Keep a single constant so the two cannot drift.
+pub const TOMBSTONE_RETENTION: chrono::Duration = chrono::Duration::days(30);
+
 pub struct VectorDb {
     pool: PgPool,
 }
@@ -1255,6 +1259,11 @@ impl VectorDb {
         let embedding = Vector::from(vector.to_vec());
 
         let started = std::time::Instant::now();
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to begin plaintext insert tx: {}", e)))?;
         let result = sqlx::query(
             "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, plaintext, importance)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
@@ -1276,7 +1285,7 @@ impl VectorDb {
         .bind(blob_size_bytes)
         .bind(plaintext)
         .bind(importance)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to insert plaintext vector: {}", e)));
         crate::observability::observe_db(
@@ -1287,9 +1296,12 @@ impl VectorDb {
         result?;
         sqlx::query("DELETE FROM memory_tombstones WHERE memory_id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to clear tombstone: {}", e)))?;
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit plaintext insert tx: {}", e)))?;
 
         tracing::debug!(
             "inserted plaintext vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
@@ -1533,10 +1545,10 @@ impl VectorDb {
         Ok(rows)
     }
 
-    /// Drop tombstones older than `retention`. Batched so a large backlog
-    /// cannot lock the table for one giant delete.
-    pub async fn sweep_expired_tombstones(&self, retention: std::time::Duration) -> Result<u64, AppError> {
-        let secs = retention.as_secs() as i64;
+    /// Drop tombstones older than `TOMBSTONE_RETENTION`. Batched so a large
+    /// backlog cannot lock the table for one giant delete.
+    pub async fn sweep_expired_tombstones(&self) -> Result<u64, AppError> {
+        let secs = TOMBSTONE_RETENTION.num_seconds();
         let mut total = 0u64;
         loop {
             let result = sqlx::query(

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -9,6 +9,13 @@ pub struct VectorDb {
 }
 
 #[cfg(test)]
+impl VectorDb {
+    pub(crate) fn from_pool(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::sync::OnceLock;
     use std::time::Duration;
@@ -873,11 +880,14 @@ const PAGINATION_INDEX_NAME: &str = "idx_vector_entries_owner_updated_id";
 /// nullable `updated_at` column) and before migration 015 (which
 /// requires no NULL rows remain before it can validate its NOT NULL
 /// constraint).
-async fn bump_namespace_watermark(
-    pool: &PgPool,
+async fn bump_namespace_watermark<'e, E>(
+    exec: E,
     owner: &str,
     namespace: &str,
-) -> Result<(), AppError> {
+) -> Result<(), AppError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
     sqlx::query(
         "INSERT INTO namespace_watermarks (owner, namespace, last_mutated_at)
          VALUES ($1, $2, NOW())
@@ -885,7 +895,7 @@ async fn bump_namespace_watermark(
     )
     .bind(owner)
     .bind(namespace)
-    .execute(pool)
+    .execute(exec)
     .await
     .map_err(|e| AppError::Internal(format!("Failed to bump namespace watermark: {}", e)))?;
     Ok(())
@@ -1190,6 +1200,11 @@ impl VectorDb {
         let embedding = Vector::from(vector.to_vec());
 
         let started = std::time::Instant::now();
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to begin insert tx: {}", e)))?;
         let result = sqlx::query(
             "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, importance, agent_id, package_id, end_epoch)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
@@ -1215,12 +1230,20 @@ impl VectorDb {
         .bind(agent_id)
         .bind(package_id)
         .bind(end_epoch)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)));
         crate::observability::observe_db("vector.insert", db_status(&result), started.elapsed());
         result?;
-        bump_namespace_watermark(&self.pool, owner, namespace).await?;
+        bump_namespace_watermark(&mut *tx, owner, namespace).await?;
+        sqlx::query("DELETE FROM memory_tombstones WHERE id = $1")
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to clear tombstone: {}", e)))?;
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit insert tx: {}", e)))?;
 
         tracing::debug!(
             "inserted vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
@@ -1284,6 +1307,12 @@ impl VectorDb {
             started.elapsed(),
         );
         result?;
+        bump_namespace_watermark(&self.pool, owner, namespace).await?;
+        sqlx::query("DELETE FROM memory_tombstones WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to clear tombstone: {}", e)))?;
 
         tracing::debug!(
             "inserted plaintext vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
@@ -1450,7 +1479,12 @@ impl VectorDb {
     /// `POST /api/forget` — authed, owner-scoped.
     pub async fn delete_by_namespace(&self, owner: &str, namespace: &str) -> Result<u64, AppError> {
         let started = std::time::Instant::now();
-        let _ = sqlx::query(
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to begin forget tx: {}", e)))?;
+        sqlx::query(
             "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
              SELECT id, owner, namespace, blob_id, NOW()
              FROM vector_entries
@@ -1459,14 +1493,14 @@ impl VectorDb {
         )
         .bind(owner)
         .bind(namespace)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to tombstone namespace: {}", e)))?;
-        bump_namespace_watermark(&self.pool, owner, namespace).await?;
+        bump_namespace_watermark(&mut *tx, owner, namespace).await?;
         let result = sqlx::query("DELETE FROM vector_entries WHERE owner = $1 AND namespace = $2")
             .bind(owner)
             .bind(namespace)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)));
         crate::observability::observe_db(
@@ -1475,8 +1509,10 @@ impl VectorDb {
             started.elapsed(),
         );
         let result = result?;
-
         let rows = result.rows_affected();
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit forget tx: {}", e)))?;
         tracing::info!(
             "deleted {} entries for owner={}, ns={}",
             rows,
@@ -1497,7 +1533,12 @@ impl VectorDb {
         namespace: &str,
     ) -> Result<u64, AppError> {
         let started = std::time::Instant::now();
-        let _ = sqlx::query(
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to begin blob-delete tx: {}", e)))?;
+        let tombstoned = sqlx::query(
             "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
              SELECT id, owner, namespace, blob_id, NOW()
              FROM vector_entries
@@ -1507,10 +1548,12 @@ impl VectorDb {
         .bind(blob_id)
         .bind(owner)
         .bind(namespace)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to tombstone blob: {}", e)))?;
-        bump_namespace_watermark(&self.pool, owner, namespace).await?;
+        if tombstoned.rows_affected() > 0 {
+            bump_namespace_watermark(&mut *tx, owner, namespace).await?;
+        }
         let result = sqlx::query(
             "DELETE FROM vector_entries
              WHERE blob_id = $1 AND owner = $2 AND namespace = $3",
@@ -1518,7 +1561,7 @@ impl VectorDb {
         .bind(blob_id)
         .bind(owner)
         .bind(namespace)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to delete vector by blob_id: {}", e)));
         crate::observability::observe_db(
@@ -1527,8 +1570,10 @@ impl VectorDb {
             started.elapsed(),
         );
         let result = result?;
-
         let rows = result.rows_affected();
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit blob-delete tx: {}", e)))?;
         if rows > 0 {
             tracing::info!(
                 "deleted expired blob from DB: blob_id={}, owner={}, namespace={}, rows={}",

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -73,6 +73,7 @@ mod tests {
             include_str!("../../migrations/017_memory_expiry_columns.sql"),
             include_str!("../../migrations/018_memory_expiry_synced_at_index.sql"),
             include_str!("../../migrations/019_memory_read_api_updated_at_set_not_null.sql"),
+            include_str!("../../migrations/020_read_api_followups.sql"),
         ] {
             sqlx::raw_sql(migration).execute(&pool).await.unwrap();
         }
@@ -872,6 +873,24 @@ const PAGINATION_INDEX_NAME: &str = "idx_vector_entries_owner_updated_id";
 /// nullable `updated_at` column) and before migration 015 (which
 /// requires no NULL rows remain before it can validate its NOT NULL
 /// constraint).
+async fn bump_namespace_watermark(
+    pool: &PgPool,
+    owner: &str,
+    namespace: &str,
+) -> Result<(), AppError> {
+    sqlx::query(
+        "INSERT INTO namespace_watermarks (owner, namespace, last_mutated_at)
+         VALUES ($1, $2, NOW())
+         ON CONFLICT (owner, namespace) DO UPDATE SET last_mutated_at = NOW()",
+    )
+    .bind(owner)
+    .bind(namespace)
+    .execute(pool)
+    .await
+    .map_err(|e| AppError::Internal(format!("Failed to bump namespace watermark: {}", e)))?;
+    Ok(())
+}
+
 async fn backfill_updated_at(pool: &PgPool) -> Result<(), AppError> {
     const BATCH_SIZE: i64 = 5000;
     let mut total_rows: u64 = 0;
@@ -1129,6 +1148,12 @@ impl VectorDb {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 019: {}", e)))?;
 
+        let migration_020 = include_str!("../../migrations/020_read_api_followups.sql");
+        sqlx::raw_sql(migration_020)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 020: {}", e)))?;
+
         tracing::info!("database connected and migrations applied");
 
         Ok(Self { pool })
@@ -1195,6 +1220,7 @@ impl VectorDb {
         .map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)));
         crate::observability::observe_db("vector.insert", db_status(&result), started.elapsed());
         result?;
+        bump_namespace_watermark(&self.pool, owner, namespace).await?;
 
         tracing::debug!(
             "inserted vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
@@ -1424,6 +1450,19 @@ impl VectorDb {
     /// `POST /api/forget` — authed, owner-scoped.
     pub async fn delete_by_namespace(&self, owner: &str, namespace: &str) -> Result<u64, AppError> {
         let started = std::time::Instant::now();
+        let _ = sqlx::query(
+            "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
+             SELECT id, owner, namespace, blob_id, NOW()
+             FROM vector_entries
+             WHERE owner = $1 AND namespace = $2
+             ON CONFLICT (id) DO UPDATE SET deleted_at = NOW()",
+        )
+        .bind(owner)
+        .bind(namespace)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to tombstone namespace: {}", e)))?;
+        bump_namespace_watermark(&self.pool, owner, namespace).await?;
         let result = sqlx::query("DELETE FROM vector_entries WHERE owner = $1 AND namespace = $2")
             .bind(owner)
             .bind(namespace)
@@ -1458,6 +1497,20 @@ impl VectorDb {
         namespace: &str,
     ) -> Result<u64, AppError> {
         let started = std::time::Instant::now();
+        let _ = sqlx::query(
+            "INSERT INTO memory_tombstones (id, owner, namespace, blob_id, deleted_at)
+             SELECT id, owner, namespace, blob_id, NOW()
+             FROM vector_entries
+             WHERE blob_id = $1 AND owner = $2 AND namespace = $3
+             ON CONFLICT (id) DO UPDATE SET deleted_at = NOW()",
+        )
+        .bind(blob_id)
+        .bind(owner)
+        .bind(namespace)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to tombstone blob: {}", e)))?;
+        bump_namespace_watermark(&self.pool, owner, namespace).await?;
         let result = sqlx::query(
             "DELETE FROM vector_entries
              WHERE blob_id = $1 AND owner = $2 AND namespace = $3",

--- a/services/server/src/storage/security_delete_store.rs
+++ b/services/server/src/storage/security_delete_store.rs
@@ -689,15 +689,24 @@ pub async fn finalize_batch_deleted(
             .map_err(|error| storage("finalize lost race", error))?;
         return Ok(None);
     }
+    // Security-delete erases the Walrus blob, so every memory row pointing at
+    // that blob_id is dangling. Identify rows by memory id (not a bare
+    // (owner, blob_id) delete) so each tombstone carries the row's own
+    // namespace. Tracking has no namespace column — PK is (owner, blob_id) —
+    // and a shared blob_id across namespaces is unreadable after the blob is
+    // gone, so every matching row is purged.
     sqlx::query(
         "WITH tracked AS (
-            SELECT owner, blob_id FROM delete_blobs_tracking
-            WHERE batch_id=$1 AND state='deleting'
+            SELECT v.id, v.owner, v.namespace, v.blob_id
+            FROM delete_blobs_tracking t
+            INNER JOIN vector_entries v
+              ON v.owner = t.owner AND v.blob_id = t.blob_id
+            WHERE t.batch_id=$1 AND t.state='deleting'
          ),
          removed AS (
             DELETE FROM vector_entries v
             USING tracked t
-            WHERE v.owner = t.owner AND v.blob_id = t.blob_id
+            WHERE v.id = t.id
             RETURNING v.id, v.owner, v.namespace, v.blob_id
          )
          INSERT INTO memory_tombstones (memory_id, owner, namespace, blob_id)

--- a/services/server/src/storage/security_delete_store.rs
+++ b/services/server/src/storage/security_delete_store.rs
@@ -689,6 +689,25 @@ pub async fn finalize_batch_deleted(
             .map_err(|error| storage("finalize lost race", error))?;
         return Ok(None);
     }
+    sqlx::query(
+        "WITH tracked AS (
+            SELECT owner, blob_id FROM delete_blobs_tracking
+            WHERE batch_id=$1 AND state='deleting'
+         ),
+         removed AS (
+            DELETE FROM vector_entries v
+            USING tracked t
+            WHERE v.owner = t.owner AND v.blob_id = t.blob_id
+            RETURNING v.id, v.owner, v.namespace, v.blob_id
+         )
+         INSERT INTO memory_tombstones (memory_id, owner, namespace, blob_id)
+         SELECT id, owner, namespace, blob_id FROM removed
+         ON CONFLICT (memory_id) DO UPDATE SET deleted_at = NOW()",
+    )
+    .bind(batch_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|error| storage("tombstone security-delete rows", error))?;
     let rows = sqlx::query(
         "UPDATE delete_blobs_tracking SET state='deleted', batch_id=NULL, updated_at=NOW()
          WHERE batch_id=$1 AND state='deleting'",


### PR DESCRIPTION
Stacked on `feat/console-integration-test` ([#554](https://github.com/MystenLabs/MemWal/pull/554)).

## What this adds

**WALM-363 deletions.** Hard delete now (1) upserts `namespace_watermarks.last_mutated_at` so `/namespaces` incremental polling resurfaces the namespace even when `MAX(updated_at)` moved backwards, and (2) writes `memory_tombstones` so `/memories` returns `status: "deleted"`. `snapshot_version` stays a wire-format constant (now 3); it does not bump on data mutations.

**WALM-364 refill script.** `services/server/scripts/backfill-read-api-metadata.sh` plus `metadata_synced_at`. New writes already dual-write `agent_id`/`package_id`; this sweep fills pre-014 rows from sidecar `/walrus/query-blobs`. Rows with no on-chain agent id stay NULL but get `metadata_synced_at` so they are not retried.

**Nits from #554 review.** Unknown `scope` / `permissions` on `POST /v1/owner-tokens` is 400. `importance` is exposed on `MemoryItem`.

**Docs CI.** Colon-form routes so Docs/Freshness passes; frontmatter; no em dashes; deletion SLA (5-minute `/namespaces` poll sees the watermark; keep a 5-6h full reconcile as safety net).

## Intentionally not in this PR

- Rebase of #554 onto current `origin/dev` (124 commits; #700 not merged so 014-019 on #554 still unique vs `dev`). Do that on #554 itself before merging to `dev`.
- WALM-365 preview / title / tags / source URL: parked pending Thanos/George/Henry. Decrypting listings would reverse the Phase 1 no-plaintext AC.