### PR TITLE
fix(relayer): align analyze charge windows and report write_ready

### DIFF
--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -80,7 +80,7 @@ These routes require no authentication.
 
 ### `GET /health`
 
-Service liveness check. `status` is `"ok"` when the relayer process is up. `write_ready` is `true` when the encryption sidecar process answered its own `/health` (cached a few seconds). A write outage can still return HTTP 200 with `write_ready: false`; `write_ready: true` is sidecar liveness, not a guarantee that remember/analyze will succeed.
+Service liveness check. `status` is `"ok"` when the relayer process is up. `write_ready` is `true` when the encryption sidecar process answered its own `/health` (cached a few seconds). A write outage can still return HTTP 200 with `write_ready: false`. `write_ready: true` is sidecar liveness, not a guarantee that remember or analyze succeed.
 
 **Response:**
 

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -80,7 +80,7 @@ These routes require no authentication.
 
 ### `GET /health`
 
-Service health check.
+Service liveness check. `status` is `"ok"` when the relayer process is up. `write_ready` is `true` when the encryption sidecar process answered its own `/health` (cached a few seconds). A write outage can still return HTTP 200 with `write_ready: false`; `write_ready: true` is sidecar liveness, not a guarantee that remember/analyze will succeed.
 
 **Response:**
 
@@ -106,7 +106,8 @@ Service health check.
   "prompt_versions": {
     "extract": "extract.v1",
     "ask": "ask.v1"
-  }
+  },
+  "write_ready": true
 }
 ```
 

--- a/services/server/scripts/mcp/tools/health.ts
+++ b/services/server/scripts/mcp/tools/health.ts
@@ -23,11 +23,18 @@ export function registerHealthTool(
         },
         wrapTool<Record<string, never>>(async () => {
             const result = await session.memwal.health();
+            const extra = result as { write_ready?: boolean };
+            const writeNote =
+                extra.write_ready === false
+                    ? " write_ready=false (relayer is up; encryption sidecar did not answer health)"
+                    : extra.write_ready === true
+                      ? " write_ready=true"
+                      : "";
             return {
                 content: [
                     {
                         type: "text",
-                        text: `Walrus Memory is reachable. status=${result.status} version=${result.version}`,
+                        text: `Walrus Memory is reachable. status=${result.status} version=${result.version}${writeNote}`,
                     },
                 ],
             };

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -83,12 +83,20 @@ export function registerRecallTool(
         },
         wrapTool<{ query: string; limit: number; namespace?: string }>(async ({ query, limit, namespace }) => {
             const result = await session.memwal.recall(query, limit, namespace);
+            const dropped =
+                typeof (result as { dropped_count?: number }).dropped_count === "number"
+                    ? (result as { dropped_count: number }).dropped_count
+                    : 0;
             if (result.results.length === 0) {
+                const empty =
+                    dropped > 0
+                        ? `No matching memories could be returned (${dropped} matched but failed to download or decrypt). This is not an empty namespace.`
+                        : "No matching memories found.";
                 return {
                     content: [
                         {
                             type: "text",
-                            text: "No matching memories found.",
+                            text: empty,
                         },
                     ],
                 };
@@ -104,6 +112,11 @@ export function registerRecallTool(
             if (collapsed > 0) {
                 lines.push(
                     `\n(${collapsed} duplicate ${collapsed === 1 ? "copy" : "copies"} of the above collapsed; the same fact is stored more than once.)`
+                );
+            }
+            if (dropped > 0) {
+                lines.push(
+                    `\n(${dropped} additional matches could not be decrypted and were omitted.)`,
                 );
             }
             return {

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -83,10 +83,8 @@ export function registerRecallTool(
         },
         wrapTool<{ query: string; limit: number; namespace?: string }>(async ({ query, limit, namespace }) => {
             const result = await session.memwal.recall(query, limit, namespace);
-            const dropped =
-                typeof (result as { dropped_count?: number }).dropped_count === "number"
-                    ? (result as { dropped_count: number }).dropped_count
-                    : 0;
+            const droppedRaw = (result as { dropped_count?: unknown }).dropped_count;
+            const dropped = typeof droppedRaw === "number" ? droppedRaw : 0;
             if (result.results.length === 0) {
                 const empty =
                     dropped > 0

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -118,6 +118,13 @@ impl RateLimitConfig {
     }
 }
 
+/// Sliding-window lower bounds shared by the live limiter and post-hoc
+/// `charge_explicit_weight`. Passing `now` as `window_start` would prune
+/// every in-window Redis member before inserting the extra charge.
+fn sliding_window_starts(now: f64) -> (f64, f64, f64) {
+    (now - 60_000.0, now - 60_000.0, now - 3_600_000.0)
+}
+
 // ============================================================
 // Cost Weights — per endpoint
 // ============================================================
@@ -447,9 +454,7 @@ pub async fn rate_limit_middleware(
     let burst_key = format!("rate:{}", auth.owner);
     let hourly_key = format!("rate:hr:{}", auth.owner);
 
-    let dk_window_start = now - 60_000.0; // 1-min window (ms)
-    let burst_window_start = now - 60_000.0; // 1-min window (ms)
-    let hourly_window_start = now - 3_600_000.0; // 1-hr  window (ms)
+    let (dk_window_start, burst_window_start, hourly_window_start) = sliding_window_starts(now);
 
     // --- Atomic check-and-record via Lua script for all 3 layers ---
     // Each layer is checked+recorded atomically. If Redis is unavailable,
@@ -1077,28 +1082,45 @@ pub async fn charge_explicit_weight(
 
     let mut redis = state.redis.clone();
     let now = chrono::Utc::now().timestamp_millis() as f64;
+    let (dk_window_start, burst_window_start, hourly_window_start) = sliding_window_starts(now);
 
     let dk_key = format!("rate:dk:{}", auth.public_key);
     let burst_key = format!("rate:{}", auth.owner);
     let hr_key = format!("rate:hr:{}", auth.owner);
 
-    // Use the same atomic Lua script for explicit weight charges
-    // (called from /api/analyze after fact count is known).
-    // Ignore WindowCheckResult here — this is a post-hoc charge after
-    // the expensive work is done; we prefer not to block the response.
-    let _ = check_and_record_window(&mut redis, &dk_key, now, now, i64::MAX, weight, 120).await;
+    // Same sliding windows as the live limiter so this post-hoc charge
+    // cannot prune in-window history. Limit is i64::MAX — we never deny
+    // after the work is already done.
     let _ = check_and_record_window(
         &mut redis,
-        &burst_key,
+        &dk_key,
+        dk_window_start,
         now,
-        now + 0.1,
         i64::MAX,
         weight,
         120,
     )
     .await;
-    let _ =
-        check_and_record_window(&mut redis, &hr_key, now, now + 0.2, i64::MAX, weight, 3700).await;
+    let _ = check_and_record_window(
+        &mut redis,
+        &burst_key,
+        burst_window_start,
+        now,
+        i64::MAX,
+        weight,
+        120,
+    )
+    .await;
+    let _ = check_and_record_window(
+        &mut redis,
+        &hr_key,
+        hourly_window_start,
+        now,
+        i64::MAX,
+        weight,
+        3700,
+    )
+    .await;
 
     Ok(())
 }
@@ -1831,6 +1853,16 @@ mod tests {
     fn test_endpoint_weight_no_regression() {
         // Double trailing slash should also normalize
         assert_eq!(endpoint_weight("/api/analyze//"), 5);
+    }
+
+    #[test]
+    fn charge_windows_match_live_limiter_not_now() {
+        let now = 1_700_000_000_000.0;
+        let (dk, burst, hourly) = sliding_window_starts(now);
+        assert_eq!(dk, now - 60_000.0);
+        assert_eq!(burst, now - 60_000.0);
+        assert_eq!(hourly, now - 3_600_000.0);
+        assert!(dk < now && burst < now && hourly < now);
     }
 
     #[test]

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -146,8 +146,44 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> 
             extract: crate::services::extractor::FACT_EXTRACTION_PROMPT_VERSION.to_string(),
             ask: ASK_SYSTEM_PROMPT_VERSION.to_string(),
         },
+        write_ready: sidecar_write_ready(&state).await,
     })
 }
+
+async fn sidecar_write_ready(state: &std::sync::Arc<AppState>) -> bool {
+    // Reuse a short TTL so unsigned /health probes do not fan out to the
+    // sidecar on every load-balancer tick.
+    {
+        let cache = WRITE_READY_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some((at, ready)) = *cache {
+            if at.elapsed() < std::time::Duration::from_secs(2) {
+                return ready;
+            }
+        }
+    }
+
+    let url = format!("{}/health", state.config.sidecar_url.trim_end_matches('/'));
+    let ready = match state
+        .http_client
+        .get(&url)
+        .timeout(std::time::Duration::from_millis(300))
+        .send()
+        .await
+    {
+        Ok(resp) => resp.status().is_success(),
+        Err(err) => {
+            tracing::debug!(error = %err, "sidecar health probe failed");
+            false
+        }
+    };
+    if let Ok(mut cache) = WRITE_READY_CACHE.lock() {
+        *cache = Some((std::time::Instant::now(), ready));
+    }
+    ready
+}
+
+static WRITE_READY_CACHE: std::sync::Mutex<Option<(std::time::Instant, bool)>> =
+    std::sync::Mutex::new(None);
 
 /// GET /version
 pub async fn version() -> Json<crate::compatibility::VersionResponse> {

--- a/services/server/src/storage/seal.rs
+++ b/services/server/src/storage/seal.rs
@@ -164,10 +164,8 @@ pub async fn seal_encrypt(
             started.elapsed(),
         );
         crate::observability::record_sidecar_failure("seal_encrypt", "transport_error");
-        AppError::Internal(format!(
-            "Sidecar seal/encrypt request failed: {}. Is the sidecar running?",
-            e
-        ))
+        tracing::error!(error = %e, "sidecar seal/encrypt transport failed");
+        AppError::UpstreamUnavailable("Memory encryption backend is unavailable".into())
     })?;
     let status_label = resp.status().as_u16().to_string();
     crate::observability::observe_external(
@@ -255,10 +253,8 @@ pub async fn seal_decrypt(
             started.elapsed(),
         );
         crate::observability::record_sidecar_failure("seal_decrypt", "transport_error");
-        AppError::Internal(format!(
-            "Sidecar seal/decrypt request failed: {}. Is the sidecar running?",
-            e
-        ))
+        tracing::error!(error = %e, "sidecar seal/decrypt transport failed");
+        AppError::UpstreamUnavailable("Memory encryption backend is unavailable".into())
     })?;
     let status_label = resp.status().as_u16().to_string();
     crate::observability::observe_external(
@@ -404,10 +400,8 @@ pub async fn seal_decrypt_batch(
             started.elapsed(),
         );
         crate::observability::record_sidecar_failure("seal_decrypt_batch", "transport_error");
-        AppError::Internal(format!(
-            "Sidecar seal/decrypt-batch request failed: {}. Is the sidecar running?",
-            e
-        ))
+        tracing::error!(error = %e, "sidecar seal/decrypt-batch transport failed");
+        AppError::UpstreamUnavailable("Memory encryption backend is unavailable".into())
     })?;
     let status_label = resp.status().as_u16().to_string();
     crate::observability::observe_external(

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1754,6 +1754,10 @@ pub struct HealthResponse {
     /// at from git history. Both fields are always populated — there is
     /// no "version unknown" state for a running server.
     pub prompt_versions: PromptVersions,
+    /// Whether the encryption sidecar process answered its own `/health`.
+    /// This is sidecar liveness, not a guarantee that remember/analyze will
+    /// succeed. `status` stays `"ok"` while the relayer process is up.
+    pub write_ready: bool,
 }
 
 /// prompt version constants surfaced on `/health`. See the
@@ -3010,10 +3014,12 @@ mod tests {
                 extract: "extract.v1".to_string(),
                 ask: "ask.v1".to_string(),
             },
+            write_ready: true,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["prompt_versions"]["extract"], "extract.v1");
         assert_eq!(json["prompt_versions"]["ask"], "ask.v1");
+        assert_eq!(json["write_ready"], true);
         assert_eq!(
             json["apiVersion"],
             crate::compatibility::RELAYER_API_VERSION


### PR DESCRIPTION
Linear: [WALM-406](https://linear.app/mysten-labs/issue/WALM-406/fix-analyze-rate-limit-window-prune-and-health-write-path-signal)
Fixes https://github.com/MystenLabs/MemWal/issues/609
Fixes https://github.com/MystenLabs/MemWal/issues/709

## What this does

- `charge_explicit_weight` used `window_start = now`, so Redis pruned in-window history after `/api/analyze`. Charge now shares the live limiter windows (`now-60s` / `now-60s` / `now-1h`).
- `GET /health` stays HTTP 200. New `write_ready` reports whether the encryption sidecar process answered `/health` (2s cache, 300ms probe).
- Seal transport errors map to `UpstreamUnavailable` with a generic client message. The reqwest URL is logged server-side only.
- Sidecar MCP `health` / `recall` tools surface `write_ready` and `dropped_count`.