### PR TITLE
fix(app): show namespace counts and persist playground namespace

### DIFF
--- a/apps/app/src/pages/ConnectMcp.tsx
+++ b/apps/app/src/pages/ConnectMcp.tsx
@@ -558,7 +558,13 @@ function SuccessCard({
     return (
         <div className="setup-classic-intro">
             <h2 className="setup-classic-title">
-                <span style={{ color: '#22c55e' }}>✓</span> MCP client connected
+                {callbackDelivered === false ? (
+                    <>On-chain key added; local login did not finish</>
+                ) : (
+                    <>
+                        <span style={{ color: '#22c55e' }}>✓</span> MCP client connected
+                    </>
+                )}
             </h2>
             {callbackDelivered === true && (
                 <p className="setup-classic-description">
@@ -568,7 +574,9 @@ function SuccessCard({
             {callbackDelivered === false && (
                 <p className="setup-classic-description" style={errorTextStyle}>
                     The on-chain registration succeeded, but the local MCP login listener at{' '}
-                    <code style={codeStyle}>http://127.0.0.1:{port}/callback</code> did not accept the callback. Restart the MCP login command and try again so credentials can be saved locally.
+                    <code style={codeStyle}>http://127.0.0.1:{port}/callback</code> did not accept the callback.
+                    A delegate key was still added on-chain. If you are not using it, remove it from the dashboard,
+                    then restart <code style={codeStyle}>memwal-mcp login</code> so credentials can be saved locally.
                 </p>
             )}
             <div className="card setup-classic-feature-card">

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -27,6 +27,7 @@ import SecurityDeleteSection from '../components/SecurityDeleteSection'
 import { SecretValueInput } from '../components/SecretValueInput'
 import { config } from '../config'
 import { getAnalyticsErrorType, trackEvent } from '../utils/analytics'
+import { apiGet } from '../utils/api'
 import { fetchAccountIdForOwner, fetchObjectJson, publicKeyToHex } from '../utils/suiClientCompat'
 
 function DelegateKeyCtaIcon(props: SVGProps<SVGSVGElement>) {
@@ -250,6 +251,10 @@ export default function Dashboard({
 
     // Delegate key management state
     const [onChainKeys, setOnChainKeys] = useState<OnChainDelegateKey[]>([])
+    const [namespaces, setNamespaces] = useState<{ name: string; memory_count: number }[]>([])
+    const [namespacesLoading, setNamespacesLoading] = useState(false)
+    const [namespacesError, setNamespacesError] = useState('')
+    const [namespacesTruncated, setNamespacesTruncated] = useState(false)
     const [loadingKeys, setLoadingKeys] = useState(false)
     const [addingKey, setAddingKey] = useState(false)
     const [removingKey, setRemovingKey] = useState<string | null>(null)
@@ -455,6 +460,63 @@ export default function Dashboard({
         setOnChainKeys([])
         fetchOnChainKeys()
     }, [fetchOnChainKeys])
+
+    const namespacesFetchGen = useRef(0)
+    const fetchNamespaces = useCallback(async () => {
+        if (!delegateKey || !effectiveAccountObjectId || !address) return
+        const gen = ++namespacesFetchGen.current
+        setNamespacesLoading(true)
+        setNamespacesError('')
+        setNamespacesTruncated(false)
+        try {
+            const owner = address.toLowerCase()
+            const collected: { name: string; memory_count: number }[] = []
+            let cursor: string | undefined
+            let truncated = false
+            for (let page = 0; page < 20; page++) {
+                const qs = new URLSearchParams({ limit: '100' })
+                if (cursor) qs.set('updated_after', cursor)
+                const path = `/v1/owners/${owner}/namespaces?${qs.toString()}`
+                const data = await apiGet(
+                    delegateKey,
+                    config.memwalServerUrl.replace(/\/+$/, ''),
+                    path,
+                    effectiveAccountObjectId,
+                ) as {
+                    namespaces?: { name?: string; memory_count?: number }[]
+                    next_cursor?: string | null
+                    has_more?: boolean
+                }
+                if (gen !== namespacesFetchGen.current) return
+                for (const ns of data.namespaces ?? []) {
+                    if (typeof ns.name === 'string') {
+                        collected.push({
+                            name: ns.name,
+                            memory_count: Number(ns.memory_count ?? 0),
+                        })
+                    }
+                }
+                if (!data.has_more) break
+                if (!data.next_cursor) break
+                cursor = data.next_cursor
+                if (page === 19) truncated = true
+            }
+            if (gen !== namespacesFetchGen.current) return
+            setNamespaces(collected)
+            setNamespacesTruncated(truncated)
+        } catch (err) {
+            if (gen !== namespacesFetchGen.current) return
+            console.error('Failed to list namespaces:', err)
+            setNamespacesError('Could not load namespace counts from the relayer.')
+        } finally {
+            if (gen === namespacesFetchGen.current) setNamespacesLoading(false)
+        }
+    }, [delegateKey, effectiveAccountObjectId, address])
+
+    useEffect(() => {
+        setNamespaces([])
+        void fetchNamespaces()
+    }, [fetchNamespaces])
 
     // ============================================================
     // Generate + add a new delegate key (via SDK)
@@ -1044,6 +1106,64 @@ const result = await generateText({
                             </div>
                         </div>
                     </div>
+                    </Card>
+                )}
+
+                {delegateKey && (
+                    <Card
+                        id="namespaces"
+                        className="dashboard-keys-card"
+                        title="Namespaces"
+                        subtitle={
+                            namespacesLoading
+                                ? 'Loading memory counts from the relayer'
+                                : namespacesError
+                                    ? namespacesError
+                                    : namespaces.length === 0
+                                        ? 'No indexed namespaces yet (or none the relayer can see for this account)'
+                                        : `${namespaces.reduce((n, ns) => n + ns.memory_count, 0)} memories across ${namespaces.length} ${namespaces.length === 1 ? 'namespace' : 'namespaces'}${namespacesTruncated ? ' (list truncated)' : ''}`
+                        }
+                        action={
+                            <button
+                                className="btn btn-secondary btn-sm dashboard-keys-refresh"
+                                onClick={() => void fetchNamespaces()}
+                                disabled={namespacesLoading}
+                                aria-busy={namespacesLoading}
+                            >
+                                <RefreshCw size={12} /> Refresh
+                            </button>
+                        }
+                    >
+                        {namespacesError && (
+                            <p style={{ color: 'var(--danger)', fontSize: '0.85rem' }}>{namespacesError}</p>
+                        )}
+                        {!namespacesLoading && namespaces.length > 0 && (
+                            <div className="dashboard-key-table-wrap">
+                                <table className="dashboard-key-table">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Namespace</th>
+                                            <th scope="col">Memories</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {namespaces.map((ns) => (
+                                            <tr key={ns.name}>
+                                                <td data-label="Namespace">
+                                                    <Link
+                                                        to={`/playground?namespace=${encodeURIComponent(ns.name)}`}
+                                                        title="Open this namespace in the playground"
+                                                    >
+                                                        <code>{ns.name}</code>
+                                                    </Link>
+                                                </td>
+                                                <td data-label="Memories">{ns.memory_count}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
                     </Card>
                 )}
 

--- a/apps/app/src/pages/Playground.tsx
+++ b/apps/app/src/pages/Playground.tsx
@@ -5,7 +5,7 @@
  * that executes the call against a live server using the real SDK.
  */
 
-import { useState, useCallback, useMemo, type ReactNode } from 'react'
+import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { LayoutDashboard, LogOut } from 'lucide-react'
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -188,7 +188,46 @@ export default function Playground() {
     // SDK Instance — created from delegate key
     // ============================================================
 
-    const [namespace, setNamespace] = useState('default')
+    const initialQueryNamespace = useMemo(() => {
+        if (typeof window === 'undefined') return null
+        const value = new URLSearchParams(window.location.search).get('namespace')?.trim()
+        return value || null
+    }, [])
+    const consumedQueryNamespace = useRef(false)
+    const [hydratedAccountId, setHydratedAccountId] = useState<string | null>(null)
+    const [namespace, setNamespace] = useState(() => {
+        if (initialQueryNamespace) return initialQueryNamespace
+        if (typeof window === 'undefined' || !accountObjectId) return 'default'
+        return window.localStorage.getItem(`memwal.playground.namespace.${accountObjectId}`) || 'default'
+    })
+
+    const persistNamespace = useCallback((accountId: string, value: string) => {
+        window.localStorage.setItem(`memwal.playground.namespace.${accountId}`, value)
+    }, [])
+
+    useEffect(() => {
+        if (!accountObjectId) {
+            setHydratedAccountId(null)
+            return
+        }
+        if (initialQueryNamespace && !consumedQueryNamespace.current) {
+            consumedQueryNamespace.current = true
+            setNamespace(initialQueryNamespace)
+            persistNamespace(accountObjectId, initialQueryNamespace)
+            const url = new URL(window.location.href)
+            url.searchParams.delete('namespace')
+            window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`)
+        } else {
+            const saved = window.localStorage.getItem(`memwal.playground.namespace.${accountObjectId}`)
+            setNamespace(saved || 'default')
+        }
+        setHydratedAccountId(accountObjectId)
+    }, [accountObjectId, initialQueryNamespace, persistNamespace])
+
+    useEffect(() => {
+        if (!accountObjectId || hydratedAccountId !== accountObjectId) return
+        persistNamespace(accountObjectId, namespace)
+    }, [accountObjectId, hydratedAccountId, namespace, persistNamespace])
 
     const memwal = useMemo(() => {
         if (!delegateKey || !accountObjectId) return null

--- a/apps/app/src/utils/api.ts
+++ b/apps/app/src/utils/api.ts
@@ -100,3 +100,45 @@ export async function apiCall(
 
     return resp.json()
 }
+
+/**
+ * Signed GET for the owner-scoped read API. Body is empty; the signature
+ * still covers path+query, timestamp, nonce, and account id.
+ */
+export async function apiGet(
+    privateKeyHex: string,
+    serverUrl: string,
+    path: string,
+    accountId?: string,
+) {
+    const { timestamp, nonce, publicKey, signature } = await signRequest(
+        privateKeyHex,
+        'GET',
+        path,
+        '',
+        accountId ?? '',
+    )
+
+    const headers: Record<string, string> = {
+        'x-public-key': publicKey,
+        'x-signature': signature,
+        'x-timestamp': timestamp,
+        'x-nonce': nonce,
+    }
+    if (accountId) {
+        headers['x-account-id'] = accountId
+    }
+
+    const resp = await fetch(`${serverUrl}${path}`, {
+        method: 'GET',
+        headers,
+        cache: 'no-store',
+    })
+
+    if (!resp.ok) {
+        const err = await resp.text()
+        throw new Error(`API error (${resp.status}): ${err}`)
+    }
+
+    return resp.json()
+}


### PR DESCRIPTION
Linear: [WALM-409](https://linear.app/mysten-labs/issue/WALM-409/show-dashboard-namespace-counts-and-persist-playground-namespace)
Fixes https://github.com/MystenLabs/MemWal/issues/723

## What this does

- Dashboard lists owner namespaces and memory counts from `GET /v1/owners/{owner}/namespaces` (signed GET). Each row links into the playground.
- Playground persists namespace per account in `localStorage`. A dashboard `?namespace=` link is applied once, then dropped so it cannot overwrite another account.
- Connect MCP callback-fail copy tells the user a delegate key was still added on-chain and to remove unused keys from the dashboard.