### PR TITLE
ci: split live JS SDK e2e out of test.yml (WALM-426)

### DIFF
--- a/.github/actions/setup-js/action.yml
+++ b/.github/actions/setup-js/action.yml
@@ -1,0 +1,24 @@
+name: Setup JS
+description: pnpm, Node, and a frozen-lockfile install
+
+inputs:
+  node-version:
+    description: Node version
+    required: false
+    default: "22"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+
+    - name: Install deps
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,26 @@
+name: Setup Playwright
+description: Cache and install Chromium for a workspace package
+
+inputs:
+  package:
+    description: pnpm filter name (e.g. @memwal/chatbot)
+    required: true
+  cache-id:
+    description: Cache key suffix so parallel jobs do not race one entry
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: pw-${{ inputs.cache-id }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pw-${{ inputs.cache-id }}-${{ runner.os }}-
+          pw-${{ runner.os }}-
+
+    - name: Install Playwright (Chromium + OS deps)
+      shell: bash
+      run: pnpm --filter ${{ inputs.package }} playwright:install

--- a/.github/actions/upload-playwright-report/action.yml
+++ b/.github/actions/upload-playwright-report/action.yml
@@ -1,0 +1,20 @@
+name: Upload Playwright report
+description: Upload Playwright HTML report and traces
+
+inputs:
+  app:
+    description: Directory name under apps/
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Upload Playwright report + traces
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-${{ inputs.app }}
+        path: |
+          apps/${{ inputs.app }}/playwright-report
+          apps/${{ inputs.app }}/test-results
+        retention-days: 14
+        if-no-files-found: ignore

--- a/.github/actions/wait-for-relayer/action.yml
+++ b/.github/actions/wait-for-relayer/action.yml
@@ -59,7 +59,11 @@ runs:
         last_error = "no successful /health response"
         while time.monotonic() < deadline:
             try:
-                with urllib.request.urlopen(url, timeout=10) as response:
+                request = urllib.request.Request(
+                    url,
+                    headers={"User-Agent": "MemWal-ci-wait-for-relayer"},
+                )
+                with urllib.request.urlopen(request, timeout=10) as response:
                     data = json.load(response)
                 status = str(data.get("status") or "")
                 ready = data.get("write_ready") is True

--- a/.github/actions/wait-for-relayer/action.yml
+++ b/.github/actions/wait-for-relayer/action.yml
@@ -40,27 +40,24 @@ runs:
           exit 1
         fi
 
-        expected="${EXPECTED_SHA:-}"
-        case "$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')" in
-          false|null|none) expected="" ;;
-        esac
-        since="${SINCE_SHA:-}"
+        expected="$(printf '%s' "${EXPECTED_SHA:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+        since="$(printf '%s' "${SINCE_SHA:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+        case "$expected" in false|null|none) expected="" ;; esac
+        case "$since" in false|null|none) since="" ;; esac
         zeros="0000000000000000000000000000000000000000"
 
         # Railway relayer watchPatterns is /services/server/**. A push that
-        # does not touch that tree is recorded SKIPPED — no build, no new SHA
-        # — so waiting for github.sha never clears (PR 804 / nikola0x0).
+        # does not touch that tree is SKIPPED — no new SHA is served — so
+        # waiting on expected-commit would hang until timeout.
         if [ -n "$expected" ] && [ -n "$since" ] && [ "$since" != "$zeros" ]; then
-          if git fetch --no-tags --depth=1 origin "$since" >/tmp/wait-relayer-fetch.log 2>&1; then
-            if ! git diff --name-only "$since" "$expected" | grep -qE '^services/server/'; then
-              echo "No services/server/** changes in this push; Railway will SKIP the relayer deploy. Waiting on write_ready only."
+          if git fetch --no-tags --depth=1 origin "$since" \
+            && changed="$(git diff --name-only "$since" "$expected")"; then
+            if ! printf '%s\n' "$changed" | grep -Eq '^services/server/'; then
+              echo "Railway will SKIP this push, so SHA wait is skipped."
               expected=""
-            else
-              echo "services/server/** changed; waiting for Railway to serve ${expected:0:12}."
             fi
           else
-            echo "Could not fetch since-commit ${since:0:12}; keeping SHA wait."
-            cat /tmp/wait-relayer-fetch.log >&2 || true
+            echo "Could not fetch/diff since-commit; keeping SHA wait."
           fi
         fi
         export EXPECTED_SHA="$expected"

--- a/.github/actions/wait-for-relayer/action.yml
+++ b/.github/actions/wait-for-relayer/action.yml
@@ -40,6 +40,9 @@ runs:
 
         base = os.environ["SERVER_URL"].rstrip("/")
         expected = os.environ.get("EXPECTED_SHA", "").strip().lower()
+        # GitHub `false && github.sha || ''` can stringify as "false".
+        if expected in {"", "false", "null", "none"}:
+            expected = ""
         timeout = int(os.environ.get("TIMEOUT_SECS", "480"))
         poll = int(os.environ.get("POLL_SECS", "10"))
         url = f"{base}/health"

--- a/.github/actions/wait-for-relayer/action.yml
+++ b/.github/actions/wait-for-relayer/action.yml
@@ -1,0 +1,91 @@
+name: Wait for relayer
+description: Poll GET /health until Railway is serving this git SHA
+
+inputs:
+  server-url:
+    description: Relayer base URL
+    required: true
+  expected-commit:
+    description: Full git SHA to wait for. Empty waits for health only.
+    required: false
+    default: ""
+  timeout-seconds:
+    description: Give up after this many seconds (Railway deploys are ~2m, cold image longer)
+    required: false
+    default: "480"
+  poll-seconds:
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Wait until /health serves the expected commit
+      shell: bash
+      env:
+        SERVER_URL: ${{ inputs.server-url }}
+        EXPECTED_SHA: ${{ inputs.expected-commit }}
+        TIMEOUT_SECS: ${{ inputs.timeout-seconds }}
+        POLL_SECS: ${{ inputs.poll-seconds }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${SERVER_URL:-}" ]; then
+          echo "::error::server-url is empty"
+          exit 1
+        fi
+
+        python3 - <<'PY'
+        import json, os, sys, time, urllib.error, urllib.request
+
+        base = os.environ["SERVER_URL"].rstrip("/")
+        expected = os.environ.get("EXPECTED_SHA", "").strip().lower()
+        timeout = int(os.environ.get("TIMEOUT_SECS", "480"))
+        poll = int(os.environ.get("POLL_SECS", "10"))
+        url = f"{base}/health"
+        deadline = time.monotonic() + timeout
+
+        print(
+            f"Waiting on {url} (timeout {timeout}s, expected commit {expected or '<any>'})",
+            flush=True,
+        )
+
+        def commit_matches(commit: str) -> bool:
+            if not expected:
+                return True
+            got = commit.lower()
+            return bool(got) and (got == expected or expected.startswith(got) or got.startswith(expected))
+
+        last_error = "no successful /health response"
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(url, timeout=10) as response:
+                    data = json.load(response)
+                status = str(data.get("status") or "")
+                ready = data.get("write_ready") is True
+                commit = str((data.get("build") or {}).get("commit") or "")
+                print(
+                    f"waiting: status={status or '?'} write_ready={str(ready).lower()} commit={commit or 'none'}",
+                    flush=True,
+                )
+                if status == "ok" and ready and commit_matches(commit):
+                    print(f"Relayer ready (commit={commit or 'none'})", flush=True)
+                    raise SystemExit(0)
+                last_error = (
+                    f"status={status!r} write_ready={ready} commit={commit or 'none'}"
+                )
+            except urllib.error.URLError as exc:
+                last_error = f"health unreachable: {exc}"
+                print(f"waiting: {last_error}", flush=True)
+            except json.JSONDecodeError as exc:
+                last_error = f"health returned non-JSON: {exc}"
+                print(f"waiting: {last_error}", flush=True)
+            time.sleep(poll)
+
+        print(
+            f"::error::Timed out after {timeout}s waiting for {url} to serve "
+            f"commit {expected or '<any>'} ({last_error}). Railway deploys take ~2m.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+        PY

--- a/.github/actions/wait-for-relayer/action.yml
+++ b/.github/actions/wait-for-relayer/action.yml
@@ -1,5 +1,5 @@
 name: Wait for relayer
-description: Poll GET /health until Railway is serving this git SHA
+description: Poll GET /health until the relayer is write-ready (and serving this SHA if Railway built it)
 
 inputs:
   server-url:
@@ -7,6 +7,10 @@ inputs:
     required: true
   expected-commit:
     description: Full git SHA to wait for. Empty waits for health only.
+    required: false
+    default: ""
+  since-commit:
+    description: Push `github.event.before`. When set, SHA wait is skipped unless services/server/** changed (Railway watchPatterns SKIP those deploys).
     required: false
     default: ""
   timeout-seconds:
@@ -25,6 +29,7 @@ runs:
       env:
         SERVER_URL: ${{ inputs.server-url }}
         EXPECTED_SHA: ${{ inputs.expected-commit }}
+        SINCE_SHA: ${{ inputs.since-commit }}
         TIMEOUT_SECS: ${{ inputs.timeout-seconds }}
         POLL_SECS: ${{ inputs.poll-seconds }}
       run: |
@@ -35,8 +40,33 @@ runs:
           exit 1
         fi
 
+        expected="${EXPECTED_SHA:-}"
+        case "$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')" in
+          false|null|none) expected="" ;;
+        esac
+        since="${SINCE_SHA:-}"
+        zeros="0000000000000000000000000000000000000000"
+
+        # Railway relayer watchPatterns is /services/server/**. A push that
+        # does not touch that tree is recorded SKIPPED — no build, no new SHA
+        # — so waiting for github.sha never clears (PR 804 / nikola0x0).
+        if [ -n "$expected" ] && [ -n "$since" ] && [ "$since" != "$zeros" ]; then
+          if git fetch --no-tags --depth=1 origin "$since" >/tmp/wait-relayer-fetch.log 2>&1; then
+            if ! git diff --name-only "$since" "$expected" | grep -qE '^services/server/'; then
+              echo "No services/server/** changes in this push; Railway will SKIP the relayer deploy. Waiting on write_ready only."
+              expected=""
+            else
+              echo "services/server/** changed; waiting for Railway to serve ${expected:0:12}."
+            fi
+          else
+            echo "Could not fetch since-commit ${since:0:12}; keeping SHA wait."
+            cat /tmp/wait-relayer-fetch.log >&2 || true
+          fi
+        fi
+        export EXPECTED_SHA="$expected"
+
         python3 - <<'PY'
-        import json, os, sys, time, urllib.error, urllib.request
+        import http.client, json, os, sys, time, urllib.error, urllib.request
 
         base = os.environ["SERVER_URL"].rstrip("/")
         expected = os.environ.get("EXPECTED_SHA", "").strip().lower()
@@ -81,11 +111,9 @@ runs:
                 last_error = (
                     f"status={status!r} write_ready={ready} commit={commit or 'none'}"
                 )
-            except urllib.error.URLError as exc:
-                last_error = f"health unreachable: {exc}"
-                print(f"waiting: {last_error}", flush=True)
-            except json.JSONDecodeError as exc:
-                last_error = f"health returned non-JSON: {exc}"
+            except (urllib.error.URLError, OSError, http.client.HTTPException,
+                    json.JSONDecodeError) as exc:
+                last_error = f"health check failed: {exc}"
                 print(f"waiting: {last_error}", flush=True)
             time.sleep(poll)
 

--- a/.github/workflows/benchmark-live.yml
+++ b/.github/workflows/benchmark-live.yml
@@ -104,11 +104,10 @@ jobs:
         run: npm ci
 
       - name: Wait for Railway deploy
-        if: github.event_name == 'push'
         uses: ./.github/actions/wait-for-relayer
         with:
           server-url: ${{ env.SERVER_URL }}
-          expected-commit: ${{ github.sha }}
+          expected-commit: ${{ github.event_name == 'push' && github.sha || '' }}
 
       - name: Run memory API latency benchmark
         shell: bash

--- a/.github/workflows/benchmark-live.yml
+++ b/.github/workflows/benchmark-live.yml
@@ -64,7 +64,7 @@ jobs:
       name: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'staging' && 'staging' || 'dev') }}
     timeout-minutes: 30
 
-    # Serializes against the sdk-e2e job in test.yml and the e2e job in
+    # Serializes against the sdk-e2e job in test-sdk.yml and the e2e job in
     # test-python-sdk.yml, which sign with this same BENCH_DELEGATE_KEY. The
     # relayer rate-limits per delegate key and per account, so two suites
     # running concurrently 429 each other. Group name must stay identical in
@@ -102,6 +102,13 @@ jobs:
       - name: Install sidecar script dependencies
         working-directory: services/server/scripts
         run: npm ci
+
+      - name: Wait for Railway deploy
+        if: github.event_name == 'push'
+        uses: ./.github/actions/wait-for-relayer
+        with:
+          server-url: ${{ env.SERVER_URL }}
+          expected-commit: ${{ github.sha }}
 
       - name: Run memory API latency benchmark
         shell: bash

--- a/.github/workflows/benchmark-live.yml
+++ b/.github/workflows/benchmark-live.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           server-url: ${{ env.SERVER_URL }}
           expected-commit: ${{ github.event_name == 'push' && github.sha || '' }}
+          since-commit: ${{ github.event_name == 'push' && github.event.before || '' }}
 
       - name: Run memory API latency benchmark
         shell: bash

--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'packages/python-sdk-memwal/**'
       - '.github/workflows/test-python-sdk.yml'
+      - '.github/actions/wait-for-relayer/**'
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
     paths:
       - 'packages/python-sdk-memwal/**'
       - '.github/workflows/test-python-sdk.yml'
+      - '.github/actions/wait-for-relayer/**'
   workflow_dispatch:
   schedule:
     # Catches relayer drift with no code change to trigger it.
@@ -135,6 +137,7 @@ jobs:
           fi
           echo "authenticated=true" >> "$GITHUB_OUTPUT"
 
+      # Push to `dev`: wait for this SHA. Dispatch/schedule: health only.
       - name: Wait for Railway deploy
         uses: ./.github/actions/wait-for-relayer
         with:

--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           server-url: ${{ env.MEMWAL_SERVER_URL }}
           expected-commit: ${{ github.event_name == 'push' && github.sha || '' }}
+          since-commit: ${{ github.event_name == 'push' && github.event.before || '' }}
 
       - name: E2E tests
         id: e2e

--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -81,10 +81,10 @@ jobs:
     # `default` and a per-run `sdk-e2e-<uuid>` — but they do not keep the
     # *rate limit* separate: the relayer meters per delegate key and per
     # account, so the concurrency group below is what stops the three suites
-    # 429ing each other. Group name must stay identical in all three
-    # workflows — byte-identical on purpose, including branches this
-    # dev-only job never runs on, so the three land in one group whatever
-    # the expression resolves to.
+    # 429ing each other. Group name must stay identical in this file,
+    # test-sdk.yml, and benchmark-live.yml — byte-identical on purpose,
+    # including branches this dev-only job never runs on, so the three land
+    # in one group whatever the expression resolves to.
     concurrency:
       group: bench-account-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
       cancel-in-progress: false
@@ -134,6 +134,13 @@ jobs:
             exit 1
           fi
           echo "authenticated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Railway deploy
+        if: github.event_name == 'push'
+        uses: ./.github/actions/wait-for-relayer
+        with:
+          server-url: ${{ env.MEMWAL_SERVER_URL }}
+          expected-commit: ${{ github.sha }}
 
       - name: E2E tests
         id: e2e

--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -137,7 +137,8 @@ jobs:
           fi
           echo "authenticated=true" >> "$GITHUB_OUTPUT"
 
-      # Push to `dev`: wait for this SHA. Dispatch/schedule: health only.
+      # Push that touched services/server/**: wait for this SHA. SDK-only
+      # pushes and dispatch/schedule: health + write_ready only.
       - name: Wait for Railway deploy
         uses: ./.github/actions/wait-for-relayer
         with:

--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -136,11 +136,10 @@ jobs:
           echo "authenticated=true" >> "$GITHUB_OUTPUT"
 
       - name: Wait for Railway deploy
-        if: github.event_name == 'push'
         uses: ./.github/actions/wait-for-relayer
         with:
           server-url: ${{ env.MEMWAL_SERVER_URL }}
-          expected-commit: ${{ github.sha }}
+          expected-commit: ${{ github.event_name == 'push' && github.sha || '' }}
 
       - name: E2E tests
         id: e2e

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -1,10 +1,13 @@
 name: Test JS SDK
 
 # Live JS SDK e2e against the bench relayer.
-# Unit tests stay in test.yml so they run on every PR.
+# Unit tests stay in test.yml so they run on every PR; this job also runs
+# them before live writes so a typecheck-only green cannot mint memories.
 #
-# push to main/staging/dev: wait until /health.build.commit == github.sha
-#   (Railway takes ~2m to serve the new replica).
+# push that touched services/server/**: wait until /health.build.commit == github.sha
+#   (Railway takes ~2m to serve the new replica). Other pushes are SKIPPED by
+#   Railway watchPatterns, so wait-for-relayer drops the SHA and waits on
+#   write_ready only.
 # workflow_dispatch / schedule: wait until /health is ok — Railway does not
 #   deploy a feature-branch SHA, so this is a preview against the live replica.
 
@@ -68,7 +71,7 @@ jobs:
         uses: ./.github/actions/setup-js
 
       - name: Build
-        run: pnpm build:sdk
+        run: pnpm build:sdk && pnpm --filter @mysten-incubation/memwal test
 
       - name: Check credentials
         id: config
@@ -99,6 +102,7 @@ jobs:
         with:
           server-url: ${{ env.MEMWAL_SERVER_URL }}
           expected-commit: ${{ github.event_name == 'push' && github.sha || '' }}
+          since-commit: ${{ github.event_name == 'push' && github.event.before || '' }}
 
       - name: E2E tests
         id: e2e

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -1,0 +1,128 @@
+name: Test JS SDK
+
+# Live JS SDK e2e against the bench relayer.
+# Unit tests stay in test.yml so they run on every PR.
+
+on:
+  push:
+    branches: [main, staging, dev]
+    paths:
+      - "packages/sdk/**"
+      - ".github/workflows/test-sdk.yml"
+      - ".github/actions/setup-js/**"
+      - ".github/actions/wait-for-relayer/**"
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Benchmark environment to run the authenticated SDK e2e suite against
+        required: false
+        type: choice
+        default: dev
+        options:
+          - dev
+          - staging
+          - production
+  schedule:
+    # Offset from benchmark-live.yml (0 9 * * 1) and test-python-sdk.yml
+    # (17 9 * * 1) so the three suites do not write through the shared bench
+    # account at once. The concurrency group below enforces that too.
+    - cron: "47 9 * * 1"
+
+concurrency:
+  group: test-js-sdk-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sdk-e2e:
+    name: SDK / E2E (live relayer)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    # Byte-identical to benchmark-live.yml and test-python-sdk.yml so the three
+    # suites serialize on the shared BENCH_DELEGATE_KEY. Do not edit one copy.
+    concurrency:
+      group: bench-account-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
+      cancel-in-progress: false
+
+    environment:
+      name: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
+
+    env:
+      ENVIRONMENT_NAME: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
+      MEMWAL_PRIVATE_KEY: ${{ secrets.BENCH_DELEGATE_KEY }}
+      MEMWAL_ACCOUNT_ID: ${{ secrets.BENCH_ACCOUNT_ID }}
+      MEMWAL_SERVER_URL: ${{ vars.BENCH_SERVER_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
+
+      - name: Build
+        run: pnpm build:sdk
+
+      - name: Check credentials
+        id: config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Without credentials the suite skips every authenticated test and
+          # the job would report success having never exercised the relayer
+          # beyond /health. Without the URL there is no safe fallback.
+          missing=0
+          for name in MEMWAL_PRIVATE_KEY MEMWAL_ACCOUNT_ID MEMWAL_SERVER_URL; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::${name} is empty — set BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID / BENCH_SERVER_URL on the ${ENVIRONMENT_NAME} environment."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+          echo "authenticated=true" >> "$GITHUB_OUTPUT"
+
+      # Push races Railway: the relayer image takes ~2m to rebuild, so /health
+      # still serves the previous SHA until the new replica is live.
+      - name: Wait for Railway deploy
+        if: github.event_name == 'push'
+        uses: ./.github/actions/wait-for-relayer
+        with:
+          server-url: ${{ env.MEMWAL_SERVER_URL }}
+          expected-commit: ${{ github.sha }}
+
+      - name: E2E tests
+        id: e2e
+        working-directory: packages/sdk
+        run: |
+          node --test --test-concurrency=1 \
+            --test-reporter=spec --test-reporter-destination=stdout \
+            --test-reporter=junit --test-reporter-destination=e2e-results.xml \
+            "test/e2e/live.e2e.mjs"
+
+      - name: Write run summary
+        if: always()
+        run: |
+          {
+            echo "## JS SDK e2e"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Environment | \`${ENVIRONMENT_NAME}\` |"
+            echo "| Relayer | \`${MEMWAL_SERVER_URL:-<unset>}\` |"
+            echo "| Authenticated | ${{ steps.config.outputs.authenticated }} |"
+            echo "| Result | ${{ steps.e2e.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload e2e results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-sdk-e2e-${{ env.ENVIRONMENT_NAME }}-${{ github.run_id }}
+          path: packages/sdk/e2e-results.xml
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -2,6 +2,11 @@ name: Test JS SDK
 
 # Live JS SDK e2e against the bench relayer.
 # Unit tests stay in test.yml so they run on every PR.
+#
+# push to main/staging/dev: wait until /health.build.commit == github.sha
+#   (Railway takes ~2m to serve the new replica).
+# workflow_dispatch / schedule: wait until /health is ok — Railway does not
+#   deploy a feature-branch SHA, so this is a preview against the live replica.
 
 on:
   push:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -94,9 +94,10 @@ jobs:
           fi
           echo "authenticated=true" >> "$GITHUB_OUTPUT"
 
-      # Push: wait until this SHA is live (Railway ~2m). Dispatch/schedule:
-      # Railway never deploys a feature-branch SHA, so only wait until the
-      # already-deployed replica is healthy.
+      # Push that touched services/server/**: wait until this SHA is live
+      # (Railway ~2m). Other pushes and dispatch/schedule: health + write_ready
+      # only — Railway never deploys a feature-branch SHA, and SKIPPED deploys
+      # keep serving the previous SHA.
       - name: Wait for Railway deploy
         uses: ./.github/actions/wait-for-relayer
         with:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -86,14 +86,14 @@ jobs:
           fi
           echo "authenticated=true" >> "$GITHUB_OUTPUT"
 
-      # Push races Railway: the relayer image takes ~2m to rebuild, so /health
-      # still serves the previous SHA until the new replica is live.
+      # Push: wait until this SHA is live (Railway ~2m). Dispatch/schedule:
+      # Railway never deploys a feature-branch SHA, so only wait until the
+      # already-deployed replica is healthy.
       - name: Wait for Railway deploy
-        if: github.event_name == 'push'
         uses: ./.github/actions/wait-for-relayer
         with:
           server-url: ${{ env.MEMWAL_SERVER_URL }}
-          expected-commit: ${{ github.sha }}
+          expected-commit: ${{ github.event_name == 'push' && github.sha || '' }}
 
       - name: E2E tests
         id: e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,32 +1,14 @@
 name: Tests
 
+# Monorepo CI: unit, lint, Playwright, contract, docs, MCP.
+# Live JS SDK e2e against a relayer is .github/workflows/test-sdk.yml.
+
 on:
   pull_request:
     branches: [main, staging, dev]
   push:
     branches: [main, staging, dev]
   workflow_dispatch:
-    inputs:
-      target_environment:
-        description: Benchmark environment to run the authenticated SDK e2e suite against
-        required: false
-        type: choice
-        default: dev
-        options:
-          - dev
-          - staging
-          - production
-  schedule:
-    # Catches relayer drift with no code change to trigger it. Only sdk-e2e
-    # runs on this trigger — every other job carries
-    # `if: github.event_name != 'schedule'` so a weekly run does not spin up
-    # Playwright, cargo and the docker services for nothing.
-    #
-    # Offset from benchmark-live.yml (0 9 * * 1) and test-python-sdk.yml
-    # (17 9 * * 1) so the three suites do not write through the shared bench
-    # account at once. The concurrency group below now enforces that too;
-    # the offsets remain as a second line of defence.
-    - cron: '47 9 * * 1'
 
 concurrency:
   group: test-${{ github.workflow }}-${{ github.ref }}
@@ -36,320 +18,67 @@ permissions:
   contents: read
 
 jobs:
-  compatibility-contract:
-    name: Compatibility / Contract metadata
-    if: github.event_name != 'schedule'
+  meta:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Check compatibility contract
-        run: node scripts/check-compatibility-contract.mjs
-
-  docs-code-sync:
-    name: Docs / Code references match packages
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      # Snippets in docs/ are copies (Mintlify cannot import code from
-      # repository files at build time). This validates every docs page
-      # against the workspace: package names and entry points come from each
-      # packages/*/package.json, and MCP config blocks from the packages/mcp
-      # README. Failing the job blocks the merge, so drift is fixed in the
-      # same pull request.
-      - name: Check docs code references against the packages
-        run: node scripts/check-docs-code-sync.mjs
-
-  docs-freshness:
-    name: Docs / Freshness
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Check docs freshness
-        run: node scripts/check-docs-freshness.mjs
-
-  mcp-tests:
-    name: MCP / Integration (login handoff)
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
-
-      # Builds the package (tsc) then runs the node:test integration suite:
-      # spawns the real stdio MCP with empty creds, writes credentials
-      # mid-process, and asserts memwal_recall is served against a mock relayer
-      # without a restart (auth-required -> bridge hot-handoff).
-      - name: MCP integration tests
-        run: pnpm --filter @mysten-incubation/memwal-mcp test
-
-  sdk-changed:
-    name: SDK / Change detection
-    # sdk-e2e never runs on pull requests, so the full-history checkout below
-    # would be pure cost on every PR. Skipping here also skips sdk-e2e, which
-    # is what its own `if` already asks for.
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      sdk: ${{ steps.filter.outputs.sdk }}
-
-    # test-sdk.yml gated its whole workflow on `paths: packages/sdk/**`. This
-    # workflow cannot: a `paths:` filter here would gate all 13 jobs. Without
-    # some gate the live e2e would fire on every dev merge — roughly 100
-    # weighted requests a run against a 500/hour per-account budget, which is
-    # the very limit the concurrency group exists to stay under. So detect the
-    # change here and let sdk-e2e decide.
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Did the SDK change?
-        id: filter
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # schedule and workflow_dispatch have no diff to inspect, and both
-          # are deliberate requests to exercise the relayer. Always run.
-          if [ "${{ github.event_name }}" != "push" ]; then
-            echo "sdk=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          base="${{ github.event.before }}"
-          # A new branch, a force-push, or a pruned commit leaves no usable
-          # base. Run rather than skip: a false positive costs one e2e run, a
-          # false negative ships an untested SDK.
-          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] \
-             || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
-            echo "base commit unavailable — running the suite"
-            echo "sdk=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if git diff --name-only "$base" "${{ github.sha }}" \
-               | grep -qE '^(packages/sdk/|\.github/workflows/test\.yml$)'; then
-            echo "sdk=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "sdk=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  sdk-checks:
-    name: SDK / Unit (Node ${{ matrix.node-version }})
-    # No schedule guard: sdk-e2e needs this job, so skipping it on the weekly
-    # cron would skip the e2e run the cron exists for.
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
     strategy:
       fail-fast: false
       matrix:
-        # 22 is what the rest of this workflow runs on; 24 is the active LTS.
+        include:
+          - name: Compatibility / Contract metadata
+            script: scripts/check-compatibility-contract.mjs
+          - name: Docs / Code references match packages
+            script: scripts/check-docs-code-sync.mjs
+          - name: Docs / Freshness
+            script: scripts/check-docs-freshness.mjs
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run check
+        run: node ${{ matrix.script }}
+
+  mcp-tests:
+    name: MCP / Integration (login handoff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
+
+      - name: MCP integration tests
+        run: pnpm --filter @mysten-incubation/memwal-mcp test
+
+  sdk-checks:
+    name: SDK / Unit (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
         node-version: ["22", "24"]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
         with:
           node-version: ${{ matrix.node-version }}
-          cache: pnpm
-
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
 
       - name: Typecheck, build and unit tests
         run: pnpm --filter @mysten-incubation/memwal test
 
-  sdk-e2e:
-    # Deliberately static. A `${{ ... }}` name renders unevaluated in the
-    # checks UI when the job is skipped, which is most of the time. The target
-    # environment is already visible in `environment:` and the run summary.
-    name: SDK / E2E (live relayer)
-    runs-on: ubuntu-latest
-    needs: [sdk-checks, sdk-changed]
-    timeout-minutes: 30
-
-    # Each long-lived branch tests the deployment it corresponds to. Pull
-    # requests are excluded because environment secrets are withheld from fork
-    # PRs, and every authenticated run writes real memories. The sdk-changed
-    # clause replaces the `paths:` filter test-sdk.yml carried before this job
-    # moved into a workflow shared with twelve unrelated jobs.
-    if: >-
-      needs.sdk-changed.outputs.sdk == 'true' &&
-      (github.event_name == 'workflow_dispatch' ||
-       github.event_name == 'schedule' ||
-       (github.event_name == 'push' &&
-        (github.ref_name == 'dev' ||
-         github.ref_name == 'staging' ||
-         github.ref_name == 'main')))
-
-    # Serializes against benchmark-live.yml and test-python-sdk.yml, which
-    # sign with the same BENCH_DELEGATE_KEY. The relayer rate-limits per
-    # delegate key (30 weighted-req/min) and per account (60/min, 500/hr), so
-    # two suites hitting one bench account concurrently 429 each other —
-    # exactly what broke this job and the benchmark on 2026-08-21. Namespace
-    # isolation does not help: the limiter keys on the credential, not the
-    # namespace. The expression is byte-identical in all three workflows on
-    # purpose, so they land in one group whatever it resolves to.
-    concurrency:
-      group: bench-account-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
-      cancel-in-progress: false
-
-    # Reuses the credentials benchmark-live.yml and test-python-sdk.yml already
-    # rely on, so this needs no new secrets. The benchmark writes to the
-    # `benchmark` namespace while these tests use a per-run `sdk-e2e-<random>`.
-    #
-    # main maps to benchmark-production, so a push to main writes real
-    # memories through the live Walrus pipeline on the production benchmark
-    # account. That is intentional, and the per-run namespace is what keeps it
-    # contained — never point this job at an account holding user data, and
-    # never relax the namespace isolation in live.e2e.mjs.
-    environment:
-      name: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
-
-    env:
-      # Which deployment this run targets. Mirrors the `environment:` name
-      # above so error messages and the run summary can name it.
-      ENVIRONMENT_NAME: benchmark-${{ github.event_name == 'workflow_dispatch' && inputs.target_environment || (github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'dev') }}
-      # BENCH_DELEGATE_KEY is the delegate private key the SDK signs with,
-      # which test/e2e/live.e2e.mjs reads as MEMWAL_PRIVATE_KEY. Stored in Sui
-      # bech32 (`suiprivkey1...`) form; the SDK normalizes both that and hex.
-      MEMWAL_PRIVATE_KEY: ${{ secrets.BENCH_DELEGATE_KEY }}
-      MEMWAL_ACCOUNT_ID: ${{ secrets.BENCH_ACCOUNT_ID }}
-      # Public URL, set per environment (docs/relayer/benchmark-ci-setup.md).
-      # Deliberately NOT defaulted: with three environments in play, a literal
-      # fallback would silently run the production job against whichever
-      # relayer the default names. A missing variable fails the job instead.
-      MEMWAL_SERVER_URL: ${{ vars.BENCH_SERVER_URL }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build:sdk
-
-      - name: Check credentials
-        id: config
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # Without the credentials the suite skips every authenticated test,
-          # and the job would report success having never exercised the
-          # relayer beyond /health. Without the URL there is no safe guess to
-          # fall back on. Fail instead of reporting a green run that proved
-          # nothing, or running the wrong deployment.
-          missing=0
-          for name in MEMWAL_PRIVATE_KEY MEMWAL_ACCOUNT_ID MEMWAL_SERVER_URL; do
-            if [ -z "${!name:-}" ]; then
-              echo "::error::${name} is empty — set BENCH_DELEGATE_KEY / BENCH_ACCOUNT_ID / BENCH_SERVER_URL on the ${ENVIRONMENT_NAME} environment."
-              missing=1
-            fi
-          done
-          if [ "$missing" -ne 0 ]; then
-            exit 1
-          fi
-          echo "authenticated=true" >> "$GITHUB_OUTPUT"
-
-      - name: E2E tests
-        id: e2e
-        working-directory: packages/sdk
-        run: |
-          node --test \
-            --test-reporter=spec --test-reporter-destination=stdout \
-            --test-reporter=junit --test-reporter-destination=e2e-results.xml \
-            "test/e2e/live.e2e.mjs"
-
-      - name: Write run summary
-        if: always()
-        run: |
-          {
-            echo "## JS SDK e2e"
-            echo
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Environment | \`${ENVIRONMENT_NAME}\` |"
-            echo "| Relayer | \`${MEMWAL_SERVER_URL:-<unset>}\` |"
-            echo "| Authenticated | ${{ steps.config.outputs.authenticated }} |"
-            echo "| Result | ${{ steps.e2e.outcome }} |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload e2e results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: js-sdk-e2e-${{ env.ENVIRONMENT_NAME }}-${{ github.run_id }}
-          path: packages/sdk/e2e-results.xml
-          if-no-files-found: warn
-          retention-days: 14
-
   chatbot-e2e:
     name: Chatbot / Playwright E2E
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -384,53 +113,32 @@ jobs:
       NODE_ENV: test
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
-
-      # Build only. The SDK's own suite runs in sdk-checks below; running it
-      # here too just made a Playwright job fail for an unrelated reason.
-      - name: Build SDK (workspace dep of chatbot)
+      - name: Build SDK
         run: pnpm build:sdk
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
+      - name: Setup Playwright
+        timeout-minutes: 8
+        uses: ./.github/actions/setup-playwright
         with:
-          path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pw-${{ runner.os }}-
-
-      - name: Install Playwright (Chromium + OS deps)
-        run: pnpm --filter @memwal/chatbot playwright:install
+          package: "@memwal/chatbot"
+          cache-id: chatbot
 
       - name: Run Playwright E2E
         run: pnpm --filter @memwal/chatbot test:e2e
 
-      - name: Upload Playwright report + traces
+      - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-playwright-report
         with:
-          name: playwright-report-chatbot
-          path: |
-            apps/chatbot/playwright-report
-            apps/chatbot/test-results
-          retention-days: 14
-          if-no-files-found: ignore
+          app: chatbot
 
   researcher-e2e:
     name: Researcher / Unit + Playwright E2E
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -460,68 +168,41 @@ jobs:
       REDIS_URL: redis://localhost:6379
       AUTH_SECRET: ci-test-secret-not-for-production
       OPENROUTER_API_KEY: mock-not-used-tests-use-local-mocks
-      # Only read by the delegate-account binding mock to fabricate the
-      # MemWalAccount type; any non-empty 0x id works.
       NEXT_PUBLIC_MEMWAL_PACKAGE_ID: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
       PORT: "3000"
       PLAYWRIGHT: "True"
       NODE_ENV: test
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
+      - name: Build SDK
+        run: pnpm build:sdk
 
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
-
-      - name: Test and build SDK (workspace dep of researcher)
-        run: pnpm --filter @mysten-incubation/memwal test
-
-      # Fast node:test unit tests (no DB/browser). Includes the retired-model
-      # regression tests for the title-model production incident.
       - name: Unit tests
         run: pnpm --filter researcher test:unit
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
+      - name: Setup Playwright
+        timeout-minutes: 8
+        uses: ./.github/actions/setup-playwright
         with:
-          path: ~/.cache/ms-playwright
-          # Separate from chatbot's/noter's `pw-` keys so the jobs don't race
-          # the same cache entry. Fall back to the shared prefix on a cold start.
-          key: pw-researcher-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pw-researcher-${{ runner.os }}-
-            pw-${{ runner.os }}-
-
-      - name: Install Playwright (Chromium + OS deps)
-        run: pnpm --filter researcher playwright:install
+          package: researcher
+          cache-id: researcher
 
       - name: Run Playwright E2E
         run: pnpm --filter researcher test:e2e
 
-      - name: Upload Playwright report + traces
+      - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-playwright-report
         with:
-          name: playwright-report-researcher
-          path: |
-            apps/researcher/playwright-report
-            apps/researcher/test-results
-          retention-days: 14
-          if-no-files-found: ignore
+          app: researcher
 
   noter-e2e:
     name: Noter / Playwright E2E
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -545,72 +226,40 @@ jobs:
       PORT: "3002"
       NODE_ENV: test
       PLAYWRIGHT: "True"
-      # NEXT_PUBLIC_* Enoki/Sui vars are inlined at build time — placeholders
-      # are fine here since the e2e suite authenticates via delegate key, not
-      # the Google/Enoki popup flow (that needs a real OAuth session and stays
-      # a manual check, same as researcher's live-Walrus canary in #680).
       NEXT_PUBLIC_ENOKI_API_KEY: ci-placeholder-not-used-tests-use-delegate-key
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: ci-placeholder-not-used-tests-use-delegate-key
       NEXT_PUBLIC_SUI_NETWORK: testnet
       NEXT_PUBLIC_MEMWAL_PACKAGE_ID: "0xcf6ad755a1cdff7217865c796778fabe5aa399cb0cf2eba986f4b582047229c6"
       NEXT_PUBLIC_MEMWAL_REGISTRY_ID: "0xe80f2feec1c139616a86c9f71210152e2a7ca552b20841f2e192f99f75864437"
       NEXT_PUBLIC_MEMWAL_SERVER_URL: https://relayer.dev.memwal.ai
-      # No live-Walrus canary in this suite: isTestEnvironment flips the
-      # binding check onto the fixture pool, so even a real on-chain key
-      # would fail at login. CI covers auth + note CRUD + the memory API
-      # contract; remember → recall against production stays a manual check.
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
-
-      - name: Build SDK (workspace dep of noter)
+      - name: Build SDK
         run: pnpm build:sdk
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          # Separate from chatbot's `pw-` key so the two jobs don't race the
-          # same cache entry. Fall back to the shared prefix on a cold start.
-          key: pw-noter-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pw-noter-${{ runner.os }}-
-            pw-${{ runner.os }}-
-
-      - name: Install Playwright (Chromium + OS deps)
+      - name: Setup Playwright
         timeout-minutes: 8
-        run: pnpm --filter @memwal/noter playwright:install
+        uses: ./.github/actions/setup-playwright
+        with:
+          package: "@memwal/noter"
+          cache-id: noter
 
       - name: Run Playwright E2E
         run: pnpm --filter @memwal/noter test:e2e
 
-      - name: Upload Playwright report + traces
+      - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-playwright-report
         with:
-          name: playwright-report-noter
-          path: |
-            apps/noter/playwright-report
-            apps/noter/test-results
-          retention-days: 14
-          if-no-files-found: ignore
+          app: noter
 
   server-e2e:
     name: Server / E2E
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -641,26 +290,14 @@ jobs:
       PORT: "8000"
       TEST_BASE_URL: http://localhost:8000
       RUST_LOG: info
-      # Required by Config::from_env(). This HTTP-only job uses the compile-time
-      # ci-offline-onchain feature below until the new contract is published;
-      # release builds remain on the strict onchain-validation path.
       SUI_NETWORK: testnet
-      # Testnet no longer serves JSON-RPC, so the server and the sidecar both
-      # refuse to start on testnet without a gRPC endpoint. Boot-only here: the
-      # CI-scoped tests never issue an onchain call through it.
       SUI_GRPC_URL: "https://fullnode.testnet.sui.io:443"
       MEMWAL_PACKAGE_ID: "0xcf6ad755a1cdff7217865c796778fabe5aa399cb0cf2eba986f4b582047229c6"
       MEMWAL_REGISTRY_ID: "0xe80f2feec1c139616a86c9f71210152e2a7ca552b20841f2e192f99f75864437"
-      # Dummy token — sidecar (scripts/sidecar-server.ts) refuses to start
-      # without it, and the server panics when the sidecar doesn't come up.
-      # Not a real secret; SEAL encrypt / Walrus upload paths aren't exercised
-      # by the CI-scoped tests, so the sidecar running in degraded mode is
-      # fine for /health + auth-contract checks.
       SIDECAR_AUTH_TOKEN: ci-test-sidecar-token-not-for-production
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -682,8 +319,6 @@ jobs:
 
       - name: Install sidecar deps
         working-directory: services/server/scripts
-        # Server boot spawns `npx tsx sidecar-server.ts` which imports express
-        # et al — those must be installed up-front or the spawn fails fast.
         run: |
           if [ -f package-lock.json ]; then
             npm ci
@@ -708,7 +343,6 @@ jobs:
       - name: Start server in background
         working-directory: services/server
         run: |
-          # Prefer the named binary; fall back to the only produced bin.
           BIN=$(ls -1 target/debug/memwal-server target/debug/memwal 2>/dev/null | head -n1)
           if [ -z "$BIN" ]; then
             BIN=$(find target/debug -maxdepth 1 -type f -perm -u+x -not -name '*.d' | head -n1)
@@ -751,58 +385,37 @@ jobs:
 
   chatbot-checks:
     name: Chatbot / Lint + Build
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
-
-      - name: Build SDK (workspace dep of chatbot)
+      - name: Build SDK
         run: pnpm build:sdk
 
       # Soft-fail: ultracite 7.3.0 passes a `--skip` flag the bundled biome
-      # rejects (verified locally on `dev`). Pre-existing, unrelated to this
-      # CI ticket. Stage kept so the signal surfaces in logs; flip to
-      # hard-fail once the ultracite/biome version mismatch is fixed.
+      # rejects. Flip to hard-fail once the version mismatch is fixed.
       - name: Lint (biome/ultracite)
         continue-on-error: true
         run: pnpm --filter @memwal/chatbot lint
 
-      # Fast unit tests (vitest, no DB/browser). Includes the document-tool
-      # ownership regression test. This step fails the job on a regression, so
-      # the signal surfaces on the PR; note it is not yet wired as a required
-      # status check in branch protection, so it does not by itself block merge.
       - name: Unit tests (vitest)
         run: pnpm --filter @memwal/chatbot test:unit
 
       - name: Build (Next.js, type-check inclusive)
         working-directory: apps/chatbot
-        # Bypass the package.json `build` script's `tsx lib/db/migrate` step —
-        # we aren't running a server here, just verifying the build + types.
         run: pnpm exec next build
 
   noter-checks:
     name: Noter / Unit tests + Build
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     env:
-      # Dummy DB — next build type-checks route handlers but doesn't connect.
       DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
       NEXT_PUBLIC_ENOKI_API_KEY: ci-placeholder-build-only
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: ci-placeholder-build-only
@@ -812,27 +425,14 @@ jobs:
       NEXT_PUBLIC_MEMWAL_SERVER_URL: https://relayer.dev.memwal.ai
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install deps
-        run: pnpm install --frozen-lockfile
-
-      - name: Build SDK (workspace dep of noter)
+      - name: Build SDK
         run: pnpm build:sdk
 
-      # Fast unit tests (vitest, no DB/browser). Covers the Enoki auth security
-      # properties: ownership-challenge purpose scoping, single-use/replay, and
-      # the insert-only delegate-credential guard. Fails the job on a regression.
       - name: Unit tests (vitest)
         run: pnpm --filter @memwal/noter test:unit
 
@@ -846,7 +446,6 @@ jobs:
 
   server-checks:
     name: Server / Clippy + Unit tests
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -876,8 +475,7 @@ jobs:
       REDIS_URL: redis://localhost:6379
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain (+ clippy)
         uses: dtolnay/rust-toolchain@stable
@@ -894,11 +492,8 @@ jobs:
           key: cargo-checks-${{ runner.os }}-${{ hashFiles('services/server/Cargo.lock') }}
           restore-keys: cargo-checks-${{ runner.os }}-
 
-      # Soft-fail: services/server emits 25+ pre-existing clippy errors with
-      # `-D warnings` on `dev` (`useless_vec`, `unnecessary_min_or_max`,
-      # `doc_lazy_continuation`, etc., verified locally). Unrelated to this
-      # CI ticket. Stage kept so the signal surfaces in logs; flip to
-      # `-- -D warnings` once the warnings are cleaned up in a follow-up.
+      # Soft-fail: services/server emits pre-existing clippy warnings with
+      # `-D warnings`. Flip to `-- -D warnings` once those are cleaned up.
       - name: Clippy
         continue-on-error: true
         working-directory: services/server
@@ -910,18 +505,14 @@ jobs:
 
   move-contract:
     name: Move / Contract tests
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     env:
-      # Keep pinned so CI is reproducible for the contract package.
-      # Bump this together with any Move feature that requires a newer CLI.
       SUI_VERSION: testnet-v1.74.0
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Cache Sui CLI
         id: sui-cache
@@ -939,9 +530,6 @@ jobs:
           curl -fsSL \
             "https://github.com/MystenLabs/sui/releases/download/${SUI_VERSION}/sui-${SUI_VERSION}-ubuntu-x86_64.tgz" \
             -o sui.tgz
-          # Archive ships every Sui binary at its root (./sui, ./sui-node, ...).
-          # Extracting the whole thing is simpler than pattern-matching and is
-          # robust across release layout changes.
           tar -xzf sui.tgz
           SUI_BIN="$(find . -maxdepth 2 -type f -name sui -perm -u+x | head -n1)"
           if [ -z "$SUI_BIN" ]; then

--- a/apps/researcher/tests/README.md
+++ b/apps/researcher/tests/README.md
@@ -102,9 +102,9 @@ remember → recall loop is verified manually against the production relayer.
 ## CI
 
 The `researcher-e2e` job in `.github/workflows/test.yml` provisions Postgres
-and Redis as service containers, runs the `node:test` unit suite, installs
-Chromium, and runs `pnpm test:e2e`. On failure these artifacts are uploaded and
-kept for 14 days:
+and Redis as service containers, builds the workspace SDK, runs the `node:test`
+unit suite, installs Chromium, and runs `pnpm test:e2e`. On failure these
+artifacts are uploaded and kept for 14 days:
 
 - `playwright-report-researcher/playwright-report/index.html` — HTML report
   with trace links

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,7 +28,7 @@
         "dev": "tsc --watch",
         "typecheck": "tsc --noEmit",
         "test": "tsc && node --test \"test/**/*.test.mjs\"",
-        "test:e2e": "tsc && node --test \"test/e2e/*.e2e.mjs\""
+        "test:e2e": "tsc && node --test --test-concurrency=1 \"test/e2e/*.e2e.mjs\""
     },
     "dependencies": {
         "@noble/ed25519": "^2.3.0",

--- a/packages/sdk/test/e2e/live.e2e.mjs
+++ b/packages/sdk/test/e2e/live.e2e.mjs
@@ -1,59 +1,33 @@
 /**
- * E2E tests for the Walrus Memory JS SDK against a live relayer.
+ * Live-relayer e2e for the JS SDK.
  *
- * Targets MEMWAL_SERVER_URL (default: https://relayer-staging.memory.walrus.xyz).
- * The structure mirrors the Python SDK's tests/test_integration.py so the two
- * suites stay comparable; `ask()` has no JS equivalent (its analogue is the
- * `ai/` integration, which needs a model provider and is out of scope here).
+ * Unauthenticated tests always run. Authenticated tests need
+ * MEMWAL_PRIVATE_KEY + MEMWAL_ACCOUNT_ID and write into a per-run namespace
+ * on the shared bench account.
  *
- * No-auth tests (always run, no env vars needed):
- *   - /health endpoint
- *   - Compatibility contract (GET /version) accepts this SDK
- *   - Unsigned request → 401
- *   - Wrong signature → 401
- *   - Expired timestamp → 401
- *   - Future timestamp → 401
- *   - Unregistered key → SDK error carrying the 401/403
+ * Keep this suite small. Every authenticated write is a full Walrus pipeline
+ * against a rate-limited account; method-level coverage belongs in unit tests.
+ * The authenticated path is one flow: remember → recall → namespace isolation.
  *
- * Authenticated tests (require MEMWAL_PRIVATE_KEY + MEMWAL_ACCOUNT_ID):
- *   - remember() acceptance, rememberAndWait(), namespace handling
- *   - recall()
- *   - analyze() / analyzeAndWait()
- *   - rememberBulkAndWait()
- *   - restore()
- *   - Full e2e: remember → recall → verify
- *
- * Usage:
- *   # Run only no-auth tests (no keys needed)
  *   pnpm --filter @mysten-incubation/memwal test:e2e
  *
- *   # Run full suite with real credentials
  *   MEMWAL_PRIVATE_KEY=<hex> MEMWAL_ACCOUNT_ID=0x... \
  *     pnpm --filter @mysten-incubation/memwal test:e2e
- *
- *   # Point at a specific relayer
- *   MEMWAL_SERVER_URL=https://relayer.dev.memwal.ai ...
  */
 
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import test from "node:test";
+import { describe, test } from "node:test";
 
 import * as ed from "@noble/ed25519";
 
 import { MemWal, MemWalCompatibilityError } from "../../dist/index.js";
 import { bytesToHex, sha256hex } from "../../dist/utils.js";
 
-// ── Config ───────────────────────────────────────────────────────────────────
-
 const SERVER_URL = (process.env.MEMWAL_SERVER_URL ?? "https://relayer-staging.memory.walrus.xyz").replace(/\/$/, "");
 const PRIVATE_KEY_HEX = process.env.MEMWAL_PRIVATE_KEY ?? "";
 const ACCOUNT_ID = process.env.MEMWAL_ACCOUNT_ID ?? "";
 
-// A live write runs embed -> SEAL encrypt -> Walrus upload -> on-chain metadata.
-// Measured around 44s against the dev relayer, so the SDK's 60s default leaves
-// too little headroom to be reliable in CI. 120s matches what the SDK already
-// uses for bulk pipelines.
 function positiveIntEnv(name, fallback) {
     const raw = process.env[name];
     if (raw === undefined || raw === "") return fallback;
@@ -64,24 +38,14 @@ function positiveIntEnv(name, fallback) {
     return parsed;
 }
 
+// A live write is embed → SEAL → Walrus → on-chain metadata (~44s on dev).
+// 120s matches the SDK bulk pipeline budget.
 const REMEMBER_TIMEOUT_MS = positiveIntEnv("MEMWAL_REMEMBER_TIMEOUT_MS", 120_000);
 
-// analyze() fans one input out into N facts, each its own full write pipeline.
-// They round-robin across relayer wallet slots and usually overlap, but the
-// bench account is shared, so a contended pool can push a 3-fact extraction
-// past the single-write budget. Give the fan-out twice the headroom rather
-// than letting a slow-but-healthy run report failed jobs.
-const ANALYZE_TIMEOUT_MS = REMEMBER_TIMEOUT_MS * 2;
-
-// Every authenticated test writes into a namespace unique to this run. The bench
-// account is shared, and `default` in particular is what real users get, so a
-// recurring job must not leave live Walrus blobs there.
 const E2E_NAMESPACE = `sdk-e2e-${randomUUID().replaceAll("-", "").slice(0, 8)}`;
 const E2E_NAMESPACE_ALT = `${E2E_NAMESPACE}-alt`;
 
 const HAS_KEY = Boolean(PRIVATE_KEY_HEX && ACCOUNT_ID);
-
-// node:test skips the test (with this reason) when the value is a string.
 const requiresKey = HAS_KEY ? false : "MEMWAL_PRIVATE_KEY and MEMWAL_ACCOUNT_ID not set";
 
 function client(namespace = E2E_NAMESPACE) {
@@ -93,10 +57,8 @@ function client(namespace = E2E_NAMESPACE) {
     });
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
 /**
- * Make a raw signed request without using the SDK (for auth rejection tests).
+ * Raw signed request without the SDK (auth-rejection cases).
  * Message format matches memwal.ts signedRequest():
  *   "{timestamp}.{method}.{path}.{body_sha256}.{nonce}.{account_id}"
  */
@@ -126,243 +88,159 @@ async function rawSignedRequest(method, path, body, privateKey, overrides = {}) 
 
 const REJECTION_BODY = { text: "hello", namespace: "default" };
 
-// ── No-auth tests (always run) ───────────────────────────────────────────────
-
-test("health returns ok with a version string", async () => {
-    const mw = MemWal.create({ key: "aa".repeat(32), accountId: "0x0", serverUrl: SERVER_URL });
-    const result = await mw.health();
-    assert.equal(result.status, "ok", `Expected 'ok', got '${result.status}'`);
-    assert.equal(typeof result.version, "string");
-});
-
-test("compatibility contract accepts this SDK version", async () => {
-    // compatibility() both fetches GET /version and validates it against this
-    // SDK's compatibility version — a MemWalCompatibilityError here means the
-    // live relayer has dropped support for the SDK as released.
-    const mw = MemWal.create({ key: "aa".repeat(32), accountId: "0x0", serverUrl: SERVER_URL });
-    const result = await mw.compatibility();
-    assert.equal(typeof result.relayerVersion, "string");
-    assert.equal(typeof result.apiVersion, "string");
-    assert.equal(typeof result.minSupportedSdk.typescript, "string");
-});
-
-test("unsigned request is rejected with 401", async () => {
-    const res = await fetch(`${SERVER_URL}/api/remember`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(REJECTION_BODY),
+describe("health and compatibility", () => {
+    test("health returns ok with a version string", async () => {
+        const mw = MemWal.create({ key: "aa".repeat(32), accountId: "0x0", serverUrl: SERVER_URL });
+        const result = await mw.health();
+        assert.equal(result.status, "ok", `Expected 'ok', got '${result.status}'`);
+        assert.equal(typeof result.version, "string");
     });
-    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
+
+    test("compatibility contract accepts this SDK version", async () => {
+        const mw = MemWal.create({ key: "aa".repeat(32), accountId: "0x0", serverUrl: SERVER_URL });
+        const result = await mw.compatibility();
+        assert.equal(typeof result.relayerVersion, "string");
+        assert.equal(typeof result.apiVersion, "string");
+        assert.equal(typeof result.minSupportedSdk.typescript, "string");
+    });
 });
 
-test("wrong signature is rejected with 401", async () => {
-    // Sign with key A but claim key B's public key.
-    const keyA = ed.utils.randomPrivateKey();
-    const keyB = ed.utils.randomPrivateKey();
-    const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, keyA, {
-        publicKeyHex: bytesToHex(await ed.getPublicKeyAsync(keyB)),
+describe("auth rejection", () => {
+    test("unsigned request is rejected with 401", async () => {
+        const res = await fetch(`${SERVER_URL}/api/remember`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(REJECTION_BODY),
+        });
+        assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
     });
-    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
-});
 
-test("expired timestamp is rejected with 401", async () => {
-    const key = ed.utils.randomPrivateKey();
-    const tenMinutesAgo = String(Math.floor(Date.now() / 1000) - 600);
-    const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, key, {
-        timestamp: tenMinutesAgo,
+    test("wrong signature is rejected with 401", async () => {
+        const keyA = ed.utils.randomPrivateKey();
+        const keyB = ed.utils.randomPrivateKey();
+        const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, keyA, {
+            publicKeyHex: bytesToHex(await ed.getPublicKeyAsync(keyB)),
+        });
+        assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
     });
-    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
-});
 
-test("future timestamp is rejected with 401", async () => {
-    const key = ed.utils.randomPrivateKey();
-    const tenMinutesAhead = String(Math.floor(Date.now() / 1000) + 600);
-    const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, key, {
-        timestamp: tenMinutesAhead,
+    test("expired timestamp is rejected with 401", async () => {
+        const key = ed.utils.randomPrivateKey();
+        const tenMinutesAgo = String(Math.floor(Date.now() / 1000) - 600);
+        const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, key, {
+            timestamp: tenMinutesAgo,
+        });
+        assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
     });
-    assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
-});
 
-test("SDK surfaces an unregistered key as an auth error", async (t) => {
-    const mw = MemWal.create({
-        key: "bb".repeat(32), // random, not registered on-chain
-        accountId: "0x0",
-        serverUrl: SERVER_URL,
+    test("future timestamp is rejected with 401", async () => {
+        const key = ed.utils.randomPrivateKey();
+        const tenMinutesAhead = String(Math.floor(Date.now() / 1000) + 600);
+        const res = await rawSignedRequest("POST", "/api/remember", REJECTION_BODY, key, {
+            timestamp: tenMinutesAhead,
+        });
+        assert.equal(res.status, 401, `Expected 401, got ${res.status}: ${await res.text()}`);
     });
-    try {
-        await mw.remember("hello");
-        assert.fail("Expected remember() with an unregistered key to throw");
-    } catch (err) {
-        if (err instanceof MemWalCompatibilityError) {
-            t.skip("live relayer does not expose compatibility metadata yet");
-            return;
+
+    test("SDK surfaces an unregistered key as an auth error", async (t) => {
+        const mw = MemWal.create({
+            key: "bb".repeat(32),
+            accountId: "0x0",
+            serverUrl: SERVER_URL,
+        });
+        try {
+            await mw.remember("hello");
+            assert.fail("Expected remember() with an unregistered key to throw");
+        } catch (err) {
+            if (err instanceof MemWalCompatibilityError) {
+                t.skip("live relayer does not expose compatibility metadata yet");
+                return;
+            }
+            const status = err.status ?? 0;
+            assert.ok(
+                status === 401 || status === 403 || /\b40[13]\b/.test(String(err.message)),
+                `Expected a 401/403 auth rejection, got: ${err.message}`,
+            );
         }
-        const status = err.status ?? 0;
+    });
+});
+
+describe("authenticated", { skip: requiresKey, concurrency: 1 }, () => {
+    test("embed returns a vector", async () => {
+        const result = await client().embed("hello world");
+        assert.ok(Array.isArray(result.vector));
+        assert.ok(result.vector.length > 0);
+        assert.equal(typeof result.vector[0], "number");
+    });
+
+    test("remember accepts a job", async () => {
+        const mw = client();
+        const result = await mw.remember("Integration test: the sky is blue");
+        assert.equal(typeof result.job_id, "string");
+        assert.ok(result.job_id.length > 0);
+        assert.ok(["pending", "running"].includes(result.status), `unexpected status: ${result.status}`);
+
+        const status = await mw.getRememberStatus(result.job_id);
+        assert.equal(status.job_id, result.job_id);
         assert.ok(
-            status === 401 || status === 403 || /\b40[13]\b/.test(String(err.message)),
-            `Expected a 401/403 auth rejection, got: ${err.message}`,
+            ["pending", "running", "uploaded", "done", "failed"].includes(status.status),
+            `unexpected job status: ${status.status}`,
         );
-    }
-});
-
-// ── Authenticated tests ──────────────────────────────────────────────────────
-
-test("remember returns a job id and an accepted status", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.remember("Integration test: the sky is blue");
-    assert.equal(typeof result.job_id, "string");
-    assert.ok(result.job_id.length > 0);
-    assert.ok(["pending", "running"].includes(result.status), `unexpected status: ${result.status}`);
-
-    // One-shot status lookup on the accepted job (no polling). This asserts the
-    // acceptance contract — the job is known to the relayer and reports a real
-    // state — so `failed` is tolerated here: whether the background pipeline
-    // succeeds is what rememberAndWait covers. `not_found` is the failure that
-    // matters, since it means the accepted job_id addresses nothing.
-    const status = await mw.getRememberStatus(result.job_id);
-    assert.equal(status.job_id, result.job_id);
-    assert.ok(
-        ["pending", "running", "uploaded", "done", "failed"].includes(status.status),
-        `unexpected job status: ${status.status}`,
-    );
-});
-
-test("rememberAndWait returns blob and owner", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.rememberAndWait("Integration test: the sky is blue", undefined, {
-        timeoutMs: REMEMBER_TIMEOUT_MS,
     });
-    assert.equal(typeof result.id, "string");
-    assert.ok(result.id.length > 0);
-    assert.equal(typeof result.blob_id, "string");
-    assert.ok(result.blob_id.length > 0);
-    assert.ok(result.owner.startsWith("0x"));
-});
 
-test("remember uses the client namespace when none is passed", { skip: requiresKey }, async () => {
-    // Omitting `namespace` falls back to the one the client was built with.
-    // The literal `"default"` fallback is asserted in the mocked suite; proving
-    // it here would mean writing a live blob into the namespace real users get.
-    const mw = client();
-    const result = await mw.rememberAndWait("Integration test: namespace fallback", undefined, {
-        timeoutMs: REMEMBER_TIMEOUT_MS,
+    test("analyze extracts facts", async () => {
+        const result = await client().analyze("I love hiking and my favorite food is pho.");
+        assert.ok(Array.isArray(result.facts));
+        assert.ok(result.fact_count >= 0);
+        assert.ok(result.owner.startsWith("0x"));
+        for (const fact of result.facts) {
+            assert.equal(typeof fact.text, "string");
+        }
     });
-    assert.equal(result.namespace, E2E_NAMESPACE);
-});
 
-test("remember honors a per-call namespace override", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.rememberAndWait(
-        "Integration test: custom namespace",
-        E2E_NAMESPACE_ALT,
-        { timeoutMs: REMEMBER_TIMEOUT_MS },
-    );
-    assert.equal(result.namespace, E2E_NAMESPACE_ALT);
-});
+    test("full flow: remember, recall, namespace isolation", async () => {
+        const unique = randomUUID().replaceAll("-", "").slice(0, 8);
+        const text = `SDK e2e test ${unique}: quantum entanglement in photonics`;
+        const mw = client();
 
-test("recall returns results with the expected fields", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.recall({ query: "sky blue", limit: 5 });
-    assert.ok(Array.isArray(result.results));
-    assert.ok(result.total >= 0);
-    for (const memory of result.results) {
-        assert.equal(typeof memory.text, "string");
-        assert.equal(typeof memory.blob_id, "string");
-        assert.equal(typeof memory.distance, "number");
-    }
-});
+        const memory = await mw.rememberAndWait(text, undefined, { timeoutMs: REMEMBER_TIMEOUT_MS });
+        assert.equal(memory.namespace, E2E_NAMESPACE);
+        assert.ok(memory.id.length > 0);
+        assert.ok(memory.blob_id.length > 0);
+        assert.ok(memory.owner.startsWith("0x"));
 
-test("recall respects the limit", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.recall({ query: "test", limit: 2 });
-    assert.ok(result.results.length <= 2);
-});
+        const recalled = await mw.recall({
+            query: `quantum photonics ${unique}`,
+            limit: 5,
+        });
+        assert.ok(recalled.total >= 1, `Expected >= 1 result, got ${recalled.total}`);
+        assert.ok(recalled.results.length <= 5);
+        assert.ok(
+            recalled.results.some((entry) => entry.text.includes(unique)),
+            `Expected unique marker '${unique}' in recalled texts: ${JSON.stringify(recalled.results.map((entry) => entry.text))}`,
+        );
+        for (const entry of recalled.results) {
+            assert.equal(typeof entry.text, "string");
+            assert.equal(typeof entry.blob_id, "string");
+            assert.equal(typeof entry.distance, "number");
+        }
 
-test("analyze extracts facts", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.analyze("I love hiking and my favorite food is pho.");
-    assert.ok(Array.isArray(result.facts));
-    assert.ok(result.fact_count >= 0);
-    assert.ok(result.owner.startsWith("0x"));
-    for (const fact of result.facts) {
-        assert.equal(typeof fact.text, "string");
-    }
-});
+        const isolated = await mw.recall({
+            query: `quantum photonics ${unique}`,
+            limit: 5,
+            namespace: E2E_NAMESPACE_ALT,
+        });
+        assert.ok(
+            !isolated.results.some((entry) => entry.text.includes(unique)),
+            `Namespace ${E2E_NAMESPACE_ALT} must not see the marker '${unique}'`,
+        );
 
-test("analyzeAndWait stores every extracted fact", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.analyzeAndWait(
-        "I moved to Lisbon last spring and I play tennis every Saturday.",
-        undefined,
-        { timeoutMs: ANALYZE_TIMEOUT_MS },
-    );
-    assert.equal(result.results.length, result.facts.length);
-    assert.equal(result.failed, 0, `analyze facts failed to store: ${JSON.stringify(result.results)}`);
-    assert.equal(result.succeeded, result.facts.length);
-});
-
-test("rememberBulkAndWait stores a batch", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.rememberBulkAndWait(
-        [
-            { text: "Bulk e2e test: I drink oat-milk coffee" },
-            { text: "Bulk e2e test: my desk faces a window" },
-        ],
-        { timeoutMs: REMEMBER_TIMEOUT_MS },
-    );
-    assert.equal(result.total, 2);
-    assert.equal(result.failed, 0, `bulk items failed: ${JSON.stringify(result.results)}`);
-    assert.equal(result.succeeded, 2);
-    for (const item of result.results) {
-        assert.equal(item.status, "done");
-        assert.ok(item.blob_id.length > 0);
-        // Client-side bookkeeping, not a server echo: the bulk status endpoint
-        // returns no namespace, so the SDK fills this in from the request.
-        assert.equal(item.namespace, E2E_NAMESPACE);
-    }
-});
-
-test("embed returns a vector", { skip: requiresKey }, async () => {
-    const mw = client();
-    const result = await mw.embed("hello world");
-    assert.ok(Array.isArray(result.vector));
-    assert.ok(result.vector.length > 0);
-    assert.equal(typeof result.vector[0], "number");
-});
-
-test("restore reports counts for the run namespace", { skip: requiresKey }, async () => {
-    // Everything this run stored is already indexed on the relayer, so restore
-    // has no work to do — assert the response shape rather than exact counts:
-    // candidate discovery is capped per-owner across namespaces (WALM-319), so
-    // `total` for a fresh namespace on the shared bench account is not stable.
-    const mw = client();
-    const result = await mw.restore(E2E_NAMESPACE);
-    assert.equal(result.namespace, E2E_NAMESPACE);
-    assert.ok(Number.isInteger(result.restored) && result.restored >= 0);
-    assert.ok(Number.isInteger(result.skipped) && result.skipped >= 0);
-    assert.ok(Number.isInteger(result.total) && result.total >= 0);
-    assert.equal(typeof result.truncated, "boolean");
-    assert.ok(result.owner.startsWith("0x"));
-});
-
-// ── Full flow ────────────────────────────────────────────────────────────────
-
-test("full flow: remember then recall finds it", { skip: requiresKey }, async () => {
-    const unique = randomUUID().replaceAll("-", "").slice(0, 8);
-    const text = `SDK e2e test ${unique}: quantum entanglement in photonics`;
-    const namespace = `sdk-e2e-${unique}`;
-
-    const mw = client();
-
-    // Store a distinctive memory in an isolated namespace.
-    const memory = await mw.rememberAndWait(text, namespace, { timeoutMs: REMEMBER_TIMEOUT_MS });
-    assert.ok(memory.id.length > 0);
-
-    // Recall — should find the stored memory.
-    const result = await mw.recall({ query: `quantum photonics ${unique}`, limit: 5, namespace });
-    assert.ok(result.total >= 1, `Expected >= 1 result, got ${result.total}`);
-    assert.ok(
-        result.results.some((r) => r.text.includes(unique)),
-        `Expected unique marker '${unique}' in recalled texts: ${JSON.stringify(result.results.map((r) => r.text))}`,
-    );
+        const restored = await mw.restore(E2E_NAMESPACE);
+        assert.equal(restored.namespace, E2E_NAMESPACE);
+        assert.ok(Number.isInteger(restored.restored) && restored.restored >= 0);
+        assert.ok(Number.isInteger(restored.skipped) && restored.skipped >= 0);
+        assert.ok(Number.isInteger(restored.total) && restored.total >= 0);
+        assert.equal(typeof restored.truncated, "boolean");
+        assert.ok(restored.owner.startsWith("0x"));
+    });
 });


### PR DESCRIPTION
## Summary
- Move live JS SDK e2e into `test-sdk.yml` so `test.yml` is no longer carrying schedule guards, `sdk-changed`, or duplicated Node/Playwright setup.
- Slim `live.e2e.mjs` to serial auth-rejection tests plus one remember → recall → namespace flow. Method-level coverage stays in unit tests.
- Push to `dev`/`staging`/`main` waits until Railway `/health.build.commit` equals this SHA before writing.
- `workflow_dispatch` / schedule wait for `/health` `write_ready` only (Railway does not deploy a feature-branch SHA).
- Live e2e does **not** run on PRs. Preview: Actions → Test JS SDK / Test Python SDK → Run workflow.

## Test plan
- [x] Cold JS e2e on `dev` (dispatch): https://github.com/MystenLabs/MemWal/actions/runs/33040805124 — 11/11
- [x] Cold Python e2e on `dev` (dispatch): https://github.com/MystenLabs/MemWal/actions/runs/33046091162 — 23/23
- [x] Preview with waiter + User-Agent fix (dispatch): JS https://github.com/MystenLabs/MemWal/actions/runs/33048699261 (11/11), Python https://github.com/MystenLabs/MemWal/actions/runs/33048702734 (23/23)
- [ ] Full run on merge to `dev` (wait for Railway SHA, then JS + Python live e2e)

Linear: WALM-426