### PR TITLE
fix(mcp): serialize SSE POSTs so concurrent recall cannot hang the bridge

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Report MCP session occupancy caps as concurrent, not a 30-second cooldown.
 - Exit with code 1 when `login` is run without a TTY, instead of booting the auth-required stub and reporting success.
 - Concurrent `memwal_login` calls reuse the in-flight listener and URL instead of starting a second flow that can hang later remember/recall.
+- Serialize outbound MCP POSTs and reconnect when the SSE handle is gone, so a burst of `memwal_recall` calls cannot poison the bridge until restart.
+- Login timeout now warns that an on-chain delegate key may already exist if the browser approved after the local listener expired.
 
 ## 0.0.10
 

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -702,6 +702,29 @@ export async function runBridge(
     let stdinClosed = false;
     let reconnectAttempt = 0;
     let reconnectPromise: Promise<void> | null = null;
+    let firstConnectDone = false;
+    /** Bumped when the live SSE session is aborted or replaced so queued
+     * POSTs captured against a stale URL are skipped (reconnect replays). */
+    let sessionEpoch = 0;
+    /** One in-flight POST per SSE session — overlapping POSTs drop the stream. */
+    let postChain: Promise<unknown> = Promise.resolve();
+    function enqueuePost<T>(fn: () => Promise<T>): Promise<T> {
+        const run = postChain.then(fn, fn);
+        postChain = run.then(
+            () => undefined,
+            () => undefined,
+        );
+        return run;
+    }
+    function postIfCurrent(
+        epoch: number,
+        postUrl: string,
+        msg: RpcMessage,
+        postCreds: MemWalCredentials,
+    ): Promise<number> {
+        if (epoch !== sessionEpoch) return Promise.resolve(0);
+        return postMessage(postUrl, msg, postCreds);
+    }
     let credentialGeneration = 0;
     let activeCredentialGeneration = 0;
 
@@ -828,6 +851,7 @@ export async function runBridge(
         if (reconnectPromise) return reconnectPromise;
 
         reconnectPromise = (async () => {
+            sessionEpoch += 1;
             try {
                 sse?.abort();
             } catch {
@@ -880,7 +904,9 @@ export async function runBridge(
                         continue;
                     }
 
+                    sessionEpoch += 1;
                     sse = candidate;
+                    firstConnectDone = true;
                     activeCredentialGeneration = openingGeneration;
                     reconnectAttempt = 0;
                     log.info("bridge.reconnected", {
@@ -914,7 +940,11 @@ export async function runBridge(
                                 suppressUpstreamReplies.delete(msg.id);
                                 expectSuppressedReply(msg.id);
                             }
-                            const status = await postMessage(sse.postUrl, msg, openingCreds);
+                            const epoch = sessionEpoch;
+                            const postUrl = sse.postUrl;
+                            const status = await enqueuePost(() =>
+                                postIfCurrent(epoch, postUrl, msg, openingCreds),
+                            );
                             log.info("bridge.replayed", { id, status });
                         } catch (err) {
                             log.error("bridge.replay_failed", {
@@ -1246,12 +1276,18 @@ export async function runBridge(
                 // arrived before it (posting directly here would let it overtake
                 // a still-queued buffered item). The flush (or the next connect)
                 // forwards it in order. Dropping it would strand the request.
-                if (sse === null || flushing) {
+                if (flushing || (sse === null && !firstConnectDone)) {
                     pendingForward.push(msg);
                     log.info("bridge.buffered_pre_connect", {
                         method: msg.method,
                         id: msg.id ?? null,
                     });
+                    return;
+                }
+                // After the first connect, do not buffer: nothing flushes
+                // pendingForward once connectInBackground has returned.
+                if (sse === null) {
+                    await reconnect("sse-missing");
                     return;
                 }
 
@@ -1262,7 +1298,16 @@ export async function runBridge(
                 if (activeCredentialGeneration !== credentialGeneration) {
                     await reconnect("post-credential-generation-mismatch", true);
                 }
-                const status = await postMessage(sse.postUrl, msg, creds);
+                if (!sse) {
+                    await reconnect("sse-missing");
+                    return;
+                }
+                const epoch = sessionEpoch;
+                const postUrl = sse.postUrl;
+                const postCreds = creds;
+                const status = await enqueuePost(() =>
+                    postIfCurrent(epoch, postUrl, msg, postCreds),
+                );
                 if (status === 404) {
                     log.warn("bridge.session_stale", { sessionUrl: sse.postUrl });
                     // reconnect() itself replays in-flight against the fresh
@@ -1296,7 +1341,12 @@ export async function runBridge(
                 if (!sse) break; // lost the session; reconnect replays inFlight
                 const msg = pendingForward.shift()!;
                 try {
-                    const status = await postMessage(sse.postUrl, msg, creds);
+                    const epoch = sessionEpoch;
+                    const postUrl = sse.postUrl;
+                    const postCreds = creds;
+                    const status = await enqueuePost(() =>
+                        postIfCurrent(epoch, postUrl, msg, postCreds),
+                    );
                     if (status === 404) {
                         // Stale session right after connect. EVERY id-bearing
                         // request is in `inFlight`, and ANY reconnect — this
@@ -1495,7 +1545,9 @@ export async function runBridge(
                     candidate.abort();
                     continue;
                 }
+                sessionEpoch += 1;
                 sse = candidate;
+                firstConnectDone = true;
                 note(`Connected. Bridging stdio MCP ↔ ${creds.relayerUrl}`);
                 log.info("bridge.connected", { relayer: creds.relayerUrl });
                 signalFirstConnect();

--- a/packages/mcp/src/login.ts
+++ b/packages/mcp/src/login.ts
@@ -261,7 +261,9 @@ export async function loginFlow(opts: LoginOptions = {}): Promise<MemWalCredenti
     const done = new Promise<void>((resolve) => {
         const timer = setTimeout(() => {
             if (!creds) {
-                error = new Error(`Login timed out after ${cfg.timeoutMs}ms`);
+                error = new Error(
+                    `Login timed out after ${cfg.timeoutMs}ms. If you already approved the wallet transaction, a delegate key may exist on-chain without local credentials. Remove unused keys from the dashboard, then run login again.`,
+                );
                 server.close();
                 resolve();
             }

--- a/packages/mcp/test/concurrent-recall.test.mjs
+++ b/packages/mcp/test/concurrent-recall.test.mjs
@@ -1,0 +1,191 @@
+/**
+ * Concurrent tools/call must not overlap POSTs on the SSE session.
+ * Overlapping POSTs drop the session; afterwards even health hung until restart.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const BEARER = "a".repeat(64);
+const ACCOUNT = "0x" + "3".repeat(64);
+
+function startMockRelayer() {
+    let sseRes = null;
+    let inFlightPosts = 0;
+    let overlap = 0;
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    apiVersion: "1.0.0",
+                    relayerVersion: "1.0.0",
+                    minSupportedSdk: { mcp: "0.0.1" },
+                }),
+            );
+            return;
+        }
+        if (req.method === "GET" && url.pathname === "/api/mcp/sse") {
+            res.writeHead(200, {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+            });
+            res.write("event: endpoint\ndata: /api/mcp/messages?sessionId=test\n\n");
+            sseRes = res;
+            return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/mcp/messages") {
+            inFlightPosts += 1;
+            if (inFlightPosts > 1) overlap += 1;
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                setTimeout(() => {
+                    inFlightPosts -= 1;
+                    res.writeHead(202);
+                    res.end();
+                    let msg;
+                    try {
+                        msg = JSON.parse(body);
+                    } catch {
+                        return;
+                    }
+                    if (msg.method === "tools/call") {
+                        sseRes?.write(
+                            `event: message\ndata: ${JSON.stringify({
+                                jsonrpc: "2.0",
+                                id: msg.id,
+                                result: {
+                                    content: [{ type: "text", text: `OK:${msg.params?.name}` }],
+                                    isError: false,
+                                },
+                            })}\n\n`,
+                        );
+                    }
+                }, 40);
+            });
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+    return new Promise((resolveListen) => {
+        server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address();
+            resolveListen({
+                server,
+                base: `http://127.0.0.1:${port}`,
+                overlap: () => overlap,
+            });
+        });
+    });
+}
+
+test("concurrent tool calls do not overlap POSTs on the SSE session", async (t) => {
+    const { server, base, overlap } = await startMockRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-test-"));
+    mkdirSync(join(home, ".memwal"));
+    writeFileSync(
+        join(home, ".memwal", "credentials.json"),
+        JSON.stringify({
+            delegatePrivateKey: BEARER,
+            delegatePublicKeyHex: "b".repeat(64),
+            delegateAddress: "0x" + "1".repeat(64),
+            walletAddress: "0x" + "2".repeat(64),
+            accountId: ACCOUNT,
+            packageId: "0x" + "4".repeat(64),
+            relayerUrl: base,
+            label: "test",
+            createdAt: new Date(0).toISOString(),
+            version: 1,
+        }),
+    );
+
+    const child = spawn(process.execPath, [BIN, "--relayer", base, "--web-url", base], {
+        env: { ...process.env, HOME: home, USERPROFILE: home },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => {
+                listeners.delete(l);
+                rej(new Error("timed out waiting for message"));
+            }, ms);
+            const l = (m) => {
+                if (pred(m)) {
+                    clearTimeout(timer);
+                    listeners.delete(l);
+                    res(m);
+                }
+            };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => {
+        child.kill("SIGKILL");
+        server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "0" } } });
+    await waitFor((m) => m.id === 1 && m.result);
+
+    send({ jsonrpc: "2.0", id: 2, method: "notifications/initialized" });
+    await waitFor((m) => m.method === "notifications/tools/list_changed");
+
+    for (const id of [10, 11, 12, 13]) {
+        send({
+            jsonrpc: "2.0",
+            id,
+            method: "tools/call",
+            params: { name: "memwal_recall", arguments: { query: `q${id}` } },
+        });
+    }
+
+    const replies = [];
+    for (const id of [10, 11, 12, 13]) {
+        replies.push(await waitFor((m) => m.id === id && (m.result || m.error)));
+    }
+    assert.equal(overlap(), 0);
+    for (const reply of replies) {
+        assert.equal(reply.error, undefined);
+        const text = reply.result?.content?.[0]?.text ?? "";
+        assert.match(text, /^OK:/);
+        assert.doesNotMatch(text, /did not answer this call/);
+    }
+});


### PR DESCRIPTION
Linear: [WALM-408](https://linear.app/mysten-labs/issue/WALM-408/serialize-mcp-sse-posts-so-concurrent-recall-cannot-hang-the-bridge)
Fixes https://github.com/MystenLabs/MemWal/issues/739

Stacked on #738 so `@mysten-incubation/memwal-mcp` stays at `0.0.11`.

## What this does

- Serialize outbound MCP POSTs on the SSE session so a burst of `memwal_recall` cannot drop the stream.
- Skip queued posts against a stale session URL after reconnect (reconnect already replays in-flight calls).
- Login timeout now warns that an on-chain delegate key may already exist if the browser approved after the local listener expired.