### PR TITLE
chore(github): add bug and feature issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,109 @@
+name: Bug report
+description: Something is broken. We need a repro, environment, and versions.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Incomplete issues (no repro, no environment) are closed.
+
+        Do not paste delegate private keys, mnemonics, or other secrets.
+
+        If this is a security finding, use a [private advisory](https://github.com/MystenLabs/MemWal/security/advisories/new) instead of this form.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      description: Where did you hit this?
+      options:
+        - TypeScript SDK (@mysten-incubation/memwal)
+        - Python SDK (memwal)
+        - MCP (@mysten-incubation/memwal-mcp)
+        - Relayer / hosted API
+        - Dashboard / Console (memory.walrus.xyz)
+        - Developer Playground
+        - OpenClaw plugin
+        - Example app (chatbot, noter, researcher)
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network
+      options:
+        - Mainnet (relayer.memory.walrus.xyz)
+        - Staging (relayer-staging.memory.walrus.xyz)
+        - Local / self-hosted
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: The package or binary version you actually ran, not "latest".
+      placeholder: "@mysten-incubation/memwal@0.0.x or memwal-mcp@0.0.x"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: One or two sentences. What did you do, and what broke?
+      placeholder: memwal_analyze reported 3 blob_ids but restore shows 6 blobs in a fresh namespace.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Commands, tool calls, or UI clicks another person can follow.
+      placeholder: |
+        1. Create a fresh namespace.
+        2. Call memwal_analyze with text X.
+        3. Call memwal_restore / memwal_recall on that namespace.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+      placeholder: Analyze writes N blobs and reports N blob_ids. Recall returns each fact once.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual
+      placeholder: Tool reports 3 blob_ids. restore total=6. recall returns each fact twice.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error text
+      description: Paste the error or tool response. Redact keys. Leave blank if none.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This report contains no private keys, mnemonics, or other secrets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Docs and troubleshooting
+    url: https://docs.wal.app/walrus-memory/troubleshooting/overview
+    about: 401s, login, empty recall, and MCP setup. Check here before filing a bug.
+  - name: Search existing issues
+    url: https://github.com/MystenLabs/MemWal/issues?q=is%3Aissue
+    about: Many requests (list, forget, timestamps, pagination) already have an issue.
+  - name: Walrus Discord
+    url: https://discord.gg/walrusprotocol
+    about: Questions and builder support that are not a bug or a feature request.
+  - name: Report a security vulnerability
+    url: https://github.com/MystenLabs/MemWal/security/advisories/new
+    about: Private advisory. Do not file a public issue for security findings.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Ask for a new capability. Search existing issues first. Duplicates are closed.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests without a concrete problem are closed.
+
+        Search existing issues first. Requests for namespace listing, forget/delete, timestamps, and recall pagination already have threads. Comment there instead of opening a new issue.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - TypeScript SDK (@mysten-incubation/memwal)
+        - Python SDK (memwal)
+        - MCP (@mysten-incubation/memwal-mcp)
+        - Relayer / hosted API
+        - Dashboard / Console (memory.walrus.xyz)
+        - Developer Playground
+        - OpenClaw plugin
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What can you not do today? A real workload beats a wishlist.
+      placeholder: After an agent reset, stale memories keep winning recall. There is no way to stop a fact from being recalled.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like?
+      description: The smallest change that would unblock you.
+      placeholder: An owner-scoped forget(memory_id) that stops the fact from appearing in recall.
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround today
+      description: What you do instead, if anything. Optional.
+      placeholder: Rotate the namespace prefix and abandon the old one.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true


### PR DESCRIPTION
Linear: [WALM-401](https://linear.app/mysten-labs/issue/WALM-401/add-github-issue-forms-to-filter-incomplete-reports) (review requested from @HoangDucBach)

## Why

The tracker is at ~184 open issues. A lot of them are blank placeholders (`Issue_memwal_1`, "No issues found"), duplicate product-gap requests, or reports with no environment and no repro. The repo had no issue template, so New Issue was a blank box.

## What this does

- Adds GitHub **issue forms** for a bug report and a feature request.
- Sets `blank_issues_enabled: false`, so you have to pick a form (or a contact link).
- Bug form requires surface, network, package version, what happened, repro, expected, and actual. Private keys are called out as off-limits.
- Feature form requires a concrete problem and a smallest-useful change, plus a search-existing-issues checkbox. The intro points at the already-open threads for list / forget / timestamps / pagination.
- Security findings go to a [private advisory](https://github.com/MystenLabs/MemWal/security/advisories/new), not a public issue.
- Contact links: troubleshooting docs, existing issues, Walrus Discord.

This will not stop a determined `n/a` paste, and it will not collapse 20 independent "please add forget()" requests into one. It will make the empty hackathon issues obviously empty, and it will make triage start with surface + network + version.

## Not in this PR

- No change to the "a team member will review it shortly" auto-comment workflow.
- No Code of Conduct checkbox (the repo does not have a CoC file).

## How to verify after merge

1. Open https://github.com/MystenLabs/MemWal/issues/new/choose
2. Confirm the chooser shows Bug report, Feature request, and the contact links.
3. Confirm you cannot open a blank issue.
4. Submit a dummy bug in a throwaway and confirm labels `bug` plus the form fields render.