### PR TITLE
fix(recall): reject whitespace-only queries (WALM-300)

### DIFF
--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -386,7 +386,7 @@ export class MemWalManual {
         limitOrOptions: number | MemWalManualRecallOptions = 10,
         namespace?: string
     ): Promise<RecallManualResult> {
-        if (!query) throw new Error("Query cannot be empty");
+        if (!query.trim()) throw new Error("Query cannot be empty");
 
         const options = typeof limitOrOptions === "number" ? { limit: limitOrOptions, namespace } : limitOrOptions;
         const limit = options.limit ?? 10;

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -8,6 +8,7 @@ const RECALL_INPUT = {
     query: z
         .string()
         .min(1)
+        .refine((v) => v.trim().length > 0, "Query cannot be empty.")
         .describe("Natural-language search query to match against stored memories."),
     limit: z
         .number()

--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -154,7 +154,7 @@ pub async fn recall(
     Extension(auth): Extension<AuthInfo>,
     Json(body): Json<RecallRequest>,
 ) -> Result<Json<RecallResponse>, AppError> {
-    if body.query.is_empty() {
+    if body.query.trim().is_empty() {
         return Err(AppError::BadRequest("Query cannot be empty".into()));
     }
 


### PR DESCRIPTION
Fixes WALM-300 / closes #425.

## Problem

`body.query.is_empty()` is a byte-length check, so `"   ".is_empty()` is `false`. A whitespace-only query passed validation, reached `generate_recall_embedding_cached` → the embeddings API, and returned a real but semantically meaningless vector. Callers got a plausible-looking 200 instead of the 400 they'd get from `query: ""`.

Severity is low: results stay scoped to `owner + namespace`, so there is no cross-tenant exposure. The cost is a wasted embedding call and a misleading success response.

## Fix

| File | Change |
|---|---|
| `services/server/src/routes/recall.rs:157` | `is_empty()` → `trim().is_empty()` |
| `services/server/scripts/mcp/tools/recall.ts` | added Zod `.refine((v) => v.trim().length > 0, ...)` |
| `packages/sdk/src/manual.ts:389` | `if (!query)` → `if (!query.trim())` |

The server gate is the one that matters: every client path (SDK, MCP tool, raw HTTP) funnels through it, so that single line closes the gap everywhere. The other two are fail-fast client-side mirrors. `recallManual()` had the same truthiness pattern and is fixed alongside.

## Verification

`cargo check --all-targets` passes in `services/server` (exit 0; remaining warnings are pre-existing and unrelated).

The two TypeScript edits are one-liners with no new imports, but they were **not** typechecked locally: `node_modules` is not installed in this worktree, so `npx tsc` fails with `MODULE_NOT_FOUND`. CI covers them.