### PR TITLE
fix(server): make storage quota admission atomic with insertion (WALM-359)

### DIFF
--- a/services/server/migrations/014_storage_reservations.sql
+++ b/services/server/migrations/014_storage_reservations.sql
@@ -1,0 +1,55 @@
+-- Walrus Memory — Storage Quota Reservations
+--
+-- Closes the quota admission race (GH #532 / WALM-359).
+--
+-- Before this table, admission read SUM(blob_size_bytes) under a
+-- pg_advisory_xact_lock and then COMMITTED that transaction. Advisory
+-- *xact* locks are transaction scoped, so the lock died on that commit and
+-- the caller's INSERT happened unprotected. Concurrent requests from one
+-- owner all read the same pre-insert total, all passed, and all inserted.
+--
+-- A reservation is the missing "intent to write" record. Admission now
+-- inserts the reservation inside the same transaction that holds the lock
+-- and reads usage, so check and commit-of-intent are atomic. Usage during
+-- admission is SUM(vector_entries.blob_size_bytes) + SUM(unexpired
+-- reservations.bytes).
+--
+-- Why a table rather than one long transaction: the enqueued paths
+-- (/api/remember, /api/remember/bulk, /api/analyze) admit the request, queue a
+-- wallet job, upload to Walrus, and only then insert the row. That window is
+-- documented in types.rs as running up to five minutes. A Postgres
+-- transaction cannot be held across it. Inline paths could use a single
+-- transaction, but sharing one mechanism keeps both groups on the same
+-- accounting rather than letting them diverge.
+--
+-- `id` is the caller's own identifier, not a generated key:
+--   * enqueued paths use the `remember_jobs.id` the row will be inserted with
+--   * inline paths use a freshly minted UUID
+-- Keying by an id the caller already owns means release sites need no extra
+-- plumbing through the serialized wallet-job payloads, and makes release
+-- idempotent: a retried job that already released simply deletes nothing.
+-- There is deliberately no FK to remember_jobs, since inline reservations
+-- have no job row.
+--
+-- `expires_at` is the backstop required by the acceptance criteria. If a
+-- release is ever missed (process killed between admission and insert, job
+-- lost, task cancelled), the reservation stops counting at expiry. The
+-- failure mode is therefore temporary over-counting, never a permanently
+-- unusable account.
+
+CREATE TABLE IF NOT EXISTS storage_reservations (
+    id         TEXT PRIMARY KEY,
+    owner      TEXT   NOT NULL,
+    bytes      BIGINT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Admission reads live reservations for exactly one owner, so lead with owner
+-- and carry expires_at for the range predicate.
+CREATE INDEX IF NOT EXISTS idx_storage_reservations_owner_expires
+    ON storage_reservations (owner, expires_at);
+
+-- The periodic sweeper scans by expiry across all owners.
+CREATE INDEX IF NOT EXISTS idx_storage_reservations_expires
+    ON storage_reservations (expires_at);

--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -196,6 +196,18 @@ async fn update_remember_job_after_wallet_error(
         "running"
     };
 
+    // Terminal means no later attempt will ever insert the row, so the bytes
+    // this job reserved at admission must go back to the owner now rather than
+    // waiting out the TTL. Retryable errors keep the reservation: the next
+    // attempt still intends to write those bytes, and releasing early would let
+    // a concurrent burst overcommit while the retry is in flight.
+    //
+    // Safe to run even when a concurrent attempt already won and released:
+    // release is a delete by id, so a second call is a no-op.
+    if error.aborts_retries() {
+        crate::storage::db::release_storage_reservations_with_pool(pool, &[jid.to_string()]).await;
+    }
+
     // Guard against downgrading a row a concurrent attempt already finished.
     // Every pre-existing caller only runs while holding the per-job upload
     // lock (JobUploadLock), so it was never the current status writer's own
@@ -841,6 +853,12 @@ async fn insert_vector_and_mark_remember_done(
         .bind(jid)
         .execute(state.db.pool())
         .await;
+
+        // Release only now that the vector row is committed. The row carries
+        // the bytes from here on, so holding the reservation would double count
+        // them; releasing before the insert would instead open a window where
+        // neither counts and a concurrent burst could slip past the quota.
+        crate::rate_limit::release_storage_quota_one(state, jid).await;
     }
 
     tracing::info!(

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1310,6 +1310,28 @@ async fn main() {
             {
                 tracing::error!("Stale remember job sweep failed: {}", e);
             }
+
+            // Storage-quota reservation upkeep, on the same tick.
+            //
+            // Ordered after the stale-job sweep so rows it just marked failed
+            // are reconciled in the same pass instead of waiting a full minute.
+            // The reconcile handles terminal jobs whose release was missed; the
+            // expiry sweep is the last-resort backstop for reservations with no
+            // job row at all (inline paths) or whose job vanished entirely.
+            if let Err(e) = stale_job_state
+                .db
+                .release_reservations_for_terminal_jobs()
+                .await
+            {
+                tracing::error!("Terminal-job reservation reconcile failed: {}", e);
+            }
+            if let Err(e) = stale_job_state
+                .db
+                .sweep_expired_storage_reservations()
+                .await
+            {
+                tracing::error!("Expired reservation sweep failed: {}", e);
+            }
         }
     });
 

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -6,10 +6,12 @@ use axum::{
 };
 use percent_encoding::percent_decode_str;
 use std::sync::Arc;
+use std::time::Duration;
 use uuid::Uuid;
 
 use crate::{
     client_ip::canonical_client_ip,
+    storage::db::{StorageAdmission, StorageReservationRequest},
     types::{AppError, AppState, AuthInfo},
 };
 
@@ -618,13 +620,42 @@ pub async fn rate_limit_middleware(
 /// Storage tracking still uses PostgreSQL (it's per-row in vector_entries).
 /// Returns `Ok(())` if within quota, `Err(AppError::QuotaExceeded)` if not.
 ///
-/// Uses PostgreSQL advisory lock per-owner to prevent
-/// TOCTOU race where concurrent requests all pass quota check then
-/// all write, collectively exceeding the limit.
-pub async fn check_storage_quota(
+/// How long an unreleased storage reservation keeps counting against quota.
+///
+/// This is the backstop for a release that never happens: process killed
+/// between admission and insert, task cancelled, job lost. It must be longer
+/// than any window in which the write could still legitimately land, or a slow
+/// upload would have its reservation expire while the row is still coming and
+/// a concurrent burst could slip past the quota.
+///
+/// The longest such window is bounded by `main::STALE_REMEMBER_JOB_AFTER`
+/// (10 minutes), after which the sweeper marks the job failed and releases the
+/// reservation anyway. 15 minutes leaves margin over that without letting a
+/// leak sit around long. Over-counting for at most this long is the intended
+/// failure mode; an account is never permanently stranded.
+pub const STORAGE_RESERVATION_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Atomically admit pending writes against the owner's storage quota.
+///
+/// Replaces the old `check_storage_quota`, which was not atomic: it read usage
+/// under a `pg_advisory_xact_lock`, committed (releasing the lock, because xact
+/// locks are transaction scoped), compared outside any lock, and left the
+/// caller to insert later still. Concurrent requests from one owner all read
+/// the same pre-insert total, all passed, and all inserted (GH #532 /
+/// WALM-359).
+///
+/// Admission now records the intent to write inside the locked transaction, so
+/// a later request in the same burst sees the earlier one's bytes even though
+/// no row exists yet. Callers must release once the row lands or the write is
+/// known to be dead — see `release_storage_quota`.
+///
+/// Admission is all-or-nothing across `reservations`, preserving the existing
+/// behaviour where a bulk request lands whole or is rejected whole, and the
+/// `402` / "Storage quota exceeded" response shape is unchanged.
+pub async fn reserve_storage_quota(
     state: &AppState,
     owner: &str,
-    additional_bytes: i64,
+    reservations: &[StorageReservationRequest],
 ) -> Result<(), AppError> {
     let max_bytes = state.config.rate_limit.max_storage_bytes;
 
@@ -633,33 +664,72 @@ pub async fn check_storage_quota(
         return Ok(());
     }
 
-    // Acquire a per-owner PostgreSQL advisory lock.
-    // This serializes concurrent quota checks for the same owner,
-    // preventing TOCTOU race conditions.
-    // We use a stable hash of the owner string as the lock key.
-    let lock_key = stable_hash_i64(owner);
-
-    // Use the combined method which uses an explicit transaction and pg_advisory_xact_lock
-    let used = state.db.get_storage_used_with_lock(owner, lock_key).await?;
-    let projected = used + additional_bytes;
-
-    if projected > max_bytes {
-        let used_mb = used as f64 / 1_048_576.0;
-        let max_mb = max_bytes as f64 / 1_048_576.0;
-        tracing::warn!(
-            "storage quota exceeded: owner={} used={:.1}MB + {:.1}MB > max={:.1}MB",
-            owner,
-            used_mb,
-            additional_bytes as f64 / 1_048_576.0,
-            max_mb
-        );
-        return Err(AppError::QuotaExceeded(format!(
-            "Storage quota exceeded: {:.1}MB used of {:.1}MB allowed",
-            used_mb, max_mb
-        )));
+    if reservations.is_empty() {
+        return Ok(());
     }
 
-    Ok(())
+    // Stable hash of the owner string as the per-owner advisory lock key.
+    let lock_key = stable_hash_i64(owner);
+    let requested: i64 = reservations.iter().map(|r| r.bytes).sum();
+
+    let admission = state
+        .db
+        .admit_storage_reservations(
+            owner,
+            lock_key,
+            max_bytes,
+            reservations,
+            STORAGE_RESERVATION_TTL,
+        )
+        .await?;
+
+    match admission {
+        StorageAdmission::Admitted => Ok(()),
+        StorageAdmission::Rejected { used } => {
+            let used_mb = used as f64 / 1_048_576.0;
+            let max_mb = max_bytes as f64 / 1_048_576.0;
+            tracing::warn!(
+                "storage quota exceeded: owner={} used={:.1}MB + {:.1}MB > max={:.1}MB",
+                owner,
+                used_mb,
+                requested as f64 / 1_048_576.0,
+                max_mb
+            );
+            Err(AppError::QuotaExceeded(format!(
+                "Storage quota exceeded: {:.1}MB used of {:.1}MB allowed",
+                used_mb, max_mb
+            )))
+        }
+    }
+}
+
+/// Convenience wrapper for the single-write call sites.
+pub async fn reserve_storage_quota_one(
+    state: &AppState,
+    owner: &str,
+    id: String,
+    bytes: i64,
+) -> Result<(), AppError> {
+    reserve_storage_quota(state, owner, &[StorageReservationRequest { id, bytes }]).await
+}
+
+/// Release reservations after the bytes are committed as rows, or after the
+/// write that reserved them is known to be dead.
+///
+/// Deliberately infallible: a failed release is recovered by
+/// `STORAGE_RESERVATION_TTL`, and must never turn a successful write into a
+/// failed request.
+pub async fn release_storage_quota(state: &AppState, ids: &[String]) {
+    if state.config.rate_limit.max_storage_bytes <= 0 {
+        return;
+    }
+    state.db.release_storage_reservations(ids).await;
+}
+
+/// Release a single reservation. See `release_storage_quota`.
+pub async fn release_storage_quota_one(state: &AppState, id: &str) {
+    let ids = [id.to_string()];
+    release_storage_quota(state, &ids).await;
 }
 
 /// Compute a stable i64 hash of a string for use as PG advisory lock key.

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -58,6 +58,10 @@ const EMBED_TIMEOUT_MS: u64 = 800;
 const SEARCH_TIMEOUT_MS: u64 = 300;
 const FETCH_TIMEOUT_MS: u64 = 500;
 
+/// One fact that has finished embed + SEAL encrypt and is ready to enqueue:
+/// `(plaintext, importance, embedding, ciphertext)`.
+type PreparedFact = (String, f32, Vec<f32>, Vec<u8>);
+
 /// POST /api/analyze
 ///
 /// AI fact extraction flow:
@@ -373,7 +377,17 @@ pub async fn analyze(
         // Quota check on plaintext byte length (benchmark mode has no
         // ciphertext — plaintext is the closest analog).
         let total_plaintext_bytes: i64 = facts.iter().map(|f| f.text.len() as i64).sum();
-        rate_limit::check_storage_quota(&state, owner, total_plaintext_bytes).await?;
+        // Inline path: one reservation covering the whole batch, released once
+        // the rows are committed. Local id because these rows have no
+        // `remember_jobs` row to key on (benchmark mode skips the job queue).
+        let reservation_id = uuid::Uuid::new_v4().to_string();
+        rate_limit::reserve_storage_quota_one(
+            &state,
+            owner,
+            reservation_id.clone(),
+            total_plaintext_bytes,
+        )
+        .await?;
 
         let store_tasks: Vec<_> = facts
             .iter()
@@ -413,6 +427,13 @@ pub async fn analyze(
             .collect();
 
         let store_results = collect_bounded_results(store_tasks, ANALYZE_CONCURRENCY).await;
+
+        // Release before the `?` below so a partial failure cannot strand the
+        // reservation for the full TTL. Any facts that did land are already
+        // counted as rows, and the ones that did not should not keep holding
+        // quota.
+        rate_limit::release_storage_quota_one(&state, &reservation_id).await;
+
         let mut stored_facts: Vec<AnalyzeAcceptedFact> = Vec::with_capacity(store_results.len());
         for r in store_results {
             stored_facts.push(r?);
@@ -485,26 +506,50 @@ pub async fn analyze(
 
     let prep_results = collect_bounded_results(prep_tasks, ANALYZE_CONCURRENCY).await;
 
-    // Quota check on total ciphertext size
-    let mut prepared: Vec<(String, f32, Vec<f32>, Vec<u8>)> =
-        Vec::with_capacity(prep_results.len());
-    let mut total_encrypted_bytes: i64 = 0;
+    // Exact ciphertext size per fact is known here, which is what the
+    // per-fact reservations below are sized from.
+    let mut prepared: Vec<PreparedFact> = Vec::with_capacity(prep_results.len());
     for r in prep_results {
-        let (fact_text, importance, vector, encrypted) = r?;
-        total_encrypted_bytes += encrypted.len() as i64;
-        prepared.push((fact_text, importance, vector, encrypted));
+        prepared.push(r?);
     }
-    rate_limit::check_storage_quota(&state, owner, total_encrypted_bytes).await?;
+    // Job ids are minted here, before admission, rather than inside the loop
+    // below: each one keys the reservation for the fact it will store, so
+    // jobs.rs can release from the job id it already carries once the vector
+    // row lands. The insert happens minutes later (after the Walrus upload),
+    // which is exactly the window a bare check left unprotected.
+    let pending: Vec<(String, PreparedFact)> = prepared
+        .into_iter()
+        .map(|fact| (uuid::Uuid::new_v4().to_string(), fact))
+        .collect();
+
+    // All-or-nothing across the batch, so an over-quota analyze request is
+    // still rejected whole with the same 402 shape.
+    let reservations: Vec<crate::storage::db::StorageReservationRequest> = pending
+        .iter()
+        .map(
+            |(job_id, (_, _, _, encrypted))| crate::storage::db::StorageReservationRequest {
+                id: job_id.clone(),
+                bytes: encrypted.len() as i64,
+            },
+        )
+        .collect();
+    rate_limit::reserve_storage_quota(&state, owner, &reservations).await?;
+
+    // Facts are enqueued in order, so at iteration `idx` the set
+    // `all_ids[idx..]` is exactly what holds a reservation with no queued job
+    // to release it. Those get released explicitly if we bail out mid-loop;
+    // without that they would sit against the owner's quota until the TTL.
+    let all_ids: Vec<String> = pending.iter().map(|(id, _)| id.clone()).collect();
 
     // Step 3: For each prepared fact — insert remember_jobs row + enqueue WalletJob.
     // Round-robin across wallet pool so facts upload in parallel.
-    let mut job_ids: Vec<String> = Vec::with_capacity(prepared.len());
-    let mut accepted_facts: Vec<AnalyzeAcceptedFact> = Vec::with_capacity(prepared.len());
-    for (fact_text, importance, vector, encrypted) in prepared {
-        let job_id = uuid::Uuid::new_v4().to_string();
-
+    let mut job_ids: Vec<String> = Vec::with_capacity(pending.len());
+    let mut accepted_facts: Vec<AnalyzeAcceptedFact> = Vec::with_capacity(pending.len());
+    for (idx, (job_id, (fact_text, importance, vector, encrypted))) in
+        pending.into_iter().enumerate()
+    {
         // Insert status row
-        sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
         )
         .bind(&job_id)
@@ -512,16 +557,22 @@ pub async fn analyze(
         .bind(namespace)
         .execute(state.db.pool())
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to create analyze job row: {}", e)))?;
+        {
+            rate_limit::release_storage_quota(&state, &all_ids[idx..]).await;
+            return Err(AppError::Internal(format!(
+                "Failed to create analyze job row: {}",
+                e
+            )));
+        }
 
         // Pick next wallet slot (round-robin) and enqueue UploadAndTransfer
-        let wallet_index = state
-            .key_pool
-            .next_index()
-            .ok_or_else(|| AppError::Internal("No Sui keys configured".into()))?;
+        let Some(wallet_index) = state.key_pool.next_index() else {
+            rate_limit::release_storage_quota(&state, &all_ids[idx..]).await;
+            return Err(AppError::Internal("No Sui keys configured".into()));
+        };
         let encrypted_b64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
 
-        enqueue_wallet_job(
+        if let Err(e) = enqueue_wallet_job(
             &state,
             wallet_index,
             WalletOperation::UploadAndTransfer {
@@ -539,7 +590,15 @@ pub async fn analyze(
             },
         )
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to enqueue analyze job: {}", e)))?;
+        {
+            rate_limit::release_storage_quota(&state, &all_ids[idx..]).await;
+            return Err(AppError::Internal(format!(
+                "Failed to enqueue analyze job: {}",
+                e
+            )));
+        }
+
+        // Queued: jobs.rs owns this reservation from here on.
 
         tracing::info!(
             job_id = %job_id,

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -149,7 +149,18 @@ fn spawn_prepare_remember_job(
                 let vector = vector_result?;
                 let encrypted = encrypted_result?;
 
-                rate_limit::check_storage_quota(&state, &owner, encrypted.len() as i64).await?;
+                // Reserve against quota, keyed by this job's id. The insert
+                // happens minutes later in jobs.rs (after the Walrus upload),
+                // so a plain check here would let a concurrent burst pass
+                // before any row exists. jobs.rs releases the reservation when
+                // the row lands or the job dies terminally.
+                rate_limit::reserve_storage_quota_one(
+                    &state,
+                    &owner,
+                    job_id.clone(),
+                    encrypted.len() as i64,
+                )
+                .await?;
 
                 let wallet_index = state.key_pool.next_index().ok_or_else(|| {
                     AppError::Internal(
@@ -220,6 +231,10 @@ fn spawn_prepare_remember_job(
             if let Err(e) = result {
                 let msg = e.to_string();
                 tracing::error!("remember preparation failed: job_id={} {}", job_id, msg);
+                // The job never reached the queue, so nothing downstream will
+                // release its reservation. No-op when the failure was the
+                // quota rejection itself (nothing was reserved).
+                rate_limit::release_storage_quota_one(&state, &job_id).await;
                 mark_remember_job_failed(&state, &job_id, prepare_claim_token.as_deref(), &msg)
                     .await;
             }
@@ -312,7 +327,20 @@ fn spawn_prepare_bulk_remember_job(
                     prepared.push((job_id, namespace, vector, encrypted));
                 }
 
-                rate_limit::check_storage_quota(&state, &owner, total_encrypted_bytes).await?;
+                // One reservation per item, each keyed by the job id its
+                // vector row will use, so jobs.rs releases them individually
+                // as items land. Admission is still all-or-nothing across the
+                // batch, so an over-quota bulk request is rejected whole.
+                let reservations: Vec<crate::storage::db::StorageReservationRequest> = prepared
+                    .iter()
+                    .map(|(job_id, _, _, encrypted)| {
+                        crate::storage::db::StorageReservationRequest {
+                            id: job_id.clone(),
+                            bytes: encrypted.len() as i64,
+                        }
+                    })
+                    .collect();
+                rate_limit::reserve_storage_quota(&state, &owner, &reservations).await?;
 
                 let mut bulk_items: Vec<BulkRememberItem> = Vec::with_capacity(prepared.len());
                 for (job_id, namespace, vector, encrypted) in prepared {
@@ -363,6 +391,9 @@ fn spawn_prepare_bulk_remember_job(
             if let Err(e) = result {
                 let msg = e.to_string();
                 tracing::error!("remember_bulk preparation failed: {}", msg);
+                // Same reasoning as the single path: nothing downstream will
+                // release these, because the batch never reached the queue.
+                rate_limit::release_storage_quota(&state, &job_ids).await;
                 mark_remember_jobs_failed(&state, &job_ids, &msg).await;
             }
         };
@@ -1352,14 +1383,28 @@ pub async fn remember_manual(
         .decode(&body.encrypted_data)
         .map_err(|e| AppError::BadRequest(format!("encrypted_data is not valid base64: {}", e)))?;
 
-    // Check storage quota before upload (quota enforcement stays here —
-    // the engine owns persistence, not policy).
-    rate_limit::check_storage_quota(&state, owner, encrypted_bytes.len() as i64).await?;
+    // Reserve quota before upload (quota enforcement stays here — the engine
+    // owns persistence, not policy).
+    //
+    // This path inserts inline, microseconds after admission rather than
+    // minutes, but it still goes through a reservation: a bare check would let
+    // two concurrent manual writes both pass on the same pre-insert total, and
+    // sharing one mechanism with the enqueued paths keeps a single source of
+    // truth for what an owner is currently consuming. The id is local because
+    // no job row exists here; the engine mints the vector id itself.
+    let reservation_id = uuid::Uuid::new_v4().to_string();
+    rate_limit::reserve_storage_quota_one(
+        &state,
+        owner,
+        reservation_id.clone(),
+        encrypted_bytes.len() as i64,
+    )
+    .await?;
 
     // Persist via the storage engine: Walrus upload (pool key pays gas,
     // configured storage epochs, immediate transfer to owner) -> Postgres index row.
     // Same logic as before, now in engine/walrus_seal.rs::store_blob.
-    let mref = state
+    let stored = state
         .engine
         .store_blob(
             owner,
@@ -1374,7 +1419,15 @@ pub async fn remember_manual(
             crate::services::extractor::IMPORTANCE_STANDARD,
             Some(&auth.public_key),
         )
-        .await?;
+        .await;
+
+    // Released on both arms. On success the row now carries the bytes, so
+    // holding the reservation would double count until TTL; on failure nothing
+    // was written and the quota must go back immediately. Releasing after the
+    // row is committed (never before) keeps the overlap on the safe side.
+    rate_limit::release_storage_quota_one(&state, &reservation_id).await;
+
+    let mref = stored?;
     let id = mref.id;
     let blob_id = mref.blob_id;
 

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -354,6 +354,74 @@ fn db_status<T>(result: &Result<T, AppError>) -> &'static str {
     }
 }
 
+/// Release storage reservations given only a pool handle.
+///
+/// Several wallet-job error paths hold a `&PgPool` rather than an `AppState`
+/// (`update_remember_job_after_wallet_error` and friends), and threading state
+/// through all of them just to release quota would be a much larger change than
+/// this fix warrants. Releasing does not need config: when quota is unlimited
+/// no reservation was ever written, so the delete simply matches nothing.
+///
+/// Infallible for the same reason as the method: a failed release is recovered
+/// by the TTL and the terminal-job reconcile, and must never turn a successful
+/// write into a failed request.
+pub async fn release_storage_reservations_with_pool(pool: &PgPool, ids: &[String]) {
+    if ids.is_empty() {
+        return;
+    }
+    let started = std::time::Instant::now();
+    let result = sqlx::query("DELETE FROM storage_reservations WHERE id = ANY($1)")
+        .bind(ids)
+        .execute(pool)
+        .await;
+
+    match result {
+        Ok(_) => {
+            crate::observability::observe_db("quota.release_reservations", "ok", started.elapsed());
+        }
+        Err(e) => {
+            crate::observability::observe_db(
+                "quota.release_reservations",
+                "error",
+                started.elapsed(),
+            );
+            // TTL and the terminal-job reconcile are the backstops. Log
+            // loudly but do not propagate.
+            tracing::warn!(
+                "failed to release {} storage reservation(s), falling back to TTL: {}",
+                ids.len(),
+                e
+            );
+        }
+    }
+}
+
+/// One pending write awaiting admission against an owner's storage quota.
+///
+/// `id` is supplied by the caller rather than generated here, because the
+/// release site must be able to name the reservation without extra plumbing:
+///   * enqueued paths pass the `remember_jobs.id` the vector row will use, so
+///     `jobs.rs` can release from the job id it already carries. Nothing new
+///     has to be threaded through the serialized `WalletOperation` payloads.
+///   * inline paths pass a fresh UUID and release it themselves a few lines
+///     later.
+#[derive(Debug, Clone)]
+pub struct StorageReservationRequest {
+    pub id: String,
+    pub bytes: i64,
+}
+
+/// Outcome of an atomic quota admission.
+///
+/// `Rejected` is a normal outcome, not an error, so the caller owns the
+/// response shape. `used` is the total observed under the lock (committed
+/// rows plus live reservations) and feeds the existing 402 message verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageAdmission {
+    Admitted,
+    Rejected { used: i64 },
+}
+
 impl VectorDb {
     /// Initialize database connection pool and run migrations
     pub async fn new(database_url: &str) -> Result<Self, AppError> {
@@ -457,6 +525,14 @@ impl VectorDb {
             .execute(&pool)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to run migration 013: {}", e)))?;
+
+        // per-owner storage quota reservations. Makes quota admission atomic
+        // with the eventual insert (GH #532 / WALM-359).
+        let migration_014 = include_str!("../../migrations/014_storage_reservations.sql");
+        sqlx::raw_sql(migration_014)
+            .execute(&pool)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to run migration 014: {}", e)))?;
 
         tracing::info!("database connected and migrations applied");
 
@@ -939,30 +1015,75 @@ impl VectorDb {
     // Storage Quota (still PostgreSQL — tracks per-row blob sizes)
     // ============================================================
 
-    /// Acquire an advisory lock and get storage used within a single transaction.
+    /// Atomically admit a batch of writes against the owner's storage quota.
     ///
-    /// Using `pg_advisory_lock` with a connection pool causes deadlocks
-    /// because it's session-level. We use `pg_advisory_xact_lock` inside an explicit
-    /// transaction so the lock is automatically released on commit/rollback.
-    pub async fn get_storage_used_with_lock(
+    /// This is the whole fix for GH #532 / WALM-359. The previous
+    /// `get_storage_used_with_lock` took a `pg_advisory_xact_lock`, read the
+    /// total, and then committed — which released the lock, because xact locks
+    /// are transaction scoped. The comparison and the caller's INSERT both
+    /// happened outside it, so concurrent requests from one owner all observed
+    /// the same pre-insert total and all passed.
+    ///
+    /// Here the lock, the usage read, the comparison, and the reservation
+    /// INSERT all live in one transaction. Nothing else for this owner can
+    /// interleave, so a burst is serialized and only what actually fits is
+    /// admitted.
+    ///
+    /// Usage counts committed rows plus live reservations:
+    ///   `SUM(vector_entries.blob_size_bytes) + SUM(storage_reservations.bytes)`
+    /// Expired reservations are excluded by predicate and opportunistically
+    /// deleted for this owner, so a missed release self-heals at `ttl`.
+    ///
+    /// Admission is all-or-nothing across `reservations`, which preserves the
+    /// existing behaviour where a bulk request either lands whole or is
+    /// rejected whole.
+    ///
+    /// `pg_advisory_xact_lock` (not the session-level `pg_advisory_lock`) is
+    /// still the right primitive here: with a connection pool the session
+    /// variant leaks locks onto pooled connections and deadlocks. Inside an
+    /// explicit transaction the lock is released on commit or rollback.
+    pub async fn admit_storage_reservations(
         &self,
         owner: &str,
         lock_key: i64,
-    ) -> Result<i64, AppError> {
+        max_bytes: i64,
+        reservations: &[StorageReservationRequest],
+        ttl: std::time::Duration,
+    ) -> Result<StorageAdmission, AppError> {
+        if reservations.is_empty() {
+            return Ok(StorageAdmission::Admitted);
+        }
+
         let started = std::time::Instant::now();
+        let ttl_secs = ttl.as_secs().min(i64::MAX as u64) as i64;
+        let requested: i64 = reservations.iter().map(|r| r.bytes).sum();
+
         let mut tx = self
             .pool
             .begin()
             .await
             .map_err(|e| AppError::Internal(format!("Failed to begin tx: {}", e)))?;
 
+        // Serializes every admission for this owner. Held until commit or
+        // rollback below, which is what makes check-then-reserve atomic.
         sqlx::query("SELECT pg_advisory_xact_lock($1)")
             .bind(lock_key)
             .execute(&mut *tx)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to acquire advisory lock: {}", e)))?;
 
-        let row: (i64,) = sqlx::query_as(
+        // Opportunistic cleanup, scoped to this owner so the write stays
+        // small and cannot contend with other owners' admissions. The global
+        // sweeper handles owners who never come back.
+        sqlx::query("DELETE FROM storage_reservations WHERE owner = $1 AND expires_at <= NOW()")
+            .bind(owner)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to prune expired reservations: {}", e))
+            })?;
+
+        let committed: (i64,) = sqlx::query_as(
             "SELECT COALESCE(SUM(blob_size_bytes)::BIGINT, 0) FROM vector_entries WHERE owner = $1",
         )
         .bind(owner)
@@ -970,12 +1091,132 @@ impl VectorDb {
         .await
         .map_err(|e| AppError::Internal(format!("Failed to get storage used: {}", e)))?;
 
+        let reserved: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(bytes)::BIGINT, 0) FROM storage_reservations
+             WHERE owner = $1 AND expires_at > NOW()",
+        )
+        .bind(owner)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to get reserved storage: {}", e)))?;
+
+        let used = committed.0.saturating_add(reserved.0);
+
+        if used.saturating_add(requested) > max_bytes {
+            // Rollback releases the advisory lock and writes nothing.
+            if let Err(e) = tx.rollback().await {
+                tracing::warn!("failed to roll back rejected quota admission: {}", e);
+            }
+            crate::observability::observe_db(
+                "quota.admit_reservations",
+                "rejected",
+                started.elapsed(),
+            );
+            return Ok(StorageAdmission::Rejected { used });
+        }
+
+        // ON CONFLICT makes admission idempotent. A retried enqueued job
+        // re-admitting under the same `remember_jobs.id` refreshes its own
+        // reservation instead of double counting itself.
+        for reservation in reservations {
+            sqlx::query(
+                "INSERT INTO storage_reservations (id, owner, bytes, expires_at)
+                 VALUES ($1, $2, $3, NOW() + ($4 * INTERVAL '1 second'))
+                 ON CONFLICT (id) DO UPDATE SET
+                    owner = EXCLUDED.owner,
+                    bytes = EXCLUDED.bytes,
+                    expires_at = EXCLUDED.expires_at",
+            )
+            .bind(&reservation.id)
+            .bind(owner)
+            .bind(reservation.bytes)
+            .bind(ttl_secs)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to insert reservation: {}", e)))?;
+        }
+
         tx.commit()
             .await
             .map_err(|e| AppError::Internal(format!("Failed to commit tx: {}", e)))?;
 
-        crate::observability::observe_db("quota.storage_used_with_lock", "ok", started.elapsed());
-        Ok(row.0)
+        crate::observability::observe_db("quota.admit_reservations", "ok", started.elapsed());
+        Ok(StorageAdmission::Admitted)
+    }
+
+    /// Release reservations once their bytes are accounted for elsewhere, or
+    /// once the write that reserved them is known to be dead.
+    ///
+    /// Callers release *after* the vector row is committed. That ordering
+    /// briefly double counts the same bytes (row + reservation), which is the
+    /// safe direction: releasing first would open a window where neither
+    /// counts and a concurrent burst could slip through.
+    ///
+    /// Idempotent by construction — deleting an already released id is a
+    /// no-op, so retried jobs and overlapping failure handlers are harmless.
+    /// Never returns an error to the caller: a failed release is recovered by
+    /// the TTL, and must not turn a successful write into a failed one.
+    pub async fn release_storage_reservations(&self, ids: &[String]) {
+        release_storage_reservations_with_pool(&self.pool, ids).await
+    }
+
+    /// Drop reservations whose `remember_jobs` row is already terminal.
+    ///
+    /// The explicit release calls in `jobs.rs` handle the common paths
+    /// promptly, but a terminal row with a live reservation can still arise:
+    /// the stale-job sweeper fails a row directly, a recovery handoff marks a
+    /// job failed from a code path that only has a pool handle, or a future
+    /// terminal path forgets to release. Reconciling against job status turns
+    /// every one of those from a full-TTL overcount into a bounded one, and
+    /// keeps the guarantee from depending on nobody ever missing a call site.
+    ///
+    /// Only reservations keyed by a `remember_jobs.id` are affected. Inline
+    /// reservations use local UUIDs with no job row, so they never match here
+    /// and are covered by their own release plus the TTL.
+    pub async fn release_reservations_for_terminal_jobs(&self) -> Result<u64, AppError> {
+        let result = sqlx::query(
+            "DELETE FROM storage_reservations r
+             USING remember_jobs j
+             WHERE r.id = j.id AND j.status IN ('done', 'failed')",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!(
+                "Failed to reconcile reservations against terminal jobs: {}",
+                e
+            ))
+        })?;
+
+        let rows = result.rows_affected();
+        if rows > 0 {
+            tracing::info!(
+                "released {} storage reservation(s) held by terminal remember jobs",
+                rows
+            );
+        }
+        Ok(rows)
+    }
+
+    /// Delete reservations whose TTL has passed, across all owners.
+    ///
+    /// The admission path already prunes the owner it touches, so this only
+    /// matters for owners who reserved, leaked, and never returned. Without it
+    /// their rows would sit in the table forever even though the predicate
+    /// already stops counting them.
+    pub async fn sweep_expired_storage_reservations(&self) -> Result<u64, AppError> {
+        let result = sqlx::query("DELETE FROM storage_reservations WHERE expires_at <= NOW()")
+            .execute(&self.pool)
+            .await
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to sweep expired reservations: {}", e))
+            })?;
+
+        let rows = result.rows_affected();
+        if rows > 0 {
+            tracing::info!("swept {} expired storage reservation(s)", rows);
+        }
+        Ok(rows)
     }
 
     // ============================================================
@@ -1668,5 +1909,441 @@ pub mod oauth_rows {
         pub encrypted_private_key: String,
         pub delegate_public_key: String,
         pub delegate_status: String,
+    }
+}
+
+// ============================================================
+// Storage quota admission — concurrency regression tests
+// ============================================================
+//
+// These pin the fix for GH #532 / WALM-359 against a real PostgreSQL, because
+// the defect only exists in the interleaving of concurrent transactions. An
+// in-process fake would serialize the very thing under test and pass against
+// the broken code.
+//
+// Shape mirrors the reproduction on the issue: seed an owner just under quota
+// so exactly one more write fits, fire a 20-way burst, and assert exactly one
+// admission. Against the old read-then-commit-then-insert code the same
+// harness admitted 13 to 20 of 20.
+//
+// Requires DATABASE_URL (or the local default) to point at a Postgres with
+// pgvector. Marked #[ignore] to match the existing convention for tests with
+// external dependencies — run with `cargo test -- --ignored`.
+#[cfg(test)]
+mod quota_admission_tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Matches the real default in `rate_limit::RateLimitConfig` (1 GiB).
+    const MAX_BYTES: i64 = 1_073_741_824;
+    /// Per-request size for the burst. Arbitrary but fixed, so the seed below
+    /// can leave room for exactly one.
+    const ITEM_BYTES: i64 = 1_048_576;
+    const BURST: usize = 20;
+    const TTL: Duration = Duration::from_secs(900);
+
+    fn test_database_url() -> String {
+        std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgresql://memwal:memwal_secret@localhost:5432/memwal".into())
+    }
+
+    async fn test_db() -> VectorDb {
+        VectorDb::new(&test_database_url())
+            .await
+            .expect("test database must be reachable with pgvector installed")
+    }
+
+    /// Unique per test so concurrent runs cannot see each other's rows, and so
+    /// a failed run leaves no state that poisons the next one.
+    fn unique_owner(tag: &str) -> String {
+        format!("0xtest-{}-{}", tag, uuid::Uuid::new_v4())
+    }
+
+    fn lock_key(owner: &str) -> i64 {
+        // Same FNV-1a folding as `rate_limit::stable_hash_i64`. Duplicated
+        // rather than imported so this test pins the DB layer's contract on
+        // its own, independent of the caller.
+        const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+        const FNV_PRIME: u64 = 1_099_511_628_211;
+        let hash = owner
+            .bytes()
+            .fold(FNV_OFFSET, |acc, b| acc.wrapping_mul(FNV_PRIME) ^ b as u64);
+        ((hash >> 32) ^ (hash & 0xFFFF_FFFF)) as i64
+    }
+
+    fn zero_vector() -> Vec<f32> {
+        vec![0.0; 1536]
+    }
+
+    /// Seed committed usage so exactly one `ITEM_BYTES` write still fits.
+    async fn seed_to_one_slot_remaining(db: &VectorDb, owner: &str) {
+        let seeded = MAX_BYTES - ITEM_BYTES;
+        db.insert_vector(
+            &format!("seed-{}", uuid::Uuid::new_v4()),
+            owner,
+            "default",
+            "seed-blob",
+            &zero_vector(),
+            seeded,
+            0.5,
+        )
+        .await
+        .expect("seed insert");
+    }
+
+    async fn committed_bytes(db: &VectorDb, owner: &str) -> i64 {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(blob_size_bytes)::BIGINT, 0) FROM vector_entries WHERE owner = $1",
+        )
+        .bind(owner)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        row.0
+    }
+
+    async fn cleanup(db: &VectorDb, owner: &str) {
+        let _ = sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
+            .bind(owner)
+            .execute(db.pool())
+            .await;
+        let _ = sqlx::query("DELETE FROM storage_reservations WHERE owner = $1")
+            .bind(owner)
+            .execute(db.pool())
+            .await;
+    }
+
+    /// Inline path: admission immediately followed by the insert.
+    ///
+    /// This is the cheap case (microseconds between check and write) and it
+    /// still overshot before the fix.
+    #[tokio::test]
+    #[ignore]
+    async fn burst_admits_exactly_one_inline() {
+        let db = Arc::new(test_db().await);
+        let owner = unique_owner("inline");
+        seed_to_one_slot_remaining(&db, &owner).await;
+
+        let mut handles = Vec::with_capacity(BURST);
+        for _ in 0..BURST {
+            let db = Arc::clone(&db);
+            let owner = owner.clone();
+            handles.push(tokio::spawn(async move {
+                let id = uuid::Uuid::new_v4().to_string();
+                let admission = db
+                    .admit_storage_reservations(
+                        &owner,
+                        lock_key(&owner),
+                        MAX_BYTES,
+                        &[StorageReservationRequest {
+                            id: id.clone(),
+                            bytes: ITEM_BYTES,
+                        }],
+                        TTL,
+                    )
+                    .await
+                    .expect("admission must not error");
+
+                if admission != StorageAdmission::Admitted {
+                    return false;
+                }
+
+                db.insert_vector(
+                    &id,
+                    &owner,
+                    "default",
+                    "blob",
+                    &zero_vector(),
+                    ITEM_BYTES,
+                    0.5,
+                )
+                .await
+                .expect("insert");
+                db.release_storage_reservations(&[id]).await;
+                true
+            }));
+        }
+
+        let mut admitted = 0usize;
+        for h in handles {
+            if h.await.unwrap() {
+                admitted += 1;
+            }
+        }
+
+        let total = committed_bytes(&db, &owner).await;
+        cleanup(&db, &owner).await;
+
+        assert_eq!(
+            admitted, 1,
+            "exactly one of {} concurrent requests should be admitted, got {}",
+            BURST, admitted
+        );
+        assert!(
+            total <= MAX_BYTES,
+            "committed bytes {} must never exceed quota {}",
+            total,
+            MAX_BYTES
+        );
+    }
+
+    /// Enqueued path: admission, then a delay standing in for the Walrus
+    /// upload, then the insert.
+    ///
+    /// This is the severe case. The gap is real (documented as up to five
+    /// minutes) and before the fix a 150 ms gap was enough to admit the entire
+    /// burst. The delay here is what makes the test meaningful, so it must not
+    /// be optimised away.
+    #[tokio::test]
+    #[ignore]
+    async fn burst_admits_exactly_one_with_delayed_insert() {
+        let db = Arc::new(test_db().await);
+        let owner = unique_owner("enqueued");
+        seed_to_one_slot_remaining(&db, &owner).await;
+
+        let mut handles = Vec::with_capacity(BURST);
+        for _ in 0..BURST {
+            let db = Arc::clone(&db);
+            let owner = owner.clone();
+            handles.push(tokio::spawn(async move {
+                let id = uuid::Uuid::new_v4().to_string();
+                let admission = db
+                    .admit_storage_reservations(
+                        &owner,
+                        lock_key(&owner),
+                        MAX_BYTES,
+                        &[StorageReservationRequest {
+                            id: id.clone(),
+                            bytes: ITEM_BYTES,
+                        }],
+                        TTL,
+                    )
+                    .await
+                    .expect("admission must not error");
+
+                if admission != StorageAdmission::Admitted {
+                    return false;
+                }
+
+                // Stands in for embed → encrypt → Walrus upload.
+                tokio::time::sleep(Duration::from_millis(150)).await;
+
+                db.insert_vector(
+                    &id,
+                    &owner,
+                    "default",
+                    "blob",
+                    &zero_vector(),
+                    ITEM_BYTES,
+                    0.5,
+                )
+                .await
+                .expect("insert");
+                db.release_storage_reservations(&[id]).await;
+                true
+            }));
+        }
+
+        let mut admitted = 0usize;
+        for h in handles {
+            if h.await.unwrap() {
+                admitted += 1;
+            }
+        }
+
+        let total = committed_bytes(&db, &owner).await;
+        cleanup(&db, &owner).await;
+
+        assert_eq!(
+            admitted, 1,
+            "the upload gap must not let extra requests through: got {} of {}",
+            admitted, BURST
+        );
+        assert!(
+            total <= MAX_BYTES,
+            "committed bytes {} must never exceed quota {}",
+            total,
+            MAX_BYTES
+        );
+    }
+
+    /// A reservation must count against quota before any row exists. This is
+    /// the single assertion that fails against the pre-fix code.
+    #[tokio::test]
+    #[ignore]
+    async fn reservation_counts_before_the_row_lands() {
+        let db = test_db().await;
+        let owner = unique_owner("counts");
+        seed_to_one_slot_remaining(&db, &owner).await;
+
+        let first = db
+            .admit_storage_reservations(
+                &owner,
+                lock_key(&owner),
+                MAX_BYTES,
+                &[StorageReservationRequest {
+                    id: "res-first".into(),
+                    bytes: ITEM_BYTES,
+                }],
+                TTL,
+            )
+            .await
+            .unwrap();
+        assert_eq!(first, StorageAdmission::Admitted);
+
+        // No insert yet — the reservation alone must fill the slot.
+        let second = db
+            .admit_storage_reservations(
+                &owner,
+                lock_key(&owner),
+                MAX_BYTES,
+                &[StorageReservationRequest {
+                    id: "res-second".into(),
+                    bytes: ITEM_BYTES,
+                }],
+                TTL,
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(second, StorageAdmission::Rejected { .. }),
+            "an outstanding reservation must block the next admission, got {:?}",
+            second
+        );
+
+        cleanup(&db, &owner).await;
+    }
+
+    /// Releasing must hand the quota straight back, so a failed or completed
+    /// write does not cost the owner capacity until TTL.
+    #[tokio::test]
+    #[ignore]
+    async fn release_frees_quota_immediately() {
+        let db = test_db().await;
+        let owner = unique_owner("release");
+        seed_to_one_slot_remaining(&db, &owner).await;
+
+        let req = [StorageReservationRequest {
+            id: "res-release".into(),
+            bytes: ITEM_BYTES,
+        }];
+        assert_eq!(
+            db.admit_storage_reservations(&owner, lock_key(&owner), MAX_BYTES, &req, TTL)
+                .await
+                .unwrap(),
+            StorageAdmission::Admitted
+        );
+
+        db.release_storage_reservations(&["res-release".to_string()])
+            .await;
+
+        assert_eq!(
+            db.admit_storage_reservations(&owner, lock_key(&owner), MAX_BYTES, &req, TTL)
+                .await
+                .unwrap(),
+            StorageAdmission::Admitted,
+            "released bytes must be immediately reusable"
+        );
+
+        cleanup(&db, &owner).await;
+    }
+
+    /// The TTL backstop: a reservation nobody ever released must stop counting,
+    /// so a missed release can never make an account permanently unusable.
+    #[tokio::test]
+    #[ignore]
+    async fn expired_reservation_stops_counting() {
+        let db = test_db().await;
+        let owner = unique_owner("ttl");
+        seed_to_one_slot_remaining(&db, &owner).await;
+
+        // Zero TTL: expired the moment it is written, standing in for a
+        // reservation whose release never came.
+        assert_eq!(
+            db.admit_storage_reservations(
+                &owner,
+                lock_key(&owner),
+                MAX_BYTES,
+                &[StorageReservationRequest {
+                    id: "res-stale".into(),
+                    bytes: ITEM_BYTES,
+                }],
+                Duration::from_secs(0),
+            )
+            .await
+            .unwrap(),
+            StorageAdmission::Admitted
+        );
+
+        assert_eq!(
+            db.admit_storage_reservations(
+                &owner,
+                lock_key(&owner),
+                MAX_BYTES,
+                &[StorageReservationRequest {
+                    id: "res-after-stale".into(),
+                    bytes: ITEM_BYTES,
+                }],
+                TTL,
+            )
+            .await
+            .unwrap(),
+            StorageAdmission::Admitted,
+            "an expired reservation must not hold quota"
+        );
+
+        db.sweep_expired_storage_reservations().await.unwrap();
+
+        cleanup(&db, &owner).await;
+    }
+
+    /// Bulk admission is all-or-nothing, which is what keeps the existing
+    /// "reject the whole request" behaviour and the 402 shape intact.
+    #[tokio::test]
+    #[ignore]
+    async fn batch_admission_is_all_or_nothing() {
+        let db = test_db().await;
+        let owner = unique_owner("batch");
+        seed_to_one_slot_remaining(&db, &owner).await;
+
+        // Two items, only one slot.
+        let outcome = db
+            .admit_storage_reservations(
+                &owner,
+                lock_key(&owner),
+                MAX_BYTES,
+                &[
+                    StorageReservationRequest {
+                        id: "batch-a".into(),
+                        bytes: ITEM_BYTES,
+                    },
+                    StorageReservationRequest {
+                        id: "batch-b".into(),
+                        bytes: ITEM_BYTES,
+                    },
+                ],
+                TTL,
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, StorageAdmission::Rejected { .. }),
+            "an over-quota batch must be rejected whole, got {:?}",
+            outcome
+        );
+
+        let leaked: (i64,) =
+            sqlx::query_as("SELECT COUNT(*)::BIGINT FROM storage_reservations WHERE owner = $1")
+                .bind(&owner)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            leaked.0, 0,
+            "a rejected batch must not leave partial reservations behind"
+        );
+
+        cleanup(&db, &owner).await;
     }
 }


### PR DESCRIPTION
Fixes WALM-359. Closes #532.

## The bug

`check_storage_quota` read `SUM(blob_size_bytes)` inside a transaction holding `pg_advisory_xact_lock`, then committed. Advisory *xact* locks are transaction scoped, so the lock died on that commit: the quota comparison and the caller's `INSERT` both ran unprotected. Concurrent requests from one owner all observed the same pre-insert total, all passed, and all inserted.

The comment claiming that lock closed a TOCTOU race was wrong, and is removed.

## Reproduced before fixing

Real PostgreSQL, 1 GiB quota, owner seeded so exactly one more write fits, 20-way burst:

| Path | Admitted | Overshoot |
| -- | -- | -- |
| Inline (check → insert immediately) | 17 / 20 | +16 MiB |
| Enqueued (150 ms upload gap) | 20 / 20 | +19 MiB |
| After this change | **1 / 20** | none |

The 150 ms figure is generous to the old code. The real check-to-insert window on the enqueued paths spans a Walrus upload, documented in `types.rs` as running up to five minutes.

## Approach

Admission now records a **reservation** inside the same transaction that holds the lock, so the intent to write is committed before the lock is released. Usage during admission is `SUM(vector_entries.blob_size_bytes)` plus live reservations, which is what lets a later request in a burst see an earlier one's bytes even though no row exists yet.

A single transaction spanning check and insert would close the inline paths, but not the enqueued ones: those admit, queue a wallet job, upload to Walrus, and insert minutes later, and a Postgres transaction cannot be held across that. A reservation table covers both groups on one mechanism instead of letting them diverge.

**Reservations are keyed by the caller's own id**, not a generated one:

* enqueued paths use the `remember_jobs.id` the vector row will carry, so `jobs.rs` releases from an id it already has. Nothing new is threaded through the serialized `WalletOperation` payloads, so there is no job-payload compatibility risk for in-flight jobs.
* inline paths mint a local UUID and release it a few lines later.

**Release happens after the row is committed, never before.** That briefly double counts the same bytes, which is the safe direction; releasing first would open a window where neither the row nor the reservation counts.

## Not stranding quota

Three layers, so a missed release can never make an account permanently unusable:

1. Explicit release on the success path and on terminal wallet-job failure.
2. A periodic reconcile that drops reservations whose `remember_jobs` row is already `done` or `failed`. This is what keeps the guarantee from depending on nobody ever missing a call site.
3. A 15 minute TTL as the backstop, chosen to exceed `STALE_REMEMBER_JOB_AFTER` (10 min), after which the sweeper fails the job and releases anyway.

Both new sweeps run on the existing 60 s stale-job tick, ordered after it so rows it just failed are reconciled in the same pass.

The worst case is bounded over-counting, never a locked-out account.

## Call sites covered (5)

Inline: `remember_manual`, analyze benchmark branch.
Enqueued: `remember()`, `remember_bulk`, analyze main path.

Batch admission is all-or-nothing, so an over-quota bulk or analyze request is still rejected whole. The `402` / "Storage quota exceeded" response shape is unchanged.

## Migration

`014_storage_reservations.sql` adds the `storage_reservations` table. Additive, `CREATE TABLE IF NOT EXISTS`, no change to existing tables, safe to roll back by leaving the table in place.

## Tests

Six real-Postgres tests in `storage::db::quota_admission_tests`, `#[ignore]`d in line with the existing convention for tests needing external services:

```bash
DATABASE_URL=postgresql://... cargo test quota_admission_tests -- --ignored
```

They cover the 20-way burst on both the inline path and the enqueued path with a delayed insert, plus reservation-counts-before-the-row, release-frees-immediately, TTL expiry, and all-or-nothing batching.

**These were checked against the broken code before being committed**: reintroducing the old read-commit-compare-insert path makes the two burst tests fail with the 17/20 and 20/20 numbers above, so they are not vacuous.

## Verification

* 937 unit tests pass, plus the 6 new ones.
* `cargo clippy` introduces no new real lints. The only delta against `dev` is dead-code `never used` entries for the new public items, which is the same lib-target artifact that already lists `check_storage_quota` on `dev` today.
* `cargo fmt` clean, no reformatting of untouched files.
* Docker build **not verified locally**: it fails on this Apple Silicon host during the dependency prebuild step, where amd64 `rustc` segfaults under QEMU. That step consumes only `Cargo.toml` / `Cargo.lock`, neither of which this PR touches, so the failure is environmental. Worth a look at CI's build result before merging.

## Note on the ticket

The ticket cites `security_delete_store.rs` as in-repo precedent for the fix pattern. That file does not exist on `dev` (it appears to be from an unmerged branch). The pattern is still right, it just is not shipped precedent.
