### PR TITLE
fix(mcp): fail non-TTY login and single-flight memwal_login

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Do not abort the SSE handshake socket on HTTP 429, 401, or a bad content-type (that crash path fired on Windows).
 - Report MCP session occupancy caps as concurrent, not a 30-second cooldown.
+- Exit with code 1 when `login` is run without a TTY, instead of booting the auth-required stub and reporting success.
+- Concurrent `memwal_login` calls reuse the in-flight listener and URL instead of starting a second flow that can hang later remember/recall.
 
 ## 0.0.10
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Report MCP session occupancy caps as concurrent, not a 30-second cooldown.
 - Exit with code 1 when `login` is run without a TTY, instead of booting the auth-required stub and reporting success.
 - Concurrent `memwal_login` calls reuse the in-flight listener and URL instead of starting a second flow that can hang later remember/recall.
+- Serialize outbound MCP POSTs and reconnect when the SSE handle is gone, so a burst of `memwal_recall` calls cannot poison the bridge until restart.
+- Login timeout now warns that an on-chain delegate key may already exist if the browser approved after the local listener expired.
 
 ## 0.0.10
 

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -23,7 +23,7 @@
  */
 import { loadCreds, type MemWalCredentials } from "./auth.js";
 import { log } from "./logger.js";
-import { loginFlow } from "./login.js";
+import { startOrReuseLoginFlow } from "./login.js";
 import { AUTH_REQUIRED_INSTRUCTIONS } from "./instructions.js";
 import { MEMWAL_MCP_VERSION } from "./version.js";
 
@@ -255,42 +255,33 @@ async function handleLoginToolCall(
     config: AuthRequiredConfig,
     _progressToken: unknown,
 ): Promise<{ text: string; isError: boolean }> {
-    let connectUrl: string | null = null;
-
-    // Promise that resolves with the URL as soon as the listener is bound.
-    const urlReady = new Promise<string>((resolve) => {
-        // Fire loginFlow but DO NOT await — it runs in the background.
-        // openBrowser: false because (a) child-process spawning a browser is
-        // unreliable across MCP clients, and (b) macOS `open <url>` often
-        // foregrounds an existing memory.walrus.xyz tab instead of navigating to
-        // the full /connect/mcp?... URL — so user lands on the homepage,
-        // not the consent screen. The agent surfaces the clickable URL
-        // from the tool result instead.
-        loginFlow({
+    // Fire login but DO NOT await the wallet callback — it runs in the
+    // background. openBrowser: false because (a) child-process spawning a
+    // browser is unreliable across MCP clients, and (b) macOS `open <url>`
+    // often foregrounds an existing memory.walrus.xyz tab instead of
+    // navigating to the full /connect/mcp?... URL. The agent surfaces the
+    // clickable URL from the tool result instead.
+    //
+    // Concurrent memwal_login calls join this in-flight flow instead of
+    // opening a second listener (that race hung later recall/remember).
+    const session = startOrReuseLoginFlow(
+        {
             relayerUrl: config.relayerUrl,
             webUrl: config.webUrl,
             label: config.label,
             timeoutMs: LOGIN_BG_TIMEOUT_MS,
             openBrowser: false,
             onUrl: (url) => {
-                connectUrl = url;
-                resolve(url);
-                // Also push to log notification — clients that surface these
-                // (Cursor) get a second visible copy of the URL.
                 sendLogMessage("info", `Walrus Memory MCP login URL: ${url}`);
             },
-        })
-            .then((creds) => {
-                log.info("memwal_login.bg.success", {
-                    accountId: creds.accountId,
-                    delegateAddress: creds.delegateAddress,
-                });
-            })
-            .catch((err) => {
-                const msg = err instanceof Error ? err.message : String(err);
-                log.warn("memwal_login.bg.failed", { msg });
+        },
+        (creds) => {
+            log.info("memwal_login.bg.success", {
+                accountId: creds.accountId,
+                delegateAddress: creds.delegateAddress,
             });
-    });
+        },
+    );
 
     // Race the URL-ready against a short timeout. The listener bind is
     // synchronous-ish (single port allocation); 5s is a hard cap for a
@@ -304,7 +295,7 @@ async function handleLoginToolCall(
 
     let url: string;
     try {
-        url = await Promise.race([urlReady, timeoutPromise]);
+        url = await Promise.race([session.url, timeoutPromise]);
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.error("memwal_login.tool.url_not_ready", { msg });

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -19,7 +19,7 @@ import { clearCreds, credsPath } from "./auth.js";
 import { TOOL_DEFINITIONS } from "./auth-required.js";
 import { ensureCompatibleRelayer, resolveConnectTimeoutMs } from "./compatibility.js";
 import { PROACTIVE_INSTRUCTIONS } from "./instructions.js";
-import { loginFlow } from "./login.js";
+import { startOrReuseLoginFlow } from "./login.js";
 import { log, note } from "./logger.js";
 import { MEMWAL_MCP_VERSION } from "./version.js";
 
@@ -559,28 +559,22 @@ async function handleLocalLogin(
     config: BridgeConfig,
     onCredentials: (creds: MemWalCredentials) => Promise<void>,
 ): Promise<{ text: string; isError: boolean }> {
-    const urlReady = new Promise<string>((resolve) => {
-        loginFlow({
+    const session = startOrReuseLoginFlow(
+        {
             relayerUrl: config.relayerUrl,
             webUrl: config.webUrl,
             label: config.label,
             timeoutMs: LOGIN_BG_TIMEOUT_MS,
             openBrowser: false,
-            onUrl: (url) => resolve(url),
-        })
-            .then(async (creds) => {
-                await onCredentials(creds);
-                log.info("memwal_login.bridge.success", {
-                    accountId: creds.accountId,
-                    delegateAddress: creds.delegateAddress,
-                });
-            })
-            .catch((err) => {
-                log.warn("memwal_login.bridge.failed", {
-                    msg: err instanceof Error ? err.message : String(err),
-                });
+        },
+        async (creds) => {
+            await onCredentials(creds);
+            log.info("memwal_login.bridge.success", {
+                accountId: creds.accountId,
+                delegateAddress: creds.delegateAddress,
             });
-    });
+        },
+    );
 
     const timeoutPromise = new Promise<string>((_, reject) =>
         setTimeout(
@@ -591,7 +585,7 @@ async function handleLocalLogin(
 
     let url: string;
     try {
-        url = await Promise.race([urlReady, timeoutPromise]);
+        url = await Promise.race([session.url, timeoutPromise]);
     } catch (err) {
         return {
             isError: true,

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -702,6 +702,29 @@ export async function runBridge(
     let stdinClosed = false;
     let reconnectAttempt = 0;
     let reconnectPromise: Promise<void> | null = null;
+    let firstConnectDone = false;
+    /** Bumped when the live SSE session is aborted or replaced so queued
+     * POSTs captured against a stale URL are skipped (reconnect replays). */
+    let sessionEpoch = 0;
+    /** One in-flight POST per SSE session — overlapping POSTs drop the stream. */
+    let postChain: Promise<unknown> = Promise.resolve();
+    function enqueuePost<T>(fn: () => Promise<T>): Promise<T> {
+        const run = postChain.then(fn, fn);
+        postChain = run.then(
+            () => undefined,
+            () => undefined,
+        );
+        return run;
+    }
+    function postIfCurrent(
+        epoch: number,
+        postUrl: string,
+        msg: RpcMessage,
+        postCreds: MemWalCredentials,
+    ): Promise<number> {
+        if (epoch !== sessionEpoch) return Promise.resolve(0);
+        return postMessage(postUrl, msg, postCreds);
+    }
     let credentialGeneration = 0;
     let activeCredentialGeneration = 0;
 
@@ -828,6 +851,7 @@ export async function runBridge(
         if (reconnectPromise) return reconnectPromise;
 
         reconnectPromise = (async () => {
+            sessionEpoch += 1;
             try {
                 sse?.abort();
             } catch {
@@ -880,7 +904,9 @@ export async function runBridge(
                         continue;
                     }
 
+                    sessionEpoch += 1;
                     sse = candidate;
+                    firstConnectDone = true;
                     activeCredentialGeneration = openingGeneration;
                     reconnectAttempt = 0;
                     log.info("bridge.reconnected", {
@@ -914,7 +940,11 @@ export async function runBridge(
                                 suppressUpstreamReplies.delete(msg.id);
                                 expectSuppressedReply(msg.id);
                             }
-                            const status = await postMessage(sse.postUrl, msg, openingCreds);
+                            const epoch = sessionEpoch;
+                            const postUrl = sse.postUrl;
+                            const status = await enqueuePost(() =>
+                                postIfCurrent(epoch, postUrl, msg, openingCreds),
+                            );
                             log.info("bridge.replayed", { id, status });
                         } catch (err) {
                             log.error("bridge.replay_failed", {
@@ -1246,12 +1276,18 @@ export async function runBridge(
                 // arrived before it (posting directly here would let it overtake
                 // a still-queued buffered item). The flush (or the next connect)
                 // forwards it in order. Dropping it would strand the request.
-                if (sse === null || flushing) {
+                if (flushing || (sse === null && !firstConnectDone)) {
                     pendingForward.push(msg);
                     log.info("bridge.buffered_pre_connect", {
                         method: msg.method,
                         id: msg.id ?? null,
                     });
+                    return;
+                }
+                // After the first connect, do not buffer: nothing flushes
+                // pendingForward once connectInBackground has returned.
+                if (sse === null) {
+                    await reconnect("sse-missing");
                     return;
                 }
 
@@ -1262,7 +1298,16 @@ export async function runBridge(
                 if (activeCredentialGeneration !== credentialGeneration) {
                     await reconnect("post-credential-generation-mismatch", true);
                 }
-                const status = await postMessage(sse.postUrl, msg, creds);
+                if (!sse) {
+                    await reconnect("sse-missing");
+                    return;
+                }
+                const epoch = sessionEpoch;
+                const postUrl = sse.postUrl;
+                const postCreds = creds;
+                const status = await enqueuePost(() =>
+                    postIfCurrent(epoch, postUrl, msg, postCreds),
+                );
                 if (status === 404) {
                     log.warn("bridge.session_stale", { sessionUrl: sse.postUrl });
                     // reconnect() itself replays in-flight against the fresh
@@ -1296,7 +1341,12 @@ export async function runBridge(
                 if (!sse) break; // lost the session; reconnect replays inFlight
                 const msg = pendingForward.shift()!;
                 try {
-                    const status = await postMessage(sse.postUrl, msg, creds);
+                    const epoch = sessionEpoch;
+                    const postUrl = sse.postUrl;
+                    const postCreds = creds;
+                    const status = await enqueuePost(() =>
+                        postIfCurrent(epoch, postUrl, msg, postCreds),
+                    );
                     if (status === 404) {
                         // Stale session right after connect. EVERY id-bearing
                         // request is in `inFlight`, and ANY reconnect — this
@@ -1495,7 +1545,9 @@ export async function runBridge(
                     candidate.abort();
                     continue;
                 }
+                sessionEpoch += 1;
                 sse = candidate;
+                firstConnectDone = true;
                 note(`Connected. Bridging stdio MCP ↔ ${creds.relayerUrl}`);
                 log.info("bridge.connected", { relayer: creds.relayerUrl });
                 signalFirstConnect();

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -139,6 +139,17 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     // applyDefaultNamespace in bridge.ts).
     const namespace = args.namespace ?? process.env.MEMWAL_NAMESPACE;
 
+    // Explicit `login` is a human command. When stdin is not a TTY the
+    // process was spawned by a script or MCP client — booting the
+    // auth-required stub here would exit 0 without ever opening a browser.
+    if (args.forceLogin && !process.stdin.isTTY) {
+        log.error("login.requires_tty", { credsPath: credsPath() });
+        note("error: `login` requires an interactive terminal (stdin is not a TTY).");
+        note("       Run it in a terminal, or call `memwal_login` from an MCP client.");
+        process.exitCode = 1;
+        return;
+    }
+
     // `login` forces a fresh sign-in by IGNORING what is on disk, not by
     // deleting it. Deleting up front meant an abandoned or failed login left
     // the user with no credentials at all and nothing to recover from — and it

--- a/packages/mcp/src/login.ts
+++ b/packages/mcp/src/login.ts
@@ -452,3 +452,74 @@ export async function loginFlow(opts: LoginOptions = {}): Promise<MemWalCredenti
     if (!creds) throw new Error("Login flow completed without credentials");
     return creds;
 }
+
+export interface InflightLogin {
+    url: Promise<string>;
+    result: Promise<MemWalCredentials>;
+}
+
+let inflightLogin: InflightLogin | null = null;
+
+/**
+ * Start a login flow, or join one already in progress in this process.
+ * Concurrent `memwal_login` calls share the same listener and URL so a
+ * second call cannot race the first and leave the bridge on a stale session.
+ */
+export function startOrReuseLoginFlow(
+    opts: LoginOptions = {},
+    onSuccess?: (creds: MemWalCredentials) => Promise<void> | void,
+): InflightLogin {
+    if (inflightLogin) return inflightLogin;
+
+    let resolveUrl!: (url: string) => void;
+    let rejectUrl!: (err: unknown) => void;
+    const url = new Promise<string>((resolve, reject) => {
+        resolveUrl = resolve;
+        rejectUrl = reject;
+    });
+
+    const userOnUrl = opts.onUrl;
+    const result = loginFlow({
+        ...opts,
+        onUrl: (connectUrl) => {
+            resolveUrl(connectUrl);
+            try {
+                userOnUrl?.(connectUrl);
+            } catch {
+                /* caller errors don't break the flow */
+            }
+        },
+    });
+
+    result.catch((err) => {
+        rejectUrl(err);
+    });
+
+    if (onSuccess) {
+        result
+            .then(async (creds) => {
+                await onSuccess(creds);
+            })
+            .catch((err) => {
+                log.warn("login.inflight.failed", {
+                    msg: err instanceof Error ? err.message : String(err),
+                });
+            });
+    }
+
+    const session: InflightLogin = { url, result };
+    inflightLogin = session;
+    void result
+        .finally(() => {
+            if (inflightLogin === session) inflightLogin = null;
+        })
+        .catch(() => {
+            /* the original `result` rejection is observed by callers */
+        });
+    return session;
+}
+
+/** Drop the in-flight handle. Does not abort a listener already bound. */
+export function resetInflightLogin(): void {
+    inflightLogin = null;
+}

--- a/packages/mcp/src/login.ts
+++ b/packages/mcp/src/login.ts
@@ -261,7 +261,9 @@ export async function loginFlow(opts: LoginOptions = {}): Promise<MemWalCredenti
     const done = new Promise<void>((resolve) => {
         const timer = setTimeout(() => {
             if (!creds) {
-                error = new Error(`Login timed out after ${cfg.timeoutMs}ms`);
+                error = new Error(
+                    `Login timed out after ${cfg.timeoutMs}ms. If you already approved the wallet transaction, a delegate key may exist on-chain without local credentials. Remove unused keys from the dashboard, then run login again.`,
+                );
                 server.close();
                 resolve();
             }

--- a/packages/mcp/test/concurrent-recall.test.mjs
+++ b/packages/mcp/test/concurrent-recall.test.mjs
@@ -1,0 +1,191 @@
+/**
+ * Concurrent tools/call must not overlap POSTs on the SSE session.
+ * Overlapping POSTs drop the session; afterwards even health hung until restart.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const BEARER = "a".repeat(64);
+const ACCOUNT = "0x" + "3".repeat(64);
+
+function startMockRelayer() {
+    let sseRes = null;
+    let inFlightPosts = 0;
+    let overlap = 0;
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    apiVersion: "1.0.0",
+                    relayerVersion: "1.0.0",
+                    minSupportedSdk: { mcp: "0.0.1" },
+                }),
+            );
+            return;
+        }
+        if (req.method === "GET" && url.pathname === "/api/mcp/sse") {
+            res.writeHead(200, {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+            });
+            res.write("event: endpoint\ndata: /api/mcp/messages?sessionId=test\n\n");
+            sseRes = res;
+            return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/mcp/messages") {
+            inFlightPosts += 1;
+            if (inFlightPosts > 1) overlap += 1;
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                setTimeout(() => {
+                    inFlightPosts -= 1;
+                    res.writeHead(202);
+                    res.end();
+                    let msg;
+                    try {
+                        msg = JSON.parse(body);
+                    } catch {
+                        return;
+                    }
+                    if (msg.method === "tools/call") {
+                        sseRes?.write(
+                            `event: message\ndata: ${JSON.stringify({
+                                jsonrpc: "2.0",
+                                id: msg.id,
+                                result: {
+                                    content: [{ type: "text", text: `OK:${msg.params?.name}` }],
+                                    isError: false,
+                                },
+                            })}\n\n`,
+                        );
+                    }
+                }, 40);
+            });
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+    return new Promise((resolveListen) => {
+        server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address();
+            resolveListen({
+                server,
+                base: `http://127.0.0.1:${port}`,
+                overlap: () => overlap,
+            });
+        });
+    });
+}
+
+test("concurrent tool calls do not overlap POSTs on the SSE session", async (t) => {
+    const { server, base, overlap } = await startMockRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-test-"));
+    mkdirSync(join(home, ".memwal"));
+    writeFileSync(
+        join(home, ".memwal", "credentials.json"),
+        JSON.stringify({
+            delegatePrivateKey: BEARER,
+            delegatePublicKeyHex: "b".repeat(64),
+            delegateAddress: "0x" + "1".repeat(64),
+            walletAddress: "0x" + "2".repeat(64),
+            accountId: ACCOUNT,
+            packageId: "0x" + "4".repeat(64),
+            relayerUrl: base,
+            label: "test",
+            createdAt: new Date(0).toISOString(),
+            version: 1,
+        }),
+    );
+
+    const child = spawn(process.execPath, [BIN, "--relayer", base, "--web-url", base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => {
+                listeners.delete(l);
+                rej(new Error("timed out waiting for message"));
+            }, ms);
+            const l = (m) => {
+                if (pred(m)) {
+                    clearTimeout(timer);
+                    listeners.delete(l);
+                    res(m);
+                }
+            };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => {
+        child.kill("SIGKILL");
+        server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "0" } } });
+    await waitFor((m) => m.id === 1 && m.result);
+
+    send({ jsonrpc: "2.0", id: 2, method: "notifications/initialized" });
+    await waitFor((m) => m.method === "notifications/tools/list_changed");
+
+    for (const id of [10, 11, 12, 13]) {
+        send({
+            jsonrpc: "2.0",
+            id,
+            method: "tools/call",
+            params: { name: "memwal_recall", arguments: { query: `q${id}` } },
+        });
+    }
+
+    const replies = [];
+    for (const id of [10, 11, 12, 13]) {
+        replies.push(await waitFor((m) => m.id === id && (m.result || m.error)));
+    }
+    assert.equal(overlap(), 0);
+    for (const reply of replies) {
+        assert.equal(reply.error, undefined);
+        const text = reply.result?.content?.[0]?.text ?? "";
+        assert.match(text, /^OK:/);
+        assert.doesNotMatch(text, /did not answer this call/);
+    }
+});

--- a/packages/mcp/test/login-non-tty.test.mjs
+++ b/packages/mcp/test/login-non-tty.test.mjs
@@ -1,0 +1,42 @@
+/**
+ * `memwal-mcp login` with no TTY must fail loudly instead of booting the
+ * auth-required stub and exiting 0.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+
+test("`login` without a TTY exits 1 and does not start the auth-required stub", async () => {
+    const home = mkdtempSync(join(tmpdir(), "memwal-test-"));
+    const child = spawn(process.execPath, [BIN, "login"], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stderr = [];
+    child.stderr.on("data", (d) => stderr.push(d.toString()));
+
+    const code = await new Promise((resolveExit, reject) => {
+        const timer = setTimeout(() => {
+            child.kill("SIGKILL");
+            reject(new Error("login without a TTY hung"));
+        }, 8000);
+        child.on("exit", (c) => {
+            clearTimeout(timer);
+            resolveExit(c);
+        });
+    });
+
+    rmSync(home, { recursive: true, force: true });
+    assert.equal(code, 1);
+    const err = stderr.join("");
+    assert.match(err, /not a TTY/);
+    assert.doesNotMatch(err, /serving_auth_required/);
+});

--- a/packages/mcp/test/login-singleflight.test.mjs
+++ b/packages/mcp/test/login-singleflight.test.mjs
@@ -1,0 +1,42 @@
+/**
+ * Concurrent startOrReuseLoginFlow calls must share one listener/URL.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resetInflightLogin, startOrReuseLoginFlow } from "../dist/login.js";
+
+test("concurrent login flows reuse one URL", async (t) => {
+    const home = mkdtempSync(join(tmpdir(), "memwal-test-"));
+    const prevHome = process.env.HOME;
+    const prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    resetInflightLogin();
+
+    t.after(() => {
+        if (prevHome === undefined) delete process.env.HOME;
+        else process.env.HOME = prevHome;
+        if (prevProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = prevProfile;
+        resetInflightLogin();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    const opts = {
+        openBrowser: false,
+        timeoutMs: 1500,
+        webUrl: "http://127.0.0.1:9",
+        relayerUrl: "http://127.0.0.1:9",
+        label: "singleflight-test",
+    };
+    const first = startOrReuseLoginFlow(opts);
+    const second = startOrReuseLoginFlow(opts);
+    const [urlA, urlB] = await Promise.all([first.url, second.url]);
+    assert.equal(urlA, urlB);
+    assert.match(urlA, /\/connect\/mcp\?/);
+    await Promise.allSettled([first.result, second.result]);
+});


### PR DESCRIPTION
Linear: [WALM-405](https://linear.app/mysten-labs/issue/WALM-405/fix-mcp-login-non-tty-exit-and-concurrent-memwal-login-race)
Fixes https://github.com/MystenLabs/MemWal/issues/629
Fixes https://github.com/MystenLabs/MemWal/issues/714

Stacked on #735 so `@mysten-incubation/memwal-mcp` stays at `0.0.11`.

## What this does

- `memwal-mcp login` with no TTY exits 1 instead of booting the auth-required stub and reporting success. Implicit MCP spawn without credentials still uses the stub.
- Concurrent `memwal_login` calls reuse the in-flight listener and URL so a second flow cannot hang later remember/recall.