### PR TITLE
fix(relayer): restore timeouts, oauth authorize cap, analyze idempotency

### DIFF
--- a/services/server/src/jobs.rs
+++ b/services/server/src/jobs.rs
@@ -2480,9 +2480,15 @@ impl WalletJobError {
     /// `GasPoolExhausted` is gated on pool-level confirmation by the caller.
     pub fn is_gas_pool_budget_error(msg: &str) -> bool {
         let lower = msg.to_ascii_lowercase();
-        (lower.contains("moveabort") || lower.contains("move abort"))
+        let move_split = (lower.contains("moveabort") || lower.contains("move abort"))
             && lower.contains("balance")
-            && lower.contains("split")
+            && lower.contains("split");
+        let gas_selection = lower.contains("gas selection") && lower.contains("insufficient");
+        let sui_balance = lower.contains("insufficient")
+            && lower.contains("sui")
+            && lower.contains("balance")
+            && !lower.contains("::wal::wal");
+        move_split || gas_selection || sui_balance
     }
 
     /// True if `msg` is the Walrus register PTB's `0x2::coin::destroy_zero`
@@ -3234,6 +3240,17 @@ different transaction: TransactionDigest(8bjFgRyXRRYwrzQapgEjpHnGhdfNDY7d6xA82Bt
             assert!(!classified.aborts_retries(), "must retry: {}", msg);
             assert!(WalletJobError::is_gas_pool_budget_error(msg));
         }
+    }
+
+    #[test]
+    fn gas_selection_insufficient_sui_is_pool_budget_error() {
+        let msg = "Internal Error: durable Walrus upload failed (503 Service Unavailable): Unable to perform gas selection due to insufficient SUI balance";
+        assert!(WalletJobError::is_gas_pool_budget_error(msg));
+        let classified = WalletJobError::classify_sidecar_error(msg);
+        assert!(matches!(classified, WalletJobError::Transient(_)));
+        assert!(!WalletJobError::is_gas_pool_budget_error(
+            LOW_WAL_BALANCE_ERR
+        ));
     }
 
     #[test]

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -461,6 +461,24 @@ pub async fn restore(
     Extension(auth): Extension<AuthInfo>,
     Json(body): Json<RestoreRequest>,
 ) -> Result<Json<RestoreResponse>, AppError> {
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(55),
+        restore_unbounded(state, auth, body),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(AppError::UpstreamUnavailable(
+            "Restore timed out; retry later or with a smaller namespace".into(),
+        )),
+    }
+}
+
+async fn restore_unbounded(
+    state: Arc<AppState>,
+    auth: AuthInfo,
+    body: RestoreRequest,
+) -> Result<Json<RestoreResponse>, AppError> {
     validate_namespace(&body.namespace)?;
 
     let owner = &auth.owner;
@@ -780,7 +798,9 @@ pub async fn restore(
         })
         .collect();
 
-    let results: Vec<(String, Vec<f32>)> = futures::future::join_all(embed_tasks)
+    let results: Vec<(String, Vec<f32>)> = stream::iter(embed_tasks)
+        .buffer_unordered(3)
+        .collect::<Vec<_>>()
         .await
         .into_iter()
         .flatten()

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -52,9 +52,11 @@ fn encode_untrusted_memory_context(memories: &[RecallResult]) -> Result<String, 
 /// Delete the vector index rows for every memory in `owner`'s
 /// `namespace` (a hard `DELETE` on `vector_entries` — the underlying
 /// Walrus blobs persist, since Walrus has no delete; the memories just
-/// stop being retrievable and stop counting toward storage quota). Used
-/// by the benchmark harness for inter-run cleanup; also a general admin
-/// op. Mode-blind — works the same in production and benchmark mode (in
+/// stop being retrievable and stop counting toward storage quota) and
+/// release `remember_jobs.idempotency_key` for that namespace so a later
+/// analyze/remember of the same text is a new write. Used by the
+/// benchmark harness for inter-run cleanup; also a general admin op.
+/// Mode-blind — works the same in production and benchmark mode (in
 /// benchmark mode this also removes the plaintext rows). Owner-scoped:
 /// only the caller's own rows are deleted.
 pub async fn forget(

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -17,6 +17,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::{Extension, Json};
 use base64::Engine as _;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 use crate::jobs::WalletOperation;
@@ -27,6 +28,11 @@ use crate::types::*;
 use super::{collect_bounded_results, enqueue_wallet_job};
 
 const ANALYZE_CONCURRENCY: usize = 5;
+
+fn analyze_fact_idempotency_key(owner: &str, namespace: &str, fact_text: &str) -> String {
+    let digest = Sha256::digest(format!("{owner}\n{namespace}\n{fact_text}").as_bytes());
+    format!("analyze:{}", hex::encode(digest))
+}
 
 // /api/analyze does not benefit from larger inputs — it sends the
 // full text to gpt-4o-mini for fact extraction in a single LLM call (no
@@ -548,21 +554,92 @@ pub async fn analyze(
     for (idx, (job_id, (fact_text, importance, vector, encrypted))) in
         pending.into_iter().enumerate()
     {
-        // Insert status row
-        if let Err(e) = sqlx::query(
-            "INSERT INTO remember_jobs (id, owner, namespace, status) VALUES ($1, $2, $3, 'pending')",
+        let idem_key = analyze_fact_idempotency_key(owner, namespace, &fact_text);
+        let inserted = match sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key, request_fingerprint)
+             VALUES ($1, $2, $3, 'pending', $4, $4)
+             ON CONFLICT (owner, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING",
         )
         .bind(&job_id)
         .bind(owner)
         .bind(namespace)
+        .bind(&idem_key)
         .execute(state.db.pool())
         .await
         {
-            rate_limit::release_storage_quota(&state, &all_ids[idx..]).await;
-            return Err(AppError::Internal(format!(
-                "Failed to create analyze job row: {}",
-                e
-            )));
+            Ok(result) => result,
+            Err(e) => {
+                rate_limit::release_storage_quota(&state, &all_ids[idx..]).await;
+                return Err(AppError::Internal(format!(
+                    "Failed to create analyze job row: {}",
+                    e
+                )));
+            }
+        };
+        let mut upload_job_id = job_id.clone();
+        if inserted.rows_affected() == 0 {
+            rate_limit::release_storage_quota(&state, std::slice::from_ref(&job_id)).await;
+            let existing = sqlx::query_as::<_, (String, String, Option<String>)>(
+                "SELECT id, status, blob_id FROM remember_jobs WHERE owner = $1 AND idempotency_key = $2",
+            )
+            .bind(owner)
+            .bind(&idem_key)
+            .fetch_optional(state.db.pool())
+            .await;
+            match existing {
+                Err(e) => {
+                    rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                    return Err(AppError::Internal(format!(
+                        "Failed to look up analyze job: {}",
+                        e
+                    )));
+                }
+                Ok(None) => {
+                    rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                    return Err(AppError::Internal(
+                        "Failed to create analyze job row: insert affected no rows".into(),
+                    ));
+                }
+                Ok(Some((existing_id, status, blob_id))) => {
+                    if status != "failed" || blob_id.is_some() {
+                        accepted_facts.push(AnalyzeAcceptedFact {
+                            text: fact_text,
+                            id: existing_id.clone(),
+                            job_id: existing_id.clone(),
+                        });
+                        job_ids.push(existing_id);
+                        continue;
+                    }
+                    if let Err(e) = sqlx::query(
+                        "UPDATE remember_jobs SET status = 'pending', error_msg = NULL, updated_at = NOW()
+                         WHERE id = $1 AND status = 'failed' AND blob_id IS NULL",
+                    )
+                    .bind(&existing_id)
+                    .execute(state.db.pool())
+                    .await
+                    {
+                        rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                        return Err(AppError::Internal(format!(
+                            "Failed to reset analyze job: {}",
+                            e
+                        )));
+                    }
+                    if let Err(e) = rate_limit::reserve_storage_quota(
+                        &state,
+                        owner,
+                        &[crate::storage::db::StorageReservationRequest {
+                            id: existing_id.clone(),
+                            bytes: encrypted.len() as i64,
+                        }],
+                    )
+                    .await
+                    {
+                        rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                        return Err(e);
+                    }
+                    upload_job_id = existing_id;
+                }
+            }
         }
 
         // Pick next wallet slot (round-robin) and enqueue UploadAndTransfer
@@ -584,14 +661,23 @@ pub async fn analyze(
                 package_id: state.config.package_id.clone(),
                 account_id: account_id.clone(),
                 agent_public_key: Some(auth_pubkey_base.clone()),
-                remember_job_id: Some(job_id.clone()),
+                remember_job_id: Some(upload_job_id.clone()),
                 prepare_claim_token: None,
                 epochs: state.config.walrus_storage_epochs,
             },
         )
         .await
         {
-            rate_limit::release_storage_quota(&state, &all_ids[idx..]).await;
+            let _ = sqlx::query(
+                "UPDATE remember_jobs SET status = 'failed', error_msg = $2, updated_at = NOW()
+                 WHERE id = $1 AND blob_id IS NULL",
+            )
+            .bind(&upload_job_id)
+            .bind(e.to_string())
+            .execute(state.db.pool())
+            .await;
+            rate_limit::release_storage_quota(&state, std::slice::from_ref(&upload_job_id)).await;
+            rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
             return Err(AppError::Internal(format!(
                 "Failed to enqueue analyze job: {}",
                 e
@@ -601,17 +687,17 @@ pub async fn analyze(
         // Queued: jobs.rs owns this reservation from here on.
 
         tracing::info!(
-            job_id = %job_id,
+            job_id = %upload_job_id,
             wallet_index,
             fact_len = fact_text.len(),
             "analyze fact enqueued"
         );
         accepted_facts.push(AnalyzeAcceptedFact {
             text: fact_text,
-            id: job_id.clone(),
-            job_id: job_id.clone(),
+            id: upload_job_id.clone(),
+            job_id: upload_job_id.clone(),
         });
-        job_ids.push(job_id);
+        job_ids.push(upload_job_id);
     }
 
     let fact_count = job_ids.len();
@@ -636,7 +722,7 @@ pub async fn analyze(
 
 #[cfg(test)]
 mod tests {
-    use super::{ANALYZE_CONCURRENCY, MAX_ANALYZE_TEXT_BYTES};
+    use super::{analyze_fact_idempotency_key, ANALYZE_CONCURRENCY, MAX_ANALYZE_TEXT_BYTES};
     use crate::routes::remember::MAX_REMEMBER_TEXT_BYTES;
     use crate::services::extractor::MAX_ANALYZE_FACTS;
 
@@ -659,6 +745,16 @@ mod tests {
     #[test]
     fn analyze_concurrency_constant_is_5() {
         assert_eq!(ANALYZE_CONCURRENCY, 5);
+    }
+
+    #[test]
+    fn analyze_fact_idempotency_key_is_stable_and_namespaced() {
+        let a = analyze_fact_idempotency_key("0xowner", "work", "likes rust");
+        let b = analyze_fact_idempotency_key("0xowner", "work", "likes rust");
+        let c = analyze_fact_idempotency_key("0xowner", "work", "likes go");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert!(a.starts_with("analyze:"));
     }
 
     #[test]

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -29,9 +29,51 @@ use super::{collect_bounded_results, enqueue_wallet_job};
 
 const ANALYZE_CONCURRENCY: usize = 5;
 
+/// Stable per-fact key so an HTTP retry of `/api/analyze` collapses onto the
+/// in-flight or completed upload instead of minting a second Walrus blob.
+///
+/// Importance is intentionally not hashed in. The extractor assigns a
+/// vital/standard/trivial bucket per fact; a later call that extracts the
+/// same text with a different bucket updates the live `vector_entries` row
+/// rather than paying for a duplicate write. `forget` NULLs this key so a
+/// re-analyze after delete is a new write, not a silent no-op.
 fn analyze_fact_idempotency_key(owner: &str, namespace: &str, fact_text: &str) -> String {
     let digest = Sha256::digest(format!("{owner}\n{namespace}\n{fact_text}").as_bytes());
     format!("analyze:{}", hex::encode(digest))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum AnalyzeJobReuse {
+    /// In-flight, or already stored with the same importance: return the existing job.
+    Collapse,
+    /// Failed before a blob was paid for: reset and re-enqueue on the same id.
+    RetryUnpaidFailure,
+    /// Live memory exists, but the extractor now scores it differently.
+    UpdateImportance,
+    /// Job completed and the vector is gone (forget / expiry): free the key and write again.
+    RewriteForgotten,
+}
+
+fn importance_changed(existing: f32, incoming: f32) -> bool {
+    (existing - incoming).abs() > 1e-6
+}
+
+fn classify_analyze_job_reuse(
+    status: &str,
+    blob_id: Option<&str>,
+    live_importance: Option<f32>,
+    incoming_importance: f32,
+) -> AnalyzeJobReuse {
+    if status == "failed" && blob_id.is_none() {
+        return AnalyzeJobReuse::RetryUnpaidFailure;
+    }
+    match live_importance {
+        None if blob_id.is_some() && status == "done" => AnalyzeJobReuse::RewriteForgotten,
+        Some(existing) if importance_changed(existing, incoming_importance) => {
+            AnalyzeJobReuse::UpdateImportance
+        }
+        _ => AnalyzeJobReuse::Collapse,
+    }
 }
 
 // /api/analyze does not benefit from larger inputs — it sends the
@@ -601,43 +643,191 @@ pub async fn analyze(
                     ));
                 }
                 Ok(Some((existing_id, status, blob_id))) => {
-                    if status != "failed" || blob_id.is_some() {
-                        accepted_facts.push(AnalyzeAcceptedFact {
-                            text: fact_text,
-                            id: existing_id.clone(),
-                            job_id: existing_id.clone(),
-                        });
-                        job_ids.push(existing_id);
-                        continue;
-                    }
-                    if let Err(e) = sqlx::query(
-                        "UPDATE remember_jobs SET status = 'pending', error_msg = NULL, updated_at = NOW()
-                         WHERE id = $1 AND status = 'failed' AND blob_id IS NULL",
+                    let live_importance = match sqlx::query_scalar::<_, f32>(
+                        "SELECT importance FROM vector_entries
+                         WHERE id = $1 AND owner = $2 AND namespace = $3",
                     )
                     .bind(&existing_id)
-                    .execute(state.db.pool())
+                    .bind(owner)
+                    .bind(namespace)
+                    .fetch_optional(state.db.pool())
                     .await
                     {
-                        rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
-                        return Err(AppError::Internal(format!(
-                            "Failed to reset analyze job: {}",
-                            e
-                        )));
+                        Ok(value) => value,
+                        Err(e) => {
+                            rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                            return Err(AppError::Internal(format!(
+                                "Failed to look up analyze memory: {}",
+                                e
+                            )));
+                        }
+                    };
+                    let reuse = classify_analyze_job_reuse(
+                        &status,
+                        blob_id.as_deref(),
+                        live_importance,
+                        importance,
+                    );
+                    let rewrite = match reuse {
+                        AnalyzeJobReuse::Collapse => {
+                            accepted_facts.push(AnalyzeAcceptedFact {
+                                text: fact_text,
+                                id: existing_id.clone(),
+                                job_id: existing_id.clone(),
+                            });
+                            job_ids.push(existing_id);
+                            continue;
+                        }
+                        AnalyzeJobReuse::UpdateImportance => {
+                            match state
+                                .db
+                                .update_vector_importance(
+                                    &existing_id,
+                                    owner,
+                                    namespace,
+                                    importance,
+                                )
+                                .await
+                            {
+                                Ok(true) => {
+                                    accepted_facts.push(AnalyzeAcceptedFact {
+                                        text: fact_text,
+                                        id: existing_id.clone(),
+                                        job_id: existing_id.clone(),
+                                    });
+                                    job_ids.push(existing_id);
+                                    continue;
+                                }
+                                Ok(false) => true,
+                                Err(e) => {
+                                    rate_limit::release_storage_quota(&state, &all_ids[idx + 1..])
+                                        .await;
+                                    return Err(e);
+                                }
+                            }
+                        }
+                        AnalyzeJobReuse::RewriteForgotten => true,
+                        AnalyzeJobReuse::RetryUnpaidFailure => false,
+                    };
+                    if rewrite {
+                        if let Err(e) = sqlx::query(
+                            "UPDATE remember_jobs
+                             SET idempotency_key = NULL, updated_at = NOW()
+                             WHERE id = $1 AND owner = $2",
+                        )
+                        .bind(&existing_id)
+                        .bind(owner)
+                        .execute(state.db.pool())
+                        .await
+                        {
+                            rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                            return Err(AppError::Internal(format!(
+                                "Failed to release analyze idempotency key: {}",
+                                e
+                            )));
+                        }
+                        let rewritten = match sqlx::query(
+                            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key, request_fingerprint)
+                             VALUES ($1, $2, $3, 'pending', $4, $4)
+                             ON CONFLICT (owner, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING",
+                        )
+                        .bind(&job_id)
+                        .bind(owner)
+                        .bind(namespace)
+                        .bind(&idem_key)
+                        .execute(state.db.pool())
+                        .await
+                        {
+                            Ok(result) => result,
+                            Err(e) => {
+                                rate_limit::release_storage_quota(&state, &all_ids[idx + 1..])
+                                    .await;
+                                return Err(AppError::Internal(format!(
+                                    "Failed to recreate analyze job row: {}",
+                                    e
+                                )));
+                            }
+                        };
+                        if rewritten.rows_affected() == 0 {
+                            // Another retry won the key after we released it.
+                            let winner = sqlx::query_scalar::<_, String>(
+                                "SELECT id FROM remember_jobs WHERE owner = $1 AND idempotency_key = $2",
+                            )
+                            .bind(owner)
+                            .bind(&idem_key)
+                            .fetch_optional(state.db.pool())
+                            .await;
+                            match winner {
+                                Ok(Some(winner_id)) => {
+                                    accepted_facts.push(AnalyzeAcceptedFact {
+                                        text: fact_text,
+                                        id: winner_id.clone(),
+                                        job_id: winner_id.clone(),
+                                    });
+                                    job_ids.push(winner_id);
+                                    continue;
+                                }
+                                Ok(None) => {
+                                    rate_limit::release_storage_quota(&state, &all_ids[idx + 1..])
+                                        .await;
+                                    return Err(AppError::Internal(
+                                        "Failed to recreate analyze job row: insert affected no rows"
+                                            .into(),
+                                    ));
+                                }
+                                Err(e) => {
+                                    rate_limit::release_storage_quota(&state, &all_ids[idx + 1..])
+                                        .await;
+                                    return Err(AppError::Internal(format!(
+                                        "Failed to look up analyze job: {}",
+                                        e
+                                    )));
+                                }
+                            }
+                        }
+                        if let Err(e) = rate_limit::reserve_storage_quota(
+                            &state,
+                            owner,
+                            &[crate::storage::db::StorageReservationRequest {
+                                id: job_id.clone(),
+                                bytes: encrypted.len() as i64,
+                            }],
+                        )
+                        .await
+                        {
+                            rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                            return Err(e);
+                        }
+                    } else {
+                        if let Err(e) = sqlx::query(
+                            "UPDATE remember_jobs SET status = 'pending', error_msg = NULL, updated_at = NOW()
+                             WHERE id = $1 AND status = 'failed' AND blob_id IS NULL",
+                        )
+                        .bind(&existing_id)
+                        .execute(state.db.pool())
+                        .await
+                        {
+                            rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                            return Err(AppError::Internal(format!(
+                                "Failed to reset analyze job: {}",
+                                e
+                            )));
+                        }
+                        if let Err(e) = rate_limit::reserve_storage_quota(
+                            &state,
+                            owner,
+                            &[crate::storage::db::StorageReservationRequest {
+                                id: existing_id.clone(),
+                                bytes: encrypted.len() as i64,
+                            }],
+                        )
+                        .await
+                        {
+                            rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
+                            return Err(e);
+                        }
+                        upload_job_id = existing_id;
                     }
-                    if let Err(e) = rate_limit::reserve_storage_quota(
-                        &state,
-                        owner,
-                        &[crate::storage::db::StorageReservationRequest {
-                            id: existing_id.clone(),
-                            bytes: encrypted.len() as i64,
-                        }],
-                    )
-                    .await
-                    {
-                        rate_limit::release_storage_quota(&state, &all_ids[idx + 1..]).await;
-                        return Err(e);
-                    }
-                    upload_job_id = existing_id;
                 }
             }
         }
@@ -722,7 +912,10 @@ pub async fn analyze(
 
 #[cfg(test)]
 mod tests {
-    use super::{analyze_fact_idempotency_key, ANALYZE_CONCURRENCY, MAX_ANALYZE_TEXT_BYTES};
+    use super::{
+        analyze_fact_idempotency_key, classify_analyze_job_reuse, AnalyzeJobReuse,
+        ANALYZE_CONCURRENCY, MAX_ANALYZE_TEXT_BYTES,
+    };
     use crate::routes::remember::MAX_REMEMBER_TEXT_BYTES;
     use crate::services::extractor::MAX_ANALYZE_FACTS;
 
@@ -752,9 +945,58 @@ mod tests {
         let a = analyze_fact_idempotency_key("0xowner", "work", "likes rust");
         let b = analyze_fact_idempotency_key("0xowner", "work", "likes rust");
         let c = analyze_fact_idempotency_key("0xowner", "work", "likes go");
+        let other_owner = analyze_fact_idempotency_key("0xother", "work", "likes rust");
+        let other_ns = analyze_fact_idempotency_key("0xowner", "home", "likes rust");
         assert_eq!(a, b);
         assert_ne!(a, c);
+        assert_ne!(a, other_owner);
+        assert_ne!(a, other_ns);
         assert!(a.starts_with("analyze:"));
+    }
+
+    #[test]
+    fn classify_collapses_inflight_and_matching_live_row() {
+        assert_eq!(
+            classify_analyze_job_reuse("pending", None, None, 0.5),
+            AnalyzeJobReuse::Collapse
+        );
+        assert_eq!(
+            classify_analyze_job_reuse("uploaded", Some("blob"), None, 0.5),
+            AnalyzeJobReuse::Collapse
+        );
+        assert_eq!(
+            classify_analyze_job_reuse("done", Some("blob"), Some(0.5), 0.5),
+            AnalyzeJobReuse::Collapse
+        );
+        // Paid-but-not-indexed: do not mint a second blob.
+        assert_eq!(
+            classify_analyze_job_reuse("failed", Some("blob"), None, 0.5),
+            AnalyzeJobReuse::Collapse
+        );
+    }
+
+    #[test]
+    fn classify_retries_unpaid_failure() {
+        assert_eq!(
+            classify_analyze_job_reuse("failed", None, None, 0.5),
+            AnalyzeJobReuse::RetryUnpaidFailure
+        );
+    }
+
+    #[test]
+    fn classify_updates_importance_on_live_row() {
+        assert_eq!(
+            classify_analyze_job_reuse("done", Some("blob"), Some(0.2), 0.9),
+            AnalyzeJobReuse::UpdateImportance
+        );
+    }
+
+    #[test]
+    fn classify_rewrites_when_done_job_has_no_live_memory() {
+        assert_eq!(
+            classify_analyze_job_reuse("done", Some("blob"), None, 0.5),
+            AnalyzeJobReuse::RewriteForgotten
+        );
     }
 
     #[test]

--- a/services/server/src/routes/oauth.rs
+++ b/services/server/src/routes/oauth.rs
@@ -293,6 +293,8 @@ fn error_page(status: StatusCode, title: &str, detail: &str) -> Response {
 }
 
 pub async fn authorize(
+    ConnectInfo(connect_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
     State(state): State<Arc<AppState>>,
     axum::extract::Query(query): axum::extract::Query<AuthorizeQuery>,
 ) -> Response {
@@ -300,6 +302,34 @@ pub async fn authorize(
         Ok(cfg) => cfg,
         Err(err) => return err.into_response(),
     };
+
+    let ip = crate::client_ip::canonical_client_ip(
+        &headers,
+        connect_addr,
+        state.config.trusted_proxy_hops,
+    );
+    let is_trusted = oauth::ip_is_trusted(ip, &cfg.registration_trusted_cidrs);
+    if !is_trusted {
+        let mut redis = state.redis.clone();
+        let key = format!("mcp_oauth:authorize_rl:{}", ip);
+        let count: i64 = redis::cmd("INCR")
+            .arg(&key)
+            .query_async(&mut redis)
+            .await
+            .unwrap_or(1);
+        let _: Result<(), redis::RedisError> = redis::cmd("EXPIRE")
+            .arg(&key)
+            .arg(3600)
+            .query_async(&mut redis)
+            .await;
+        if count > 60 {
+            return error_page(
+                StatusCode::TOO_MANY_REQUESTS,
+                "Too many requests",
+                "Authorization rate limit exceeded, try again later.",
+            );
+        }
+    }
 
     // Client and redirect_uri must both check out before we're willing to
     // redirect anywhere — an invalid client or redirect target is an error

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -1211,22 +1211,34 @@ impl VectorDb {
 
         // per-owner storage quota reservations. Makes quota admission atomic
         // with the eventual insert (GH #532 / WALM-359).
-        let migration_014_reservations = include_str!("../../migrations/014_storage_reservations.sql");
+        let migration_014_reservations =
+            include_str!("../../migrations/014_storage_reservations.sql");
         sqlx::raw_sql(migration_014_reservations)
             .execute(&pool)
             .await
-            .map_err(|e| AppError::Internal(format!("Failed to run migration 014 (storage reservations): {}", e)))?;
+            .map_err(|e| {
+                AppError::Internal(format!(
+                    "Failed to run migration 014 (storage reservations): {}",
+                    e
+                ))
+            })?;
 
         // owner-scoped read API: updated_at cursor column + agent_id/package_id.
         // Split across 014-019 (see each file's header, and
         // backfill_updated_at's / recover_invalid_pagination_index's doc
         // comments above) to avoid holding ACCESS EXCLUSIVE across the
         // full-table backfill or index build.
-        let migration_014_read_api = include_str!("../../migrations/014_memory_read_api_columns.sql");
+        let migration_014_read_api =
+            include_str!("../../migrations/014_memory_read_api_columns.sql");
         sqlx::raw_sql(migration_014_read_api)
             .execute(&pool)
             .await
-            .map_err(|e| AppError::Internal(format!("Failed to run migration 014 (read API columns): {}", e)))?;
+            .map_err(|e| {
+                AppError::Internal(format!(
+                    "Failed to run migration 014 (read API columns): {}",
+                    e
+                ))
+            })?;
 
         // Backfill runs as batched Rust code, not a migration file, since
         // Postgres can't COMMIT mid-loop inside a plain migration
@@ -1399,11 +1411,9 @@ impl VectorDb {
         let embedding = Vector::from(vector.to_vec());
 
         let started = std::time::Instant::now();
-        let mut tx = self
-            .pool
-            .begin()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to begin plaintext insert tx: {}", e)))?;
+        let mut tx = self.pool.begin().await.map_err(|e| {
+            AppError::Internal(format!("Failed to begin plaintext insert tx: {}", e))
+        })?;
         let result = sqlx::query(
             "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, plaintext, importance)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
@@ -1439,9 +1449,9 @@ impl VectorDb {
             .execute(&mut *tx)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to clear tombstone: {}", e)))?;
-        tx.commit()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to commit plaintext insert tx: {}", e)))?;
+        tx.commit().await.map_err(|e| {
+            AppError::Internal(format!("Failed to commit plaintext insert tx: {}", e))
+        })?;
 
         tracing::debug!(
             "inserted plaintext vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
@@ -2641,8 +2651,34 @@ impl VectorDb {
                 AppError::Internal(format!("Failed to evict expired oauth codes: {}", e))
             })?;
         total += codes.rows_affected();
+        let pending = sqlx::query(
+            "DELETE FROM mcp_oauth_delegates d
+             WHERE d.status = 'pending'
+               AND d.created_at <= NOW() - INTERVAL '1 hour'
+               AND NOT EXISTS (
+                   SELECT 1 FROM mcp_oauth_authorize_sessions s
+                   WHERE s.delegate_ref = d.delegate_ref
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM mcp_oauth_codes c
+                   WHERE c.delegate_ref = d.delegate_ref
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM mcp_oauth_grants g
+                   WHERE g.delegate_ref = d.delegate_ref
+               )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!("Failed to prune abandoned oauth delegates: {}", e))
+        })?;
+        total += pending.rows_affected();
         if total > 0 {
-            tracing::info!("Evicted {} expired MCP OAuth session/code rows", total);
+            tracing::info!(
+                "Evicted {} expired MCP OAuth session/code/pending-delegate rows",
+                total
+            );
         }
         Ok(total)
     }

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -900,6 +900,196 @@ mod tests {
             .await
             .unwrap();
     }
+
+    async fn remember_jobs_test_db() -> Option<VectorDb> {
+        let db = test_db().await?;
+        for migration in [
+            include_str!("../../migrations/005_remember_jobs.sql"),
+            include_str!("../../migrations/012_remember_write_idempotency.sql"),
+            include_str!("../../migrations/013_remember_write_idempotency_index.sql"),
+        ] {
+            sqlx::raw_sql(migration).execute(db.pool()).await.unwrap();
+        }
+        Some(db)
+    }
+
+    #[tokio::test]
+    async fn update_vector_importance_is_owner_and_namespace_scoped() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0ximp-owner-{suffix}");
+        let other_owner = format!("0ximp-other-{suffix}");
+        let id = format!("imp-row-{suffix}");
+        let other_id = format!("imp-other-{suffix}");
+
+        db.insert_vector(
+            &id,
+            &owner,
+            "notes",
+            "blob-imp",
+            &[0.1_f32; 1536],
+            1,
+            0.2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.insert_vector(
+            &other_id,
+            &other_owner,
+            "notes",
+            "blob-imp-other",
+            &[0.1_f32; 1536],
+            1,
+            0.2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(db
+            .update_vector_importance(&id, &owner, "notes", 0.9)
+            .await
+            .unwrap());
+        assert!(
+            !db.update_vector_importance(&id, &other_owner, "notes", 0.5)
+                .await
+                .unwrap(),
+            "must not update another owner's row"
+        );
+        assert!(
+            !db.update_vector_importance(&id, &owner, "other-ns", 0.5)
+                .await
+                .unwrap(),
+            "must not update another namespace"
+        );
+
+        let scores: Vec<(String, f32)> = sqlx::query_as(
+            "SELECT id, importance FROM vector_entries WHERE id = ANY($1) ORDER BY id",
+        )
+        .bind(vec![id.clone(), other_id.clone()])
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+
+        sqlx::query("DELETE FROM vector_entries WHERE id = ANY($1)")
+            .bind(vec![id.clone(), other_id.clone()])
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        assert_eq!(scores, vec![(other_id, 0.2), (id, 0.9)]);
+    }
+
+    #[tokio::test]
+    async fn forget_clears_idempotency_keys_so_the_same_text_can_be_rewritten() {
+        let Some(db) = remember_jobs_test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xforget-idem-{suffix}");
+        let other_ns_owner_job = format!("other-ns-job-{suffix}");
+        let job_id = format!("forget-job-{suffix}");
+        let vector_id = job_id.clone();
+        let key = format!("analyze:{suffix}");
+
+        db.insert_vector(
+            &vector_id,
+            &owner,
+            "notes",
+            "blob-forget",
+            &[0.1_f32; 1536],
+            1,
+            0.5,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key, blob_id)
+             VALUES ($1, $2, 'notes', 'done', $3, 'blob-forget')",
+        )
+        .bind(&job_id)
+        .bind(&owner)
+        .bind(&key)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key)
+             VALUES ($1, $2, 'keep', 'done', $3)",
+        )
+        .bind(&other_ns_owner_job)
+        .bind(&owner)
+        .bind(format!("analyze-keep:{suffix}"))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(db.delete_by_namespace(&owner, "notes").await.unwrap(), 1);
+
+        let remaining_key: Option<String> =
+            sqlx::query_scalar("SELECT idempotency_key FROM remember_jobs WHERE id = $1")
+                .bind(&job_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(remaining_key, None);
+
+        let kept_key: Option<String> =
+            sqlx::query_scalar("SELECT idempotency_key FROM remember_jobs WHERE id = $1")
+                .bind(&other_ns_owner_job)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            kept_key.as_deref(),
+            Some(format!("analyze-keep:{suffix}").as_str())
+        );
+
+        let rewritten = sqlx::query(
+            "INSERT INTO remember_jobs (id, owner, namespace, status, idempotency_key)
+             VALUES ($1, $2, 'notes', 'pending', $3)
+             ON CONFLICT (owner, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING",
+        )
+        .bind(format!("rewrite-job-{suffix}"))
+        .bind(&owner)
+        .bind(&key)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            rewritten.rows_affected(),
+            1,
+            "the same analyze key must insert after forget"
+        );
+
+        sqlx::query("DELETE FROM remember_jobs WHERE owner = $1")
+            .bind(&owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
+            .bind(&owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM memory_tombstones WHERE owner = $1")
+            .bind(&owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
 }
 
 fn db_status<T>(result: &Result<T, AppError>) -> &'static str {
@@ -1616,8 +1806,18 @@ impl VectorDb {
     /// removes the local `vector_entries` rows, so the memories stop being
     /// retrievable and stop counting toward storage quota.) Reachable via
     /// `POST /api/forget` — authed, owner-scoped.
+    ///
+    /// Also NULLs `remember_jobs.idempotency_key` for the same owner +
+    /// namespace. Analyze (and client-keyed remember) collapse retries on
+    /// that unique key; leaving it set after forget makes a later write of
+    /// the same text return success without storing anything.
     pub async fn delete_by_namespace(&self, owner: &str, namespace: &str) -> Result<u64, AppError> {
         let started = std::time::Instant::now();
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to begin forget tx: {}", e)))?;
         let result = sqlx::query(
             "WITH removed AS (
                 DELETE FROM vector_entries
@@ -1630,15 +1830,52 @@ impl VectorDb {
         )
         .bind(owner)
         .bind(namespace)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to delete by namespace: {}", e)));
-        crate::observability::observe_db(
-            "vector.delete_by_namespace",
-            db_status(&result),
-            started.elapsed(),
-        );
-        let result = result?;
+        let result = match result {
+            Ok(result) => result,
+            Err(e) => {
+                crate::observability::observe_db(
+                    "vector.delete_by_namespace",
+                    "error",
+                    started.elapsed(),
+                );
+                return Err(e);
+            }
+        };
+        let clear = sqlx::query(
+            "UPDATE remember_jobs
+             SET idempotency_key = NULL, updated_at = NOW()
+             WHERE owner = $1 AND namespace = $2 AND idempotency_key IS NOT NULL",
+        )
+        .bind(owner)
+        .bind(namespace)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!("Failed to clear remember idempotency keys: {}", e))
+        });
+        if let Err(e) = clear {
+            crate::observability::observe_db(
+                "vector.delete_by_namespace",
+                "error",
+                started.elapsed(),
+            );
+            return Err(e);
+        }
+        if let Err(e) = tx.commit().await {
+            crate::observability::observe_db(
+                "vector.delete_by_namespace",
+                "error",
+                started.elapsed(),
+            );
+            return Err(AppError::Internal(format!(
+                "Failed to commit forget tx: {}",
+                e
+            )));
+        }
+        crate::observability::observe_db("vector.delete_by_namespace", "ok", started.elapsed());
         let rows = result.rows_affected();
         tracing::info!(
             "deleted {} entries for owner={}, ns={}",
@@ -1647,6 +1884,36 @@ impl VectorDb {
             namespace
         );
         Ok(rows)
+    }
+
+    /// Change importance on one live memory without rewriting the blob.
+    /// Returns whether a matching owner-scoped row existed.
+    pub async fn update_vector_importance(
+        &self,
+        id: &str,
+        owner: &str,
+        namespace: &str,
+        importance: f32,
+    ) -> Result<bool, AppError> {
+        let started = std::time::Instant::now();
+        let result = sqlx::query(
+            "UPDATE vector_entries
+             SET importance = $4, updated_at = NOW()
+             WHERE id = $1 AND owner = $2 AND namespace = $3",
+        )
+        .bind(id)
+        .bind(owner)
+        .bind(namespace)
+        .bind(importance)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to update vector importance: {}", e)));
+        crate::observability::observe_db(
+            "vector.update_importance",
+            db_status(&result),
+            started.elapsed(),
+        );
+        Ok(result?.rows_affected() > 0)
     }
 
     /// Delete vector entries for one expired blob within an owner + namespace.

--- a/services/server/src/storage/walrus.rs
+++ b/services/server/src/storage/walrus.rs
@@ -852,7 +852,7 @@ pub async fn query_blobs_by_owner(
             started.elapsed(),
         );
         crate::observability::record_sidecar_failure("walrus_query_blobs", "transport_error");
-        AppError::Internal(format!("Sidecar walrus/query-blobs failed: {}", e))
+        AppError::UpstreamUnavailable(format!("Sidecar walrus/query-blobs failed: {}", e))
     })?;
     let status_label = resp.status().as_u16().to_string();
     crate::observability::observe_external(
@@ -865,7 +865,7 @@ pub async fn query_blobs_by_owner(
     if !resp.status().is_success() {
         crate::observability::record_sidecar_failure("walrus_query_blobs", "http_error");
         let body = resp.text().await.unwrap_or_default();
-        return Err(AppError::Internal(format!(
+        return Err(AppError::UpstreamUnavailable(format!(
             "walrus query-blobs failed: {}",
             body
         )));


### PR DESCRIPTION
Linear: [WALM-322](https://linear.app/mysten-labs/issue/WALM-322/bug-high-memwal-restore-maps-transient-errors-to-http-500-and-can-hang), [WALM-357](https://linear.app/mysten-labs/issue/WALM-357/security-high-rate-limit-oauth-authorize-and-prune-abandoned-delegates), [WALM-375](https://linear.app/mysten-labs/issue/WALM-375/gh-655-hosted-relayer-gas-exhaustion-surfaces-as-an-ambiguous-503), [WALM-403](https://linear.app/mysten-labs/issue/WALM-403/analyze-retries-mint-duplicate-blobs-add-per-fact-idempotency)
Fixes https://github.com/MystenLabs/MemWal/issues/414
Fixes https://github.com/MystenLabs/MemWal/issues/620
Fixes https://github.com/MystenLabs/MemWal/issues/729
Related: https://github.com/MystenLabs/MemWal/issues/655

## What this does

- `/api/restore`: sidecar query failures are 503; 55s deadline; embed fan-out capped at 3.
- `/oauth/authorize`: per-IP Redis rate limit; abandoned pending delegates older than 1 hour are pruned.
- `/api/analyze`: per-fact idempotency so a retry does not mint a second blob; failed no-blob rows can restart; enqueue failure marks the row failed.
- SUI gas-selection / insufficient SUI errors classify as pool budget failures (WAL excluded). Preflight-before-202 and rate-limit refund are not in this PR.

## Package

Relayer only. No SDK/MCP version bump.