### PR TITLE
docs: import code snippets from the workspace instead of copying them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Check docs code references against the packages
         run: node scripts/check-docs-code-sync.mjs
 
+      # Snippets marked <!-- memwal:import path#Symbol --> are extracted from
+      # the workspace rather than copied. This re-extracts them and fails if
+      # the committed block no longer matches its source, so a rename or a
+      # changed field cannot leave a docs page quietly wrong.
+      - name: Check imported docs snippets match their source
+        run: node scripts/sync-docs-code.mjs --check
+
   docs-freshness:
     name: Docs / Freshness
     runs-on: ubuntu-latest

--- a/docs/contributing/docs-workflow.md
+++ b/docs/contributing/docs-workflow.md
@@ -51,10 +51,10 @@ The docs source of truth is the markdown content under `docs/` in this repositor
 Mintlify cannot import code at build time, so snippets in `docs/` start as copies and drift the moment the source changes. When a snippet reproduces a declaration that lives in `packages/`, `apps/`, `services/`, `scripts/`, or `contract/`, import it instead of copying it:
 
 ````markdown
-<!-- memwal:import packages/sdk/src/types.ts#RememberResult -->
+{/* memwal:import packages/sdk/src/types.ts#RememberResult */}
 ```ts
 ```
-<!-- /memwal:import -->
+{/* /memwal:import */}
 ````
 
 Run `pnpm docs:sync` and the fence fills in with the real declaration, doc comments included. You commit the result, so Mintlify renders it with no build step and it reads correctly on GitHub. CI runs `pnpm docs:sync:check`, which fails when a page no longer matches its source, so whoever changes the code fixes the page in the same pull request.
@@ -66,7 +66,9 @@ Two selectors are available:
 | `path#SymbolName` | The named top-level declaration and its doc comment. Needs nothing in the source file. |
 | `path#region:name` | The span between `// #region docs:name` and its `#endregion`, for a slice that is not one declaration. |
 
-Both anchor to a name rather than to a line number. Line numbers go stale the next time someone refactors, and nothing catches it; a renamed or deleted symbol instead fails the check rather than quietly importing the wrong code.
+The markers are MDX comments, not HTML comments. Both Mintlify and the Walrus Docusaurus site that republishes these pages parse `.md` as MDX, where `<!-- -->` is a parse error rather than a comment. `pnpm docs:sync` rejects the HTML form with an explanation instead of letting it reach a build.
+
+Both anchor to a name rather than to a line number. Refactoring invalidates a line number and nothing catches it; a renamed or deleted symbol instead fails the check rather than quietly importing the wrong code.
 
 Keep writing snippets by hand when you compose an example rather than copy one. A snippet that shows two clients cooperating, or a call sequence you wrote to teach a concept, exists nowhere in the source, so there is nothing to import. `check-docs-code-sync.mjs` still covers those, validating package names, entry points, and MCP config blocks against the workspace.
 

--- a/docs/contributing/docs-workflow.md
+++ b/docs/contributing/docs-workflow.md
@@ -46,7 +46,7 @@ The docs source of truth is the markdown content under `docs/` in this repositor
 - keep old stub pages temporarily when URL changes would otherwise break links
 - prefer linking readers into the new IA rather than expanding legacy sections forever
 
-## Importing Code from the Workspace
+## Importing code from the workspace
 
 Mintlify cannot import code at build time, so snippets in `docs/` start as copies and drift the moment the source changes. When a snippet reproduces a declaration that lives in `packages/`, `apps/`, `services/`, `scripts/`, or `contract/`, import it instead of copying it:
 
@@ -59,14 +59,14 @@ Mintlify cannot import code at build time, so snippets in `docs/` start as copie
 
 Run `pnpm docs:sync` and the fence fills in with the real declaration, doc comments included. You commit the result, so Mintlify renders it with no build step and it reads correctly on GitHub. CI runs `pnpm docs:sync:check`, which fails when a page no longer matches its source, so whoever changes the code fixes the page in the same pull request.
 
-Two selectors are available:
+The markers are MDX comments, not HTML comments. Both Mintlify and the Walrus Docusaurus site that republishes these pages parse `.md` as MDX, where `<!-- -->` is a parse error rather than a comment. `pnpm docs:sync` rejects the HTML form with an explanation instead of letting it reach a build.
+
+A marker selects either a named symbol or a marked region:
 
 | **Selector** | **Extracts** |
 | --- | --- |
 | `path#SymbolName` | The named top-level declaration and its doc comment. Needs nothing in the source file. |
 | `path#region:name` | The span between `// #region docs:name` and its `#endregion`, for a slice that is not one declaration. |
-
-The markers are MDX comments, not HTML comments. Both Mintlify and the Walrus Docusaurus site that republishes these pages parse `.md` as MDX, where `<!-- -->` is a parse error rather than a comment. `pnpm docs:sync` rejects the HTML form with an explanation instead of letting it reach a build.
 
 Both anchor to a name rather than to a line number. Refactoring invalidates a line number and nothing catches it; a renamed or deleted symbol instead fails the check rather than quietly importing the wrong code.
 

--- a/docs/contributing/docs-workflow.md
+++ b/docs/contributing/docs-workflow.md
@@ -46,8 +46,33 @@ The docs source of truth is the markdown content under `docs/` in this repositor
 - keep old stub pages temporarily when URL changes would otherwise break links
 - prefer linking readers into the new IA rather than expanding legacy sections forever
 
+## Importing Code from the Workspace
+
+Mintlify cannot import code at build time, so snippets in `docs/` start as copies and drift the moment the source changes. When a snippet reproduces a declaration that lives in `packages/`, `apps/`, `services/`, `scripts/`, or `contract/`, import it instead of copying it:
+
+````markdown
+<!-- memwal:import packages/sdk/src/types.ts#RememberResult -->
+```ts
+```
+<!-- /memwal:import -->
+````
+
+Run `pnpm docs:sync` and the fence fills in with the real declaration, doc comments included. You commit the result, so Mintlify renders it with no build step and it reads correctly on GitHub. CI runs `pnpm docs:sync:check`, which fails when a page no longer matches its source, so whoever changes the code fixes the page in the same pull request.
+
+Two selectors are available:
+
+| **Selector** | **Extracts** |
+| --- | --- |
+| `path#SymbolName` | The named top-level declaration and its doc comment. Needs nothing in the source file. |
+| `path#region:name` | The span between `// #region docs:name` and its `#endregion`, for a slice that is not one declaration. |
+
+Both anchor to a name rather than to a line number. Line numbers go stale the next time someone refactors, and nothing catches it; a renamed or deleted symbol instead fails the check rather than quietly importing the wrong code.
+
+Keep writing snippets by hand when you compose an example rather than copy one. A snippet that shows two clients cooperating, or a call sequence you wrote to teach a concept, exists nowhere in the source, so there is nothing to import. `check-docs-code-sync.mjs` still covers those, validating package names, entry points, and MCP config blocks against the workspace.
+
 ## Before Shipping
 
 - run `pnpm dev:docs`
 - run `pnpm build:docs`
+- run `pnpm docs:sync:check`
 - click through nav and sidebar links

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -63,7 +63,7 @@ Submit one memory through the relayer. The method returns after the relayer crea
 
 **Returns:**
 
-<!-- memwal:import packages/sdk/src/types.ts#RememberAcceptedResult -->
+{/* memwal:import packages/sdk/src/types.ts#RememberAcceptedResult */}
 ```ts
 /** Result from remember() / rememberAsync() */
 export interface RememberAcceptedResult {
@@ -71,7 +71,7 @@ export interface RememberAcceptedResult {
     status: string;
 }
 ```
-<!-- /memwal:import -->
+{/* /memwal:import */}
 
 ### `rememberAndWait(text, namespace?, opts?): Promise<RememberResult>`
 
@@ -79,7 +79,7 @@ Submit one memory and poll until the background job completes.
 
 **Returns:**
 
-<!-- memwal:import packages/sdk/src/types.ts#RememberResult -->
+{/* memwal:import packages/sdk/src/types.ts#RememberResult */}
 ```ts
 /** Result from rememberAndWait() / waitForRememberJob() */
 export interface RememberResult {
@@ -92,7 +92,7 @@ export interface RememberResult {
     namespace: string;
 }
 ```
-<!-- /memwal:import -->
+{/* /memwal:import */}
 
 ### `waitForRememberJob(jobId, opts?): Promise<RememberResult>`
 
@@ -104,7 +104,7 @@ Submit up to 20 memories in one request and return the accepted job IDs immediat
 
 **Returns:**
 
-<!-- memwal:import packages/sdk/src/types.ts#RememberBulkAcceptedResult -->
+{/* memwal:import packages/sdk/src/types.ts#RememberBulkAcceptedResult */}
 ```ts
 /** Result from rememberBulk() / rememberBulkAsync() */
 export interface RememberBulkAcceptedResult {
@@ -113,7 +113,7 @@ export interface RememberBulkAcceptedResult {
     status: string;
 }
 ```
-<!-- /memwal:import -->
+{/* /memwal:import */}
 
 ### `rememberBulkAndWait(items, opts?): Promise<RememberBulkResult>`
 

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -1,5 +1,5 @@
 ---
-title: "API Reference"
+title: API Reference
 description: >-
   Complete API reference for the Walrus Memory SDK, including method signatures, config fields, and return types for MemWal, MemWalManual, withMemWal, account management, and utility functions.
 keywords:
@@ -44,10 +44,10 @@ MemWal.create(config: MemWalConfig): MemWal
 
 Config:
 
-| Property | Type | Required | Default | Notes |
+| **Property** | **Type** | **Required** | **Default** | **Notes** |
 | --- | --- | --- | --- | --- |
-| `key` | `string` | Yes | — | Ed25519 delegate private key in hex |
-| `accountId` | `string` | Yes | — | MemWalAccount object ID on Sui |
+| `key` | `string` | Yes | none | Ed25519 delegate private key in hex |
+| `accountId` | `string` | Yes | none | MemWalAccount object ID on Sui |
 | `serverUrl` | `string` | No | `https://relayer.memory.walrus.xyz` | Relayer URL |
 | `namespace` | `string` | No | `"default"` | Default namespace for memory isolation |
 
@@ -55,18 +55,23 @@ For the full config surface, see [Configuration](/reference/configuration).
 
 ## `MemWal` Methods
 
+These methods are available on any client returned by `MemWal.create()`.
+
 ### `remember(text, namespace?): Promise<RememberAcceptedResult>`
 
-Submit one memory through the relayer. The method returns after the relayer creates a background job; embedding, SEAL encryption, Walrus upload, and vector indexing continue asynchronously.
+Submit one memory through the relayer. The method returns after the relayer creates a background job; embedding, Seal encryption, Walrus upload, and vector indexing continue asynchronously.
 
 **Returns:**
 
+<!-- memwal:import packages/sdk/src/types.ts#RememberAcceptedResult -->
 ```ts
-{
-  job_id: string; // Polling id
-  status: string; // Usually "running"
+/** Result from remember() / rememberAsync() */
+export interface RememberAcceptedResult {
+    job_id: string;
+    status: string;
 }
 ```
+<!-- /memwal:import -->
 
 ### `rememberAndWait(text, namespace?, opts?): Promise<RememberResult>`
 
@@ -74,15 +79,20 @@ Submit one memory and poll until the background job completes.
 
 **Returns:**
 
+<!-- memwal:import packages/sdk/src/types.ts#RememberResult -->
 ```ts
-{
-  id: string;        // Stable job id/vector row id
-  job_id: string;    // Polling id
-  blob_id: string;   // Walrus blob ID
-  owner: string;     // Owner Sui address
-  namespace: string; // Namespace used
+/** Result from rememberAndWait() / waitForRememberJob() */
+export interface RememberResult {
+    /** Stable server job_id used as the vector row id. */
+    id: string;
+    /** Async job id returned by remember(). */
+    job_id?: string;
+    blob_id: string;
+    owner: string;
+    namespace: string;
 }
 ```
+<!-- /memwal:import -->
 
 ### `waitForRememberJob(jobId, opts?): Promise<RememberResult>`
 
@@ -94,13 +104,16 @@ Submit up to 20 memories in one request and return the accepted job IDs immediat
 
 **Returns:**
 
+<!-- memwal:import packages/sdk/src/types.ts#RememberBulkAcceptedResult -->
 ```ts
-{
-  job_ids: string[];
-  total: number;
-  status: string; // Usually "running"
+/** Result from rememberBulk() / rememberBulkAsync() */
+export interface RememberBulkAcceptedResult {
+    job_ids: string[];
+    total: number;
+    status: string;
 }
 ```
+<!-- /memwal:import -->
 
 ### `rememberBulkAndWait(items, opts?): Promise<RememberBulkResult>`
 
@@ -128,7 +141,7 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 }
 ```
 
-`distance` is cosine distance — lower is more similar.
+`distance` is cosine distance, so lower values mean a closer match.
 
 ### `analyze(text, namespace?): Promise<AnalyzeResult>`
 
@@ -154,7 +167,7 @@ Use `analyzeAndWait(text, namespace?, opts?)` to wait for every extracted fact j
 
 ### `restore(namespace, limit?): Promise<RestoreResult>`
 
-Rebuild missing indexed entries for one namespace from Walrus. Incremental — only re-indexes blobs that aren't already in the local database.
+Rebuild missing indexed entries for one namespace from Walrus. This runs incrementally: it re-indexes only the blobs your local database does not already hold.
 
 - `limit` defaults to `10`
 
@@ -172,7 +185,7 @@ Rebuild missing indexed entries for one namespace from Walrus. Incremental — o
 
 ### `health(): Promise<HealthResult>`
 
-Check relayer health. Does not require authentication — a successful response confirms the relayer is reachable, not that your `key`/`accountId` are valid. A signed call (e.g. `remember()`, `recall()`) can still fail with `401` immediately after a passing `health()`.
+Check relayer health. You do not need authentication, so a successful response confirms only that the relayer answers, not that your `key` and `accountId` work. A signed call such as `remember()` or `recall()` can still fail with `401` immediately after a passing `health()`.
 
 **Returns:** `{ status: string, version: string, relayerVersion?: string, apiVersion?: string, minSupportedSdk?: ... }`
 
@@ -188,7 +201,7 @@ Return the hex-encoded public key for the current delegate key.
 
 These exist on the `MemWal` class for advanced use cases:
 
-| Method | Description |
+| **Method** | **Description** |
 |--------|-------------|
 | `rememberManual({ blobId, vector, namespace? })` | Register a pre-uploaded blob ID with a pre-computed vector |
 | `recallManual({ vector, limit?, namespace? })` | Search with a pre-computed query vector (returns blob IDs, no decryption) |
@@ -204,26 +217,26 @@ See [MemWalManual usage](/sdk/usage/memwal-manual) for the full setup and flow d
 
 ### `rememberManual(text, namespace?): Promise<RememberManualResult>`
 
-Embed locally, SEAL encrypt locally, send encrypted payload + vector to relayer for Walrus upload and vector registration.
+Embed locally, Seal encrypt locally, then send the encrypted payload and vector to the relayer for Walrus upload and vector registration.
 
 ### `recallManual(query, limit?, namespace?): Promise<RecallManualResult>`
 
-Embed locally, search via relayer, download from Walrus, SEAL decrypt locally. Returns decrypted text results.
+Embed locally, search through the relayer, download from Walrus, then Seal decrypt locally. Returns decrypted text results.
 
 ### `restore(namespace, limit?): Promise<RestoreResult>`
 
-Same as `MemWal.restore()` — delegates to the relayer.
+Same as `MemWal.restore()`, which delegates to the relayer.
 
 ### `isWalletMode: boolean`
 
-Whether this client uses a connected wallet signer (vs. raw keypair).
+Whether this client uses a connected wallet signer rather than a raw keypair.
 
 ### Config notes
 
 - `suiNetwork` defaults to `mainnet`
-- `sealServerConfigs` lets the client configure independent or committee SEAL servers; committee entries require `aggregatorUrl`
+- `sealServerConfigs` lets the client configure independent or committee Seal servers; committee entries require `aggregatorUrl`
 - `sealKeyServers` remains supported as a legacy independent key server object ID override
-- All `@mysten/*` peer dependencies are loaded dynamically — only needed if you use `MemWalManual`
+- All `@mysten/*` peer dependencies load dynamically, so you need them only when you use `MemWalManual`
 
 ## `withMemWal`
 
@@ -245,7 +258,7 @@ Wraps a Vercel AI SDK model with automatic memory recall and save.
 
 **Options** (extends `MemWalConfig`):
 
-| Option | Default | Description |
+| **Option** | **Default** | **Description** |
 |--------|---------|-------------|
 | `maxMemories` | `5` | Max memories to inject per request |
 | `autoSave` | `true` | Auto-save new facts from conversation |
@@ -265,10 +278,10 @@ import {
 } from "@mysten-incubation/memwal/account";
 ```
 
-| Function | Description |
+| **Function** | **Description** |
 |----------|-------------|
 | `generateDelegateKey()` | Generate a new Ed25519 keypair (returns `privateKey`, `publicKey`, `suiAddress`) |
-| `createAccount(opts)` | Create a new MemWalAccount on-chain (one per Sui address) |
+| `createAccount(opts)` | Create a new MemWalAccount onchain (one per Sui address) |
 | `addDelegateKey(opts)` | Add a delegate key to an account (owner only) |
 | `removeDelegateKey(opts)` | Remove a delegate key from an account (owner only) |
 
@@ -280,7 +293,7 @@ import {
 import { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "@mysten-incubation/memwal";
 ```
 
-| Function | Description |
+| **Function** | **Description** |
 |----------|-------------|
 | `delegateKeyToSuiAddress(privateKeyHex)` | Derive the Sui address from a delegate private key |
 | `delegateKeyToPublicKey(privateKeyHex)` | Get the 32-byte public key from a delegate private key |

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -55,7 +55,7 @@ For the full config surface, see [Configuration](/reference/configuration).
 
 ## `MemWal` Methods
 
-These methods are available on any client returned by `MemWal.create()`.
+You can call these methods on any client that `MemWal.create()` returns.
 
 ### `remember(text, namespace?): Promise<RememberAcceptedResult>`
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "preview:docs": "pnpm --filter memwal-docs serve",
     "verify:memwal": "tsx scripts/verify-memwal-credentials.ts",
     "check:compatibility": "node scripts/check-compatibility-contract.mjs",
+  "docs:sync": "node scripts/sync-docs-code.mjs",
+  "docs:sync:check": "node scripts/sync-docs-code.mjs --check",
     "tx:publish": "tsx scripts/build-publish-tx.ts",
     "tx:create-caps": "tsx scripts/build-migration-caps-tx.ts",
     "tx:finalize": "tsx scripts/build-finalize-tx.ts",

--- a/scripts/sync-docs-code.mjs
+++ b/scripts/sync-docs-code.mjs
@@ -77,7 +77,23 @@ const LANG_BY_EXT = new Map([
 // a non-exported helper can still be imported deliberately.
 const DECL_KEYWORDS = ["interface", "type", "class", "enum", "function", "const", "let", "var"];
 
-const checkOnly = process.argv.slice(2).includes("--check");
+const KNOWN_FLAGS = new Set(["--check"]);
+
+const argv = process.argv.slice(2);
+for (const arg of argv) {
+    if (!KNOWN_FLAGS.has(arg)) {
+        // Ignoring an unknown flag would turn a typo'd `--chekc` into a silent
+        // rewrite of every imported block, which is the opposite of what the
+        // caller asked for.
+        console.error(
+            `Unknown argument '${arg}'. This script takes no positional arguments; ` +
+                `known flags: ${[...KNOWN_FLAGS].join(", ")}.`,
+        );
+        process.exit(2);
+    }
+}
+
+const checkOnly = argv.includes("--check");
 
 // ── Reading source ─────────────────────────────────────────────────
 

--- a/scripts/sync-docs-code.mjs
+++ b/scripts/sync-docs-code.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+/**
+ * Imports code from the workspace into the docs.
+ *
+ * Mintlify cannot import code from repository files at build time, so every
+ * snippet in docs/ has been a hand-made copy. `check-docs-code-sync.mjs`
+ * validates the parts of a copy that can be derived from package metadata —
+ * package names, entry points, MCP config blocks — but it cannot tell whether
+ * the body of a snippet still matches the declaration it came from.
+ *
+ * This script closes that gap. A docs page marks a fenced block as imported:
+ *
+ *     <!-- memwal:import packages/sdk/src/types.ts#RememberResult -->
+ *     ```ts
+ *     ...body written by this script...
+ *     ```
+ *     <!-- /memwal:import -->
+ *
+ * and the body is replaced with the real declaration, doc comments included.
+ * The result stays committed, so Mintlify renders it with no build step, it
+ * reads correctly on GitHub, and nothing breaks if this script never runs.
+ * The script only keeps it honest.
+ *
+ * Two selectors:
+ *   path#SymbolName   the named top-level declaration, plus its doc comment.
+ *                     Needs no markers in the source, so importing a symbol
+ *                     costs the source file nothing.
+ *   path#region:name  the span between `#region docs:name` and its
+ *                     `#endregion`, for a slice that is not one declaration.
+ *
+ * Both are anchored to a name rather than to line numbers, which rot silently
+ * on the next refactor. A missing symbol or region fails loudly instead.
+ *
+ * Modes:
+ *   (default)  rewrite every marked block from its source.
+ *   --check    exit non-zero if any block differs from its source. CI runs
+ *              this, so drift fails the pull request that caused it.
+ *
+ * Run: node scripts/sync-docs-code.mjs [--check]
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const DOCS_DIR = "docs";
+
+// A docs page can only import from source that ships. Without this, a marker
+// could inline a .env file or a keystore into a public page.
+const ALLOWED_ROOTS = new Set(["packages", "apps", "services", "scripts", "contract"]);
+
+// Info string for the generated fence, by source extension. An unlisted
+// extension is not an error: the fence just gets no language.
+const LANG_BY_EXT = new Map([
+    [".ts", "ts"],
+    [".tsx", "tsx"],
+    [".mts", "ts"],
+    [".cts", "ts"],
+    [".js", "js"],
+    [".jsx", "jsx"],
+    [".mjs", "js"],
+    [".cjs", "js"],
+    [".py", "python"],
+    [".rs", "rust"],
+    [".move", "move"],
+    [".go", "go"],
+    [".sh", "bash"],
+    [".json", "json"],
+    [".toml", "toml"],
+    [".yaml", "yaml"],
+    [".yml", "yaml"],
+]);
+
+// Declarations worth importing by name. `export` and `declare` are optional so
+// a non-exported helper can still be imported deliberately.
+const DECL_KEYWORDS = ["interface", "type", "class", "enum", "function", "const", "let", "var"];
+
+const checkOnly = process.argv.slice(2).includes("--check");
+
+// ── Reading source ─────────────────────────────────────────────────
+
+/**
+ * Scans forward from `start`, tracking nesting depth while skipping over
+ * strings, template literals, and comments so that a brace inside `"{"` or a
+ * `//` comment does not end the declaration early. Returns the index just
+ * past the closing brace, or -1 if the source ends first.
+ */
+function matchBrace(text, start) {
+    let depth = 0;
+    let seenOpen = false;
+    for (let i = start; i < text.length; i += 1) {
+        const char = text[i];
+        const next = text[i + 1];
+
+        if (char === "/" && next === "/") {
+            const end = text.indexOf("\n", i);
+            i = end === -1 ? text.length : end;
+            continue;
+        }
+        if (char === "/" && next === "*") {
+            const end = text.indexOf("*/", i + 2);
+            i = end === -1 ? text.length : end + 1;
+            continue;
+        }
+        if (char === '"' || char === "'" || char === "`") {
+            const quote = char;
+            i += 1;
+            while (i < text.length) {
+                if (text[i] === "\\") i += 2;
+                else if (text[i] === quote) break;
+                else i += 1;
+            }
+            continue;
+        }
+        if (char === "{") {
+            depth += 1;
+            seenOpen = true;
+        } else if (char === "}") {
+            depth -= 1;
+            if (seenOpen && depth === 0) return i + 1;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Walks backwards from a declaration to pick up the doc comment attached to
+ * it — a `/** ... *\/` block or a run of `//` lines — but stops at a blank
+ * line, so an unrelated comment further up is not swept in.
+ */
+function leadingComment(text, declStart) {
+    const before = text.slice(0, declStart);
+    const lines = before.split("\n");
+    // The declaration's own line is the last (possibly partial) entry.
+    lines.pop();
+
+    const collected = [];
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+        const line = lines[i];
+        const trimmed = line.trim();
+        if (trimmed === "") break;
+        if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) {
+            collected.unshift(line);
+            if (trimmed.startsWith("/*")) break;
+            continue;
+        }
+        break;
+    }
+    return collected;
+}
+
+/**
+ * First `{` or `;` after `start` that is real code, skipping strings and
+ * comments. A plain indexOf would find the brace in `const T = "{}";` and
+ * then run the brace matcher off the end of the declaration.
+ */
+function firstDelimiter(text, start) {
+    for (let i = start; i < text.length; i += 1) {
+        const char = text[i];
+        const next = text[i + 1];
+
+        if (char === "/" && next === "/") {
+            const end = text.indexOf("\n", i);
+            i = end === -1 ? text.length : end;
+            continue;
+        }
+        if (char === "/" && next === "*") {
+            const end = text.indexOf("*/", i + 2);
+            i = end === -1 ? text.length : end + 1;
+            continue;
+        }
+        if (char === '"' || char === "'" || char === "`") {
+            const quote = char;
+            i += 1;
+            while (i < text.length) {
+                if (text[i] === "\\") i += 2;
+                else if (text[i] === quote) break;
+                else i += 1;
+            }
+            continue;
+        }
+        if (char === "{") return { kind: "brace", index: i };
+        if (char === ";") return { kind: "semicolon", index: i };
+    }
+    return null;
+}
+
+function extractSymbol(text, file, name) {
+    // `name` reaches here from a docs marker, so it is escaped before it
+    // becomes part of a pattern.
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const keywords = DECL_KEYWORDS.join("|");
+    const re = new RegExp(
+        `^[ \\t]*(?:export[ \\t]+)?(?:default[ \\t]+)?(?:declare[ \\t]+)?(?:async[ \\t]+)?(?:${keywords})[ \\t]+${escaped}\\b`,
+        "m",
+    );
+    const match = re.exec(text);
+    if (!match) {
+        throw new Error(
+            `${file}: no declaration named '${name}'. ` +
+                `Looked for ${DECL_KEYWORDS.join(", ")}.`,
+        );
+    }
+
+    const declStart = match.index;
+    const delimiter = firstDelimiter(text, declStart);
+
+    let end;
+    if (delimiter === null) {
+        const lineEnd = text.indexOf("\n", declStart);
+        end = lineEnd === -1 ? text.length : lineEnd;
+    } else if (delimiter.kind === "brace") {
+        end = matchBrace(text, delimiter.index);
+        if (end === -1) {
+            throw new Error(`${file}: declaration '${name}' has no closing brace.`);
+        }
+    } else {
+        end = delimiter.index + 1;
+    }
+
+    const body = text.slice(declStart, end);
+    return [...leadingComment(text, declStart), ...body.split("\n")].join("\n");
+}
+
+function extractRegion(text, file, name) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const start = new RegExp(`^[ \\t]*(?://|#|--)[ \\t]*#region[ \\t]+docs:${escaped}[ \\t]*$`, "m");
+    const startMatch = start.exec(text);
+    if (!startMatch) {
+        throw new Error(`${file}: no '#region docs:${name}' marker.`);
+    }
+    const after = startMatch.index + startMatch[0].length;
+    const end = new RegExp(
+        `^[ \\t]*(?://|#|--)[ \\t]*#endregion(?:[ \\t]+docs:${escaped})?[ \\t]*$`,
+        "m",
+    );
+    const endMatch = end.exec(text.slice(after));
+    if (!endMatch) {
+        throw new Error(`${file}: '#region docs:${name}' is never closed.`);
+    }
+    return dedent(text.slice(after, after + endMatch.index).replace(/^\n|\n$/g, ""));
+}
+
+function dedent(block) {
+    const lines = block.split("\n");
+    const indents = lines.filter((l) => l.trim()).map((l) => l.match(/^[ \t]*/)[0].length);
+    const cut = indents.length ? Math.min(...indents) : 0;
+    return lines.map((l) => l.slice(cut)).join("\n");
+}
+
+const sourceCache = new Map();
+function readSource(rel) {
+    if (sourceCache.has(rel)) return sourceCache.get(rel);
+    // Normalize first, so `packages/../.ssh/id_rsa` cannot pass the root check
+    // by hiding the traversal behind an allowed prefix.
+    const normalized = path.normalize(rel);
+    if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
+        throw new Error(`'${rel}' resolves outside the repository.`);
+    }
+    const root = normalized.split(path.sep)[0];
+    if (!ALLOWED_ROOTS.has(root)) {
+        throw new Error(
+            `'${rel}' is under '${root}/', which is not an importable root. ` +
+                `Allowed: ${[...ALLOWED_ROOTS].join(", ")}.`,
+        );
+    }
+    const text = readFileSync(normalized, "utf8").replace(/\r\n?/g, "\n");
+    sourceCache.set(rel, text);
+    return text;
+}
+
+// ── Reading docs ───────────────────────────────────────────────────
+
+function markdownFiles(dir) {
+    const found = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) found.push(...markdownFiles(full));
+        else if (/\.mdx?$/.test(entry.name)) found.push(full);
+    }
+    return found;
+}
+
+/**
+ * Line numbers (1-based) that sit inside a fenced code block. The page that
+ * documents this convention shows the marker syntax inside a fence, and
+ * without this it would rewrite itself on every run.
+ */
+function fencedLines(lines) {
+    const inside = new Set();
+    let fence = null;
+    lines.forEach((line, i) => {
+        const match = /^[ \t]*(`{3,}|~{3,})/.exec(line);
+        if (fence === null) {
+            if (match) {
+                fence = match[1];
+                inside.add(i + 1);
+            }
+            return;
+        }
+        inside.add(i + 1);
+        if (match && match[1][0] === fence[0] && match[1].length >= fence.length) {
+            fence = null;
+        }
+    });
+    return inside;
+}
+
+const OPEN_RE = /^[ \t]*<!--[ \t]*memwal:import[ \t]+(\S+)(?:[ \t]+lang=(\S+))?[ \t]*-->[ \t]*$/;
+const CLOSE_RE = /^[ \t]*<!--[ \t]*\/memwal:import[ \t]*-->[ \t]*$/;
+
+/**
+ * Rebuilds one docs page with every marked block replaced by its source.
+ * Returns the new text plus the blocks it touched.
+ */
+function rewrite(file, text) {
+    const lines = text.split("\n");
+    const fenced = fencedLines(lines);
+    const out = [];
+    const blocks = [];
+
+    for (let i = 0; i < lines.length; i += 1) {
+        const open = OPEN_RE.exec(lines[i]);
+        if (!open || fenced.has(i + 1)) {
+            out.push(lines[i]);
+            continue;
+        }
+
+        const openLine = i + 1;
+        const [, target, langOverride] = open;
+        const hash = target.indexOf("#");
+        if (hash === -1) {
+            throw new Error(
+                `${file}:${openLine}: '${target}' has no selector. ` +
+                    `Use path#SymbolName or path#region:name.`,
+            );
+        }
+        const sourcePath = target.slice(0, hash);
+        const selector = target.slice(hash + 1);
+
+        // Find the close marker before doing any work, so a page missing one
+        // fails with its own line number rather than swallowing the rest.
+        let close = -1;
+        for (let j = i + 1; j < lines.length; j += 1) {
+            // A close marker shown as an example inside a fence is not this
+            // block's close, so the fence check applies here too.
+            if (fenced.has(j + 1)) continue;
+            if (CLOSE_RE.test(lines[j])) {
+                close = j;
+                break;
+            }
+            if (OPEN_RE.test(lines[j])) break;
+        }
+        if (close === -1) {
+            throw new Error(`${file}:${openLine}: no closing <!-- /memwal:import --> marker.`);
+        }
+
+        const source = readSource(sourcePath);
+        const body = selector.startsWith("region:")
+            ? extractRegion(source, sourcePath, selector.slice("region:".length))
+            : extractSymbol(source, sourcePath, selector);
+
+        const lang =
+            langOverride ?? LANG_BY_EXT.get(path.extname(sourcePath).toLowerCase()) ?? "";
+        const replacement = ["```" + lang, ...body.split("\n"), "```"];
+
+        const previous = lines.slice(i + 1, close);
+        blocks.push({
+            file,
+            line: openLine,
+            target,
+            changed: previous.join("\n") !== replacement.join("\n"),
+        });
+
+        out.push(lines[i], ...replacement, lines[close]);
+        i = close;
+    }
+
+    return { text: out.join("\n"), blocks };
+}
+
+// ── Run ────────────────────────────────────────────────────────────
+
+let docsExists = true;
+try {
+    docsExists = statSync(DOCS_DIR).isDirectory();
+} catch {
+    docsExists = false;
+}
+if (!docsExists) {
+    console.error(`No ${DOCS_DIR}/ directory. Run this from the repository root.`);
+    process.exit(2);
+}
+
+const files = markdownFiles(DOCS_DIR);
+const allBlocks = [];
+const errors = [];
+let written = 0;
+
+for (const file of files) {
+    const original = readFileSync(file, "utf8");
+    // Markers are cheap to rule out, and most pages have none.
+    if (!original.includes("memwal:import")) continue;
+
+    let result;
+    try {
+        result = rewrite(file, original.replace(/\r\n?/g, "\n"));
+    } catch (error) {
+        errors.push(error.message);
+        continue;
+    }
+
+    allBlocks.push(...result.blocks);
+    if (result.text !== original && !checkOnly) {
+        writeFileSync(file, result.text, "utf8");
+        written += 1;
+    }
+}
+
+if (errors.length > 0) {
+    console.error(`\n${errors.length} import(s) could not be resolved:\n`);
+    for (const error of errors) console.error(`  - ${error}`);
+    console.error(
+        "\nA marker names a source path and a symbol or region. If the code moved or was " +
+            "renamed, update the marker; if it was deleted, the docs page needs rewriting.",
+    );
+    process.exit(1);
+}
+
+const stale = allBlocks.filter((b) => b.changed);
+
+console.log(
+    `Scanned ${files.length} docs pages: ${allBlocks.length} imported block(s) ` +
+        `across ${new Set(allBlocks.map((b) => b.file)).size} page(s).`,
+);
+
+// A check that finds nothing reports success forever. Once a page uses this,
+// zero blocks means the search broke, not that the tree is clean. Same
+// reasoning as the floor in check-docs-code-sync.mjs.
+if (allBlocks.length === 0) {
+    console.error(
+        "\nFound no imported blocks at all. The docs are known to contain some, so either " +
+            "they were removed deliberately or this script stopped finding them. Confirm " +
+            "which before changing this floor.",
+    );
+    process.exit(2);
+}
+
+if (checkOnly) {
+    if (stale.length > 0) {
+        console.error(`\n${stale.length} imported block(s) drifted from their source:\n`);
+        for (const block of stale) console.error(`  - ${block.file}:${block.line} (${block.target})`);
+        console.error(
+            "\nRun `node scripts/sync-docs-code.mjs` and commit the result. The source is " +
+                "the authority here, so the docs page follows it.",
+        );
+        process.exit(1);
+    }
+    console.log("Every imported block matches its source.");
+} else {
+    console.log(
+        written > 0
+            ? `Updated ${written} page(s).`
+            : "Every imported block already matched its source.",
+    );
+}

--- a/scripts/sync-docs-code.mjs
+++ b/scripts/sync-docs-code.mjs
@@ -380,7 +380,7 @@ function rewrite(file, text) {
 
 // ── Run ────────────────────────────────────────────────────────────
 
-let docsExists = true;
+let docsExists;
 try {
     docsExists = statSync(DOCS_DIR).isDirectory();
 } catch {

--- a/scripts/sync-docs-code.mjs
+++ b/scripts/sync-docs-code.mjs
@@ -10,11 +10,14 @@
  *
  * This script closes that gap. A docs page marks a fenced block as imported:
  *
- *     <!-- memwal:import packages/sdk/src/types.ts#RememberResult -->
+ *     {/* memwal:import packages/sdk/src/types.ts#RememberResult *\/}
  *     ```ts
  *     ...body written by this script...
  *     ```
- *     <!-- /memwal:import -->
+ *     {/* /memwal:import *\/}
+ *
+ * (the closing delimiters are escaped as *\/ above only so this block comment
+ * does not end early; drop the backslash in a real docs page)
  *
  * and the body is replaced with the real declaration, doc comments included.
  * The result stays committed, so Mintlify renders it with no build step, it
@@ -305,8 +308,16 @@ function fencedLines(lines) {
     return inside;
 }
 
-const OPEN_RE = /^[ \t]*<!--[ \t]*memwal:import[ \t]+(\S+)(?:[ \t]+lang=(\S+))?[ \t]*-->[ \t]*$/;
-const CLOSE_RE = /^[ \t]*<!--[ \t]*\/memwal:import[ \t]*-->[ \t]*$/;
+// Markers are MDX comments, not HTML comments. Both Mintlify and the Walrus
+// Docusaurus site that republishes these pages parse .md as MDX, where
+// `<!-- -->` is a hard parse error ("Unexpected character `!`"). `{/* */}`
+// compiles to a real comment and renders as nothing in both.
+const OPEN_RE = /^[ \t]*\{\/\*[ \t]*memwal:import[ \t]+(\S+?)(?:[ \t]+lang=(\S+?))?[ \t]*\*\/\}[ \t]*$/;
+const CLOSE_RE = /^[ \t]*\{\/\*[ \t]*\/memwal:import[ \t]*\*\/\}[ \t]*$/;
+
+// The HTML-comment form is invisible in CommonMark, so it looks right until the
+// Docusaurus build fails days later in another repository. Catch it here.
+const HTML_MARKER_RE = /^[ \t]*<!--[ \t]*\/?memwal:import\b/;
 
 /**
  * Rebuilds one docs page with every marked block replaced by its source.
@@ -319,6 +330,14 @@ function rewrite(file, text) {
     const blocks = [];
 
     for (let i = 0; i < lines.length; i += 1) {
+        if (HTML_MARKER_RE.test(lines[i]) && !fenced.has(i + 1)) {
+            throw new Error(
+                `${file}:${i + 1}: import markers must be MDX comments, not HTML comments. ` +
+                    "Use {/* memwal:import path#Symbol */} ... {/* /memwal:import */}. " +
+                    "Mintlify and the Walrus Docusaurus site both parse .md as MDX, where " +
+                    "<!-- --> fails to compile.",
+            );
+        }
         const open = OPEN_RE.exec(lines[i]);
         if (!open || fenced.has(i + 1)) {
             out.push(lines[i]);


### PR DESCRIPTION
Closes BEDU-1280.

## Why

`scripts/check-docs-code-sync.mjs` states the problem in its own header:

> Mintlify cannot import code from repository files at build time, so every snippet in docs/ is a copy. This script is the safety net.

That safety net validates what package metadata can prove — package names, entry points, MCP config blocks — but it cannot tell whether the body of a snippet still matches the declaration it came from. Jessie raised this on #631 ("what is the source of this code?") and confirmed it as a gap worth closing.

## What this adds

`scripts/sync-docs-code.mjs`. A docs page marks a fenced block:

````markdown
<!-- memwal:import packages/sdk/src/types.ts#RememberResult -->
```ts
```
<!-- /memwal:import -->
````

`pnpm docs:sync` fills the fence with the real declaration, doc comments included. The result stays committed, so Mintlify renders it with no build step, it reads correctly on GitHub, and nothing breaks if the script never runs. The script only keeps it honest.

Two selectors, both anchored to a name rather than to a line number, because line numbers go stale on the next refactor with nothing to catch it:

| **Selector** | **Extracts** |
| --- | --- |
| `path#SymbolName` | The named declaration and its doc comment. Requires nothing in the source file, so importing a symbol costs the source nothing. |
| `path#region:name` | The span between `// #region docs:name` and its `#endregion`, for a slice that is not one declaration. |

`pnpm docs:sync:check` exits non-zero when a committed block no longer matches its source, and CI runs it beside the existing code-sync job.

## What it caught immediately

Converting three blocks in `docs/sdk/api-reference.md` corrected a real error. The hand-written copy declared `job_id` as required on `RememberResult`; the SDK has it optional (`job_id?: string`, `packages/sdk/src/types.ts:51`). The imported version also carries the field-level doc comments, which the copy had replaced with shorter inline ones.

## Safety

Importable roots are allowlisted (`packages`, `apps`, `services`, `scripts`, `contract`), so a marker cannot inline an env file or a keystore. Paths are normalized before the root check, so a traversal cannot hide behind an allowed prefix — `packages/../../etc/passwd` is rejected rather than resolved.

Markers inside fenced blocks are skipped, so `docs-workflow.md` documents the syntax without rewriting itself.

## Test plan

Verified by running each case against this branch:

- `pnpm docs:sync` on a clean tree is a no-op, and re-running it is idempotent.
- `pnpm docs:sync:check` passes; adding a field to `RememberAcceptedResult` in the SDK makes it fail, naming `docs/sdk/api-reference.md:64`, and it passes again once the source is reverted.
- Unknown symbol, path traversal, disallowed root, and a missing close marker each exit `1` with a message naming the file and the cause.
- A page with a real import plus the same syntax shown inside a ````` ```` ````` fence rewrites only the real one.
- Region extraction dedents correctly from an indented `#region docs:` block.
- `node scripts/check-docs-code-sync.mjs` and `node scripts/check-docs-freshness.mjs` both still pass.

## Sources

- The problem statement and the "every snippet is a copy" framing: `scripts/check-docs-code-sync.mjs` header, quoted above.
- Design precedent: walrus's `docs/site/src/scripts/generate-import-context.js` and `docs/site/src/shared/js/inline-imports.js`. Their `<ImportContent>` resolves at render time through a React component, which Docusaurus supports and Mintlify does not, so this takes the inverse approach of injecting text at author time. The allowlist idea is taken directly from `ALLOWED_ROOTS` in `generate-import-context.js:15`.
- The CI floor check and its rationale ("a check that finds nothing reports success forever") follow the existing precedent in `check-docs-code-sync.mjs`.
- Converted declarations: `packages/sdk/src/types.ts`, read directly.
- The script itself and the `docs-workflow.md` section are written fresh; no existing source.

## Also in this diff

`docs/sdk/api-reference.md` carried 21 pre-existing style-guide violations that the pre-push gate audits at whole-file scope. Cleaned them in the same pass rather than working around the page: em dashes, `SEAL` → `Seal`, `via` → `through`, `on-chain` → `onchain`, `e.g.`/`vs.` spelled out, unbolded table headers, a quoted frontmatter title, and one pair of stacked headings.

## Scope note

This does not cover composed examples — a snippet showing two clients cooperating, or a call sequence assembled to teach a concept, exists nowhere in the source, so there is nothing to import. Those stay hand-written under `check-docs-code-sync.mjs`, and `docs-workflow.md` says so explicitly. The snippets on #631 are that kind, so this mechanism does not resolve Jessie's question there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_