### PR TITLE
fix(sdk): align remember-manual, embed, hex, and env=dev

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -163,7 +163,7 @@ const stored = await memwal.waitForRememberJob(accepted.job_id, {
 
 | Method | Description |
 |---|---|
-| `rememberManual({ blobId, vector, namespace? })` | Register pre-uploaded blob with pre-computed vector |
+| `rememberManual({ encryptedData, vector, namespace? })` | Send SEAL-encrypted bytes + pre-computed vector; relayer uploads |
 | `recallManual({ vector, limit?, namespace? })` | Search with pre-computed vector (returns blob IDs only) |
 | `embed(text)` | Generate embedding vector (no storage) |
 

--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -211,7 +211,7 @@ Hex-encoded public key for the current delegate key.
 
 | Method | Description |
 | --- | --- |
-| `remember_manual(RememberManualOptions)` | Register a pre-uploaded blob with a pre-computed vector → `RememberManualResult` |
+| `remember_manual(RememberManualOptions)` | Send SEAL-encrypted bytes + a pre-computed vector; the relayer uploads to Walrus → `RememberManualResult` |
 | `recall_manual(RecallManualOptions)` | Search with a pre-computed query vector → `RecallManualResult` (blob_id + distance only) |
 | `embed(text)` | Embedding vector for text, no storage → `EmbedResult(vector)` |
 

--- a/docs/python-sdk/usage/memwal-manual.md
+++ b/docs/python-sdk/usage/memwal-manual.md
@@ -2,7 +2,7 @@
 title: "Manual Methods"
 description: >-
   Lower-level remember_manual, recall_manual, and embed methods for callers that manage
-  their own vectors or have pre-uploaded Walrus blobs in the Python SDK.
+  their own vectors or already have SEAL-encrypted payloads in the Python SDK.
 keywords:
   - Walrus Memory
   - MemWal
@@ -12,7 +12,7 @@ keywords:
   - remember_manual
   - recall_manual
 goal:
-  description: Call the manual Python SDK methods to register a pre-uploaded blob, search with a pre-computed embedding vector, and compute embeddings independently from storage.
+  description: Call the manual Python SDK methods to register SEAL-encrypted bytes with a pre-computed embedding vector, search with a pre-computed vector, and compute embeddings independently from storage.
   requires:
     - has_frontmatter:
         - title
@@ -31,13 +31,14 @@ questions:
   - When should I use manual methods vs standard remember/recall in MemWal?
 answer: >-
   The Python SDK provides lower-level manual methods on the same MemWal/MemWalSync client:
-  `embed` computes a vector without storing anything, `remember_manual` registers a
-  pre-uploaded blob with a pre-computed vector, and `recall_manual` searches with a
-  pre-computed query vector returning raw blob IDs and distances.
+  `embed` computes a vector without storing anything, `remember_manual` sends
+  base64 SEAL-encrypted bytes plus a pre-computed vector (the relayer uploads to
+  Walrus), and `recall_manual` searches with a pre-computed query vector returning
+  raw blob IDs and distances.
 ---
 
 <Note>
-Unlike the TypeScript SDK there is **no separate `MemWalManual` class** in Python. The Python SDK is relayer-backed: the relayer always handles embedding, SEAL encryption, and Walrus storage. The "manual" methods are lower-level entry points on the same `MemWal` / `MemWalSync` client for callers that already have a vector or a pre-uploaded blob.
+Unlike the TypeScript SDK there is **no separate `MemWalManual` class** in Python. The Python SDK is relayer-backed for the standard `remember` / `recall` flow. The "manual" methods are lower-level entry points on the same `MemWal` / `MemWalSync` client for callers that already have a vector and SEAL-encrypted bytes.
 </Note>
 
 Use these when you want to control indexing or do your own vector math. For the standard flow, prefer [`remember` / `recall`](/python-sdk/usage/memwal).
@@ -57,14 +58,14 @@ print(len(vec.vector))
 
 ## `remember_manual`
 
-Register a pre-uploaded Walrus blob with a pre-computed vector. The relayer stores the `{blob_id, vector, owner, namespace}` mapping; it does not upload for you here.
+Send base64 SEAL-encrypted bytes plus a pre-computed vector. The relayer uploads the ciphertext to Walrus and stores the `{blob_id, vector, owner, namespace}` mapping.
 
 ```python
 from memwal import RememberManualOptions
 
 result = await memwal.remember_manual(
     RememberManualOptions(
-        blob_id="<walrus-blob-id>",
+        encrypted_data="<base64-seal-ciphertext>",
         vector=vec.vector,
         namespace="chatbot-prod",   # optional; falls back to client default
     )
@@ -93,7 +94,7 @@ for hit in hits.results:
 | --- | --- |
 | Plain text, want it stored | `remember` / `remember_and_wait` |
 | Plain text, want only the vector | `embed` |
-| A vector + an already-uploaded blob | `remember_manual` |
+| A vector + SEAL-encrypted bytes | `remember_manual` |
 | A query vector, want raw hits | `recall_manual` |
 | Plain query text, want decrypted matches | `recall` |
 

--- a/docs/python-sdk/usage/memwal.md
+++ b/docs/python-sdk/usage/memwal.md
@@ -98,9 +98,9 @@ print(result.restored, result.skipped, result.total)
 
 ## Lower-Level Methods
 
-Use these when you already have a vector or a pre-uploaded blob — see [Manual methods](/python-sdk/usage/memwal-manual):
+Use these when you already have a vector or SEAL-encrypted bytes — see [Manual methods](/python-sdk/usage/memwal-manual):
 
-- `remember_manual(RememberManualOptions(blob_id=..., vector=..., namespace=...))`
+- `remember_manual(RememberManualOptions(encrypted_data=..., vector=..., namespace=...))`
 - `recall_manual(RecallManualOptions(vector=..., limit=..., namespace=...))`
 - `embed(text)` — embedding vector only, no storage
 - `get_public_key_hex()` — the delegate public key

--- a/docs/python-sdk/usage/memwal.md
+++ b/docs/python-sdk/usage/memwal.md
@@ -98,7 +98,7 @@ print(result.restored, result.skipped, result.total)
 
 ## Lower-Level Methods
 
-Use these when you already have a vector or SEAL-encrypted bytes — see [Manual methods](/python-sdk/usage/memwal-manual):
+Use these when you already have a vector or SEAL-encrypted bytes. See [Manual methods](/python-sdk/usage/memwal-manual):
 
 - `remember_manual(RememberManualOptions(encrypted_data=..., vector=..., namespace=...))`
 - `recall_manual(RecallManualOptions(vector=..., limit=..., namespace=...))`

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -1,7 +1,7 @@
 ---
 title: API Reference
 description: >-
-  Complete HTTP API reference for the Walrus Memory relayer, including authentication headers, public routes, the protected endpoints for remember, recall, analyze, ask, restore, forget, and stats, and the MCP transport endpoints.
+  Complete HTTP API reference for the Walrus Memory relayer, including authentication headers, public routes, the protected endpoints for remember, recall, analyze, embed, ask, restore, forget, and stats, and the MCP transport endpoints.
 keywords:
   - Walrus Memory
   - MemWal
@@ -28,7 +28,7 @@ questions:
   - "How do I authenticate requests to the MemWal relayer?"
   - "What is the request and response format for the remember and recall APIs?"
 answer: >-
-  The Walrus Memory relayer exposes public routes (health, version, config, metrics, sponsor) and protected routes (remember, recall, analyze, ask, restore, forget, stats) that require Ed25519 signed headers, plus MCP transport endpoints that use bearer authentication. Signed authentication uses x-public-key, x-signature, x-timestamp, and x-nonce headers, with the signature covering the timestamp, method, path, body hash, nonce, and account ID.
+  The Walrus Memory relayer exposes public routes (health, version, config, metrics, sponsor) and protected routes (remember, recall, analyze, embed, ask, restore, forget, stats) that require Ed25519 signed headers, plus MCP transport endpoints that use bearer authentication. Signed authentication uses x-public-key, x-signature, x-timestamp, and x-nonce headers, with the signature covering the timestamp, method, path, body hash, nonce, and account ID.
 ---
 
 The Rust relayer exposes these routes. The route table lives in `services/server/src/main.rs`.
@@ -378,6 +378,28 @@ Extract facts from text using an LLM, then enqueue each fact as a separate memor
   "fact_count": 2,
   "status": "pending",
   "owner": "0x..."
+}
+```
+
+### `POST /api/embed`
+
+Return an embedding vector for `text` without storing a memory. Uses the same model and width as remember, recall, and analyze. Requires signed-header auth.
+
+**Request:**
+
+```json
+{
+  "text": "hello world"
+}
+```
+
+`text` must be non-empty and at most 64 KiB.
+
+**Response:**
+
+```json
+{
+  "vector": [0.01, -0.02]
 }
 ```
 

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -190,7 +190,7 @@ These exist on the `MemWal` class for advanced use cases:
 
 | Method | Description |
 |--------|-------------|
-| `rememberManual({ blobId, vector, namespace? })` | Register a pre-uploaded blob ID with a pre-computed vector |
+| `rememberManual({ encryptedData, vector, namespace? })` | Send SEAL-encrypted bytes + a pre-computed vector; the relayer uploads to Walrus |
 | `recallManual({ vector, limit?, namespace? })` | Search with a pre-computed query vector (returns blob IDs, no decryption) |
 | `embed(text)` | Generate an embedding vector for text (no storage) |
 

--- a/docs/sdk/usage/memwal.md
+++ b/docs/sdk/usage/memwal.md
@@ -84,6 +84,6 @@ const result = await memwal.restore("chatbot-prod", 10);
 
 Use these when you already have a vector or encrypted payload:
 
-- `rememberManual({ blobId, vector, namespace? })`
+- `rememberManual({ encryptedData, vector, namespace? })`
 - `recallManual({ vector, limit?, namespace? })`
 - `embed(text)`

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,10 +1,16 @@
 # memwal
 
-## Unreleased
+## 0.1.8
 
 ### Added
 
 - Added `MemWalClockDriftError`, raised when the relayer rejects a request because the signed timestamp is outside its accepted clock-drift window (`401` + `x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS`). Surfaces an actionable "synchronize the client clock" message instead of an opaque `401`. Subclasses `MemWalError`, so existing `except MemWalError` handlers still catch it.
+- Added the `dev` relayer preset (`https://relayer.dev.memwal.ai`) to `ENV_PRESETS`.
+
+### Fixed
+
+- `hex_to_bytes` now rejects empty, odd-length, whitespace, and non-hex input instead of silently decoding a different key.
+- `remember_manual` sends `encrypted_data` (base64 SEAL ciphertext) instead of a pre-uploaded `blob_id`, matching `POST /api/remember/manual`.
 
 ## 0.1.7
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `recall()` results include `dropped_count` when the relayer omitted matches that failed to download or decrypt.
+- `health()` surfaces optional `write_ready` when the relayer reports write-path sidecar liveness.
 - Added `MemWalClockDriftError`, raised when the relayer rejects a request because the signed timestamp is outside its accepted clock-drift window (`401` + `x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS`). Surfaces an actionable "synchronize the client clock" message instead of an opaque `401`. Subclasses `MemWalError`, so existing `except MemWalError` handlers still catch it.
 - Added the `dev` relayer preset (`https://relayer.dev.memwal.ai`) to `ENV_PRESETS`.
 
@@ -11,6 +13,7 @@
 
 - `hex_to_bytes` now rejects empty, odd-length, whitespace, and non-hex input instead of silently decoding a different key.
 - `remember_manual` sends `encrypted_data` (base64 SEAL ciphertext) instead of a pre-uploaded `blob_id`, matching `POST /api/remember/manual`.
+- HTTP error messages and remember-job error strings no longer forward `localhost` / `127.0.0.1` URLs to callers.
 
 ## 0.1.7
 

--- a/packages/python-sdk-memwal/README.md
+++ b/packages/python-sdk-memwal/README.md
@@ -133,6 +133,7 @@ memwal = MemWal.create(
 | `env` | Relayer URL |
 |-------|-------------|
 | `prod` | `https://relayer.memory.walrus.xyz` |
+| `dev` | `https://relayer.dev.memwal.ai` |
 | `staging` | `https://relayer-staging.memory.walrus.xyz` |
 
 Precedence: an explicit non-default **`server_url` wins over `env`**, which wins
@@ -206,7 +207,7 @@ Create a new async client.
 | `await ask(question, limit?, namespace?)` | Ask a question answered using memories |
 | `await restore(namespace, limit?)` | Restore a namespace |
 | `await health()` | Check server health |
-| `await remember_manual(opts)` | Store with pre-computed vector |
+| `await remember_manual(opts)` | Store encrypted payload + pre-computed vector |
 | `await recall_manual(opts)` | Search with pre-computed vector |
 | `await get_public_key_hex()` | Get Ed25519 public key |
 

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -30,6 +30,7 @@ import base64
 import json
 import logging
 import random
+import re
 import time
 import uuid
 from datetime import datetime, timezone
@@ -652,10 +653,21 @@ class MemWal:
             )
             for m in data.get("results", [])
         ]
+        raw_dropped = data.get("dropped_count") or 0
+        try:
+            dropped = int(raw_dropped)
+        except (TypeError, ValueError):
+            dropped = 0
         if max_distance is not None:
             memories = [m for m in memories if m.distance < max_distance]
-            return RecallResult(results=memories, total=len(memories))
-        return RecallResult(results=memories, total=data.get("total", len(memories)))
+            return RecallResult(
+                results=memories, total=len(memories), dropped_count=dropped
+            )
+        return RecallResult(
+            results=memories,
+            total=data.get("total", len(memories)),
+            dropped_count=dropped,
+        )
 
     async def analyze(
         self,
@@ -893,6 +905,7 @@ class MemWal:
             deprecations=data.get("deprecations"),
             build=data.get("build"),
             mode=data.get("mode"),
+            write_ready=data.get("write_ready"),
         )
 
     async def compatibility(self) -> Dict[str, Any]:
@@ -1235,6 +1248,15 @@ class MemWalClockDriftError(MemWalError):
     pass
 
 
+def _redact_internal_urls(text: str) -> str:
+    return re.sub(
+        r"https?://(?:localhost|127\.0\.0\.1)(?::\d+)?[^\s)\]>'\"]*",
+        "[internal]",
+        text,
+        flags=re.IGNORECASE,
+    )
+
+
 class _HttpStatusError(MemWalError):
     """Internal: raised when an HTTP response status is not in ``accepted_statuses``.
 
@@ -1247,7 +1269,9 @@ class _HttpStatusError(MemWalError):
         if status == 401:
             super().__init__(AUTH_REJECTED_MESSAGE)
         else:
-            super().__init__(f"Walrus Memory API error ({status}): {body}")
+            super().__init__(
+                f"Walrus Memory API error ({status}): {_redact_internal_urls(body)}"
+            )
         self.status = status
         self.body = body
 
@@ -1265,7 +1289,7 @@ class MemWalRememberJobFailed(MemWalError):
     """The async remember job reached terminal status=failed."""
 
     def __init__(self, job_id: str, error: str) -> None:
-        super().__init__(f"remember job failed: {error}")
+        super().__init__(f"remember job failed: {_redact_internal_urls(error)}")
         self.status = 500
         self.job_id = job_id
         self.error = error

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -774,6 +774,7 @@ class MemWal:
             "POST",
             "/api/embed",
             {"text": text},
+            include_seal_session=False,
         )
         return EmbedResult(vector=list(data.get("vector", [])))
 
@@ -906,11 +907,12 @@ class MemWal:
     async def remember_manual(self, opts: RememberManualOptions) -> RememberManualResult:
         """Remember (manual mode).
 
-        User handles SEAL encrypt, embedding, and Walrus upload externally.
-        Server only stores the vector <-> blobId mapping.
+        User handles SEAL encrypt and embedding. The relayer uploads the
+        encrypted bytes to Walrus and stores the vector mapping.
 
         Args:
-            opts: :class:`RememberManualOptions` with blob_id, vector, and optional namespace.
+            opts: :class:`RememberManualOptions` with encrypted_data (base64),
+                vector, and optional namespace.
 
         Returns:
             :class:`RememberManualResult` with id, blob_id, owner, namespace.
@@ -919,7 +921,7 @@ class MemWal:
             "POST",
             "/api/remember/manual",
             {
-                "blob_id": opts.blob_id,
+                "encrypted_data": opts.encrypted_data,
                 "vector": opts.vector,
                 "namespace": opts.namespace or self._namespace,
             },

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -23,6 +23,7 @@ DEFAULT_SERVER_URL = "http://localhost:8000"
 #: Named relayer environments for the public Walrus Memory deployments.
 ENV_PRESETS = {
     "prod": "https://relayer.memory.walrus.xyz",
+    "dev": "https://relayer.dev.memwal.ai",
     "staging": "https://relayer-staging.memory.walrus.xyz",
     "local": "http://127.0.0.1:8000",
 }
@@ -39,8 +40,8 @@ class MemWalConfig:
         server_url: Server URL (default: http://localhost:8000). An explicit
             non-default value always wins over ``env``.
         namespace: Default namespace for memory isolation (default: "default").
-        env: Optional relayer preset — one of ``"prod"``, ``"staging"``,
-            ``"local"``. Resolves ``server_url`` to the matching
+        env: Optional relayer preset — one of ``"prod"``, ``"dev"``,
+            ``"staging"``, ``"local"``. Resolves ``server_url`` to the matching
             hosted relayer when ``server_url`` is left at its default.
             Precedence: explicit ``server_url`` > ``env`` > default.
     """
@@ -242,12 +243,13 @@ class RememberManualOptions:
     """Options for remember_manual().
 
     Attributes:
-        blob_id: Walrus blob ID (user already uploaded encrypted data).
+        encrypted_data: Base64-encoded SEAL-encrypted bytes. The relayer
+            uploads them to Walrus.
         vector: Embedding vector (user already generated).
         namespace: Namespace (default: config namespace or "default").
     """
 
-    blob_id: str
+    encrypted_data: str
     vector: List[float]
     namespace: Optional[str] = None
 

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -114,6 +114,9 @@ class RecallResult:
 
     results: List[RecallMemory]
     total: int
+    # Matches omitted because download or decrypt failed. 0 also means the
+    # relayer omitted the field (older servers).
+    dropped_count: int = 0
 
 
 @dataclass
@@ -191,6 +194,7 @@ class HealthResult:
     deprecations: Optional[List[Dict[str, Any]]] = None
     build: Optional[Dict[str, Any]] = None
     mode: Optional[str] = None
+    write_ready: Optional[bool] = None
 
 
 @dataclass

--- a/packages/python-sdk-memwal/memwal/utils.py
+++ b/packages/python-sdk-memwal/memwal/utils.py
@@ -21,15 +21,33 @@ _SUI_ED25519_SCHEME_FLAG = 0
 def hex_to_bytes(hex_str: str) -> bytes:
     """Convert a hex string to bytes.
 
-    Handles optional ``0x`` prefix.
+    Handles optional ``0x`` / ``0X`` prefix. Rejects empty strings, odd
+    length, ASCII whitespace, and any non-hex character. ``bytes.fromhex``
+    would otherwise strip whitespace and decode a *different* valid key.
 
     Args:
         hex_str: Hex-encoded string, optionally prefixed with ``0x``.
 
     Returns:
         Raw bytes.
+
+    Raises:
+        TypeError: If ``hex_str`` is not a ``str``.
+        ValueError: If the input is empty, odd-length, or contains
+            non-hex characters (including whitespace).
     """
-    clean = hex_str[2:] if hex_str.startswith("0x") else hex_str
+    if not isinstance(hex_str, str):
+        raise TypeError("hex_to_bytes: expected str")
+    clean = hex_str[2:] if hex_str[:2].lower() == "0x" else hex_str
+    if len(clean) == 0:
+        raise ValueError("hex_to_bytes: empty hex string")
+    if len(clean) % 2 != 0:
+        raise ValueError(
+            f"hex_to_bytes: odd-length hex string (length={len(clean)}); "
+            "hex must have an even number of digits"
+        )
+    if any(c not in "0123456789abcdefABCDEF" for c in clean):
+        raise ValueError("hex_to_bytes: input contains non-hex characters")
     return bytes.fromhex(clean)
 
 

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.7"
+version = "0.1.8"
 description = "Python SDK for Walrus Memory — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -370,9 +370,23 @@ class TestRecall:
 
         assert len(result.results) == 2
         assert result.total == 2
+        assert result.dropped_count == 0
         assert result.results[0].text == "I love coffee"
         assert result.results[0].distance == 0.1
         assert result.results[1].blob_id == "b2"
+
+    @respx.mock
+    async def test_recall_surfaces_dropped_count(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/recall").mock(
+            return_value=httpx.Response(
+                200,
+                json={"results": [], "total": 0, "dropped_count": 3},
+            )
+        )
+        result = await memwal_client.recall("coffee")
+        assert result.results == []
+        assert result.dropped_count == 3
 
     @respx.mock
     async def test_accepts_recall_params_object(
@@ -573,6 +587,20 @@ class TestErrorHandling:
 
         with pytest.raises(MemWalError, match="500"):
             await memwal_client.recall("test")
+
+    @respx.mock
+    async def test_500_strips_localhost_sidecar_urls(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/recall").mock(
+            return_value=httpx.Response(
+                500,
+                text="Sidecar seal/encrypt request failed: error sending request for url (http://localhost:9000/seal/encrypt)",
+            )
+        )
+        with pytest.raises(MemWalError) as exc:
+            await memwal_client.recall("test")
+        assert "localhost:9000" not in str(exc.value)
+        assert "[internal]" in str(exc.value)
 
     @respx.mock
     async def test_health_non_200_raises(self, memwal_client: MemWal) -> None:

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -866,18 +866,32 @@ class TestManualAPI:
         )
 
         opts = RememberManualOptions(
-            blob_id="blob-xyz",
+            encrypted_data="dGVzdA==",
             vector=[0.1, 0.2, 0.3],
         )
         result = await memwal_client.remember_manual(opts)
 
         body = json.loads(route.calls[0].request.content)
         headers = route.calls[0].request.headers
-        assert body["blob_id"] == "blob-xyz"
+        assert body["encrypted_data"] == "dGVzdA=="
+        assert "blob_id" not in body
         assert body["vector"] == [0.1, 0.2, 0.3]
         assert "x-seal-session" not in headers
         assert "x-delegate-key" not in headers
         assert result.blob_id == "blob-xyz"
+
+    @respx.mock
+    async def test_embed(self, memwal_client: MemWal) -> None:
+        _mock_version()
+        route = respx.post(f"{_TEST_SERVER}/api/embed").mock(
+            return_value=httpx.Response(200, json={"vector": [0.1, 0.2, 0.3]})
+        )
+
+        result = await memwal_client.embed("hello")
+
+        body = json.loads(route.calls[0].request.content)
+        assert body["text"] == "hello"
+        assert result.vector == [0.1, 0.2, 0.3]
 
     @respx.mock
     async def test_recall_manual(self, memwal_client: MemWal) -> None:

--- a/packages/python-sdk-memwal/tests/test_env_presets.py
+++ b/packages/python-sdk-memwal/tests/test_env_presets.py
@@ -1,4 +1,4 @@
-"""Tests for the relayer environment presets (prod/staging/local).
+"""Tests for the relayer environment presets (prod/dev/staging/local).
 
 Pure config resolution — no network. Mirrors the precedence rule documented
 in the README: explicit non-default ``server_url`` > ``env`` > default.
@@ -18,6 +18,7 @@ ACCOUNT = "0x" + "ab" * 32
     "env,expected",
     [
         ("prod", "https://relayer.memory.walrus.xyz"),
+        ("dev", "https://relayer.dev.memwal.ai"),
         ("staging", "https://relayer-staging.memory.walrus.xyz"),
         ("local", "http://127.0.0.1:8000"),
     ],

--- a/packages/python-sdk-memwal/tests/test_signing.py
+++ b/packages/python-sdk-memwal/tests/test_signing.py
@@ -40,6 +40,31 @@ class TestHexConversion:
     def test_hex_to_bytes_no_prefix(self) -> None:
         assert hex_to_bytes("deadbeef") == bytes.fromhex("deadbeef")
 
+    def test_hex_to_bytes_strips_0X_prefix(self) -> None:
+        assert hex_to_bytes("0Xdeadbeef") == bytes.fromhex("deadbeef")
+
+    def test_hex_to_bytes_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="empty hex string"):
+            hex_to_bytes("")
+        with pytest.raises(ValueError, match="empty hex string"):
+            hex_to_bytes("0x")
+
+    def test_hex_to_bytes_rejects_odd_length(self) -> None:
+        with pytest.raises(ValueError, match="odd-length"):
+            hex_to_bytes("abc")
+
+    def test_hex_to_bytes_rejects_whitespace_and_non_hex(self) -> None:
+        with pytest.raises(ValueError, match="non-hex"):
+            hex_to_bytes("ab  cd")
+        with pytest.raises(ValueError, match="non-hex"):
+            hex_to_bytes("ab\t\tcd")
+        with pytest.raises(ValueError, match="non-hex"):
+            hex_to_bytes("zz")
+
+    def test_hex_to_bytes_rejects_non_str(self) -> None:
+        with pytest.raises(TypeError, match="expected str"):
+            hex_to_bytes(b"deadbeef")  # type: ignore[arg-type]
+
     def test_bytes_to_hex_lowercase(self) -> None:
         assert bytes_to_hex(b"\xDE\xAD") == "dead"
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @mysten-incubation/memwal
 
+## 0.1.5
+
+### Changed
+
+- `rememberManual` now sends `encryptedData` (base64 SEAL ciphertext) instead of a pre-uploaded `blobId`, matching `POST /api/remember/manual`.
+
+### Fixed
+
+- Manual recall decodes SEAL object ids with `hexToBytes` instead of an unguarded `parseInt` / `.match!` path that could coerce `NaN` to `0` or throw on empty input.
+
 ## 0.1.4
 
 ### Fixed

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.1.5
 
+### Added
+
+- `recall()` results include `dropped_count` when the relayer omitted matches that failed to download or decrypt.
+- `health()` surfaces optional `write_ready` when the relayer reports write-path sidecar liveness.
+
 ### Changed
 
 - `rememberManual` now sends `encryptedData` (base64 SEAL ciphertext) instead of a pre-uploaded `blobId`, matching `POST /api/remember/manual`.
@@ -9,6 +14,7 @@
 ### Fixed
 
 - Manual recall decodes SEAL object ids with `hexToBytes` instead of an unguarded `parseInt` / `.match!` path that could coerce `NaN` to `0` or throw on empty input.
+- HTTP error messages and remember-job error strings no longer forward `localhost` / `127.0.0.1` URLs to callers.
 
 ## 0.1.4
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -498,10 +498,9 @@ export class MemWalManual {
             try {
                 const fullId = blob.parsed.id;
 
-                // Build seal_approve PTB
-                const idBytes = Array.from(
-                    Uint8Array.from(fullId.match(/.{1,2}/g)!.map((b: string) => parseInt(b, 16)))
-                );
+                // Build seal_approve PTB. hexToBytes rejects empty, odd-length,
+                // and non-hex ids instead of coercing NaN to 0.
+                const idBytes = Array.from(hexToBytes(fullId));
                 const tx = new Transaction();
                 tx.moveCall({
                     target: `${this.config.sealPolicyPackageId ?? this.config.packageId}::account::seal_approve`,

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -63,6 +63,7 @@ import {
     normalizePrivateKey,
     normalizeServerUrl,
     sanitizeServerError,
+    redactInternalUrls,
     clockDriftErrorFromResponse,
     scoringWeightsToWire,
 } from "./utils.js";
@@ -350,7 +351,9 @@ export class MemWal {
             }
             if (status.status === "failed") {
                 throw Object.assign(
-                    new Error(`remember job failed: ${status.error ?? "unknown error"}`),
+                    new Error(
+                        `remember job failed: ${redactInternalUrls(status.error ?? "unknown error")}`,
+                    ),
                     { status: 500, jobId },
                 );
             }
@@ -529,7 +532,7 @@ export class MemWal {
                         error:
                             status.status === "not_found"
                                 ? "job not found"
-                                : status.error ?? "unknown error",
+                                : redactInternalUrls(status.error ?? "unknown error"),
                     };
                     pending.delete(jobId);
                 }

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -707,25 +707,23 @@ export class MemWal {
     // ============================================================
 
     /**
-     * Remember (manual mode) — user handles SEAL encrypt, embedding,
-     * and Walrus upload externally. Server only stores the vector ↔ blobId mapping.
+     * Remember (manual mode) — user handles SEAL encrypt and embedding.
+     * The relayer uploads the encrypted bytes to Walrus and stores the
+     * vector ↔ blobId mapping.
      *
      * Trust boundary (ENG-1696): the delegate private key is NOT transmitted on
      * this request. Manual-mode handlers on the server never invoke SEAL
      * decrypt, so the key stays client-side as the name implies.
      *
-     * @param opts.blobId - Walrus blob ID (user already uploaded encrypted data)
+     * @param opts.encryptedData - Base64-encoded SEAL-encrypted bytes
      * @param opts.vector - Embedding vector (user already generated, e.g. 1536-dim)
      * @returns RememberManualResult with id, blob_id, owner
      *
      * @example
      * ```typescript
-     * // 1. User encrypts + uploads + embeds on their own
-     * const blobId = await myWalrusUpload(sealEncryptedData)
+     * const encryptedData = Buffer.from(sealEncryptedBytes).toString("base64")
      * const vector = await myEmbeddingModel.embed(text)
-     *
-     * // 2. Register vector mapping with server
-     * const result = await memwal.rememberManual({ blobId, vector })
+     * const result = await memwal.rememberManual({ encryptedData, vector })
      * ```
      */
     async rememberManual(opts: RememberManualOptions): Promise<RememberManualResult> {
@@ -733,7 +731,7 @@ export class MemWal {
             "POST",
             "/api/remember/manual",
             {
-                blob_id: opts.blobId,
+                encrypted_data: opts.encryptedData,
                 vector: opts.vector,
                 namespace: opts.namespace ?? this.namespace,
             },
@@ -792,7 +790,12 @@ export class MemWal {
      * @returns EmbedResult with vector
      */
     async embed(text: string): Promise<EmbedResult> {
-        return this.signedRequest<EmbedResult>("POST", "/api/embed", { text });
+        return this.signedRequest<EmbedResult>(
+            "POST",
+            "/api/embed",
+            { text },
+            { includeDelegateKey: false },
+        );
     }
 
     /**

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -320,8 +320,8 @@ export interface RelayerVersionMetadata {
 
 /** Options for rememberManual() on MemWal class */
 export interface RememberManualOptions {
-    /** Walrus blob ID (user already uploaded encrypted data) */
-    blobId: string;
+    /** Base64-encoded SEAL-encrypted bytes. The relayer uploads them to Walrus. */
+    encryptedData: string;
     /** Embedding vector (user already generated) */
     vector: number[];
     /** Namespace (default: config namespace or "default") */

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -87,6 +87,8 @@ export interface RecallResult {
      * unaffected.
      */
     meta?: RecallTokenMeta;
+    /** Matches omitted because blob download or decrypt failed. Omitted when 0. */
+    dropped_count?: number;
 }
 
 /**
@@ -277,6 +279,8 @@ export interface HealthResult extends Partial<RelayerVersionMetadata> {
     version: string;
     /** "production" or "benchmark" when returned by modern relayers. */
     mode?: string;
+    /** False when writes are not ready; omit means the relayer did not report it. */
+    write_ready?: boolean;
     prompt_versions?: {
         extract: string;
         ask: string;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -285,6 +285,14 @@ export function normalizeServerUrl(url: string): string {
 // Error Sanitization (LOW-26)
 // ============================================================
 
+/** Replace loopback URLs that leak sidecar topology into client-facing errors. */
+export function redactInternalUrls(text: string): string {
+    return text.replace(
+        /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?[^ \t)\]>'"]*/gi,
+        "[internal]",
+    );
+}
+
 /**
  * LOW-26: Sanitize a raw server error body before surfacing it to callers.
  *
@@ -331,7 +339,9 @@ export function sanitizeServerError(
 
     // Strip ASCII control chars (0x00-0x1F, 0x7F) that could corrupt logs.
     // eslint-disable-next-line no-control-regex
-    const stripped = text.replace(/[\u0000-\u001F\u007F]/g, " ").trim();
+    const stripped = redactInternalUrls(
+        text.replace(/[\u0000-\u001F\u007F]/g, " "),
+    ).trim();
     const truncated =
         stripped.length > MAX ? `${stripped.slice(0, MAX)}...` : stripped;
     const message = `Walrus Memory server error (${status}): ${truncated || "<no message>"}`;

--- a/packages/sdk/test/e2e/live.e2e.mjs
+++ b/packages/sdk/test/e2e/live.e2e.mjs
@@ -322,13 +322,13 @@ test("rememberBulkAndWait stores a batch", { skip: requiresKey }, async () => {
     }
 });
 
-// `embed()` and the lightweight manual mode (`rememberManual` / `recallManual`)
-// are deliberately NOT covered here: both SDK methods target contracts this
-// relayer does not serve. `/api/embed` is absent from the protected route table
-// (services/server/src/main.rs), and `RememberManualRequest`
-// (services/server/src/types.rs) requires `encrypted_data` where the SDK sends
-// `blob_id`, so the call 422s before reaching the handler. Tests for them would
-// be guaranteed red on the first authenticated run. Tracked in WALM-371.
+test("embed returns a vector", { skip: requiresKey }, async () => {
+    const mw = client();
+    const result = await mw.embed("hello world");
+    assert.ok(Array.isArray(result.vector));
+    assert.ok(result.vector.length > 0);
+    assert.equal(typeof result.vector[0], "number");
+});
 
 test("restore reports counts for the run namespace", { skip: requiresKey }, async () => {
     // Everything this run stored is already indexed on the relayer, so restore

--- a/packages/sdk/test/hex.test.mjs
+++ b/packages/sdk/test/hex.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hexToBytes } from "../dist/utils.js";
+
+test("hexToBytes round-trips even hex", () => {
+    assert.deepEqual(hexToBytes("deadbeef"), Uint8Array.from([0xde, 0xad, 0xbe, 0xef]));
+    assert.deepEqual(hexToBytes("0xdeadbeef"), Uint8Array.from([0xde, 0xad, 0xbe, 0xef]));
+    assert.deepEqual(hexToBytes("0XDEADBEEF"), Uint8Array.from([0xde, 0xad, 0xbe, 0xef]));
+});
+
+test("hexToBytes rejects empty, odd-length, and non-hex input", () => {
+    assert.throws(() => hexToBytes(""), /empty hex string/);
+    assert.throws(() => hexToBytes("0x"), /empty hex string/);
+    assert.throws(() => hexToBytes("abc"), /odd-length/);
+    assert.throws(() => hexToBytes("zz"), /non-hex/);
+    assert.throws(() => hexToBytes("ab  cd"), /non-hex/);
+});

--- a/packages/sdk/test/recall-token-budget-e2e.test.mjs
+++ b/packages/sdk/test/recall-token-budget-e2e.test.mjs
@@ -46,6 +46,35 @@ function client() {
 
 const chars = (n) => "a".repeat(n);
 
+test("recall surfaces dropped_count when the relayer omitted matches", async () => {
+    globalThis.fetch = async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        if (path === "/version") {
+            return Response.json({
+                apiVersion: "1.0.0",
+                relayerVersion: "1.0.0",
+                minSupportedSdk: { typescript: "0.0.4" },
+            });
+        }
+        if (path === "/api/config") {
+            return Response.json({ packageId: "0x1", network: "testnet" });
+        }
+        if (path === "/api/recall" && init.method === "POST") {
+            return Response.json({ results: [], total: 0, dropped_count: 3 });
+        }
+        throw new Error(`unexpected request ${path}`);
+    };
+    const result = await client().recall({ query: "x", namespace: "default" });
+    assert.equal(result.dropped_count, 3);
+    assert.equal(result.results.length, 0);
+});
+
+test("recall omits dropped_count when the relayer does", async () => {
+    stubRecall([]);
+    const result = await client().recall({ query: "x", namespace: "default" });
+    assert.equal("dropped_count" in result, false);
+});
+
 test("recall without maxTokens: response unchanged, NO meta (backward compatible)", async () => {
     const hits = [
         { blob_id: "b1", text: chars(40), distance: 0.1 },

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -34,3 +34,12 @@ test("non-401 empty bodies still use the <no message> placeholder", () => {
     const { message } = sanitizeServerError(500, "");
     assert.equal(message, "Walrus Memory server error (500): <no message>");
 });
+
+test("localhost sidecar URLs are stripped from error text", () => {
+    const { message } = sanitizeServerError(
+        500,
+        "Sidecar seal/encrypt request failed: error sending request for url (http://localhost:9000/seal/encrypt)",
+    );
+    assert.doesNotMatch(message, /localhost:9000/);
+    assert.match(message, /\[internal\]/);
+});

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -1611,6 +1611,7 @@ async fn main() {
             post(routes::remember_bulk).layer(DefaultBodyLimit::max(2 * 1024 * 1024)),
         )
         .route("/api/analyze", post(routes::analyze))
+        .route("/api/embed", post(routes::embed))
         .route("/api/ask", post(routes::ask))
         .route("/api/restore", post(routes::restore))
         // admin/harness endpoints — namespace delete + stats.

--- a/services/server/src/observability.rs
+++ b/services/server/src/observability.rs
@@ -694,6 +694,7 @@ fn route_label(path: &str) -> String {
         "/api/recall/manual" => "/api/recall/manual".to_string(),
         "/api/analyze" => "/api/analyze".to_string(),
         "/api/ask" => "/api/ask".to_string(),
+        "/api/embed" => "/api/embed".to_string(),
         "/api/restore" => "/api/restore".to_string(),
         "/api/forget" => "/api/forget".to_string(),
         "/api/stats" => "/api/stats".to_string(),

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -149,6 +149,7 @@ fn endpoint_weight(path: &str) -> i64 {
         "/api/remember/manual" => 3, // Walrus upload only (client did embed/encrypt)
         "/api/restore" => 3,         // download + decrypt + re-embed
         "/api/ask" => 2,             // recall + LLM
+        "/api/embed" => 2,           // embedding API only
         // Owner-scoped read API — {owner} is a variable path segment, so
         // match by prefix/suffix like the observability route_label()
         // normalization does for the same three routes.
@@ -1807,6 +1808,7 @@ mod tests {
         assert_eq!(endpoint_weight("/api/remember/manual"), 3);
         assert_eq!(endpoint_weight("/api/restore"), 3);
         assert_eq!(endpoint_weight("/api/ask"), 2);
+        assert_eq!(endpoint_weight("/api/embed"), 2);
 
         // With trailing slash — must return SAME weight.
         assert_eq!(

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -1,4 +1,4 @@
-//! Admin / utility handlers: `/api/ask`, `/api/forget`, `/api/stats`,
+//! Admin / utility handlers: `/api/embed`, `/api/ask`, `/api/forget`, `/api/stats`,
 //! `/api/restore`, `GET /health`, `GET /config`.
 //!
 //! `ask` is the AI-with-memory demo (recall → inject memories into the LLM
@@ -203,6 +203,35 @@ pub async fn get_config(State(state): State<Arc<AppState>>) -> Json<ConfigRespon
         security_delete_execution_grace_secs: state.config.exec_grace_secs,
         security_delete_expiry_margin_epochs: state.config.expiry_margin_epochs,
     })
+}
+
+// ============================================================
+// /api/embed
+// ============================================================
+
+const MAX_EMBED_TEXT_BYTES: usize = 64 * 1024;
+
+/// POST /api/embed
+///
+/// Return an embedding vector for `text` without storing anything.
+/// Same model and width as remember / recall / analyze.
+pub async fn embed(
+    State(state): State<Arc<AppState>>,
+    Extension(_auth): Extension<AuthInfo>,
+    Json(body): Json<EmbedRequest>,
+) -> Result<Json<EmbedResponse>, AppError> {
+    if body.text.is_empty() {
+        return Err(AppError::BadRequest("text cannot be empty".into()));
+    }
+    if body.text.len() > MAX_EMBED_TEXT_BYTES {
+        return Err(AppError::BadRequest(format!(
+            "text exceeds maximum length of {} bytes",
+            MAX_EMBED_TEXT_BYTES
+        )));
+    }
+
+    let vector = state.embedder.embed(&body.text).await?;
+    Ok(Json(EmbedResponse { vector }))
 }
 
 // ============================================================

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -5,7 +5,7 @@
 //!   (+ the async prep tasks and the summarize-for-embedding helpers)
 //! - `recall` — `/api/recall`, `/api/recall/manual` (+ the recall-embedding cache)
 //! - `analyze` — `/api/analyze` (fact extraction → store; sync bypass in benchmark mode)
-//! - `admin` — `/api/ask`, `/api/forget`, `/api/stats`, `/api/restore`,
+//! - `admin` — `/api/embed`, `/api/ask`, `/api/forget`, `/api/stats`, `/api/restore`,
 //!   `/health`, `/version`, `/config`
 //! - `sponsor` — `/sponsor`, `/sponsor/execute` (Enoki proxy)
 //! - `accounts` — `/api/accounts/{owner}/exists` (public MemWalAccount
@@ -39,7 +39,7 @@ mod sponsor;
 // Re-export every handler so `main.rs` keeps using `routes::<name>`
 // without having to know which submodule each handler lives in.
 pub use accounts::account_exists;
-pub use admin::{ask, forget, get_config, health, restore, stats, version};
+pub use admin::{ask, embed, forget, get_config, health, restore, stats, version};
 pub use analyze::analyze;
 pub use memory_read::{list_owner_agents, list_owner_memories, list_owner_namespaces};
 pub use owner_token::{issue_token, token_probe};

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1608,6 +1608,18 @@ pub struct RememberManualResponse {
     pub namespace: String,
 }
 
+/// POST /api/embed
+/// Embed text into a vector without storing anything.
+#[derive(Debug, Deserialize)]
+pub struct EmbedRequest {
+    pub text: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmbedResponse {
+    pub vector: Vec<f32>,
+}
+
 /// POST /api/recall/manual
 /// User provides pre-computed query vector.
 /// Server returns matching blobIds + distances (no download/decrypt).


### PR DESCRIPTION
Linear: [WALM-404](https://linear.app/mysten-labs/issue/WALM-404/align-sdk-remember-manual-embed-hex-and-envdev-contracts)
Fixes https://github.com/MystenLabs/MemWal/issues/608
Fixes https://github.com/MystenLabs/MemWal/issues/618
Fixes https://github.com/MystenLabs/MemWal/issues/726
Fixes https://github.com/MystenLabs/MemWal/issues/727
Fixes https://github.com/MystenLabs/MemWal/issues/728

## What this does

- `MemWal.rememberManual` / `remember_manual` send `encrypted_data` (base64 SEAL ciphertext) instead of a pre-uploaded `blob_id`.
- Relayer registers signed `POST /api/embed` so SDK `embed()` is no longer a 100% 404.
- Manual recall decodes SEAL ids with `hexToBytes`.
- Python `hex_to_bytes` rejects empty, odd-length, whitespace, and non-hex input.
- Adds the documented `env="dev"` preset (`https://relayer.dev.memwal.ai`).

## Package

- `@mysten-incubation/memwal` `0.1.4` → `0.1.5`
- `memwal` (Python) `0.1.7` → `0.1.8`