### PR TITLE
fix(bench): retry Cloudflare HTML in the live latency check

### DIFF
--- a/docs/api/memory-read-api.md
+++ b/docs/api/memory-read-api.md
@@ -110,9 +110,9 @@ sends the signature in `x-signature`:
 Server-side verification flow (`auth.rs::verify_signature`): validate the
 Ed25519 signature against the canonical string → check the nonce hasn't
 been seen before (Redis, fail-closed on Redis outage) → resolve the account
-(cache, then the `x-account-id` hint, then a bounded on-chain registry scan
+(cache, then the `x-account-id` hint, then a bounded onchain registry scan
 as a last resort) → verify the public key is a registered delegate key on
-that account's on-chain `MemWalAccount.delegate_keys` (cached in
+that account's onchain `MemWalAccount.delegate_keys` (cached in
 `delegate_key_cache`, revoked entries evicted).
 
 ### 401 responses
@@ -128,7 +128,7 @@ distinguishing failure reasons):
   string, or body).
 - Nonce already seen (replay): or the Redis nonce check itself failing
   (fail-closed).
-- Public key not found among the resolved account's on-chain delegate keys,
+- Public key not found among the resolved account's onchain delegate keys,
   or the account is deactivated.
 
 A request missing `x-nonce` entirely gets `426 Upgrade Required` instead of
@@ -164,13 +164,13 @@ own Redis prefix (`rate:read:dk:{public_key}`, distinct from the write
 path's `rate:dk:{public_key}`), no separate per-account burst/sustained
 tiers on top. Default limit is **200 weighted-requests/min per delegate
 key** (`ReadApiRateLimitConfig::per_delegate_key_per_minute`), overridable
-via the `READ_API_RATE_LIMIT_PER_MINUTE` env var. Weights for this API:
+through the `READ_API_RATE_LIMIT_PER_MINUTE` env var. Weights for this API:
 
 | Endpoint | Weight | Why |
 |---|---|---|
 | `GET /v1/owners/{owner}/namespaces` | 1 | DB read only |
 | `GET /v1/owners/{owner}/memories` | 1 | DB read only |
-| `GET /v1/owners/{owner}/agents` | 2 | Makes a live on-chain `sui_getObject` RPC call (short-TTL cached, but uncached on a cold/expired cache entry) |
+| `GET /v1/owners/{owner}/agents` | 2 | Makes a live onchain `sui_getObject` RPC call (short-TTL cached, but uncached on a cold/expired cache entry) |
 
 Exceeding the limit returns `429 Too Many Requests`:
 
@@ -324,7 +324,7 @@ owner. `has_more` is correct in both cases; page-length heuristics are not.
 
 ## `GET /v1/owners/:owner/agents`
 
-Live on-chain read of `MemWalAccount.delegate_keys`, short-TTL cached
+Live onchain read of `MemWalAccount.delegate_keys`, short-TTL cached
 per-account (same 30s window `sui/client.rs::walrus_epoch()` uses) so
 repeated calls within the TTL window don't re-hit the chain.
 
@@ -351,7 +351,7 @@ Authentication and Rate limiting above) use the envelope
 | `403` | `{owner}` path segment does not match the authenticated identity, or (bearer-token path) the token's `permissions` lack `memories.read` |
 | `400` | Invalid/malformed cursor, or non-positive/non-integer `limit` |
 | `429` | Rate limit exceeded (see Rate limiting) |
-| `500` | Internal error, including an on-chain RPC failure on `/agents` |
+| `500` | Internal error, including an onchain RPC failure on `/agents` |
 
 An empty list (owner with no memories/namespaces, or no delegate keys) is
 a valid `200`, not a `404`.

--- a/docs/api/owner-token-auth.md
+++ b/docs/api/owner-token-auth.md
@@ -41,7 +41,7 @@ Lets Console call WM's owner-scoped read API without ever holding
 a delegate key. Console proves control of a WM owner address `Y` entirely on
 its own side (its own identity-link flow, Enoki Connect or a wallet-signature
 challenge; WM is never involved in that proof). It then calls `POST /v1/owner-tokens`,
-authenticating itself as a legitimate client via a single static **service
+authenticating itself as a legitimate client through a single static **service
 credential** WM issues to Console out of band, to mint a short-lived bearer
 token scoped to `Y`. Console presents that token as `Authorization: Bearer
 <token>` on subsequent read calls.
@@ -72,10 +72,10 @@ Missing header, wrong value, or the secret being unconfigured on WM's side
 (`OWNER_TOKEN_SERVICE_CREDENTIAL` unset) all collapse to a bare `401` with no
 body, no detail is leaked about which of these it was.
 
-**Trust boundary, stated explicitly:** this credential is the *only* thing
-gating who can request a token, and a request's `owner` is taken as a plain
-request parameter, trusted because the caller already proved it holds the
-credential. If the credential leaks, whoever holds it can mint a
+**Trust boundary, stated explicitly:** this credential is the **only** thing
+gating who can request a token, and the server treats a request's `owner` as a
+plain request parameter and trusts it because the caller already proved it
+holds the credential. If the credential leaks, whoever holds it can mint a
 `memories.read` token for **any** owner address, there is no secondary check
 tying a specific token request back to a specific proven identity-link event.
 This is an accepted Phase-1 trade-off, a deliberate choice of a shared
@@ -98,7 +98,7 @@ Validation order: per-IP rate limit (outer middleware, throttles credential
 guessing regardless of validity) → service credential (middleware) →
 per-credential rate limit (middleware) → Sui address format (handler,
 cheapest handler-level check) → per-owner rate limit → `MemWalAccount`
-existence → mint. `owner` is canonicalized to lowercase before every
+existence → mint. The handler canonicalizes `owner` to lowercase before every
 downstream check and before it's embedded in the token's claims.
 
 Response (`200 OK`):
@@ -119,7 +119,7 @@ lowercase), `audience` (constant `"memwal"`), `issued_at`/`expires_at` (Unix
 seconds), `nonce` (a UUID identifying this specific token, see "Replay and
 revocation" below), `permissions` (`["memories.read"]` in Phase 1).
 
-TTL defaults to 900s (15 minutes), configurable via `OWNER_TOKEN_TTL_SECS`.
+TTL defaults to 900s (15 minutes), configurable through `OWNER_TOKEN_TTL_SECS`.
 **Refresh path:** there is no separate refresh/rotate endpoint in Phase 1, 
 when a token is at or near expiry, call `POST /v1/owner-tokens` again with
 the same `owner` to mint a fresh one. There is no reuse or extension of an
@@ -144,7 +144,7 @@ Authorization: Bearer <token>
 ```
 
 `GET /v1/owners/{owner}/namespaces`, `.../memories`, and `.../agents`
-all accept this same bearer token via `auth::verify_read_api_auth`
+all accept this same bearer token through `auth::verify_read_api_auth`
 (`services/server/src/auth.rs`), which dispatches between it and the
 existing Ed25519 signed-request scheme based on whether the request carries
 an `Authorization` header, see `docs/api/memory-read-api.md`'s
@@ -155,11 +155,12 @@ the real handlers existed; it is redundant now and a candidate for removal
 in a follow-up, not something Console should call.
 
 `{owner}` in the path must exactly equal the token's `owner_address` claim
-(canonical-address comparison, not raw string equality) or the request is
-rejected `403`. The token's `permissions` must include the scope the route
-requires (`memories.read` for all three read routes) or the request is
-rejected `403`. An expired, tampered, wrongly-signed, or wrong-audience token
-is rejected `401`, with no distinction in the response between those causes.
+(canonical-address comparison, not raw string equality) or the server rejects
+the request with `403`. The token's `permissions` must include the scope the
+route requires (`memories.read` for all three read routes) or the server
+rejects the request with `403`. For an expired, tampered, wrongly-signed, or
+wrong-audience token, the server rejects it with `401`, with no distinction in
+the response between those causes.
 
 ## Rate limiting
 
@@ -275,7 +276,7 @@ Each token's `nonce` claim is a unique UUID generated at mint time. It is
 scheme's `x-nonce` is, a bearer token is meant to be reused across many read
 requests during its TTL window, so per-request single-use tracking would
 break normal usage. Its purpose in Phase 1 is forward-compatibility
-(identifying a specific issued token, in case a revocation list is added
+(identifying a specific issued token, in case you add a revocation list
 later) and observability (logging which token served a given request). A
 stolen, unexpired token is fully usable for its entire remaining TTL, the
 short default TTL (15 minutes) is the primary mitigation, not the nonce.

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -33,6 +33,8 @@ answer: >-
 
 ## 0.1.4
 
+This release points empty-body 401s at `memwal_login` instead of `<no message>`.
+
 ### Fixed
 
 - Empty-body 401s now tell first-time MCP callers to run `memwal_login` instead of showing `<no message>`. Credential 401s still point at the AUTH_REJECTED troubleshooting guide.

--- a/services/server/scripts/__tests__/live-bench-retry.test.ts
+++ b/services/server/scripts/__tests__/live-bench-retry.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+    isCloudflareHtmlBody,
+    isRetryableLiveBenchFailure,
+    liveBenchRetryDelayMs,
+} from "../live-bench-retry.js";
+
+const CF_HTML = `<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
+<html lang="en-US">
+<head><title>Attention Required! | Cloudflare</title></head>
+<body>cloudflare</body>
+</html>`;
+
+test("cloudflare HTML error pages are retryable regardless of status", () => {
+    assert.equal(isCloudflareHtmlBody(CF_HTML), true);
+    assert.equal(
+        isRetryableLiveBenchFailure({ statusCode: 403, error: CF_HTML }),
+        true,
+    );
+    assert.equal(
+        isRetryableLiveBenchFailure({
+            statusCode: 200,
+            contentType: "text/html; charset=UTF-8",
+            error: CF_HTML,
+        }),
+        true,
+    );
+});
+
+test("gateway and rate-limit statuses are retryable", () => {
+    assert.equal(isRetryableLiveBenchFailure({ statusCode: 429, error: "Too Many Requests" }), true);
+    assert.equal(isRetryableLiveBenchFailure({ statusCode: 502, error: "Bad Gateway" }), true);
+    assert.equal(isRetryableLiveBenchFailure({ statusCode: 503, error: "Unavailable" }), true);
+    assert.equal(isRetryableLiveBenchFailure({ statusCode: 524, error: "timeout" }), true);
+});
+
+test("auth and contract 4xx JSON stay fatal", () => {
+    assert.equal(
+        isRetryableLiveBenchFailure({
+            statusCode: 401,
+            contentType: "application/json",
+            error: '{"error":"unauthorized"}',
+        }),
+        false,
+    );
+    assert.equal(
+        isRetryableLiveBenchFailure({
+            statusCode: 403,
+            contentType: "application/json",
+            error: '{"error":"forbidden"}',
+        }),
+        false,
+    );
+    assert.equal(
+        isRetryableLiveBenchFailure({
+            statusCode: 400,
+            contentType: "application/json",
+            error: '{"error":"Text cannot be empty"}',
+        }),
+        false,
+    );
+});
+
+test("network throws and HTML-as-JSON parse errors are retryable", () => {
+    assert.equal(isRetryableLiveBenchFailure({ error: "fetch failed" }), true);
+    assert.equal(
+        isRetryableLiveBenchFailure({ error: "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON" }),
+        true,
+    );
+});
+
+test("retry backoff doubles from 400ms", () => {
+    assert.equal(liveBenchRetryDelayMs(1), 400);
+    assert.equal(liveBenchRetryDelayMs(2), 800);
+    assert.equal(liveBenchRetryDelayMs(3), 1600);
+});

--- a/services/server/scripts/bench-recall-latency.ts
+++ b/services/server/scripts/bench-recall-latency.ts
@@ -32,6 +32,11 @@
 import { createHash, randomUUID } from "crypto";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import {
+  isRetryableLiveBenchFailure,
+  LIVE_BENCH_MAX_ATTEMPTS,
+  liveBenchRetryDelayMs,
+} from "./live-bench-retry.js";
 
 // ============================================================
 // CLI
@@ -264,6 +269,7 @@ interface ApiRunResult {
   memoryId?: string;
   blobId?: string;
   statusCode?: number;
+  contentType?: string | null;
   error?: string;
 }
 
@@ -279,23 +285,42 @@ async function rememberOnce(args: Args): Promise<ApiRunResult> {
     });
 
     const latencyMs = performance.now() - start;
+    const contentType = resp.headers.get("content-type");
 
     if (!resp.ok) {
       const body = await resp.text().catch(() => "");
-      return { ok: false, latencyMs, statusCode: resp.status, error: body.slice(0, 300) };
+      return {
+        ok: false,
+        latencyMs,
+        statusCode: resp.status,
+        contentType,
+        error: body.slice(0, 300),
+      };
     }
 
-    const json = (await resp.json()) as { id?: string; blob_id?: string };
+    const json = (await resp.json().catch((err: unknown) => {
+      throw Object.assign(err instanceof Error ? err : new Error(String(err)), {
+        statusCode: resp.status,
+        contentType,
+      });
+    })) as { id?: string; blob_id?: string };
     return {
       ok: true,
       latencyMs,
       statusCode: resp.status,
+      contentType,
       memoryId: json.id,
       blobId: json.blob_id,
     };
   } catch (err: any) {
     const latencyMs = performance.now() - start;
-    return { ok: false, latencyMs, error: err?.message ?? String(err) };
+    return {
+      ok: false,
+      latencyMs,
+      statusCode: err?.statusCode,
+      contentType: err?.contentType,
+      error: err?.message ?? String(err),
+    };
   }
 }
 
@@ -311,23 +336,42 @@ async function recallOnce(args: Args): Promise<ApiRunResult> {
     });
 
     const latencyMs = performance.now() - start;
+    const contentType = resp.headers.get("content-type");
 
     if (!resp.ok) {
       const body = await resp.text().catch(() => "");
-      return { ok: false, latencyMs, statusCode: resp.status, error: body.slice(0, 300) };
+      return {
+        ok: false,
+        latencyMs,
+        statusCode: resp.status,
+        contentType,
+        error: body.slice(0, 300),
+      };
     }
 
-    const json = (await resp.json()) as { results?: unknown[]; total?: number; dropped_count?: number };
+    const json = (await resp.json().catch((err: unknown) => {
+      throw Object.assign(err instanceof Error ? err : new Error(String(err)), {
+        statusCode: resp.status,
+        contentType,
+      });
+    })) as { results?: unknown[]; total?: number; dropped_count?: number };
     return {
       ok: true,
       latencyMs,
       statusCode: resp.status,
+      contentType,
       resultCount: json.total ?? json.results?.length ?? 0,
       droppedCount: json.dropped_count ?? 0,
     };
   } catch (err: any) {
     const latencyMs = performance.now() - start;
-    return { ok: false, latencyMs, error: err?.message ?? String(err) };
+    return {
+      ok: false,
+      latencyMs,
+      statusCode: err?.statusCode,
+      contentType: err?.contentType,
+      error: err?.message ?? String(err),
+    };
   }
 }
 
@@ -357,14 +401,26 @@ async function runBatch(
 
   for (let i = 0; i < runs; i++) {
     process.stdout.write(`  [${label}] run ${i + 1}/${runs}... `);
-    const result = await callOnce();
-    if (result.ok) {
-      rawMs.push(result.latencyMs);
+    let result: ApiRunResult | undefined;
+    for (let attempt = 1; attempt <= LIVE_BENCH_MAX_ATTEMPTS; attempt++) {
+      result = await callOnce();
+      if (
+        result.ok ||
+        !isRetryableLiveBenchFailure(result) ||
+        attempt === LIVE_BENCH_MAX_ATTEMPTS
+      ) {
+        break;
+      }
+      process.stdout.write(`retry ${attempt}/${LIVE_BENCH_MAX_ATTEMPTS - 1}... `);
+      await sleep(liveBenchRetryDelayMs(attempt));
+    }
+    if (result!.ok) {
+      rawMs.push(result!.latencyMs);
       successCount++;
-      console.log(`ok ${ms(result.latencyMs)} ${formatOk(result)}`);
+      console.log(`ok ${ms(result!.latencyMs)} ${formatOk(result!)}`);
     } else {
       failCount++;
-      const errMsg = result.error ?? `HTTP ${result.statusCode}`;
+      const errMsg = result!.error ?? `HTTP ${result!.statusCode}`;
       errors.push(errMsg);
       console.log(`FAILED: ${errMsg.slice(0, 120)}`);
     }

--- a/services/server/scripts/live-bench-retry.ts
+++ b/services/server/scripts/live-bench-retry.ts
@@ -1,0 +1,57 @@
+/**
+ * Retry classification for the live memory-API latency bench.
+ *
+ * The bench hits the public relayer through Cloudflare. A burst of HTML
+ * error/challenge pages (status 403/5xx/429, body starts with <!DOCTYPE html>)
+ * is an edge flap, not a failed recall. Auth 401/403 JSON and 4xx contract
+ * errors stay fatal.
+ */
+
+export const LIVE_BENCH_MAX_ATTEMPTS = 4;
+export const LIVE_BENCH_RETRY_BASE_MS = 400;
+
+const RETRYABLE_HTTP_STATUS = new Set([
+  408, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 527,
+]);
+
+export function isCloudflareHtmlBody(body: string): boolean {
+  const head = body.slice(0, 400).toLowerCase();
+  return (
+    head.includes("<!doctype html") ||
+    head.includes("<html") ||
+    head.includes("cloudflare")
+  );
+}
+
+export function isRetryableLiveBenchFailure(opts: {
+  statusCode?: number;
+  contentType?: string | null;
+  error?: string;
+}): boolean {
+  const contentType = (opts.contentType ?? "").toLowerCase();
+  const error = opts.error ?? "";
+
+  if (contentType.includes("text/html") || isCloudflareHtmlBody(error)) {
+    return true;
+  }
+  if (opts.statusCode !== undefined && RETRYABLE_HTTP_STATUS.has(opts.statusCode)) {
+    return true;
+  }
+  if (opts.statusCode === undefined && error) {
+    const msg = error.toLowerCase();
+    return (
+      msg.includes("fetch") ||
+      msg.includes("network") ||
+      msg.includes("econnreset") ||
+      msg.includes("etimedout") ||
+      msg.includes("socket") ||
+      msg.includes("unexpected token") ||
+      msg.includes("not valid json")
+    );
+  }
+  return false;
+}
+
+export function liveBenchRetryDelayMs(attempt: number): number {
+  return LIVE_BENCH_RETRY_BASE_MS * 2 ** Math.max(0, attempt - 1);
+}


### PR DESCRIPTION
## Summary

Unblocks the style-guide comment and the Memory API Latency failure on #751 (promote `dev` → `staging`).

**Style guide (#751 bot audit).** `docs/api/memory-read-api.md`, `docs/api/owner-token-auth.md`, and `docs/sdk/changelog.mdx`: `on-chain` → `onchain`, `via` → `through`, italic `*only*` → `**only**`, passive voice on the owner-token path, unstacked `## 0.1.4` heading.

**Latency check.** The job failed because 5/10 warm `/api/recall` calls got a Cloudflare HTML error page (`<!DOCTYPE html> … ie6 oldie`) in ~365ms, then later runs succeeded. The bench treated that as a failed recall and exited 1. The 500ms warm-p50 line in the log is informational only; it does not fail the job, and this PR does not try to make live Walrus+SEAL recall hit 500ms.

The bench now retries Cloudflare HTML, 429, and 5xx (up to 4 attempts, 400ms backoff). JSON 401/403/400 stay fatal.

## Test plan

- [x] Style-guide nits match the #751 audit list
- [x] `cd services/server/scripts && npm test` (includes new `live-bench-retry` cases)
- [ ] After merge to `dev`, #751's Memory API Latency re-run should no longer fail on a one-off Cloudflare HTML burst