### PR TITLE
feat(mcp): identify coding agent on MCP sessions and log it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.11"
+      "version": "0.0.12"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.11"
+      "version": "0.0.12"
     }
   ]
 }

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,12 +28,16 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.11. It makes memwal_logout actually cut the running bridge session, so memory tools stop after sign-out instead of keeping the deleted delegate key in memory. Version 0.0.10 closes out orphaned tool calls whose responses never arrive with a retryable error, injects the configured default namespace into memwal_remember_bulk calls that omit one, and sends proactive-usage instructions in the MCP initialize handshake so the model knows when to save and recall without being asked, which lazy tool loading had broken. An unreleased fix resolves the credential directory on every access and lets MEMWAL_CREDS_DIR override it.
+  The latest MCP package release is 0.0.12. It forwards the MCP client's initialize.clientInfo to the relayer so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, and others) on each session and tool call, and it resolves the credential directory on every access so MEMWAL_CREDS_DIR can override it. Version 0.0.11 makes memwal_logout cut the running bridge session so memory tools stop after sign-out.
 ---
 
-## Unreleased
+## 0.0.12
 
-This unreleased change resolves the credential directory on every access and lets `MEMWAL_CREDS_DIR` override it.
+This release forwards the MCP client's identity to the relayer so sidecar logs can name the coding agent, and it resolves the credential directory on every access.
+
+### Added
+
+- Forward the MCP client's `initialize.clientInfo` to the relayer as `x-memwal-client` / `x-memwal-client-version` so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, …) on each session and tool call.
 
 ### Fixed
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @mysten-incubation/memwal-mcp
 
-## Unreleased
+## 0.0.12
 
 ### Added
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Forward the MCP client's `initialize.clientInfo` to the relayer as `x-memwal-client` / `x-memwal-client-version` so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, …) on each session and tool call.
+
 ### Fixed
 
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)

--- a/packages/mcp/TESTING.md
+++ b/packages/mcp/TESTING.md
@@ -209,7 +209,7 @@ What merging to `dev` triggers, and how to try the result end-to-end.
 
 | Surface | Trigger | Result |
 |---|---|---|
-| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.11-dev.N` under the `dev` dist-tag (`latest` stays 0.0.10 until `main`) |
+| npm prerelease | `release-mcp.yml` (path `packages/mcp/**`) | `@mysten-incubation/memwal-mcp@0.0.12-dev.N` under the `dev` dist-tag (`latest` stays 0.0.11 until `main`) |
 | Plugin marketplace (Claude Code) | none needed — `dev` is the repo's **default branch** | `/plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge |
 | Plugin marketplace (Codex) | none needed — `codex plugin marketplace add` reads `.agents/plugins/marketplace.json` off the ref you give it, default branch or not | `codex plugin marketplace add MystenLabs/MemWal` serves the new plugin immediately after merge; can also be tested pre-merge with `codex plugin marketplace add .` from a local checkout |
 | Sidecar tools (Layer 1) | Railway image rebuild (`services/server/Dockerfile` copies `scripts/mcp/`) | New agentic descriptions + `memwal_remember_bulk`/`memwal_health` on `relayer.dev.memwal.ai` — **verify the Railway dev environment actually redeployed**; this is not a repo workflow |
@@ -273,5 +273,5 @@ node /tmp/memwal-plugin/scripts/install_codex_hooks.mjs
 ### Step 5 — Promotion sanity (before merging dev → main later)
 
 - [ ] Prod relayer redeployed with the new sidecar (same Step 1 check against `relayer.memory.walrus.xyz`)
-- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.11-dev.N`; after main merge, `latest` = `0.0.11`
+- [ ] `npm view @mysten-incubation/memwal-mcp dist-tags` — `dev` points at `0.0.12-dev.N`; after main merge, `latest` = `0.0.12`
 - [ ] Mintlify docs published (the 6 provider pages + reference + changelog render, nav matches)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -22,6 +22,7 @@
  * and coexist.
  */
 import { loadCreds, type MemWalCredentials } from "./auth.js";
+import { rememberInitializeClientInfo } from "./client-info.js";
 import { log } from "./logger.js";
 import { startOrReuseLoginFlow, resolveLoginTimeoutMs } from "./login.js";
 import { AUTH_REQUIRED_INSTRUCTIONS } from "./instructions.js";
@@ -407,6 +408,14 @@ function handleAuthLine(
     const method = req.method;
 
     if (method === "initialize") {
+        const clientInfo = rememberInitializeClientInfo(req.params);
+        if (clientInfo) {
+            log.info("bridge.agent_client", {
+                clientName: clientInfo.name,
+                clientVersion: clientInfo.version,
+                mode: "auth-required",
+            });
+        }
         writeStdoutMessage({
             jsonrpc: "2.0",
             id,

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -748,9 +748,16 @@ export async function runBridge(
      * remember to check — after logout there is simply nothing left to sign
      * with. `adoptCredentials` republishes it on the next login. */
     let creds: MemWalCredentials | null = initialCreds;
-    /** Set from the MCP client's `initialize.clientInfo`; forwarded on every
-     * relayer request as `x-memwal-client` so the sidecar can log which
-     * coding agent owns the session. */
+    /**
+     * Best-effort `x-memwal-client` / `x-memwal-client-version` forwarded to
+     * the sidecar. Seeded from `lastClientInfoHeaders()`, which is only
+     * populated after the auth-required → bridge handoff (that path does not
+     * replay `initialize`). On a normal already-signed-in start this object
+     * is empty at first SSE connect: `connectInBackground` opens the stream
+     * before stdin is wired. Headers are filled when we see `initialize` and
+     * then land on reconnects / later POSTs. The sidecar treats the MCP
+     * handshake (`initialize.clientInfo`) as the authoritative source.
+     */
     const extraHeaders: Record<string, string> = { ...lastClientInfoHeaders() };
 
     let stdinClosed = false;

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -17,6 +17,11 @@
 import type { MemWalCredentials } from "./auth.js";
 import { clearCreds, credsPath } from "./auth.js";
 import { TOOL_DEFINITIONS } from "./auth-required.js";
+import {
+    clientInfoHeaders,
+    lastClientInfoHeaders,
+    rememberInitializeClientInfo,
+} from "./client-info.js";
 import { ensureCompatibleRelayer, resolveConnectTimeoutMs } from "./compatibility.js";
 import { PROACTIVE_INSTRUCTIONS } from "./instructions.js";
 import { startOrReuseLoginFlow, resolveLoginTimeoutMs } from "./login.js";
@@ -248,16 +253,21 @@ interface SseHandshakeResult {
     abort: () => void;
 }
 
-function mcpAuthHeaders(creds: MemWalCredentials): Record<string, string> {
+function mcpAuthHeaders(
+    creds: MemWalCredentials,
+    extra: Record<string, string> = {},
+): Record<string, string> {
     return {
         authorization: `Bearer ${creds.delegatePrivateKey}`,
         "x-memwal-account-id": creds.accountId,
+        ...extra,
     };
 }
 
 async function openSseStream(
     relayerUrl: string,
     creds: MemWalCredentials,
+    extraHeaders: Record<string, string> = {},
 ): Promise<SseHandshakeResult> {
     const connectTimeoutMs = resolveConnectTimeoutMs();
     // One shared budget for the WHOLE attempt: the compatibility check (GET
@@ -299,7 +309,7 @@ async function openSseStream(
         resp = await fetch(url, {
             method: "GET",
             headers: {
-                ...mcpAuthHeaders(creds),
+                ...mcpAuthHeaders(creds, extraHeaders),
                 accept: "text/event-stream",
                 "cache-control": "no-cache",
             },
@@ -525,11 +535,12 @@ async function postMessage(
     postUrl: string,
     msg: RpcMessage,
     creds: MemWalCredentials,
+    extraHeaders: Record<string, string> = {},
 ): Promise<number> {
     const resp = await fetch(postUrl, {
         method: "POST",
         headers: {
-            ...mcpAuthHeaders(creds),
+            ...mcpAuthHeaders(creds, extraHeaders),
             "content-type": "application/json",
         },
         body: JSON.stringify(msg),
@@ -737,6 +748,10 @@ export async function runBridge(
      * remember to check — after logout there is simply nothing left to sign
      * with. `adoptCredentials` republishes it on the next login. */
     let creds: MemWalCredentials | null = initialCreds;
+    /** Set from the MCP client's `initialize.clientInfo`; forwarded on every
+     * relayer request as `x-memwal-client` so the sidecar can log which
+     * coding agent owns the session. */
+    const extraHeaders: Record<string, string> = { ...lastClientInfoHeaders() };
 
     let stdinClosed = false;
     /** Set by `memwal_logout`. Unlike `stdinClosed` the process stays up and
@@ -775,7 +790,7 @@ export async function runBridge(
         postCreds: MemWalCredentials,
     ): Promise<number> {
         if (epoch !== sessionEpoch) return Promise.resolve(0);
-        return postMessage(postUrl, msg, postCreds);
+        return postMessage(postUrl, msg, postCreds, extraHeaders);
     }
     let credentialGeneration = 0;
     let activeCredentialGeneration = 0;
@@ -949,6 +964,7 @@ export async function runBridge(
                     const candidate = await openSseStream(
                         openingCreds.relayerUrl,
                         openingCreds,
+                        extraHeaders,
                     );
 
                     // Logout can also land mid-handshake. Same reasoning as the
@@ -1338,6 +1354,14 @@ export async function runBridge(
                 // session negotiates capabilities — but suppress that upstream
                 // reply, since the client already has this one.
                 if (msg.method === "initialize" && msg.id != null) {
+                    const clientInfo = rememberInitializeClientInfo(msg.params);
+                    if (clientInfo) {
+                        Object.assign(extraHeaders, clientInfoHeaders(clientInfo));
+                        log.info("bridge.agent_client", {
+                            clientName: clientInfo.name,
+                            clientVersion: clientInfo.version,
+                        });
+                    }
                     writeStdoutMessage({
                         jsonrpc: "2.0",
                         id: msg.id,
@@ -1729,7 +1753,7 @@ export async function runBridge(
             }
             const openingGeneration = credentialGeneration;
             try {
-                const candidate = await openSseStream(creds.relayerUrl, creds);
+                const candidate = await openSseStream(creds.relayerUrl, creds, extraHeaders);
                 if (stdinClosed) {
                     candidate.abort();
                     break;

--- a/packages/mcp/src/client-info.ts
+++ b/packages/mcp/src/client-info.ts
@@ -1,0 +1,59 @@
+/**
+ * Capture MCP `initialize` `clientInfo` so the stdio bridge can tell the
+ * relayer/sidecar which coding agent opened the session.
+ *
+ * Header names must stay under the `x-memwal-` prefix: the relayer proxy
+ * forwards that family and drops everything else.
+ */
+
+export const CLIENT_NAME_HEADER = "x-memwal-client";
+export const CLIENT_VERSION_HEADER = "x-memwal-client-version";
+
+const MAX_TOKEN = 64;
+
+export function sanitizeClientToken(raw: unknown): string | null {
+    if (typeof raw !== "string") return null;
+    // HTTP header values cannot carry CR/LF; keep printable ASCII.
+    const cleaned = raw.replace(/[^\x20-\x7e]/g, "").trim();
+    if (!cleaned) return null;
+    return cleaned.slice(0, MAX_TOKEN);
+}
+
+export function clientInfoFromInitializeParams(
+    params: unknown,
+): { name: string; version: string | null } | null {
+    if (params == null || typeof params !== "object") return null;
+    const info = (params as { clientInfo?: unknown }).clientInfo;
+    if (info == null || typeof info !== "object") return null;
+    const name = sanitizeClientToken((info as { name?: unknown }).name);
+    if (!name) return null;
+    return {
+        name,
+        version: sanitizeClientToken((info as { version?: unknown }).version),
+    };
+}
+
+export function clientInfoHeaders(info: {
+    name: string;
+    version: string | null;
+}): Record<string, string> {
+    const headers: Record<string, string> = { [CLIENT_NAME_HEADER]: info.name };
+    if (info.version) headers[CLIENT_VERSION_HEADER] = info.version;
+    return headers;
+}
+
+/** Last `initialize.clientInfo` seen on this process. Survives the
+ * auth-required → bridge handoff, which does not replay `initialize`. */
+let lastClientInfo: { name: string; version: string | null } | null = null;
+
+export function rememberInitializeClientInfo(
+    params: unknown,
+): { name: string; version: string | null } | null {
+    const info = clientInfoFromInitializeParams(params);
+    if (info) lastClientInfo = info;
+    return info;
+}
+
+export function lastClientInfoHeaders(): Record<string, string> {
+    return lastClientInfo ? clientInfoHeaders(lastClientInfo) : {};
+}

--- a/packages/mcp/src/client-info.ts
+++ b/packages/mcp/src/client-info.ts
@@ -14,6 +14,8 @@ const MAX_TOKEN = 64;
 export function sanitizeClientToken(raw: unknown): string | null {
     if (typeof raw !== "string") return null;
     // HTTP header values cannot carry CR/LF; keep printable ASCII.
+    // Sidecar copy (`services/server/scripts/mcp/agent-client.ts`) only
+    // strips C0/DEL so JSON logs can keep non-ASCII names. Do not unify.
     const cleaned = raw.replace(/[^\x20-\x7e]/g, "").trim();
     if (!cleaned) return null;
     return cleaned.slice(0, MAX_TOKEN);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -125,10 +125,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
         args.relayerUrl ?? process.env.MEMWAL_SERVER_URL ?? "https://relayer.memory.walrus.xyz";
     const webUrl =
         args.webUrl ?? process.env.MEMWAL_WEB_URL ?? "https://memory.walrus.xyz";
-    // Label is the on-chain delegate-key name shown in the dashboard.
-    // Default is generic; the user can rename anytime. Which coding agent
-    // opened the MCP session is detected from `initialize.clientInfo` and
-    // logged on the sidecar — it is not this login-time label.
+    // On-chain delegate-key display name; users can rename it in the dashboard.
     const label = args.label ?? process.env.MEMWAL_CLIENT_LABEL ?? "MCP Client";
     // Default memory namespace applied to memory tool calls when the agent
     // omits one. CLI > env, then UNSET — we deliberately do NOT hardcode a

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -125,11 +125,10 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
         args.relayerUrl ?? process.env.MEMWAL_SERVER_URL ?? "https://relayer.memory.walrus.xyz";
     const webUrl =
         args.webUrl ?? process.env.MEMWAL_WEB_URL ?? "https://memory.walrus.xyz";
-    // Label is the on-chain delegate-key name shown in the dashboard. We
-    // default to a generic value at registration time — the bridge updates
-    // it to the actual client's `clientInfo.name` ("Cursor", "Claude",
-    // "Antigravity", ...) after the first MCP `initialize` request. User
-    // can rename anytime from the dashboard.
+    // Label is the on-chain delegate-key name shown in the dashboard.
+    // Default is generic; the user can rename anytime. Which coding agent
+    // opened the MCP session is detected from `initialize.clientInfo` and
+    // logged on the sidecar — it is not this login-time label.
     const label = args.label ?? process.env.MEMWAL_CLIENT_LABEL ?? "MCP Client";
     // Default memory namespace applied to memory tool calls when the agent
     // omits one. CLI > env, then UNSET — we deliberately do NOT hardcode a

--- a/packages/mcp/test/client-info.test.mjs
+++ b/packages/mcp/test/client-info.test.mjs
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    CLIENT_NAME_HEADER,
+    CLIENT_VERSION_HEADER,
+    clientInfoFromInitializeParams,
+    clientInfoHeaders,
+    lastClientInfoHeaders,
+    rememberInitializeClientInfo,
+    sanitizeClientToken,
+} from "../dist/client-info.js";
+
+test("clientInfoFromInitializeParams reads name and version", () => {
+    assert.deepEqual(
+        clientInfoFromInitializeParams({
+            protocolVersion: "2025-06-18",
+            clientInfo: { name: "claude-code", version: "2.0.0" },
+        }),
+        { name: "claude-code", version: "2.0.0" },
+    );
+});
+
+test("sanitizeClientToken strips CR/LF and non-ascii", () => {
+    assert.equal(sanitizeClientToken("claude-code\r\nHost: evil"), "claude-codeHost: evil"); // newlines stripped, not interpreted as a new header
+    assert.equal(sanitizeClientToken(""), null);
+    assert.equal(sanitizeClientToken("x".repeat(80)).length, 64);
+});
+
+test("rememberInitializeClientInfo seeds lastClientInfoHeaders for handoff", () => {
+    rememberInitializeClientInfo({
+        clientInfo: { name: "codex", version: "0.1" },
+    });
+    assert.deepEqual(lastClientInfoHeaders(), {
+        [CLIENT_NAME_HEADER]: "codex",
+        [CLIENT_VERSION_HEADER]: "0.1",
+    });
+    assert.deepEqual(clientInfoHeaders({ name: "Cursor", version: null }), {
+        [CLIENT_NAME_HEADER]: "Cursor",
+    });
+});

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -23,7 +23,7 @@ const releases = [
     },
     {
         name: "MCP package",
-        version: "0.0.11",
+        version: "0.0.12",
         manifests: [
             ["packages/mcp/package.json", "version"],
             [".claude-plugin/marketplace.json", "plugin-version"],

--- a/services/server/scripts/mcp/__tests__/agent-client.test.ts
+++ b/services/server/scripts/mcp/__tests__/agent-client.test.ts
@@ -3,34 +3,44 @@ import test from "node:test";
 
 import type { MemWalSession } from "../auth.js";
 import {
+    AGENT_CLIENT_IDS,
     applyAgentClient,
     clientInfoFromInitializeParams,
     identifyAgentClient,
     sanitizeClientToken,
+    type AgentClientId,
 } from "../agent-client.js";
 
+const IDENTIFY_CASES: Array<[string, AgentClientId]> = [
+    ["claude-code", "claude-code"],
+    ["Claude Code", "claude-code"],
+    ["codex", "codex"],
+    ["openai-codex", "codex"],
+    ["Cursor", "cursor"],
+    ["cursor-vscode", "cursor"],
+    ["antigravity", "antigravity"],
+    ["OpenCode", "opencode"],
+    ["windsurf", "windsurf"],
+    ["claude-desktop", "claude-desktop"],
+    ["Claude", "claude-desktop"],
+    ["claude.ai", "claude-desktop"],
+    ["Visual Studio Code", "vscode-copilot"],
+    ["ChatGPT", "chatgpt"],
+    ["gemini-cli", "gemini"],
+    ["Grok", "grok"],
+    ["mystery-ide", "other"],
+];
+
 test("identifyAgentClient maps known coding agents", () => {
-    const cases: Array<[string, string]> = [
-        ["claude-code", "claude-code"],
-        ["Claude Code", "claude-code"],
-        ["codex", "codex"],
-        ["openai-codex", "codex"],
-        ["Cursor", "cursor"],
-        ["cursor-vscode", "cursor"],
-        ["antigravity", "antigravity"],
-        ["OpenCode", "opencode"],
-        ["windsurf", "windsurf"],
-        ["claude-desktop", "claude-desktop"],
-        ["Claude", "claude-desktop"],
-        ["claude.ai", "claude-desktop"],
-        ["Visual Studio Code", "vscode-copilot"],
-        ["ChatGPT", "chatgpt"],
-        ["gemini-cli", "gemini"],
-        ["Grok", "grok"],
-        ["mystery-ide", "other"],
-    ];
-    for (const [raw, id] of cases) {
+    for (const [raw, id] of IDENTIFY_CASES) {
         assert.equal(identifyAgentClient(raw), id, raw);
+    }
+});
+
+test("every AgentClientId is produced by at least one fixture", () => {
+    const seen = new Set(IDENTIFY_CASES.map(([, id]) => id));
+    for (const id of AGENT_CLIENT_IDS) {
+        assert.ok(seen.has(id), id);
     }
 });
 
@@ -68,4 +78,26 @@ test("applyAgentClient stamps the session once and is idempotent", () => {
     assert.equal(session.clientName, "claude-code");
     assert.equal(session.clientVersion, "9");
     assert.equal(applyAgentClient(session, { name: "claude-code", version: "9" }), false);
+});
+
+test("applyAgentClient fills in version after a header stamp without one", () => {
+    const session = { accountId: "0xabc" } as MemWalSession;
+    assert.equal(applyAgentClient(session, { name: "claude-code" }), true);
+    assert.equal(session.clientVersion, undefined);
+    assert.equal(
+        applyAgentClient(session, { name: "claude-code", version: "2.0.1" }),
+        true,
+    );
+    assert.equal(session.clientVersion, "2.0.1");
+    assert.equal(
+        applyAgentClient(session, { name: "claude-code", version: "2.0.1" }),
+        false,
+    );
+});
+
+test("applyAgentClient does not wipe a known version when a later call omits it", () => {
+    const session = { accountId: "0xabc" } as MemWalSession;
+    assert.equal(applyAgentClient(session, { name: "claude-code", version: "9" }), true);
+    assert.equal(applyAgentClient(session, { name: "claude-code" }), false);
+    assert.equal(session.clientVersion, "9");
 });

--- a/services/server/scripts/mcp/__tests__/agent-client.test.ts
+++ b/services/server/scripts/mcp/__tests__/agent-client.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { MemWalSession } from "../auth.js";
+import {
+    applyAgentClient,
+    clientInfoFromInitializeParams,
+    identifyAgentClient,
+    sanitizeClientToken,
+} from "../agent-client.js";
+
+test("identifyAgentClient maps known coding agents", () => {
+    const cases: Array<[string, string]> = [
+        ["claude-code", "claude-code"],
+        ["Claude Code", "claude-code"],
+        ["codex", "codex"],
+        ["openai-codex", "codex"],
+        ["Cursor", "cursor"],
+        ["cursor-vscode", "cursor"],
+        ["antigravity", "antigravity"],
+        ["OpenCode", "opencode"],
+        ["windsurf", "windsurf"],
+        ["claude-desktop", "claude-desktop"],
+        ["Claude", "claude-desktop"],
+        ["claude.ai", "claude-desktop"],
+        ["Visual Studio Code", "vscode-copilot"],
+        ["ChatGPT", "chatgpt"],
+        ["gemini-cli", "gemini"],
+        ["Grok", "grok"],
+        ["mystery-ide", "other"],
+    ];
+    for (const [raw, id] of cases) {
+        assert.equal(identifyAgentClient(raw), id, raw);
+    }
+});
+
+test("claude-code wins over a generic claude substring", () => {
+    assert.equal(identifyAgentClient("claude-code-nightly"), "claude-code");
+});
+
+test("sanitizeClientToken strips control chars and caps length", () => {
+    assert.equal(sanitizeClientToken("  claude-code\n "), "claude-code");
+    assert.equal(sanitizeClientToken(""), null);
+    assert.equal(sanitizeClientToken(1), null);
+    assert.equal(sanitizeClientToken("x".repeat(80))?.length, 64);
+});
+
+test("clientInfoFromInitializeParams reads MCP initialize params", () => {
+    assert.deepEqual(
+        clientInfoFromInitializeParams({
+            protocolVersion: "2025-06-18",
+            clientInfo: { name: "claude-code", version: "1.2.3" },
+        }),
+        { name: "claude-code", version: "1.2.3" },
+    );
+    assert.equal(clientInfoFromInitializeParams({}), null);
+    assert.equal(clientInfoFromInitializeParams(null), null);
+    assert.equal(
+        clientInfoFromInitializeParams({ clientInfo: { name: "\x00" } }),
+        null,
+    );
+});
+
+test("applyAgentClient stamps the session once and is idempotent", () => {
+    const session = { accountId: "0xabc" } as MemWalSession;
+    assert.equal(applyAgentClient(session, { name: "claude-code", version: "9" }), true);
+    assert.equal(session.agentClient, "claude-code");
+    assert.equal(session.clientName, "claude-code");
+    assert.equal(session.clientVersion, "9");
+    assert.equal(applyAgentClient(session, { name: "claude-code", version: "9" }), false);
+});

--- a/services/server/scripts/mcp/__tests__/agent-identify.handshake.test.ts
+++ b/services/server/scripts/mcp/__tests__/agent-identify.handshake.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { MemWalSession } from "../auth.js";
+import { createMcpServer } from "../server.js";
+
+test("MCP initialize stamps the coding-agent id on the session", async (t) => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const session = {
+        accountId: "0xabc",
+        oauthScope: "memwal:read memwal:write",
+    } as MemWalSession;
+    const server = createMcpServer(session);
+    const client = new Client({ name: "claude-code", version: "9.9.9" });
+
+    t.after(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    assert.equal(session.agentClient, "claude-code");
+    assert.equal(session.clientName, "claude-code");
+    assert.equal(session.clientVersion, "9.9.9");
+});

--- a/services/server/scripts/mcp/agent-client.ts
+++ b/services/server/scripts/mcp/agent-client.ts
@@ -18,6 +18,33 @@ const MAX_TOKEN = 64;
 export const CLIENT_NAME_HEADER = "x-memwal-client";
 export const CLIENT_VERSION_HEADER = "x-memwal-client-version";
 
+/**
+ * Stable ids written to `session.agentClient` / sidecar logs.
+ * Keep in lockstep with the branches in `identifyAgentClient`.
+ */
+export const AGENT_CLIENT_IDS = [
+    "claude-code",
+    "codex",
+    "cursor",
+    "antigravity",
+    "opencode",
+    "windsurf",
+    "claude-desktop",
+    "vscode-copilot",
+    "chatgpt",
+    "gemini",
+    "grok",
+    "other",
+] as const;
+
+export type AgentClientId = (typeof AGENT_CLIENT_IDS)[number];
+
+/**
+ * Sidecar copy of token sanitizing. Strips C0/DEL only so JSON logs can
+ * keep non-ASCII client names. The stdio-bridge copy in
+ * `packages/mcp/src/client-info.ts` is stricter (printable ASCII) because
+ * it produces HTTP header values. Do not unify them.
+ */
 export function sanitizeClientToken(raw: unknown): string | null {
     if (typeof raw !== "string") return null;
     const cleaned = raw.replace(/[\u0000-\u001f\u007f]/g, "").trim();
@@ -26,7 +53,7 @@ export function sanitizeClientToken(raw: unknown): string | null {
 }
 
 /** Stable id used in logs. Order matters: `claude-code` before `claude`. */
-export function identifyAgentClient(rawName: string): string {
+export function identifyAgentClient(rawName: string): AgentClientId {
     const n = rawName.toLowerCase();
     if (n.includes("claude-code") || n.includes("claude code")) return "claude-code";
     if (n.includes("codex")) return "codex";
@@ -34,6 +61,8 @@ export function identifyAgentClient(rawName: string): string {
     if (n.includes("antigravity")) return "antigravity";
     if (n.includes("opencode") || n.includes("open-code")) return "opencode";
     if (n.includes("windsurf") || n.includes("codeium")) return "windsurf";
+    // Claude Desktop's web UI has historically sent `claude.ai` / `claude-ai`
+    // as clientInfo.name. Unknown names still fall through to `other`.
     if (
         n.includes("claude-desktop") ||
         n.includes("claude desktop") ||
@@ -67,8 +96,11 @@ export function clientInfoFromInitializeParams(
 }
 
 /**
- * Stamp `session.agentClient` the first time we learn a name. Idempotent:
- * later calls with the same id do not emit another log line.
+ * Stamp `session.agentClient` the first time we learn a name. Idempotent for
+ * the same id+name: later calls do not emit another log line, except when they
+ * fill in a version that the first stamp lacked (header without version, then
+ * handshake with version). A later call that omits version must not wipe one
+ * we already stored.
  */
 export function applyAgentClient(
     session: MemWalSession,
@@ -79,15 +111,22 @@ export function applyAgentClient(
     if (!name) return false;
     const id = identifyAgentClient(name);
     const version = sanitizeClientToken(input.version);
-    if (session.agentClient === id && session.clientName === name) return false;
+    const sameIdentity = session.agentClient === id && session.clientName === name;
+    if (sameIdentity && (version == null || session.clientVersion === version)) {
+        return false;
+    }
     const first = session.agentClient == null;
     session.agentClient = id;
     session.clientName = name;
-    session.clientVersion = version ?? undefined;
+    if (!sameIdentity) {
+        session.clientVersion = version ?? undefined;
+    } else if (version) {
+        session.clientVersion = version;
+    }
     log.info(first ? "session.identified" : "session.identified.updated", {
         agentClient: id,
         clientName: name,
-        clientVersion: version,
+        clientVersion: session.clientVersion ?? version,
         accountId: session.accountId,
         ...fields,
     });

--- a/services/server/scripts/mcp/agent-client.ts
+++ b/services/server/scripts/mcp/agent-client.ts
@@ -1,0 +1,112 @@
+/**
+ * Map MCP `clientInfo.name` (and the optional `x-memwal-client` header) onto
+ * a stable agent-client id so sidecar logs can say which coding agent a
+ * session belongs to.
+ *
+ * Names are untrusted client-supplied strings. We sanitize length/control
+ * chars, never log tool arguments, and treat unknown names as `other` while
+ * keeping the raw name in the log line.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { MemWalSession } from "./auth.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("mcp");
+
+const MAX_TOKEN = 64;
+
+export const CLIENT_NAME_HEADER = "x-memwal-client";
+export const CLIENT_VERSION_HEADER = "x-memwal-client-version";
+
+export function sanitizeClientToken(raw: unknown): string | null {
+    if (typeof raw !== "string") return null;
+    const cleaned = raw.replace(/[\u0000-\u001f\u007f]/g, "").trim();
+    if (!cleaned) return null;
+    return cleaned.slice(0, MAX_TOKEN);
+}
+
+/** Stable id used in logs. Order matters: `claude-code` before `claude`. */
+export function identifyAgentClient(rawName: string): string {
+    const n = rawName.toLowerCase();
+    if (n.includes("claude-code") || n.includes("claude code")) return "claude-code";
+    if (n.includes("codex")) return "codex";
+    if (n.includes("cursor")) return "cursor";
+    if (n.includes("antigravity")) return "antigravity";
+    if (n.includes("opencode") || n.includes("open-code")) return "opencode";
+    if (n.includes("windsurf") || n.includes("codeium")) return "windsurf";
+    if (
+        n.includes("claude-desktop") ||
+        n.includes("claude desktop") ||
+        n.includes("claude.ai") ||
+        n === "claude-ai" ||
+        n === "claude"
+    ) {
+        return "claude-desktop";
+    }
+    if (n.includes("visual studio") || n.includes("github copilot") || n.includes("vscode")) {
+        return "vscode-copilot";
+    }
+    if (n.includes("chatgpt")) return "chatgpt";
+    if (n.includes("gemini")) return "gemini";
+    if (n.includes("grok")) return "grok";
+    return "other";
+}
+
+export function clientInfoFromInitializeParams(
+    params: unknown,
+): { name: string; version: string | null } | null {
+    if (params == null || typeof params !== "object") return null;
+    const info = (params as { clientInfo?: unknown }).clientInfo;
+    if (info == null || typeof info !== "object") return null;
+    const name = sanitizeClientToken((info as { name?: unknown }).name);
+    if (!name) return null;
+    return {
+        name,
+        version: sanitizeClientToken((info as { version?: unknown }).version),
+    };
+}
+
+/**
+ * Stamp `session.agentClient` the first time we learn a name. Idempotent:
+ * later calls with the same id do not emit another log line.
+ */
+export function applyAgentClient(
+    session: MemWalSession,
+    input: { name?: string | null; version?: string | null },
+    fields: Record<string, unknown> = {},
+): boolean {
+    const name = sanitizeClientToken(input.name);
+    if (!name) return false;
+    const id = identifyAgentClient(name);
+    const version = sanitizeClientToken(input.version);
+    if (session.agentClient === id && session.clientName === name) return false;
+    const first = session.agentClient == null;
+    session.agentClient = id;
+    session.clientName = name;
+    session.clientVersion = version ?? undefined;
+    log.info(first ? "session.identified" : "session.identified.updated", {
+        agentClient: id,
+        clientName: name,
+        clientVersion: version,
+        accountId: session.accountId,
+        ...fields,
+    });
+    return true;
+}
+
+export function applyAgentClientFromServer(
+    server: McpServer,
+    session: MemWalSession,
+    header?: { name?: string | null; version?: string | null },
+    fields: Record<string, unknown> = {},
+): boolean {
+    const sdk = server.server.getClientVersion();
+    return applyAgentClient(
+        session,
+        {
+            name: sdk?.name ?? header?.name,
+            version: sdk?.version ?? header?.version,
+        },
+        fields,
+    );
+}

--- a/services/server/scripts/mcp/auth.ts
+++ b/services/server/scripts/mcp/auth.ts
@@ -26,6 +26,11 @@ export interface MemWalSession {
     memwal: MemWal;
     authMethod: "delegate-key";
     oauthScope?: string;
+    /** Stable coding-agent id (`claude-code`, `codex`, `other`, …). */
+    agentClient?: string;
+    /** Raw MCP `clientInfo.name` after sanitizing. */
+    clientName?: string;
+    clientVersion?: string;
 }
 
 export interface AuthResolution {

--- a/services/server/scripts/mcp/index.ts
+++ b/services/server/scripts/mcp/index.ts
@@ -21,11 +21,18 @@ import { randomUUID } from "node:crypto";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
-import type { AuthResolution } from "./auth.js";
+import type { AuthResolution, MemWalSession } from "./auth.js";
 import { McpAuthError, resolveAuth } from "./auth.js";
+import {
+    applyAgentClient,
+    applyAgentClientFromServer,
+    CLIENT_NAME_HEADER,
+    CLIENT_VERSION_HEADER,
+} from "./agent-client.js";
 import { createLogger } from "./logger.js";
 import { createMcpServer } from "./server.js";
 import { McpRateLimiter, clientIpFromRequest } from "./rateLimit.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const log = createLogger("mcp");
 
@@ -70,6 +77,8 @@ function rateLimitDeny(
 
 interface McpConnection {
     sessionKey: string;
+    session: MemWalSession;
+    server: McpServer;
     transport: SSEServerTransport;
     cleanup: () => void;
 }
@@ -87,9 +96,35 @@ const sessionsById = new Map<string, McpConnection>();
  */
 interface StreamableConnection {
     sessionKey: string;
+    session: MemWalSession;
+    server: McpServer;
     transport: StreamableHTTPServerTransport;
     cleanup: () => void;
     lastActiveMs: number;
+}
+
+function headerToken(req: Request, name: string): string | null {
+    const raw = req.headers[name];
+    return typeof raw === "string" ? raw : null;
+}
+
+function agentClientFromHeaders(req: Request): {
+    name: string | null;
+    version: string | null;
+} {
+    return {
+        name: headerToken(req, CLIENT_NAME_HEADER),
+        version: headerToken(req, CLIENT_VERSION_HEADER),
+    };
+}
+
+function identifyConnection(
+    server: McpServer,
+    session: MemWalSession,
+    req: Request,
+    fields: Record<string, unknown>,
+): void {
+    applyAgentClientFromServer(server, session, agentClientFromHeaders(req), fields);
 }
 const streamableSessions = new Map<string, StreamableConnection>();
 
@@ -215,6 +250,7 @@ async function handleSse(
         log.info("session.closed", {
             sessionKey: auth.sessionKey,
             transportId: transport.sessionId,
+            agentClient: auth.session.agentClient ?? null,
         });
     };
 
@@ -223,8 +259,16 @@ async function handleSse(
 
     sessionsById.set(transport.sessionId, {
         sessionKey: auth.sessionKey,
+        session: auth.session,
+        server,
         transport,
         cleanup,
+    });
+
+    applyAgentClient(auth.session, agentClientFromHeaders(req), {
+        transport: "sse",
+        transportId: transport.sessionId,
+        sessionKey: auth.sessionKey,
     });
 
     log.info("session.opened", {
@@ -232,6 +276,7 @@ async function handleSse(
         accountId: auth.session.accountId,
         delegatePubKey: auth.session.delegatePubKeyHex,
         transportId: transport.sessionId,
+        agentClient: auth.session.agentClient ?? null,
     });
 
     await server.connect(transport);
@@ -284,6 +329,11 @@ async function handlePostMessage(
     // SSEServerTransport.handlePostMessage expects the raw IncomingMessage.
     // Express `req` is an IncomingMessage subtype; passing it through works.
     await conn.transport.handlePostMessage(req, res);
+    identifyConnection(conn.server, conn.session, req, {
+        transport: "sse",
+        transportId: sessionId,
+        sessionKey: conn.sessionKey,
+    });
 }
 
 /**
@@ -353,6 +403,11 @@ async function handleStreamableHttp(
         }
         conn.lastActiveMs = Date.now();
         await conn.transport.handleRequest(req, res);
+        identifyConnection(conn.server, conn.session, req, {
+            transport: "streamable",
+            transportId: sessionId,
+            sessionKey: conn.sessionKey,
+        });
         return;
     }
 
@@ -384,8 +439,10 @@ async function handleStreamableHttp(
 
     // Spawn a fresh transport. `sessionIdGenerator` is invoked once on
     // the first message-init response; we cache the connection only
-    // after we know the assigned id.
+    // after we know the assigned id. `server` is assigned before
+    // `handleRequest`, which is when `onsessioninitialized` actually runs.
     let initialized = false;
+    let server!: McpServer;
     const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (newId: string) => {
@@ -400,11 +457,14 @@ async function handleStreamableHttp(
                     transport: "streamable",
                     sessionKey: auth.sessionKey,
                     transportId: newId,
+                    agentClient: auth.session.agentClient ?? null,
                 });
             };
             transport.onclose = cleanup;
             streamableSessions.set(newId, {
                 sessionKey: auth.sessionKey,
+                session: auth.session,
+                server,
                 transport,
                 cleanup,
                 lastActiveMs: Date.now(),
@@ -415,6 +475,7 @@ async function handleStreamableHttp(
                 accountId: auth.session.accountId,
                 delegatePubKey: auth.session.delegatePubKeyHex,
                 transportId: newId,
+                agentClient: auth.session.agentClient ?? null,
             });
         },
     });
@@ -425,7 +486,7 @@ async function handleStreamableHttp(
     // the catch below handles handleRequest throwing before init completes.
     transport.onclose = releaseSlot;
 
-    const server = createMcpServer(auth.session);
+    server = createMcpServer(auth.session);
     try {
         await server.connect(transport);
         // The SDK's handleRequest takes the raw IncomingMessage. We
@@ -433,6 +494,11 @@ async function handleStreamableHttp(
         // mounted on this route so req still has the raw stream.
         // The transport reads the body itself.
         await transport.handleRequest(req, res);
+        identifyConnection(server, auth.session, req, {
+            transport: "streamable",
+            transportId: transport.sessionId ?? null,
+            sessionKey: auth.sessionKey,
+        });
         if (!initialized) {
             releaseSlot();
             await transport.close().catch((err) => {

--- a/services/server/scripts/mcp/index.ts
+++ b/services/server/scripts/mcp/index.ts
@@ -265,6 +265,9 @@ async function handleSse(
         cleanup,
     });
 
+    // Headers are a best-effort hint (auth-required handoff / reconnect).
+    // The first SSE GET usually has none; identity is logged on
+    // session.identified once the handshake (or a later header) lands.
     applyAgentClient(auth.session, agentClientFromHeaders(req), {
         transport: "sse",
         transportId: transport.sessionId,
@@ -276,7 +279,6 @@ async function handleSse(
         accountId: auth.session.accountId,
         delegatePubKey: auth.session.delegatePubKeyHex,
         transportId: transport.sessionId,
-        agentClient: auth.session.agentClient ?? null,
     });
 
     await server.connect(transport);
@@ -328,6 +330,11 @@ async function handlePostMessage(
 
     // SSEServerTransport.handlePostMessage expects the raw IncomingMessage.
     // Express `req` is an IncomingMessage subtype; passing it through works.
+    applyAgentClient(conn.session, agentClientFromHeaders(req), {
+        transport: "sse",
+        transportId: sessionId,
+        sessionKey: conn.sessionKey,
+    });
     await conn.transport.handlePostMessage(req, res);
     identifyConnection(conn.server, conn.session, req, {
         transport: "sse",
@@ -402,6 +409,16 @@ async function handleStreamableHttp(
             );
         }
         conn.lastActiveMs = Date.now();
+        // Stamp from headers first when present. Handshake identity is
+        // applied after handleRequest because the SDK only exposes
+        // clientInfo once initialize has been processed; a request that
+        // both initializes and calls a tool can therefore emit tool.call
+        // before session.identified.
+        applyAgentClient(conn.session, agentClientFromHeaders(req), {
+            transport: "streamable",
+            transportId: sessionId,
+            sessionKey: conn.sessionKey,
+        });
         await conn.transport.handleRequest(req, res);
         identifyConnection(conn.server, conn.session, req, {
             transport: "streamable",
@@ -439,13 +456,22 @@ async function handleStreamableHttp(
 
     // Spawn a fresh transport. `sessionIdGenerator` is invoked once on
     // the first message-init response; we cache the connection only
-    // after we know the assigned id. `server` is assigned before
-    // `handleRequest`, which is when `onsessioninitialized` actually runs.
+    // after we know the assigned id. Holder (not `let server!`) so a
+    // future reorder of assign vs `onsessioninitialized` logs instead of
+    // throwing a TDZ ReferenceError.
     let initialized = false;
-    let server!: McpServer;
+    const holder: { server: McpServer | null } = { server: null };
     const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (newId: string) => {
+            const server = holder.server;
+            if (!server) {
+                log.error("mcp.streamable_session_without_server", {
+                    transportId: newId,
+                });
+                releaseSlot();
+                return;
+            }
             initialized = true;
             let cleanedUp = false;
             const cleanup = () => {
@@ -469,13 +495,20 @@ async function handleStreamableHttp(
                 cleanup,
                 lastActiveMs: Date.now(),
             });
+            applyAgentClient(auth.session, agentClientFromHeaders(req), {
+                transport: "streamable",
+                transportId: newId,
+                sessionKey: auth.sessionKey,
+            });
+            // Identity is logged on session.identified once known (headers
+            // or handshake). Streamable init runs before the SDK stores
+            // clientInfo, so agentClient is usually still empty here.
             log.info("session.opened", {
                 transport: "streamable",
                 sessionKey: auth.sessionKey,
                 accountId: auth.session.accountId,
                 delegatePubKey: auth.session.delegatePubKeyHex,
                 transportId: newId,
-                agentClient: auth.session.agentClient ?? null,
             });
         },
     });
@@ -486,15 +519,15 @@ async function handleStreamableHttp(
     // the catch below handles handleRequest throwing before init completes.
     transport.onclose = releaseSlot;
 
-    server = createMcpServer(auth.session);
+    holder.server = createMcpServer(auth.session);
     try {
-        await server.connect(transport);
+        await holder.server.connect(transport);
         // The SDK's handleRequest takes the raw IncomingMessage. We
         // intentionally do NOT pre-parse the body — express.json() is not
         // mounted on this route so req still has the raw stream.
         // The transport reads the body itself.
         await transport.handleRequest(req, res);
-        identifyConnection(server, auth.session, req, {
+        identifyConnection(holder.server, auth.session, req, {
             transport: "streamable",
             transportId: transport.sessionId ?? null,
             sessionKey: auth.sessionKey,

--- a/services/server/scripts/mcp/server.ts
+++ b/services/server/scripts/mcp/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createRequire } from "node:module";
+import { applyAgentClientFromServer } from "./agent-client.js";
 import type { MemWalSession } from "./auth.js";
 import { registerTools } from "./tools/index.js";
 
@@ -75,6 +76,12 @@ export function createMcpServer(session: MemWalSession): McpServer {
     );
 
     registerTools(server, session);
+
+    // SDK populates getClientVersion() during initialize; this fires after
+    // the client sends `notifications/initialized`.
+    server.server.oninitialized = () => {
+        applyAgentClientFromServer(server, session);
+    };
 
     return server;
 }

--- a/services/server/scripts/mcp/tools/analyze.ts
+++ b/services/server/scripts/mcp/tools/analyze.ts
@@ -36,7 +36,7 @@ export function registerAnalyzeTool(
                 "Extract memorable facts from a longer passage of text (preferences, habits, biographical info, constraints) and save each as a separate Walrus Memory memory. Use this when you want MemWal's LLM to split the facts out of a transcript or notes for you; if you already know the exact facts, use memwal_remember or memwal_remember_bulk instead.",
             inputSchema: ANALYZE_INPUT,
         },
-        wrapTool<{ text: string; namespace?: string }>(async ({ text, namespace }) => {
+        wrapTool<{ text: string; namespace?: string }>(session, "memwal_analyze", async ({ text, namespace }) => {
             const result = await session.memwal.analyzeAndWait(text, namespace, {
                 timeoutMs: 180_000,
             });

--- a/services/server/scripts/mcp/tools/health.ts
+++ b/services/server/scripts/mcp/tools/health.ts
@@ -21,7 +21,7 @@ export function registerHealthTool(
                 "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
             inputSchema: {},
         },
-        wrapTool<Record<string, never>>(async () => {
+        wrapTool<Record<string, never>>(session, "memwal_health", async () => {
             const result = await session.memwal.health();
             const extra = result as { write_ready?: boolean };
             const writeNote =

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -82,7 +82,7 @@ export function registerRecallTool(
                 "Search the user's Walrus Memory for relevant facts before responding. Call this PROACTIVELY at the start of a task, or whenever the user references past work, prior decisions, their preferences, or anything you may have stored earlier — don't wait to be asked. A single focused query is usually enough — recall is a real retrieval over encrypted storage, so do NOT fire multiple redundant searches for the same question. Returns matching memories ranked by relevance.",
             inputSchema: RECALL_INPUT,
         },
-        wrapTool<{ query: string; limit: number; namespace?: string }>(async ({ query, limit, namespace }) => {
+        wrapTool<{ query: string; limit: number; namespace?: string }>(session, "memwal_recall", async ({ query, limit, namespace }) => {
             const result = await session.memwal.recall(query, limit, namespace);
             const droppedRaw = (result as { dropped_count?: unknown }).dropped_count;
             const dropped = typeof droppedRaw === "number" ? droppedRaw : 0;

--- a/services/server/scripts/mcp/tools/remember-bulk.ts
+++ b/services/server/scripts/mcp/tools/remember-bulk.ts
@@ -39,7 +39,7 @@ export function registerRememberBulkTool(
                 "Save multiple durable facts in one call. Use when you learned several distinct facts at once (onboarding details, a list of preferences, decisions from a discussion). Pass an array of complete fact statements (max 20) — do not summarize. Prefer this over repeated memwal_remember calls.",
             inputSchema: REMEMBER_BULK_INPUT,
         },
-        wrapTool<{ facts: string[]; namespace?: string }>(async ({ facts, namespace }) => {
+        wrapTool<{ facts: string[]; namespace?: string }>(session, "memwal_remember_bulk", async ({ facts, namespace }) => {
             const items = facts.map((text) => ({ text, namespace }));
             const result = await session.memwal.rememberBulkAndWait(items, {
                 timeoutMs: 120_000,

--- a/services/server/scripts/mcp/tools/remember.ts
+++ b/services/server/scripts/mcp/tools/remember.ts
@@ -41,7 +41,7 @@ export function registerRememberTool(
                 "Save a durable fact about the user or project to their Walrus Memory. Call this PROACTIVELY whenever the user states a preference, decision, constraint, correction, identity detail, or recurring workflow — even if they did not say 'remember this'. Skip one-off tasks, the current file or bug, and small talk. Pass the full statement; do not summarize. To save several facts at once, use memwal_remember_bulk instead.",
             inputSchema: REMEMBER_INPUT,
         },
-        wrapTool<{ text: string; namespace?: string }>(async ({ text, namespace }) => {
+        wrapTool<{ text: string; namespace?: string }>(session, "memwal_remember", async ({ text, namespace }) => {
             const result = await session.memwal.rememberAndWait(
                 text,
                 namespace,

--- a/services/server/scripts/mcp/tools/restore.ts
+++ b/services/server/scripts/mcp/tools/restore.ts
@@ -54,7 +54,7 @@ export function registerRestoreTool(
                 "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. If truncated=true, increase limit and call again. Call memwal_recall afterwards to query the rebuilt index.",
             inputSchema: RESTORE_INPUT,
         },
-        wrapTool<{ namespace: string; limit: number }>(async ({ namespace, limit }) => {
+        wrapTool<{ namespace: string; limit: number }>(session, "memwal_restore", async ({ namespace, limit }) => {
             const result = await session.memwal.restore(namespace, limit);
             return {
                 content: [

--- a/services/server/scripts/mcp/tools/util.ts
+++ b/services/server/scripts/mcp/tools/util.ts
@@ -1,6 +1,10 @@
 /**
  * Shared helpers for tool implementations.
  */
+import type { MemWalSession } from "../auth.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("mcp");
 
 interface ToolResultLike {
     [x: string]: unknown;
@@ -43,9 +47,17 @@ export function explorerFooter(): string {
 }
 
 export function wrapTool<Args>(
+    session: MemWalSession,
+    tool: string,
     handler: (args: Args) => Promise<ToolResultLike>
 ): (args: Args) => Promise<ToolResultLike> {
     return async (args) => {
+        log.info("tool.call", {
+            tool,
+            agentClient: session.agentClient ?? null,
+            clientName: session.clientName ?? null,
+            accountId: session.accountId ?? null,
+        });
         try {
             return await handler(args);
         } catch (err: any) {
@@ -58,7 +70,7 @@ export function wrapTool<Args>(
 
             // Operator-side diagnostic — full chain to sidecar stderr.
             console.error(
-                `[mcp.tool.error] name=${name} msg=${msg}` +
+                `[mcp.tool.error] tool=${tool} agentClient=${session.agentClient ?? ""} name=${name} msg=${msg}` +
                 (cause
                     ? ` cause_name=${cause?.constructor?.name} cause_msg=${cause?.message} cause_code=${cause?.code}`
                     : "")

--- a/services/server/src/mcp_proxy.rs
+++ b/services/server/src/mcp_proxy.rs
@@ -696,6 +696,8 @@ mod tests {
             "last-event-id",
             "x-memwal-account-id",
             "x-memwal-namespace",
+            "x-memwal-client",
+            "x-memwal-client-version",
         ] {
             let name = AxumHeaderName::from_bytes(h.as_bytes()).unwrap();
             assert!(should_forward(&name), "should forward {h}");


### PR DESCRIPTION
Closes WALM-373.

## What

The relayer sidecar can tell which coding agent an MCP session belongs to, and logs it.

1. Stdio `memwal-mcp` reads `initialize.clientInfo` and forwards `x-memwal-client` / `x-memwal-client-version` (the proxy already forwards `x-memwal-*`).
2. Sidecar maps the name to a stable `agentClient` (`claude-code`, `codex`, `cursor`, …; unknown stays `other` with the raw `clientName`).
3. JSON stderr logs: `session.identified`, `tool.call`, `session.closed`.

View in **Railway → Relayer** after this sidecar is deployed. Search `session.identified` or `agentClient":"claude-code"`.

## Not in this PR

No install CLI / marketplace / per-client plugin pack. Local `memwal-mcp` stderr is only on the user's machine.

## Test

- `packages/mcp`: 60/60
- sidecar MCP scripts: 233/233 (includes handshake stamp for `claude-code`)