### PR TITLE
fix(python-sdk): read package version via Sui GraphQL, stop hanging init on a dead JSON-RPC mirror

### DIFF
--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -83,6 +83,13 @@ from .utils import (
 
 T = TypeVar("T")
 SEAL_SESSION_TTL_MIN = 5
+
+# Networks with a public Sui GraphQL read endpoint (https://graphql.<network>.sui.io).
+PUBLIC_SUI_GRAPHQL_NETWORKS = ("mainnet", "testnet", "devnet")
+
+# Fail the package-version preflight fast instead of hanging client init when a
+# Sui read endpoint is unresponsive.
+PACKAGE_VERSION_CHECK_TIMEOUT_S = 10.0
 SEAL_SESSION_SAFETY_MARGIN_MS = 30_000
 AUTH_REJECTED_MESSAGE = (
     "401 from relayer: typically wrong private key, key not registered on this "
@@ -1039,17 +1046,46 @@ class MemWal:
         package_id = data.get("packageId")
         network = data.get("network")
         sui_rpc_url = data.get("suiRpcUrl")
-        if not package_id or not network or not sui_rpc_url:
-            raise MemWalError("GET /config response missing packageId / network / suiRpcUrl")
+        if not package_id or not network:
+            raise MemWalError("GET /config response missing packageId / network")
 
         self._server_config = {
             "packageId": package_id,
             "network": network,
-            "suiRpcUrl": sui_rpc_url,
+            "suiRpcUrl": sui_rpc_url or "",
         }
         return self._server_config
 
-    async def _assert_first_package_version(self, sui_rpc_url: str, package_id: str) -> None:
+    async def _fetch_package_version_graphql(self, network: str, package_id: str):
+        """Read the package object version via Sui GraphQL RPC.
+
+        JSON-RPC on public fullnodes is sunset (see
+        https://docs.sui.io/develop/accessing-data/json-rpc-migration), and the
+        third-party JSON-RPC mirror the relayer used to advertise has gone
+        unresponsive, hanging every client init. GraphQL is the plain-HTTPS
+        read layer that survives the sunset without pulling gRPC deps into
+        this SDK.
+        """
+        graphql_url = f"https://graphql.{network}.sui.io/graphql"
+        response = await self._http.post(
+            graphql_url,
+            json={
+                "query": "query($a:SuiAddress!){object(address:$a){version}}",
+                "variables": {"a": package_id},
+            },
+            timeout=PACKAGE_VERSION_CHECK_TIMEOUT_S,
+        )
+        if response.status_code != 200:
+            raise MemWalError(f"Sui GraphQL returned {response.status_code}")
+        body = response.json()
+        obj = (body.get("data") or {}).get("object")
+        if not isinstance(obj, dict) or obj.get("version") is None:
+            raise MemWalError(f"Sui GraphQL could not resolve package {package_id}")
+        return obj["version"]
+
+    async def _fetch_package_version_jsonrpc(self, sui_rpc_url: str, package_id: str):
+        """Legacy JSON-RPC fallback for custom / local networks that have no
+        public GraphQL endpoint and still serve `sui_getObject`."""
         response = await self._http.post(
             sui_rpc_url,
             json={
@@ -1058,6 +1094,7 @@ class MemWal:
                 "method": "sui_getObject",
                 "params": [package_id, {"showBcs": False, "showContent": False, "showType": False}],
             },
+            timeout=PACKAGE_VERSION_CHECK_TIMEOUT_S,
         )
         if response.status_code != 200:
             raise MemWalError(f"sui_getObject returned {response.status_code}")
@@ -1073,6 +1110,20 @@ class MemWal:
                 obj = result.get("object")
                 if isinstance(obj, dict):
                     version = obj.get("version")
+        return version
+
+    async def _assert_first_package_version(
+        self, network: str, sui_rpc_url: str, package_id: str
+    ) -> None:
+        if network in PUBLIC_SUI_GRAPHQL_NETWORKS:
+            version = await self._fetch_package_version_graphql(network, package_id)
+        elif sui_rpc_url:
+            version = await self._fetch_package_version_jsonrpc(sui_rpc_url, package_id)
+        else:
+            raise MemWalError(
+                f"No Sui read endpoint available for network {network!r}: "
+                "no public GraphQL endpoint and GET /config carried no suiRpcUrl"
+            )
         if str(version) != "1":
             raise MemWalError(
                 f"SEAL package {package_id} must be at version 1 to build "
@@ -1081,7 +1132,9 @@ class MemWal:
 
     async def _build_seal_session_inner(self) -> str:
         cfg = await self._fetch_server_config()
-        await self._assert_first_package_version(cfg["suiRpcUrl"], cfg["packageId"])
+        await self._assert_first_package_version(
+            cfg["network"], cfg["suiRpcUrl"], cfg["packageId"]
+        )
 
         session_signing_key = nacl.signing.SigningKey.generate()
         session_public_key = bytes(session_signing_key.verify_key)

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -86,6 +86,12 @@ def mock_seal_session_prereqs() -> None:
             },
         )
     )
+    respx.post("https://graphql.testnet.sui.io/graphql").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"object": {"version": 1}}},
+        )
+    )
     respx.post(_TEST_SUI_RPC).mock(
         return_value=httpx.Response(
             200,

--- a/packages/python-sdk-memwal/tests/test_middleware.py
+++ b/packages/python-sdk-memwal/tests/test_middleware.py
@@ -99,6 +99,12 @@ def _mock_seal_session_prereqs() -> None:
             },
         )
     )
+    respx.post("https://graphql.testnet.sui.io/graphql").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"object": {"version": 1}}},
+        )
+    )
     respx.post(_SUI_RPC_URL).mock(
         return_value=httpx.Response(
             200,


### PR DESCRIPTION
Fixes the 16 `httpx.ReadTimeout` failures in **Test Python SDK / E2E / dev relayer** (run 32828782938, both attempts).

## Root cause

The x-seal-session preflight `_assert_first_package_version()` called JSON-RPC `sui_getObject` against the `suiRpcUrl` advertised by `GET /config`, with no timeout. That URL is `rpc-testnet.suiscan.xyz`, a third-party mirror kept around because JSON-RPC on public fullnodes is sunset. The mirror went unresponsive today (accepts TCP, never replies), so every client init hung for the full read timeout and all 16 relayer-touching e2e tests failed identically. The relayer itself was unaffected: it already routes delegate verification through gRPC (`SUI_GRPC_URL`), and the TS SDK already supports the gRPC transport. The Python SDK preflight was the one caller left on JSON-RPC.

## Fix

* Preflight now queries the public **Sui GraphQL** endpoint (`https://graphql.<network>.sui.io/graphql`) for mainnet/testnet/devnet, plain HTTPS via the existing httpx client, no new dependencies. Verified live: it returns `version: 1` for the dev SEAL package `0x0a625e...`.
* JSON-RPC `sui_getObject` kept only as a fallback for custom/local networks that have no public GraphQL endpoint.
* Both paths capped at **10s** so an unresponsive endpoint fails fast with a clear error instead of stalling init.
* `GET /config` parsing no longer hard-requires `suiRpcUrl` (GraphQL path does not need it); still read when present for the fallback.

## Verification

* All **136 unit tests pass** (GraphQL endpoint mocked in test_client / test_middleware fixtures).
* Live GraphQL probe against the real dev package id returns version 1, matching the preflight's assertion.

## Follow-ups (not this PR)

* Published `memwal` 0.1.7 on PyPI still calls the dead mirror; the Railway `SUI_RPC_URL` on the dev relayer should be pointed at a live provider (or dropped once clients no longer need it) — infra decision.
* This lands after the version-sync PR #792, so it will ride under a future 0.1.9 bump when published.