### PR TITLE
fix(sdk): surface dropped_count and redact loopback URLs

### DIFF
--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `recall()` results include `dropped_count` when the relayer omitted matches that failed to download or decrypt.
+- `health()` surfaces optional `write_ready` when the relayer reports write-path sidecar liveness.
 - Added `MemWalClockDriftError`, raised when the relayer rejects a request because the signed timestamp is outside its accepted clock-drift window (`401` + `x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS`). Surfaces an actionable "synchronize the client clock" message instead of an opaque `401`. Subclasses `MemWalError`, so existing `except MemWalError` handlers still catch it.
 - Added the `dev` relayer preset (`https://relayer.dev.memwal.ai`) to `ENV_PRESETS`.
 
@@ -11,6 +13,7 @@
 
 - `hex_to_bytes` now rejects empty, odd-length, whitespace, and non-hex input instead of silently decoding a different key.
 - `remember_manual` sends `encrypted_data` (base64 SEAL ciphertext) instead of a pre-uploaded `blob_id`, matching `POST /api/remember/manual`.
+- HTTP error messages and remember-job error strings no longer forward `localhost` / `127.0.0.1` URLs to callers.
 
 ## 0.1.7
 

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -30,6 +30,7 @@ import base64
 import json
 import logging
 import random
+import re
 import time
 import uuid
 from datetime import datetime, timezone
@@ -652,10 +653,21 @@ class MemWal:
             )
             for m in data.get("results", [])
         ]
+        raw_dropped = data.get("dropped_count") or 0
+        try:
+            dropped = int(raw_dropped)
+        except (TypeError, ValueError):
+            dropped = 0
         if max_distance is not None:
             memories = [m for m in memories if m.distance < max_distance]
-            return RecallResult(results=memories, total=len(memories))
-        return RecallResult(results=memories, total=data.get("total", len(memories)))
+            return RecallResult(
+                results=memories, total=len(memories), dropped_count=dropped
+            )
+        return RecallResult(
+            results=memories,
+            total=data.get("total", len(memories)),
+            dropped_count=dropped,
+        )
 
     async def analyze(
         self,
@@ -893,6 +905,7 @@ class MemWal:
             deprecations=data.get("deprecations"),
             build=data.get("build"),
             mode=data.get("mode"),
+            write_ready=data.get("write_ready"),
         )
 
     async def compatibility(self) -> Dict[str, Any]:
@@ -1235,6 +1248,15 @@ class MemWalClockDriftError(MemWalError):
     pass
 
 
+def _redact_internal_urls(text: str) -> str:
+    return re.sub(
+        r"https?://(?:localhost|127\.0\.0\.1)(?::\d+)?[^\s)\]>'\"]*",
+        "[internal]",
+        text,
+        flags=re.IGNORECASE,
+    )
+
+
 class _HttpStatusError(MemWalError):
     """Internal: raised when an HTTP response status is not in ``accepted_statuses``.
 
@@ -1247,7 +1269,9 @@ class _HttpStatusError(MemWalError):
         if status == 401:
             super().__init__(AUTH_REJECTED_MESSAGE)
         else:
-            super().__init__(f"Walrus Memory API error ({status}): {body}")
+            super().__init__(
+                f"Walrus Memory API error ({status}): {_redact_internal_urls(body)}"
+            )
         self.status = status
         self.body = body
 
@@ -1265,7 +1289,7 @@ class MemWalRememberJobFailed(MemWalError):
     """The async remember job reached terminal status=failed."""
 
     def __init__(self, job_id: str, error: str) -> None:
-        super().__init__(f"remember job failed: {error}")
+        super().__init__(f"remember job failed: {_redact_internal_urls(error)}")
         self.status = 500
         self.job_id = job_id
         self.error = error

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -114,6 +114,9 @@ class RecallResult:
 
     results: List[RecallMemory]
     total: int
+    # Matches omitted because download or decrypt failed. 0 also means the
+    # relayer omitted the field (older servers).
+    dropped_count: int = 0
 
 
 @dataclass
@@ -191,6 +194,7 @@ class HealthResult:
     deprecations: Optional[List[Dict[str, Any]]] = None
     build: Optional[Dict[str, Any]] = None
     mode: Optional[str] = None
+    write_ready: Optional[bool] = None
 
 
 @dataclass

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -370,9 +370,23 @@ class TestRecall:
 
         assert len(result.results) == 2
         assert result.total == 2
+        assert result.dropped_count == 0
         assert result.results[0].text == "I love coffee"
         assert result.results[0].distance == 0.1
         assert result.results[1].blob_id == "b2"
+
+    @respx.mock
+    async def test_recall_surfaces_dropped_count(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/recall").mock(
+            return_value=httpx.Response(
+                200,
+                json={"results": [], "total": 0, "dropped_count": 3},
+            )
+        )
+        result = await memwal_client.recall("coffee")
+        assert result.results == []
+        assert result.dropped_count == 3
 
     @respx.mock
     async def test_accepts_recall_params_object(
@@ -573,6 +587,20 @@ class TestErrorHandling:
 
         with pytest.raises(MemWalError, match="500"):
             await memwal_client.recall("test")
+
+    @respx.mock
+    async def test_500_strips_localhost_sidecar_urls(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/recall").mock(
+            return_value=httpx.Response(
+                500,
+                text="Sidecar seal/encrypt request failed: error sending request for url (http://localhost:9000/seal/encrypt)",
+            )
+        )
+        with pytest.raises(MemWalError) as exc:
+            await memwal_client.recall("test")
+        assert "localhost:9000" not in str(exc.value)
+        assert "[internal]" in str(exc.value)
 
     @respx.mock
     async def test_health_non_200_raises(self, memwal_client: MemWal) -> None:

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.1.5
 
+### Added
+
+- `recall()` results include `dropped_count` when the relayer omitted matches that failed to download or decrypt.
+- `health()` surfaces optional `write_ready` when the relayer reports write-path sidecar liveness.
+
 ### Changed
 
 - `rememberManual` now sends `encryptedData` (base64 SEAL ciphertext) instead of a pre-uploaded `blobId`, matching `POST /api/remember/manual`.
@@ -9,6 +14,7 @@
 ### Fixed
 
 - Manual recall decodes SEAL object ids with `hexToBytes` instead of an unguarded `parseInt` / `.match!` path that could coerce `NaN` to `0` or throw on empty input.
+- HTTP error messages and remember-job error strings no longer forward `localhost` / `127.0.0.1` URLs to callers.
 
 ## 0.1.4
 

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -63,6 +63,7 @@ import {
     normalizePrivateKey,
     normalizeServerUrl,
     sanitizeServerError,
+    redactInternalUrls,
     clockDriftErrorFromResponse,
     scoringWeightsToWire,
 } from "./utils.js";
@@ -350,7 +351,9 @@ export class MemWal {
             }
             if (status.status === "failed") {
                 throw Object.assign(
-                    new Error(`remember job failed: ${status.error ?? "unknown error"}`),
+                    new Error(
+                        `remember job failed: ${redactInternalUrls(status.error ?? "unknown error")}`,
+                    ),
                     { status: 500, jobId },
                 );
             }
@@ -529,7 +532,7 @@ export class MemWal {
                         error:
                             status.status === "not_found"
                                 ? "job not found"
-                                : status.error ?? "unknown error",
+                                : redactInternalUrls(status.error ?? "unknown error"),
                     };
                     pending.delete(jobId);
                 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -87,6 +87,8 @@ export interface RecallResult {
      * unaffected.
      */
     meta?: RecallTokenMeta;
+    /** Matches omitted because blob download or decrypt failed. Omitted when 0. */
+    dropped_count?: number;
 }
 
 /**
@@ -277,6 +279,8 @@ export interface HealthResult extends Partial<RelayerVersionMetadata> {
     version: string;
     /** "production" or "benchmark" when returned by modern relayers. */
     mode?: string;
+    /** False when writes are not ready; omit means the relayer did not report it. */
+    write_ready?: boolean;
     prompt_versions?: {
         extract: string;
         ask: string;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -285,6 +285,14 @@ export function normalizeServerUrl(url: string): string {
 // Error Sanitization (LOW-26)
 // ============================================================
 
+/** Replace loopback URLs that leak sidecar topology into client-facing errors. */
+export function redactInternalUrls(text: string): string {
+    return text.replace(
+        /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?[^ \t)\]>'"]*/gi,
+        "[internal]",
+    );
+}
+
 /**
  * LOW-26: Sanitize a raw server error body before surfacing it to callers.
  *
@@ -331,7 +339,9 @@ export function sanitizeServerError(
 
     // Strip ASCII control chars (0x00-0x1F, 0x7F) that could corrupt logs.
     // eslint-disable-next-line no-control-regex
-    const stripped = text.replace(/[\u0000-\u001F\u007F]/g, " ").trim();
+    const stripped = redactInternalUrls(
+        text.replace(/[\u0000-\u001F\u007F]/g, " "),
+    ).trim();
     const truncated =
         stripped.length > MAX ? `${stripped.slice(0, MAX)}...` : stripped;
     const message = `Walrus Memory server error (${status}): ${truncated || "<no message>"}`;

--- a/packages/sdk/test/recall-token-budget-e2e.test.mjs
+++ b/packages/sdk/test/recall-token-budget-e2e.test.mjs
@@ -46,6 +46,35 @@ function client() {
 
 const chars = (n) => "a".repeat(n);
 
+test("recall surfaces dropped_count when the relayer omitted matches", async () => {
+    globalThis.fetch = async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        if (path === "/version") {
+            return Response.json({
+                apiVersion: "1.0.0",
+                relayerVersion: "1.0.0",
+                minSupportedSdk: { typescript: "0.0.4" },
+            });
+        }
+        if (path === "/api/config") {
+            return Response.json({ packageId: "0x1", network: "testnet" });
+        }
+        if (path === "/api/recall" && init.method === "POST") {
+            return Response.json({ results: [], total: 0, dropped_count: 3 });
+        }
+        throw new Error(`unexpected request ${path}`);
+    };
+    const result = await client().recall({ query: "x", namespace: "default" });
+    assert.equal(result.dropped_count, 3);
+    assert.equal(result.results.length, 0);
+});
+
+test("recall omits dropped_count when the relayer does", async () => {
+    stubRecall([]);
+    const result = await client().recall({ query: "x", namespace: "default" });
+    assert.equal("dropped_count" in result, false);
+});
+
 test("recall without maxTokens: response unchanged, NO meta (backward compatible)", async () => {
     const hits = [
         { blob_id: "b1", text: chars(40), distance: 0.1 },

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -34,3 +34,12 @@ test("non-401 empty bodies still use the <no message> placeholder", () => {
     const { message } = sanitizeServerError(500, "");
     assert.equal(message, "Walrus Memory server error (500): <no message>");
 });
+
+test("localhost sidecar URLs are stripped from error text", () => {
+    const { message } = sanitizeServerError(
+        500,
+        "Sidecar seal/encrypt request failed: error sending request for url (http://localhost:9000/seal/encrypt)",
+    );
+    assert.doesNotMatch(message, /localhost:9000/);
+    assert.match(message, /\[internal\]/);
+});


### PR DESCRIPTION
Linear: [WALM-407](https://linear.app/mysten-labs/issue/WALM-407/surface-recall-dropped-count-and-redact-loopback-urls-in-the-sdks)
Fixes https://github.com/MystenLabs/MemWal/issues/622
Fixes https://github.com/MystenLabs/MemWal/issues/636

Stacked on #737 so `@mysten-incubation/memwal` stays at `0.1.5` and Python `memwal` stays at `0.1.8`.

## What this does

- `recall()` results include `dropped_count` when the relayer omitted matches that failed to download or decrypt.
- `health()` surfaces optional `write_ready`.
- HTTP error messages and remember-job error strings redact `localhost` / `127.0.0.1` URLs.