### PR TITLE
fix(python-sdk): with_memwal auto_save save_mode + confirmable saves (WALM-307)

### DIFF
--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -223,7 +223,7 @@ See [Manual methods](/python-sdk/usage/memwal-manual).
 from memwal import with_memwal_langchain, with_memwal_openai
 ```
 
-Both wrap an existing LLM client with automatic recall + save and accept: `key`, `account_id`, `server_url`, `namespace`, `env`, `max_memories` (5), `auto_save` (True), `min_relevance` (0.3), `debug` (False). The alias `withMemWal` maps to `with_memwal_langchain`. See [with_memwal](/python-sdk/usage/with-memwal).
+Both wrap an existing LLM client with automatic recall + save and accept: `key`, `account_id`, `server_url`, `namespace`, `env`, `max_memories` (5), `auto_save` (True), `save_mode` (`"analyze"` or `"remember"`), `min_relevance` (0.3), `debug` (False). The wrapped client also exposes `memwal`, `memwal_flush()`, and `memwal_wait_for_saves()` for confirming saves. The alias `withMemWal` maps to `with_memwal_langchain`. See [with_memwal](/python-sdk/usage/with-memwal).
 
 ## Exceptions
 

--- a/docs/python-sdk/usage/with-memwal.md
+++ b/docs/python-sdk/usage/with-memwal.md
@@ -112,8 +112,49 @@ response = await smart_client.chat.completions.create(
 
 **After generation:**
 
-- If `auto_save` (default `True`), runs `analyze()` on the user message fire-and-forget
-- Extracted facts are stored asynchronously
+- If `auto_save` (default `True`), saves the user message fire-and-forget using `save_mode`
+- With the default `save_mode="analyze"`, `analyze()` extracts spoken-fact-style statements and stores one memory per fact, asynchronously
+- With `save_mode="remember"`, the message is stored verbatim as a single memory
+
+### Choosing a save mode
+
+`analyze()` is lossy by design: it only extracts facts it can read as spoken statements. Code snippets, JSON, logs, and other non-sentence content produce zero facts, so nothing is stored. That path used to be silent; it now logs a warning naming the fix. When you are saving content like that, ask for verbatim storage:
+
+```python
+smart_client = with_memwal_openai(
+    client,
+    key=os.environ["MEMWAL_PRIVATE_KEY"],
+    account_id=os.environ["MEMWAL_ACCOUNT_ID"],
+    env="prod",
+    save_mode="remember",  # store the message as-is, no fact extraction
+)
+```
+
+## Confirming a Save
+
+Auto-save is fire-and-forget, so the LLM response returns before the memory is durable. The wrapper exposes controls to close that gap:
+
+| Control | Purpose |
+| --- | --- |
+| `await client.memwal_flush()` | Wait for in-flight auto-saves to be submitted |
+| `client.memwal_flush_sync()` | Same, from sync code |
+| `await client.memwal_wait_for_saves(opts)` | Flush, then poll every enqueued remember job to a terminal state |
+| `client.memwal_wait_for_saves_sync(opts)` | Same, from sync code |
+| `client.memwal` | The underlying `MemWal` client, for anything lower-level |
+
+```python
+response = await smart_client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "def f(): return 1"}],
+)
+
+result = await smart_client.memwal_wait_for_saves()
+print(result.succeeded, result.failed, result.timed_out)
+for item in result.results:
+    print(item.status, item.blob_id)
+```
+
+`memwal_wait_for_saves()` returns a `RememberBulkResult`, so you get per-job status and blob IDs. Job IDs are drained once waited on: a second call only covers saves made since the first. Pass a `RememberBulkOptions` to tune `poll_interval_ms` and `timeout_ms`. Short-lived scripts should call one of these before exiting, or pending saves are lost when the process ends.
 
 ## Options
 
@@ -126,6 +167,7 @@ Both wrappers accept the same keyword arguments:
 | `namespace` | `"default"` | Memory namespace |
 | `max_memories` | `5` | Max memories injected per request |
 | `auto_save` | `True` | Auto-save new facts from the conversation |
+| `save_mode` | `"analyze"` | How auto-save persists the message: `"analyze"` (extract facts) or `"remember"` (store verbatim) |
 | `min_relevance` | `0.3` | Minimum similarity (0–1) to include a memory |
 | `debug` | `False` | Verbose logging via the `memwal` logger |
 

--- a/packages/python-sdk-memwal/memwal/middleware.py
+++ b/packages/python-sdk-memwal/memwal/middleware.py
@@ -55,7 +55,7 @@ from typing import (
 )
 
 from .client import MemWal, _with_fresh_http_client
-from .types import RecallMemory
+from .types import RecallMemory, RememberBulkOptions, RememberBulkResult
 
 if TYPE_CHECKING:
     from langchain_core.language_models.chat_models import BaseChatModel
@@ -130,6 +130,25 @@ def _format_memories(
     ])
 
 
+SAVE_MODES = ("analyze", "remember")
+"""Valid ``save_mode`` values for the auto-save path.
+
+``"analyze"`` extracts spoken-fact-style statements via the server LLM and
+stores one memory per fact — it is lossy by design, and non-sentence content
+(code snippets, structured data) yields zero facts. ``"remember"`` stores the
+user message verbatim as a single memory, which is what callers saving code or
+other non-conversational content want.
+"""
+
+
+def _validate_save_mode(save_mode: str) -> str:
+    if save_mode not in SAVE_MODES:
+        raise ValueError(
+            f"save_mode must be one of {SAVE_MODES}, got {save_mode!r}"
+        )
+    return save_mode
+
+
 class _PendingSaves:
     """Tracks in-flight fire-and-forget auto-save work (asyncio Tasks and
     background Threads) so a caller can drain it deterministically via
@@ -143,7 +162,23 @@ class _PendingSaves:
     def __init__(self) -> None:
         self._tasks: "set[asyncio.Task[Any]]" = set()
         self._threads: List[threading.Thread] = []
+        self._job_ids: List[str] = []
         self._lock = threading.Lock()
+
+    def track_job_ids(self, job_ids: List[str]) -> None:
+        """Record the background remember jobs an auto-save enqueued, so a
+        caller can later confirm they finished and read their blob IDs."""
+        if not job_ids:
+            return
+        with self._lock:
+            self._job_ids.extend(job_ids)
+
+    def drain_job_ids(self) -> List[str]:
+        """Return every job ID recorded so far and forget them, so a second
+        wait does not re-poll jobs that already settled."""
+        with self._lock:
+            job_ids, self._job_ids = self._job_ids, []
+        return job_ids
 
     def track_task(self, task: "asyncio.Task[Any]") -> None:
         self._tasks.add(task)
@@ -205,6 +240,41 @@ class _PendingSaves:
             thread.join()
 
 
+async def _run_auto_save(
+    memwal: MemWal,
+    text: str,
+    namespace: str,
+    save_mode: str,
+    pending: _PendingSaves,
+    log: Callable[..., Any],
+) -> None:
+    """Persist `text` via the configured save mode and record its job IDs.
+
+    ``analyze()`` returns cleanly with zero facts for content it cannot read
+    as spoken facts (code, structured data), so a plain call there looks
+    identical to a successful save. Warn in that case and point at
+    ``save_mode="remember"`` rather than dropping the write silently.
+    """
+    try:
+        if save_mode == "remember":
+            accepted = await memwal.remember(text, namespace)
+            pending.track_job_ids([accepted.job_id])
+            return
+
+        result = await memwal.analyze(text, namespace)
+        pending.track_job_ids(list(result.job_ids))
+        if not result.facts and not result.job_ids:
+            logger.warning(
+                "Walrus Memory auto-save extracted 0 facts from a %d-character "
+                "message and stored nothing. analyze() only extracts "
+                "spoken-fact-style statements — pass save_mode=\"remember\" to "
+                "store the message verbatim instead.",
+                len(text),
+            )
+    except Exception as e:  # noqa: BLE001 -- auto-save must never break the LLM call
+        log(f"[Walrus Memory] Auto-save failed: {e}")
+
+
 def _expose_memwal_controls(obj: Any, memwal: MemWal, pending: _PendingSaves) -> None:
     """Attach the underlying client and a way to drain pending auto-saves —
     without this, a short-lived process has no way to avoid silently
@@ -221,9 +291,35 @@ def _expose_memwal_controls(obj: Any, memwal: MemWal, pending: _PendingSaves) ->
     (obj.memwal_flush) still finds it — OpenAI clients aren't Pydantic
     models and work the same way either way.
     """
+    async def memwal_wait_for_saves(
+        opts: Optional[RememberBulkOptions] = None,
+    ) -> RememberBulkResult:
+        """Drain pending auto-saves, then poll their remember jobs to a
+        terminal state and return per-job status + blob IDs."""
+        await pending.flush()
+        return await memwal.wait_for_remember_jobs(pending.drain_job_ids(), opts)
+
+    def memwal_wait_for_saves_sync(
+        opts: Optional[RememberBulkOptions] = None,
+    ) -> RememberBulkResult:
+        """Sync counterpart of ``memwal_wait_for_saves`` for callers on the
+        blocking entry points (``OpenAI``, ``llm.invoke``)."""
+        pending.flush_sync()
+        job_ids = pending.drain_job_ids()
+        return _run_blocking(
+            lambda: _with_fresh_http_client(
+                memwal, memwal.wait_for_remember_jobs(job_ids, opts)
+            )
+        )
+
     object.__setattr__(obj, "_memwal", memwal)
+    # Public alias: reaching wait_for_remember_jobs() and the rest of the
+    # low-level client shouldn't require touching a private attribute.
+    object.__setattr__(obj, "memwal", memwal)
     object.__setattr__(obj, "memwal_flush", pending.flush)
     object.__setattr__(obj, "memwal_flush_sync", pending.flush_sync)
+    object.__setattr__(obj, "memwal_wait_for_saves", memwal_wait_for_saves)
+    object.__setattr__(obj, "memwal_wait_for_saves_sync", memwal_wait_for_saves_sync)
 
 
 async def _warn_if_cancelled(coro: Any, label: str) -> None:
@@ -288,6 +384,7 @@ def with_memwal_langchain(
     namespace: str = "default",
     max_memories: int = 5,
     auto_save: bool = True,
+    save_mode: str = "analyze",
     min_relevance: float = 0.3,
     debug: bool = False,
     env: Optional[str] = None,
@@ -309,6 +406,11 @@ def with_memwal_langchain(
         namespace: Default namespace.
         max_memories: Max memories to inject per request.
         auto_save: Auto-save new facts from conversation.
+        save_mode: How auto_save persists the user message. ``"analyze"``
+            (default) extracts spoken-fact-style statements and stores one
+            memory per fact — non-sentence content such as code yields zero
+            facts and stores nothing. ``"remember"`` stores the message
+            verbatim as a single memory.
         min_relevance: Minimum similarity score (0-1) to include a memory.
         debug: Enable debug logging.
         env: Optional relayer preset (``"prod"`` / ``"dev"`` / ``"staging"`` /
@@ -325,6 +427,8 @@ def with_memwal_langchain(
             "LangChain integration requires langchain-core. "
             "Install with: pip install memwal[langchain]"
         ) from e
+
+    _validate_save_mode(save_mode)
 
     memwal = MemWal.create(
         key=key,
@@ -379,15 +483,12 @@ def with_memwal_langchain(
             return messages
 
     async def _post_analyze(messages: List[BaseMessage]) -> None:
-        """Analyze user message for new facts."""
+        """Persist the user message via the configured save mode."""
         if not auto_save:
             return
         user_text = _find_last_user_message(messages)
         if user_text:
-            try:
-                await memwal.analyze(user_text, namespace)
-            except Exception as e:
-                log(f"[Walrus Memory] Auto-save failed: {e}")
+            await _run_auto_save(memwal, user_text, namespace, save_mode, pending, log)
 
     async def patched_agenerate(
         messages: List[List[BaseMessage]], *args: Any, **kwargs: Any
@@ -447,6 +548,7 @@ def with_memwal_openai(
     namespace: str = "default",
     max_memories: int = 5,
     auto_save: bool = True,
+    save_mode: str = "analyze",
     min_relevance: float = 0.3,
     debug: bool = False,
     env: Optional[str] = None,
@@ -470,6 +572,11 @@ def with_memwal_openai(
         namespace: Default namespace.
         max_memories: Max memories to inject per request.
         auto_save: Auto-save new facts from conversation.
+        save_mode: How auto_save persists the user message. ``"analyze"``
+            (default) extracts spoken-fact-style statements and stores one
+            memory per fact — non-sentence content such as code yields zero
+            facts and stores nothing. ``"remember"`` stores the message
+            verbatim as a single memory.
         min_relevance: Minimum similarity score (0-1) to include a memory.
         debug: Enable debug logging.
         env: Optional relayer preset (``"prod"`` / ``"dev"`` / ``"staging"`` /
@@ -478,6 +585,8 @@ def with_memwal_openai(
     Returns:
         The same client, with ``chat.completions.create`` wrapped to use Walrus Memory.
     """
+    _validate_save_mode(save_mode)
+
     memwal = MemWal.create(
         key=key,
         account_id=account_id,
@@ -493,11 +602,13 @@ def with_memwal_openai(
 
     if is_async:
         _wrap_async_openai(
-            client, memwal, namespace, max_memories, auto_save, min_relevance, log, pending
+            client, memwal, namespace, max_memories, auto_save, save_mode,
+            min_relevance, log, pending,
         )
     else:
         _wrap_sync_openai(
-            client, memwal, namespace, max_memories, auto_save, min_relevance, log, pending
+            client, memwal, namespace, max_memories, auto_save, save_mode,
+            min_relevance, log, pending,
         )
 
     _expose_memwal_controls(client, memwal, pending)
@@ -511,6 +622,7 @@ def _wrap_async_openai(
     namespace: str,
     max_memories: int,
     auto_save: bool,
+    save_mode: str,
     min_relevance: float,
     log: Callable[..., Any],
     pending: _PendingSaves,
@@ -545,15 +657,12 @@ def _wrap_async_openai(
 
         result = await original_create(*args, **kwargs)
 
-        # Fire-and-forget analyze
+        # Fire-and-forget auto-save
         if auto_save and user_text:
-            async def _analyze() -> None:
-                try:
-                    await memwal.analyze(user_text, namespace)
-                except Exception as e:
-                    log(f"[Walrus Memory] Auto-save failed: {e}")
-
-            _fire_and_forget(_analyze(), pending)
+            _fire_and_forget(
+                _run_auto_save(memwal, user_text, namespace, save_mode, pending, log),
+                pending,
+            )
 
         return result
 
@@ -566,6 +675,7 @@ def _wrap_sync_openai(
     namespace: str,
     max_memories: int,
     auto_save: bool,
+    save_mode: str,
     min_relevance: float,
     log: Callable[..., Any],
     pending: _PendingSaves,
@@ -606,15 +716,22 @@ def _wrap_sync_openai(
 
         result = original_create(*args, **kwargs)
 
-        # Fire-and-forget analyze
+        # Fire-and-forget auto-save
         if auto_save and user_text:
-            def _analyze() -> None:
+            def _save() -> None:
+                # _run_auto_save swallows request failures itself; this guards
+                # the loop/http-client plumbing around it so a failure there
+                # can't take down the background thread.
                 try:
-                    _run_memwal(lambda: memwal.analyze(user_text, namespace))
-                except Exception as e:
+                    _run_memwal(
+                        lambda: _run_auto_save(
+                            memwal, user_text, namespace, save_mode, pending, log
+                        )
+                    )
+                except Exception as e:  # noqa: BLE001
                     log(f"[Walrus Memory] Auto-save failed: {e}")
 
-            pending.spawn_thread(_analyze)
+            pending.spawn_thread(_save)
 
         return result
 

--- a/packages/python-sdk-memwal/tests/test_middleware.py
+++ b/packages/python-sdk-memwal/tests/test_middleware.py
@@ -30,10 +30,11 @@ from memwal.middleware import (
     _format_memories,
     _inject_openai_memory,
     _PendingSaves,
+    _run_auto_save,
     with_memwal_langchain,
     with_memwal_openai,
 )
-from memwal.types import RecallMemory
+from memwal.types import RecallMemory, RememberBulkOptions
 from memwal.utils import bytes_to_hex
 
 # ============================================================
@@ -129,6 +130,27 @@ def _mock_analyze() -> httpx.Response:
         200,
         json={"facts": [], "total": 0, "owner": "0xowner"},
     )
+
+
+_REMEMBER_URL = f"{_SERVER}/api/remember"
+_BULK_STATUS_URL = f"{_SERVER}/api/remember/bulk/status"
+
+
+def _mock_analyze_with_facts(*job_ids: str) -> httpx.Response:
+    return httpx.Response(
+        202,
+        json={
+            "facts": [{"text": f"fact {i}", "id": job_id} for i, job_id in enumerate(job_ids)],
+            "job_ids": list(job_ids),
+            "fact_count": len(job_ids),
+            "status": "pending",
+            "owner": "0xowner",
+        },
+    )
+
+
+def _mock_remember_accepted(job_id: str = "job-remember") -> httpx.Response:
+    return httpx.Response(202, json={"job_id": job_id, "status": "pending"})
 
 
 # ============================================================
@@ -878,3 +900,147 @@ class TestPendingSaves:
 
         time.sleep(0.05)
         assert len(pending._threads) == 0
+
+
+# ============================================================
+# WALM-307: auto_save save_mode + confirmable saves
+# ============================================================
+
+
+class TestAutoSaveMode:
+    """analyze() silently stores nothing for non-fact content (GH #411);
+    save_mode="remember" must store it verbatim instead."""
+
+    def _memwal(self) -> MemWal:
+        return MemWal.create(
+            key=_KEY_HEX, account_id=_ACCOUNT_ID, server_url=_SERVER, namespace="default"
+        )
+
+    @respx.mock
+    async def test_analyze_mode_warns_when_zero_facts_extracted(self) -> None:
+        _mock_seal_session_prereqs()
+        respx.post(_ANALYZE_URL).mock(return_value=_mock_analyze())
+
+        pending = _PendingSaves()
+        with patch("memwal.middleware.logger") as mock_logger:
+            await _run_auto_save(
+                self._memwal(), "def f():\n    return 1", "default", "analyze",
+                pending, lambda *_: None,
+            )
+
+        assert mock_logger.warning.called
+        assert "save_mode" in mock_logger.warning.call_args[0][0]
+        assert pending.drain_job_ids() == []
+
+    @respx.mock
+    async def test_analyze_mode_tracks_job_ids_without_warning(self) -> None:
+        _mock_seal_session_prereqs()
+        respx.post(_ANALYZE_URL).mock(return_value=_mock_analyze_with_facts("j1", "j2"))
+
+        pending = _PendingSaves()
+        with patch("memwal.middleware.logger") as mock_logger:
+            await _run_auto_save(
+                self._memwal(), "I am allergic to peanuts", "default", "analyze",
+                pending, lambda *_: None,
+            )
+
+        assert not mock_logger.warning.called
+        assert pending.drain_job_ids() == ["j1", "j2"]
+
+    @respx.mock
+    async def test_remember_mode_stores_verbatim_and_skips_analyze(self) -> None:
+        _mock_seal_session_prereqs()
+        analyze_route = respx.post(_ANALYZE_URL).mock(return_value=_mock_analyze())
+        remember_route = respx.post(_REMEMBER_URL).mock(
+            return_value=_mock_remember_accepted("job-1")
+        )
+
+        pending = _PendingSaves()
+        await _run_auto_save(
+            self._memwal(), "def f():\n    return 1", "default", "remember",
+            pending, lambda *_: None,
+        )
+
+        assert remember_route.called
+        assert not analyze_route.called
+        assert pending.drain_job_ids() == ["job-1"]
+
+    def test_invalid_save_mode_rejected_at_wrap_time(self) -> None:
+        client = MagicMock()
+        try:
+            with_memwal_openai(
+                client, key=_KEY_HEX, account_id=_ACCOUNT_ID, server_url=_SERVER,
+                save_mode="verbatim",
+            )
+        except ValueError as e:
+            assert "save_mode" in str(e)
+        else:
+            raise AssertionError("expected ValueError for an unknown save_mode")
+
+    def test_drain_job_ids_is_one_shot(self) -> None:
+        pending = _PendingSaves()
+        pending.track_job_ids(["a", "b"])
+        assert pending.drain_job_ids() == ["a", "b"]
+        assert pending.drain_job_ids() == []
+
+
+class TestConfirmableSaves:
+    """GH #410/#412: the easy-setup path had no way to confirm a save
+    landed or read its blob ID without dropping to the low-level client."""
+
+    def _make_async_client(self) -> MagicMock:
+        client = MagicMock()
+        client._async_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "answer"
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=mock_response)
+        return client
+
+    @respx.mock
+    async def test_wait_for_saves_returns_blob_ids(self) -> None:
+        _mock_seal_session_prereqs()
+        respx.post(_RECALL_URL).mock(return_value=_mock_recall([]))
+        respx.post(_REMEMBER_URL).mock(return_value=_mock_remember_accepted("job-1"))
+        respx.post(_BULK_STATUS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"job_id": "job-1", "status": "done", "blob_id": "blob-abc"}
+                    ]
+                },
+            )
+        )
+
+        smart = with_memwal_openai(
+            self._make_async_client(), key=_KEY_HEX, account_id=_ACCOUNT_ID,
+            server_url=_SERVER, auto_save=True, save_mode="remember",
+        )
+        await smart.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "def f(): return 1"}],
+        )
+
+        result = await smart.memwal_wait_for_saves(
+            RememberBulkOptions(poll_interval_ms=1, timeout_ms=5000)
+        )
+
+        assert result.total == 1
+        assert result.succeeded == 1
+        assert result.results[0].blob_id == "blob-abc"
+
+    @respx.mock
+    async def test_wrapper_exposes_low_level_client_publicly(self) -> None:
+        _mock_seal_session_prereqs()
+        smart = with_memwal_openai(
+            self._make_async_client(), key=_KEY_HEX, account_id=_ACCOUNT_ID,
+            server_url=_SERVER, auto_save=False,
+        )
+
+        assert isinstance(smart.memwal, MemWal)
+        assert callable(smart.memwal.wait_for_remember_jobs)
+        assert callable(smart.memwal_wait_for_saves)
+        assert callable(smart.memwal_wait_for_saves_sync)


### PR DESCRIPTION
Fixes the two compounding gaps in the Python SDK `with_memwal_*` auto-save path reported in GH #411, #410, #412 (WALM-307).

## Problem

1. **Non-fact content was silently dropped (#411).** `_post_analyze()` called `memwal.analyze()` exclusively. `analyze()` only extracts spoken-fact-style statements, so a code snippet or other non-sentence content came back with zero facts: no error, no warning, nothing stored, while the AI reported success.
2. **No way to confirm a save (#410, #412).** `wait_for_remember_jobs()` lives on the low-level client, and the wrapper never surfaced it or the job IDs its auto-saves enqueued, so anyone on the easy-setup path could not poll for completion or read a blob ID.

Verified against `origin/dev` before changing anything: both gaps were still present.

## Changes

`packages/python-sdk-memwal/memwal/middleware.py`

1. New `save_mode` option on `with_memwal_langchain` and `with_memwal_openai`: `"analyze"` (default, unchanged behavior) or `"remember"` to store the user message verbatim as a single memory. Invalid values raise `ValueError` at wrap time, not on the first save.
2. When `analyze()` extracts zero facts, the middleware now logs a warning that names `save_mode="remember"` instead of returning silently.
3. `_PendingSaves` records the remember job IDs each auto-save enqueues. Two new controls on the wrapped client drain pending saves and then poll those jobs to a terminal state, returning a `RememberBulkResult` with per-job status and blob IDs:
   * `await client.memwal_wait_for_saves(opts)`
   * `client.memwal_wait_for_saves_sync(opts)`
4. The underlying client is exposed as a public `client.memwal` attribute, so reaching `wait_for_remember_jobs()` and friends no longer means touching `_memwal`.

Shared `_run_auto_save()` now backs all three call sites (LangChain, async OpenAI, sync OpenAI) so the modes and warning behave identically across them.

## Docs

`docs/python-sdk/usage/with-memwal.md` gains a "Choosing a save mode" section explaining that `analyze()` is lossy by design, a "Confirming a Save" section covering flush/wait and the returned blob IDs, and a `save_mode` row in the options table. `api-reference.md` updated to match.

## Tests

Seven new tests in `tests/test_middleware.py`: the zero-fact warning, job-ID tracking on a successful analyze, `save_mode="remember"` storing verbatim without calling `/api/analyze`, wrap-time rejection of an unknown mode, one-shot job-ID draining, end-to-end `memwal_wait_for_saves()` returning a blob ID, and the public client surface.

Full suite: 143 passed. `ruff check memwal/ tests/` clean. Both are what `test-python-sdk.yml` runs.

## Not in scope

No version bump or changelog entry: this repo bumps 11 files together as a separate release step.
