### PR TITLE
fix(oauth): persist the client loopback redirect URI (GH #619)

### DIFF
--- a/services/server/src/oauth.rs
+++ b/services/server/src/oauth.rs
@@ -594,6 +594,23 @@ pub fn redirect_uri_matches(candidate: &str, registered: &str) -> bool {
         && candidate_url.query() == registered_url.query()
 }
 
+/// Redirect URI to persist on the authorize session and code row.
+///
+/// Matching is port-agnostic for RFC 8252 loopback, but RFC 6749 §4.1.3
+/// requires the token request to send the *same* URI used at authorize
+/// time. Store the client-presented candidate (`http://localhost:51234/callback`),
+/// not the registered URI (`http://localhost/callback`), so the code
+/// redirect hits the ephemeral listener and token exchange succeeds.
+pub fn authorize_redirect_uri<'a>(
+    candidate: &'a str,
+    registered_uris: impl IntoIterator<Item = &'a str>,
+) -> Option<&'a str> {
+    registered_uris
+        .into_iter()
+        .any(|registered| redirect_uri_matches(candidate, registered))
+        .then_some(candidate)
+}
+
 /// Decision D4: registration only accepts redirect URIs on a known-safe
 /// host allowlist (Anthropic's own callback domain) or an RFC 8252 loopback
 /// pattern. This is the direct fix for the objection that stalled PR #193
@@ -962,6 +979,30 @@ mod tests {
             "http://127.0.0.1:9999/callback",
             "http://127.0.0.1/callback"
         ));
+    }
+
+    #[test]
+    fn authorize_stores_loopback_candidate_not_registered_uri() {
+        let registered = ["http://localhost/callback"];
+        assert_eq!(
+            authorize_redirect_uri("http://localhost:51234/callback", registered),
+            Some("http://localhost:51234/callback")
+        );
+        assert_eq!(
+            authorize_redirect_uri("http://localhost/callback", registered),
+            Some("http://localhost/callback")
+        );
+        assert_eq!(
+            authorize_redirect_uri("http://localhost:51234/evil", registered),
+            None
+        );
+        assert_eq!(
+            authorize_redirect_uri(
+                "https://claude.ai/api/mcp/auth_callback",
+                ["https://claude.ai/api/mcp/auth_callback"]
+            ),
+            Some("https://claude.ai/api/mcp/auth_callback")
+        );
     }
 
     #[test]

--- a/services/server/src/routes/oauth.rs
+++ b/services/server/src/routes/oauth.rs
@@ -322,12 +322,15 @@ pub async fn authorize(
             )
         }
     };
-    let Some(redirect_uri) = client
-        .redirect_uris
-        .iter()
-        .find(|registered| oauth::redirect_uri_matches(&query.redirect_uri, registered))
-        .cloned()
-    else {
+    // Match against the registered list (port-agnostic for loopback), but
+    // persist the client-presented URI. Cloning the registered URI here
+    // sent Claude Code's auth code to port 80 and made token exchange
+    // reject the real `http://localhost:<ephemeral>/callback` (#619).
+    let Some(redirect_uri) = oauth::authorize_redirect_uri(
+        &query.redirect_uri,
+        client.redirect_uris.iter().map(String::as_str),
+    )
+    .map(str::to_owned) else {
         return error_page(
             StatusCode::BAD_REQUEST,
             "Redirect not recognized",


### PR DESCRIPTION
Linear: [WALM-382](https://linear.app/mysten-labs/issue/WALM-382/bug-oauth-loopback-flow-claude-code-rfc-8252-is-internally)
Fixes https://github.com/MystenLabs/MemWal/issues/619

## Why

`GET /oauth/authorize` matches loopback redirect URIs port-agnostically (RFC 8252 / Claude Code ephemeral ports), then stored the **registered** URI (`http://localhost/callback`). Two failures follow:

1. The authorization code is redirected to port 80, not the client's listener on e.g. `:51234`.
2. Token exchange exact-matches `redirect_uri` (RFC 6749 §4.1.3), so the real port-bearing URI gets `invalid_grant`.

## What this does

After a successful match, persist the **client-presented** candidate URI on the session (and therefore the code row and the redirect target). HTTPS hosted callbacks are unchanged (registered == candidate).

## Tests

`oauth::tests::authorize_stores_loopback_candidate_not_registered_uri` — stores `http://localhost:51234/callback`, keeps exact HTTPS, rejects a different path.