### PR TITLE
fix(sdk): accept a bech32 suiprivkey delegate key, not just hex

### DIFF
--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -43,6 +43,7 @@ import {
     sha256hex,
     hexToBytes,
     bytesToHex,
+    normalizePrivateKey,
     u64ToLeHex,
     normalizeServerUrl,
     sanitizeServerError,
@@ -169,7 +170,10 @@ export class MemWalManual {
         if (config.suiPrivateKey && config.walletSigner) {
             throw new Error("MemWalManual: provide suiPrivateKey OR walletSigner, not both");
         }
-        this.delegatePrivateKey = typeof config.key === "string" ? hexToBytes(config.key) : config.key;
+        this.delegatePrivateKey =
+            typeof config.key === "string"
+                ? hexToBytes(normalizePrivateKey(config.key))
+                : config.key;
         // LOW-22: default to HTTPS; warn (do not throw) on plaintext HTTP
         // against non-localhost hosts.
         this.serverUrl = normalizeServerUrl(config.serverUrl ?? "https://relayer.memory.walrus.xyz");

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -60,6 +60,7 @@ import {
     sha256hex,
     hexToBytes,
     bytesToHex,
+    normalizePrivateKey,
     normalizeServerUrl,
     sanitizeServerError,
     clockDriftErrorFromResponse,
@@ -200,7 +201,10 @@ export class MemWal {
     private pendingRememberKeys = new Map<string, string>();
 
     private constructor(config: MemWalConfig) {
-        this.privateKey = typeof config.key === "string" ? hexToBytes(config.key) : config.key;
+        this.privateKey =
+            typeof config.key === "string"
+                ? hexToBytes(normalizePrivateKey(config.key))
+                : config.key;
         this.accountId = config.accountId;
         // LOW-22: default to HTTPS for production usage; normalizeServerUrl
         // warns (does not throw) if a user passes plain http:// for a
@@ -212,7 +216,7 @@ export class MemWal {
     /**
      * Create a new Walrus Memory client instance.
      *
-     * @param config.key - Ed25519 private key (hex string) — the delegate key
+     * @param config.key - Ed25519 private key (hex or `suiprivkey1...`) — the delegate key
      * @param config.serverUrl - Server URL (default: https://relayer.memory.walrus.xyz)
      */
     static create(config: MemWalConfig): MemWal {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -10,7 +10,10 @@
 // ============================================================
 
 export interface MemWalConfig {
-    /** Ed25519 private key (hex string or Uint8Array). This is the Walrus Memory delegate key. */
+    /**
+     * Ed25519 private key — the Walrus Memory delegate key. Accepts hex (with
+     * or without `0x`), a Sui `suiprivkey1...` bech32 string, or raw bytes.
+     */
     key: string | Uint8Array;
     /** Walrus Memory account object ID on Sui (ensures correct account when delegate key exists in multiple accounts) */
     accountId: string;
@@ -393,7 +396,7 @@ export interface SealServerConfig {
 
 /** Config for MemWalManual (full client-side: SEAL + Walrus + embedding) */
 export interface MemWalManualConfig {
-    /** Ed25519 delegate private key (hex or Uint8Array) for server auth */
+    /** Ed25519 delegate private key (hex, `suiprivkey1...`, or Uint8Array) for server auth */
     key: string | Uint8Array;
     /** Server URL (default: https://relayer.memory.walrus.xyz) */
     serverUrl?: string;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -100,6 +100,150 @@ export function scoringWeightsToWire(weights?: ScoringWeights): object | undefin
 }
 
 // ============================================================
+// Sui Private Key Formats
+// ============================================================
+
+// Bech32 (BIP-173) charset, and the Sui scheme flag for Ed25519.
+const BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const SUI_ED25519_SCHEME_FLAG = 0;
+
+/**
+ * Hand-rolled rather than pulling in `decodeSuiPrivateKey` from `@mysten/sui`:
+ * this package keeps `@mysten/*` as peer dependencies so the core client works
+ * without them, and `MemWal`'s constructor is synchronous so it cannot await a
+ * dynamic import. The Python SDK hand-rolls it in `memwal/utils.py` for the
+ * same reason.
+ */
+function bech32Polymod(values: number[]): number {
+    const generators = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+    let chk = 1;
+    for (const value of values) {
+        const top = chk >> 25;
+        chk = ((chk & 0x1ffffff) << 5) ^ value;
+        for (let i = 0; i < 5; i++) {
+            if ((top >> i) & 1) {
+                chk ^= generators[i]!;
+            }
+        }
+    }
+    return chk;
+}
+
+function bech32HrpExpand(hrp: string): number[] {
+    const high: number[] = [];
+    const low: number[] = [];
+    for (const char of hrp) {
+        const code = char.charCodeAt(0);
+        high.push(code >> 5);
+        low.push(code & 31);
+    }
+    return [...high, 0, ...low];
+}
+
+/**
+ * Regroup `data` from `frombits`-wide values to `tobits`-wide ones. Bech32
+ * carries 5-bit values; a private key is bytes, so decoding is 5 -> 8.
+ */
+function convertBits(data: number[], frombits: number, tobits: number, pad: boolean): number[] {
+    let acc = 0;
+    let bits = 0;
+    const ret: number[] = [];
+    const maxv = (1 << tobits) - 1;
+    const maxAcc = (1 << (frombits + tobits - 1)) - 1;
+    for (const value of data) {
+        if (value < 0 || value >> frombits) {
+            throw new Error("convertBits: value out of range");
+        }
+        acc = ((acc << frombits) | value) & maxAcc;
+        bits += frombits;
+        while (bits >= tobits) {
+            bits -= tobits;
+            ret.push((acc >> bits) & maxv);
+        }
+    }
+    if (pad) {
+        if (bits) {
+            ret.push((acc << (tobits - bits)) & maxv);
+        }
+    } else if (bits >= frombits || ((acc << (tobits - bits)) & maxv)) {
+        throw new Error("convertBits: invalid incomplete group");
+    }
+    return ret;
+}
+
+/** Decode a bech32 string into its human-readable part and 5-bit data. */
+function bech32Decode(bech: string): { hrp: string; data: number[] } {
+    if (bech !== bech.toLowerCase() && bech !== bech.toUpperCase()) {
+        throw new Error("bech32 string is mixed case");
+    }
+    const lower = bech.toLowerCase();
+    const pos = lower.lastIndexOf("1");
+    if (pos < 1 || pos + 7 > lower.length) {
+        throw new Error("bech32 string has no valid separator");
+    }
+
+    const hrp = lower.slice(0, pos);
+    const data: number[] = [];
+    for (const char of lower.slice(pos + 1)) {
+        const index = BECH32_CHARSET.indexOf(char);
+        if (index === -1) {
+            throw new Error("bech32 string has a character outside the charset");
+        }
+        data.push(index);
+    }
+
+    if (bech32Polymod([...bech32HrpExpand(hrp), ...data]) !== 1) {
+        throw new Error("bech32 checksum mismatch");
+    }
+    return { hrp, data: data.slice(0, -6) };
+}
+
+/**
+ * Decode a Sui bech32 `suiprivkey1...` string to its 32-byte Ed25519 seed.
+ *
+ * Mirrors `decodeSuiPrivateKey` from `@mysten/sui`.
+ */
+export function decodeSuiPrivateKey(encoded: string): Uint8Array {
+    const { hrp, data } = bech32Decode(encoded);
+    if (hrp !== "suiprivkey") {
+        throw new Error(`expected a suiprivkey string, got prefix '${hrp}'`);
+    }
+
+    const payload = convertBits(data, 5, 8, false);
+    if (payload.length === 0 || payload[0] !== SUI_ED25519_SCHEME_FLAG) {
+        throw new Error("only Ed25519 private keys are supported");
+    }
+
+    const seed = payload.slice(1);
+    if (seed.length !== 32) {
+        throw new Error(`Ed25519 seed must be exactly 32 bytes, got ${seed.length}`);
+    }
+    return Uint8Array.from(seed);
+}
+
+/**
+ * Accept either a hex seed or a Sui `suiprivkey1...` string, return hex.
+ *
+ * Both forms are in circulation — `sui keytool` and wallets hand out bech32,
+ * while `generateDelegateKey()` returns hex — so hex-only input would reject a
+ * key a user reasonably expects to work, and the "non-hex characters" error it
+ * raised named nothing they could act on. Matches the Python SDK's
+ * `normalize_private_key`.
+ */
+export function normalizePrivateKey(key: string): string {
+    if (typeof key !== "string") {
+        throw new TypeError("normalizePrivateKey: expected string input");
+    }
+    const candidate = key.trim();
+    if (candidate.toLowerCase().startsWith("suiprivkey1")) {
+        return bytesToHex(decodeSuiPrivateKey(candidate));
+    }
+    return candidate.startsWith("0x") || candidate.startsWith("0X")
+        ? candidate.slice(2)
+        : candidate;
+}
+
+// ============================================================
 // Transport Security Helpers
 // ============================================================
 
@@ -229,7 +373,7 @@ export function clockDriftErrorFromResponse(
  * This allows a delegate key to be used as a Sui keypair for signing transactions
  * (e.g. calling seal_approve for SEAL decryption).
  *
- * @param privateKeyHex - Ed25519 private key as hex string
+ * @param privateKeyHex - Ed25519 private key, hex or `suiprivkey1...`
  * @returns Sui address as 0x-prefixed hex string
  *
  * @example
@@ -242,7 +386,7 @@ export async function delegateKeyToSuiAddress(privateKeyHex: string): Promise<st
     const ed = await import("@noble/ed25519");
     const { blake2b } = await import("@noble/hashes/blake2.js");
 
-    const privateKey = hexToBytes(privateKeyHex);
+    const privateKey = hexToBytes(normalizePrivateKey(privateKeyHex));
     const publicKey = await ed.getPublicKeyAsync(privateKey);
 
     // Sui Ed25519 address = blake2b256(0x00 || public_key)
@@ -255,12 +399,12 @@ export async function delegateKeyToSuiAddress(privateKeyHex: string): Promise<st
 }
 
 /**
- * Get the Ed25519 public key bytes from a delegate key private key hex.
+ * Get the Ed25519 public key bytes from a delegate private key.
  *
- * @param privateKeyHex - Ed25519 private key as hex string
+ * @param privateKeyHex - Ed25519 private key, hex or `suiprivkey1...`
  * @returns 32-byte public key as Uint8Array
  */
 export async function delegateKeyToPublicKey(privateKeyHex: string): Promise<Uint8Array> {
     const ed = await import("@noble/ed25519");
-    return ed.getPublicKeyAsync(hexToBytes(privateKeyHex));
+    return ed.getPublicKeyAsync(hexToBytes(normalizePrivateKey(privateKeyHex)));
 }

--- a/packages/sdk/test/private-key-formats.test.mjs
+++ b/packages/sdk/test/private-key-formats.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * `MemWal.create({ key })` must accept every form a delegate key is handed out
+ * in, not just bare hex.
+ *
+ * The Python SDK already normalizes all of them (memwal/utils.py
+ * `normalize_private_key`), and its docstring states the TypeScript SDK takes
+ * both forms — it did not, so a `suiprivkey1...` key died inside `hexToBytes`
+ * with "input contains non-hex characters" before any request went out. That
+ * is what broke the JS SDK e2e job against the dev relayer: the shared
+ * BENCH_DELEGATE_KEY secret is stored in bech32.
+ *
+ * Vectors below were produced by `encodeSuiPrivateKey` from `@mysten/sui`,
+ * which is the canonical implementation both SDKs mirror.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWal } from "../dist/memwal.js";
+import { bytesToHex, decodeSuiPrivateKey, normalizePrivateKey } from "../dist/utils.js";
+
+const SEED_HEX = "17dc3c1eecfcdc014c0eba65c1f87897abbbd214fa32d4018f48669b5d37c413";
+const SEED_BECH32 = "suiprivkey1qqtac0q7an7dcq2vp6axts0c0zt6hw7jznar94qp3ayxdx6axlzpxcetm48";
+// Same seed, scheme flag 1 (secp256k1) instead of 0 (Ed25519).
+const SECP256K1_BECH32 = "suiprivkey1qytac0q7an7dcq2vp6axts0c0zt6hw7jznar94qp3ayxdx6axlzpxzx7yks";
+
+const ACCOUNT_ID = `0x${"02".repeat(32)}`;
+
+test("decodeSuiPrivateKey recovers the Ed25519 seed from a suiprivkey string", () => {
+    assert.equal(bytesToHex(decodeSuiPrivateKey(SEED_BECH32)), SEED_HEX);
+});
+
+test("normalizePrivateKey accepts every form a delegate key is handed out in", () => {
+    for (const form of [SEED_HEX, `0x${SEED_HEX}`, SEED_BECH32, `  ${SEED_BECH32}  `]) {
+        assert.equal(normalizePrivateKey(form), SEED_HEX, `form: ${form}`);
+    }
+});
+
+test("a bech32 key produces the same client identity as its hex form", async () => {
+    const fromHex = MemWal.create({ key: SEED_HEX, accountId: ACCOUNT_ID });
+    const fromBech32 = MemWal.create({ key: SEED_BECH32, accountId: ACCOUNT_ID });
+
+    assert.equal(await fromBech32.getPublicKeyHex(), await fromHex.getPublicKeyHex());
+});
+
+test("decodeSuiPrivateKey rejects a non-Ed25519 scheme", () => {
+    assert.throws(() => decodeSuiPrivateKey(SECP256K1_BECH32), /Ed25519/);
+});
+
+test("decodeSuiPrivateKey rejects a corrupted checksum", () => {
+    const corrupted = `${SEED_BECH32.slice(0, -1)}${SEED_BECH32.at(-1) === "q" ? "p" : "q"}`;
+    assert.throws(() => decodeSuiPrivateKey(corrupted), /checksum/);
+});
+
+test("an unparseable key still reports what was wrong with it", () => {
+    assert.throws(() => MemWal.create({ key: "not-a-key", accountId: ACCOUNT_ID }), /hex/);
+});
+
+// Every entry point that takes a user-supplied delegate key must accept the
+// same forms. `delegateKeyToPublicKey` in particular is what a user calls to
+// register their key on-chain, so rejecting bech32 there strands them before
+// they ever construct a client.
+
+test("MemWalManual signs with the same delegate key whether given hex or bech32", async () => {
+    const { MemWalManual } = await import("../dist/manual.js");
+
+    // The delegate key's whole job is the x-public-key header the relayer
+    // authenticates on, so assert on that rather than on internal state.
+    async function publicKeyHeaderFor(key) {
+        const manual = MemWalManual.create({
+            key,
+            walletSigner: {
+                address: "0x2",
+                signAndExecuteTransaction: async () => ({ digest: "0xtx" }),
+                signPersonalMessage: async () => ({ signature: "sig" }),
+            },
+            suiClient: {},
+            embeddingApiKey: "test",
+            packageId: `0x${"33".repeat(32)}`,
+            accountId: ACCOUNT_ID,
+            registryId: "0xregistry",
+            serverUrl: "https://relayer.example",
+            sealServerConfigs: [{ objectId: "0xserver", weight: 1 }],
+        });
+
+        let captured = null;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async (url, init) => {
+            // signedRequest probes GET /version for compatibility first.
+            if (String(url).endsWith("/version")) {
+                return Response.json({
+                    apiVersion: "1.0.0",
+                    relayerVersion: "1.0.0",
+                    minSupportedSdk: { typescript: "0.0.4" },
+                });
+            }
+            captured = new Headers(init.headers).get("x-public-key");
+            return Response.json({ restored: 0, skipped: 0, total: 0, namespace: "demo", owner: "0x1" });
+        };
+        try {
+            await manual.restore("demo");
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+        return captured;
+    }
+
+    const fromHex = await publicKeyHeaderFor(SEED_HEX);
+    assert.ok(fromHex, "expected the request to carry an x-public-key header");
+    assert.equal(await publicKeyHeaderFor(SEED_BECH32), fromHex);
+});
+
+test("delegateKeyToPublicKey accepts a bech32 delegate key", async () => {
+    const { delegateKeyToPublicKey } = await import("../dist/utils.js");
+
+    assert.deepEqual(
+        await delegateKeyToPublicKey(SEED_BECH32),
+        await delegateKeyToPublicKey(SEED_HEX),
+    );
+});
+
+test("delegateKeyToSuiAddress accepts a bech32 delegate key", async () => {
+    const { delegateKeyToSuiAddress } = await import("../dist/utils.js");
+
+    assert.equal(
+        await delegateKeyToSuiAddress(SEED_BECH32),
+        await delegateKeyToSuiAddress(SEED_HEX),
+    );
+});


### PR DESCRIPTION
`MemWal.create({ key })` fed the key straight into `hexToBytes`, which only accepts hex. A Sui `suiprivkey1...` string therefore died at construction with "hexToBytes: input contains non-hex characters", before any request went out.

That is what broke the JS SDK e2e job against the dev relayer: all 11 authenticated tests failed while the 7 no-auth ones passed, because the shared BENCH_DELEGATE_KEY secret is stored in bech32. The Python SDK reads that same secret and passes, since it normalizes the key first (`memwal/utils.py` `normalize_private_key`) — and its docstring already claimed the TypeScript SDK took both forms. It did not. This closes that gap rather than working around it in CI, because the two forms are both in circulation: `sui keytool` and wallets hand out bech32, while `generateDelegateKey()` returns hex.

Port `normalize_private_key` to `utils.ts` and call it everywhere a user-supplied delegate key is parsed: both client constructors and the two `delegateKeyTo*` helpers. `account.ts` is untouched — its `hexToBytes` calls take public keys, where suiprivkey does not apply.

The bech32 decoder is hand-rolled rather than imported from `@mysten/sui`, for the reason `u64ToLeHex` gives: the core path keeps `@mysten/*` as peer dependencies so the client works without them, and the constructor is synchronous so it cannot await a dynamic import. The Python SDK hand-rolls it for the same reason. Verified against `@mysten/sui` on 2000 random keys.