### PR TITLE
fix(frontend): WALM-326 scope the dashboard no-key notice to this bro…

### DIFF
--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -11930,3 +11930,58 @@ h1, h2, h3 {
     padding: 20px;
   }
 }
+
+.dash-page .dash-alert--info {
+  min-height: 0;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 28px !important;
+  padding: 14px 18px;
+  border: 1px solid var(--dash-panel-border);
+  border-radius: var(--radius-md);
+  background: var(--dash-panel);
+  color: var(--dash-subtle);
+}
+
+.dash-page .dash-alert--info .dash-alert-icon {
+  width: 20px;
+  height: 20px;
+  margin-top: 2px;
+  color: var(--dash-yellow);
+}
+
+.dash-page .dash-alert--info p {
+  color: var(--dash-subtle);
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.dash-page .dash-alert-link {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--dash-yellow);
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.dash-page .dash-alert-link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.dash-page .dashboard-key-current-badge {
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .dash-page .dash-alert--info {
+    padding: 12px 14px;
+  }
+
+  .dash-page .dash-alert--info p {
+    font-size: 14px;
+  }
+}

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -14,7 +14,7 @@ import { useSponsoredTransaction } from '../hooks/useSponsoredTransaction'
 import { generateDelegateKey } from '@mysten-incubation/memwal/account'
 import type { WalletSigner } from '@mysten-incubation/memwal/manual'
 import { Link, useNavigate } from 'react-router-dom'
-import { TriangleAlert, Copy, Eye, EyeOff, Trash2, RefreshCw, Plus, LogOut, Github, MessageCircle } from 'lucide-react'
+import { TriangleAlert, Info, Copy, Eye, EyeOff, Trash2, RefreshCw, Plus, LogOut, Github, MessageCircle } from 'lucide-react'
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
 import js from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript'
 import python from 'react-syntax-highlighter/dist/esm/languages/hljs/python'
@@ -118,6 +118,7 @@ interface OnChainDelegateKey {
 
 const MAX_DELEGATE_KEYS = 20
 const MAX_DELEGATE_KEYS_MESSAGE = 'This wallet already has 20 delegate keys. Remove an old key before creating a new delegate key.'
+const DELEGATE_KEYS_SECTION_ID = 'delegate-keys'
 const PRIVATE_KEY_ENV = 'MEMWAL_PRIVATE_KEY'
 const ACCOUNT_ID_ENV = 'MEMWAL_ACCOUNT_ID'
 const SERVER_URL_ENV = 'MEMWAL_SERVER_URL'
@@ -368,7 +369,6 @@ export default function Dashboard({
 
     const hasResolvedAccount = Boolean(effectiveAccountObjectId)
     const accountLookupPending = loadingAccount || (shouldResolveAccount && (!accountLookupComplete || accountLookupAddress !== address))
-    const isRecoveringExistingAccount = !delegateKey && hasResolvedAccount && !previewReady
     const activeEnvironmentLabel = config.suiNetwork === 'mainnet'
         ? 'production / mainnet'
         : 'staging / testnet'
@@ -401,11 +401,20 @@ export default function Dashboard({
     const hasMaxDelegateKeys = onChainKeys.length >= MAX_DELEGATE_KEYS
     const isKeyListLoading = accountLookupPending || (loadingKeys && onChainKeys.length === 0)
     const isKeyListRefreshing = loadingKeys && onChainKeys.length > 0
+    const onChainKeyCount = onChainKeys.length
+    const browserHasNoKey = !delegateKey && hasResolvedAccount && !previewReady
+    const showNoBrowserKeyNotice = browserHasNoKey && !isKeyListLoading
     const selectableKeyPublicKeys = useMemo(() => onChainKeys.map((key) => key.publicKey), [onChainKeys])
     const selectedKeySet = useMemo(() => new Set(selectedKeyPublicKeys), [selectedKeyPublicKeys])
     const selectedKeyCount = selectedKeyPublicKeys.length
     const keyRemovalBusy = removingSelectedKeys || Boolean(removingKey)
     const showKeySelectionControls = Boolean(effectiveAccountObjectId) && selectedKeyCount > 0 && !accountLookupPending
+
+    const scrollToDelegateKeys = useCallback(() => {
+        document
+            .getElementById(DELEGATE_KEYS_SECTION_ID)
+            ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, [])
 
     useEffect(() => {
         setSelectedKeyPublicKeys((prev) => {
@@ -775,12 +784,30 @@ const result = await generateText({
                     {showDashboardSubtitle && <p>{dashboardSubtitle}</p>}
                 </div>
 
-                {isRecoveringExistingAccount && (
-                    <div className="dash-alert" style={{ marginBottom: 24 }}>
-                        <TriangleAlert className="dash-alert-icon" size={24} strokeWidth={2.3} aria-hidden="true" />
-                        <p>
-                            Your Walrus Memory account is active, but this browser has no saved delegate key. Create a new key to continue, or revoke an old one below.
-                        </p>
+                {showNoBrowserKeyNotice && (
+                    <div className="dash-alert dash-alert--info">
+                        <Info className="dash-alert-icon" size={24} strokeWidth={2.3} aria-hidden="true" />
+                        {onChainKeyCount > 0 ? (
+                            <p>
+                                This browser doesn't have a key bound to it yet. Your account has{' '}
+                                {onChainKeyCount} delegate {onChainKeyCount === 1 ? 'key' : 'keys'} for
+                                other clients (
+                                <button
+                                    type="button"
+                                    className="dash-alert-link"
+                                    onClick={scrollToDelegateKeys}
+                                >
+                                    see below
+                                </button>
+                                ). Create a browser key to manage your account from here, or use the
+                                dashboard from a client that has one.
+                            </p>
+                        ) : (
+                            <p>
+                                Your Walrus Memory account is active but has no delegate keys yet.
+                                Create one to connect this browser and the SDK to your account.
+                            </p>
+                        )}
                     </div>
                 )}
 
@@ -1022,9 +1049,14 @@ const result = await generateText({
 
                 {/* On-Chain Delegate Keys Management */}
                 <Card
+                    id={DELEGATE_KEYS_SECTION_ID}
                     className={`dashboard-keys-card${isKeyListRefreshing ? ' dashboard-keys-card--refreshing' : ''}`}
                     title="Delegate keys"
-                    subtitle="All keys registered to your Walrus Memory account"
+                    subtitle={
+                        isKeyListLoading || onChainKeyCount === 0
+                            ? 'All keys registered to your account, across every browser and client'
+                            : `${onChainKeyCount} ${onChainKeyCount === 1 ? 'key' : 'keys'} registered to your account, across every browser and client`
+                    }
                     action={
                         <div className="card-header-actions">
                             <button
@@ -1224,7 +1256,14 @@ const result = await generateText({
                                                 <td data-label="Key name">
                                                     <div className="dashboard-key-name">
                                                         <span>{k.label || 'Untitled'}</span>
-                                                        {isCurrentKey && <span className="dashboard-key-current-badge">current</span>}
+                                                        {isCurrentKey && (
+                                                            <span
+                                                                className="dashboard-key-current-badge"
+                                                                title="This is the delegate key saved in this browser"
+                                                            >
+                                                                This browser
+                                                            </span>
+                                                        )}
                                                     </div>
                                                 </td>
                                                 <td data-label="Public key">


### PR DESCRIPTION
## Ticket

[WALM-326](https://linear.app/mysten-labs/issue/WALM-326/issue-dashboard-no-delegate-key-in-this-browser-banner-conflicts-with) — the dashboard's "no delegate key in this browser" banner contradicts the delegate-keys list below it.

## What changed?

### `src/pages/Dashboard.tsx`

`isRecoveringExistingAccount` gated the banner on `!delegateKey` alone — the key in this tab's `sessionStorage` — and never read `onChainKeys`. It is replaced by `browserHasNoKey` plus `onChainKeyCount`, so the notice and the list draw from one fetch and cannot disagree. The copy names each scope: this browser has no key bound to it, the account has N for other clients.

A separate branch covers the empty account; the old copy said "revoke an old one below" with nothing to revoke. Render waits on `!isKeyListLoading`, or N shows a stale 0 and then jumps.

The list now carries the boundary itself rather than only describing it: the per-row badge changes from `current` to `This browser`, and the card subtitle gains the count.

### `src/index.css`

New `.dash-alert--info` variant — neutral panel, `Info` icon, 15px/400 instead of 21px/500 — so the notice no longer outweighs the list it points at. `hasMaxDelegateKeys` keeps the yellow `.dash-alert`, which is now reserved for real errors.

## Why is this needed?

Both surfaces said "delegate key" with nothing separating browser scope from account scope — the word "saved" carried all of it. An account with keys registered for other clients got a yellow warning above the fold, styled identically to the delegate-key-limit error, directly above a card listing those very keys. Users read the pair as a broken dashboard.

## Scope

The dashboard's no-key notice and the delegate-keys card.

### Out of scope

The notice says "Create a browser key" while the CTA below says "Create a delegate key". The issue's suggested copy is kept verbatim.

## How was this tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not applicable

Manually on testnet. Existing suite 84/84; `tsc -b`, `eslint`, and `vite build` clean.

No tests added. The change is copy plus a CSS variant over three booleans derived from values that already existed — there is no new logic worth pinning.

Verified the two states the issue is about, and that they disagree correctly:

- Browser holds a key → no notice, badge on that row, subtitle reads "1 key registered…".
- `sessionStorage` cleared → notice names "1 delegate key for other clients", list shows the key with no badge.

Also stashed the diff and reloaded, to confirm the old yellow banner reproduces the reported contradiction.

## How can the reviewer verify it?

Sign in, create a delegate key, then unbind this tab:

```js
sessionStorage.removeItem('memwal_delegate'); location.reload()
```

The notice should name the key count and no row should carry the `This browser` badge. Create a key again and both invert.

## Risks and dependencies

- **Two states are unverified.** An account with an on-chain Account object but zero keys, and the `This browser` badge below 640px with a long key name — it is wider than `current` and shares the row with an ellipsised name.
- **`.dash-alert--info` is appended at the end of an 11.9k-line stylesheet** and wins on source order over the `.dash-page .dash-alert` blocks above it. A later rule of equal specificity would silently take it back.

## Screenshots
### Before (current dev) - Removed cache browser
<img width="1470" height="840" alt="Before (with cleared cache)" src="https://github.com/user-attachments/assets/f8f81848-4d76-4b9d-934c-8d7743c75fa4" />

### After - Removed cache browser
<img width="1470" height="838" alt="After (with cleared cache)" src="https://github.com/user-attachments/assets/f3c4e9ca-552a-45b4-979a-4152f4095a5e" />


## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [ ] The branch is up to date with its target branch.
- [ ] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
