### PR TITLE
chore(release): sync TS SDK 0.1.5 and Python SDK 0.1.8 release file set

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,12 +29,29 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.7. It adds deterministic async and sync mock clients and idempotency keys that make remember retries reuse the accepted paid job.
+  The latest Python SDK release is 0.1.8. It adds `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset, and hardens hex decoding and error redaction. 0.1.7 added deterministic mock clients and idempotency keys.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
 
 For the latest version, see the [PyPI project page](https://pypi.org/project/memwal/).
+
+## 0.1.8
+
+This release surfaces partial recall results and write-path health, adds a clock-drift error, and aligns manual remember with the relayer contract.
+
+### Added
+
+- `recall()` results include `dropped_count` when the relayer omitted matches that failed to download or decrypt.
+- `health()` surfaces optional `write_ready` when the relayer reports write-path sidecar liveness.
+- Added `MemWalClockDriftError`, raised when the relayer rejects a request because the signed timestamp is outside its accepted clock-drift window (`401` + `x-auth-error: ERR_TIMESTAMP_OUT_OF_BOUNDS`). Surfaces an actionable "synchronize the client clock" message instead of an opaque `401`. Subclasses `MemWalError`, so existing `except MemWalError` handlers still catch it.
+- Added the `dev` relayer preset (`https://relayer.dev.memwal.ai`) to `ENV_PRESETS`.
+
+### Fixed
+
+- `hex_to_bytes` now rejects empty, odd-length, whitespace, and non-hex input instead of silently decoding a different key.
+- `remember_manual` sends `encrypted_data` (base64 SEAL ciphertext) instead of a pre-uploaded `blob_id`, matching `POST /api/remember/manual`.
+- HTTP error messages and remember-job error strings no longer forward `localhost` / `127.0.0.1` URLs to callers.
 
 ## 0.1.7
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,8 +28,26 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.4. It points empty-body 401s at `memwal_login` instead of `<no message>`. 0.1.3 added client-side token estimation and recall token budgets, and updated the default relayer URL.
+  The latest TypeScript SDK release is 0.1.5. It adds `dropped_count` on recall results and `write_ready` on health, switches `rememberManual` to sending `encryptedData`, and hardens hex decoding and error redaction. 0.1.4 pointed empty-body 401s at `memwal_login`.
 ---
+
+## 0.1.5
+
+This release surfaces partial recall results and write-path health, and aligns manual remember with the relayer contract.
+
+### Added
+
+- `recall()` results include `dropped_count` when the relayer omitted matches that failed to download or decrypt.
+- `health()` surfaces optional `write_ready` when the relayer reports write-path sidecar liveness.
+
+### Changed
+
+- `rememberManual` now sends `encryptedData` (base64 SEAL ciphertext) instead of a pre-uploaded `blobId`, matching `POST /api/remember/manual`.
+
+### Fixed
+
+- Manual recall decodes SEAL object ids with `hexToBytes` instead of an unguarded `parseInt` / `.match!` path that could coerce `NaN` to `0` or throw on empty input.
+- HTTP error messages and remember-job error strings no longer forward `localhost` / `127.0.0.1` URLs to callers.
 
 ## 0.1.4
 

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -122,4 +122,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -5,13 +5,13 @@ import { readFileSync } from "node:fs";
 const releases = [
     {
         name: "TypeScript SDK",
-        version: "0.1.4",
+        version: "0.1.5",
         manifests: [["packages/sdk/package.json", "version"]],
         changelogs: ["packages/sdk/CHANGELOG.md", "docs/sdk/changelog.mdx"],
     },
     {
         name: "Python SDK",
-        version: "0.1.7",
+        version: "0.1.8",
         manifests: [
             ["packages/python-sdk-memwal/pyproject.toml", "toml-version"],
             ["packages/python-sdk-memwal/memwal/__init__.py", "python-version"],


### PR DESCRIPTION
Completes the manual version bumps that landed partially in #737 / #747: `packages/sdk/package.json` (0.1.5) and `pyproject.toml` (0.1.8) were bumped, but the rest of the manual release file set was not, so `node scripts/verify-manual-sdk-release.mjs` fails on dev today.

Fixes:

* `packages/python-sdk-memwal/memwal/__init__.py` — `__version__` 0.1.7 → 0.1.8 (was mismatched with pyproject inside the same package)
* `scripts/verify-manual-sdk-release.mjs` — pins updated to 0.1.5 / 0.1.8
* `docs/sdk/changelog.mdx` — adds the 0.1.5 section (ported from packages/sdk/CHANGELOG.md) and refreshes the frontmatter answer summary
* `docs/python-sdk/changelog.mdx` — adds the 0.1.8 section (ported from the package CHANGELOG) and refreshes the answer summary

Verified: `node scripts/verify-manual-sdk-release.mjs` now passes for all four packages, and `memwal.__version__` imports as 0.1.8.

Not addressed here: MCP has one unpublished fix (fa5c8134, TS2352 cast) sitting on dev under the already-published 0.0.11; it needs a 0.0.12 bump whenever the next MCP publish happens.

Should merge into dev before the dev → staging promotion (#788).