### PR TITLE
fix(auth): don't treat Sui RPC 429 as a revoked delegate key (WALM-429)

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,7 +29,7 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.9. It rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, and aligns restore `truncated` docs with WALM-431 retryable semantics. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
+  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, and aligns restore `truncated` docs with WALM-431 retryable semantics. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
@@ -38,10 +38,11 @@ For the latest version, see the [PyPI project page](https://pypi.org/project/mem
 
 ## 0.1.9
 
-This release aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids.
+This release reports HTTP 503 as a retryable upstream outage and aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids.
 
 ### Fixed
 
+- HTTP 503 from the relayer is reported as a retryable upstream outage, not a credential failure.
 - `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 - restore `truncated` docs now match WALM-431 retryable semantics.
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,17 +28,21 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.6. It adds optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`. 0.1.5 added `dropped_count` on recall results and `write_ready` on health, switched `rememberManual` to sending `encryptedData`, and hardened hex decoding and error redaction.
+  The latest TypeScript SDK release is 0.1.6. It adds optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`. HTTP 503 from the relayer is reported as a retryable upstream outage instead of a sign-in failure. 0.1.5 added `dropped_count` on recall results and `write_ready` on health, switched `rememberManual` to sending `encryptedData`, and hardened hex decoding and error redaction.
 ---
 
 ## 0.1.6
 
-This release adds write-time on recall results and lets callers sort by recency or pass scoring weights.
+This release adds write-time on recall results, lets callers sort by recency or pass scoring weights, and stops mapping relayer 503s to a sign-in failure.
 
 ### Added
 
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
+
+### Fixed
+
+- HTTP 503 from the relayer is reported as a retryable upstream outage, not a sign-in failure. Empty-body 401s still point at `memwal_login`.
 
 ## 0.1.5
 

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -56,6 +56,14 @@ To triage quickly, confirm 3 things in order: the key is listed under the correc
 A version mismatch is rarely the cause here. The relayer reports its minimum supported SDK version, which is TypeScript 0.0.4 at the time of writing, so 0.1.0 is supported. A true version mismatch surfaces as `MemWalCompatibilityError` rather than `AUTH_REJECTED`.
 </Info>
 
+### Intermittent `isn't signed in` / `memwal_login` on recall
+
+**Symptom:** The same credentials recall successfully one moment and fail the next with `Walrus Memory isn't signed in. Call the memwal_login tool, then retry.` `memwal_login` does not fix it. Other clients or a retry a few seconds later succeed.
+
+**Cause:** The relayer re-checks the delegate key on Sui on every signed request. When Sui gRPC `GetObject` returns 429 or is otherwise unavailable, older relayers treated that as a revoked key, evicted the cache, and returned an empty HTTP 401. The SDK maps empty 401s to the login hint. The key is usually still registered.
+
+**Fix:** Retry. This is not a sign-in failure. Current relayers keep the cached mapping when Sui cannot be consulted, or return HTTP 503 `upstream unavailable` on a cache miss. A 503 from the SDK means "retry"; it does not mean call `memwal_login`. If every call 401s, including after a few minutes, then follow the `AUTH_REJECTED` checks above.
+
 ## MCP connection issues
 
 This section covers problems that appear before the memory tools work.

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- HTTP 503 from the relayer is reported as a retryable upstream outage, not a credential failure.
 - `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 - restore `truncated` docs now match WALM-431 retryable semantics.
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- HTTP 503 from the relayer is reported as a retryable upstream outage, not a credential failure.
+- HTTP 503 with `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` is reported as a retryable credential-verification outage, not a sign-in failure. Other 503s keep the generic sanitized body.
 - `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 - restore `truncated` docs now match WALM-431 retryable semantics.
 

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -97,6 +97,10 @@ AUTH_REJECTED_MESSAGE = (
     "and dashboard credentials. Full troubleshooting: "
     "https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors"
 )
+UPSTREAM_UNAVAILABLE_MESSAGE = (
+    "Walrus Memory temporarily cannot verify credentials (upstream unavailable). "
+    "Retry; this is not a sign-in failure."
+)
 
 
 logger = logging.getLogger("memwal")
@@ -1331,6 +1335,8 @@ class _HttpStatusError(MemWalError):
     def __init__(self, status: int, body: str) -> None:
         if status == 401:
             super().__init__(AUTH_REJECTED_MESSAGE)
+        elif status == 503:
+            super().__init__(UPSTREAM_UNAVAILABLE_MESSAGE)
         else:
             super().__init__(
                 f"Walrus Memory API error ({status}): {_redact_internal_urls(body)}"

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -97,6 +97,7 @@ AUTH_REJECTED_MESSAGE = (
     "and dashboard credentials. Full troubleshooting: "
     "https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors"
 )
+AUTH_UPSTREAM_UNAVAILABLE = "AUTH_UPSTREAM_UNAVAILABLE"
 UPSTREAM_UNAVAILABLE_MESSAGE = (
     "Walrus Memory temporarily cannot verify credentials (upstream unavailable). "
     "Retry; this is not a sign-in failure."
@@ -1289,6 +1290,8 @@ class MemWal:
             raise _HttpStatusError(
                 status=response.status_code,
                 body=err_text,
+                auth_error=response.headers.get("x-auth-error"),
+                retry_after=response.headers.get("retry-after"),
             )
 
         return response.json()
@@ -1332,10 +1335,16 @@ class _HttpStatusError(MemWalError):
     explicitly accepted).
     """
 
-    def __init__(self, status: int, body: str) -> None:
+    def __init__(
+        self,
+        status: int,
+        body: str,
+        auth_error: str | None = None,
+        retry_after: str | None = None,
+    ) -> None:
         if status == 401:
             super().__init__(AUTH_REJECTED_MESSAGE)
-        elif status == 503:
+        elif status == 503 and auth_error == AUTH_UPSTREAM_UNAVAILABLE:
             super().__init__(UPSTREAM_UNAVAILABLE_MESSAGE)
         else:
             super().__init__(
@@ -1343,6 +1352,8 @@ class _HttpStatusError(MemWalError):
             )
         self.status = status
         self.body = body
+        self.auth_error = auth_error
+        self.retry_after = retry_after
 
 
 class MemWalRememberJobNotFound(MemWalError):

--- a/packages/python-sdk-memwal/tests/test_auth_rejected_message.py
+++ b/packages/python-sdk-memwal/tests/test_auth_rejected_message.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
-from memwal.client import AUTH_REJECTED_MESSAGE, UPSTREAM_UNAVAILABLE_MESSAGE, _HttpStatusError
+from memwal.client import (
+    AUTH_REJECTED_MESSAGE,
+    AUTH_UPSTREAM_UNAVAILABLE,
+    UPSTREAM_UNAVAILABLE_MESSAGE,
+    _HttpStatusError,
+)
 
 
 def test_auth_rejected_message_points_to_troubleshooting_guide() -> None:
     assert "docs.wal.app/walrus-memory/troubleshooting/overview" in AUTH_REJECTED_MESSAGE
 
 
-def test_503_is_retryable_not_a_credential_failure() -> None:
-    err = _HttpStatusError(503, "upstream unavailable")
+def test_auth_503_is_retryable_not_a_credential_failure() -> None:
+    err = _HttpStatusError(
+        503, "upstream unavailable", auth_error=AUTH_UPSTREAM_UNAVAILABLE, retry_after="5"
+    )
     assert str(err) == UPSTREAM_UNAVAILABLE_MESSAGE
     assert "sign-in" in str(err)
     assert "401" not in str(err)
+    assert err.retry_after == "5"
+
+
+def test_non_auth_503_keeps_generic_body() -> None:
+    err = _HttpStatusError(503, "Rate limiter temporarily unavailable")
+    assert "Rate limiter temporarily unavailable" in str(err)
+    assert "cannot verify credentials" not in str(err)

--- a/packages/python-sdk-memwal/tests/test_auth_rejected_message.py
+++ b/packages/python-sdk-memwal/tests/test_auth_rejected_message.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
-from memwal.client import AUTH_REJECTED_MESSAGE
+from memwal.client import AUTH_REJECTED_MESSAGE, UPSTREAM_UNAVAILABLE_MESSAGE, _HttpStatusError
 
 
 def test_auth_rejected_message_points_to_troubleshooting_guide() -> None:
     assert "docs.wal.app/walrus-memory/troubleshooting/overview" in AUTH_REJECTED_MESSAGE
+
+
+def test_503_is_retryable_not_a_credential_failure() -> None:
+    err = _HttpStatusError(503, "upstream unavailable")
+    assert str(err) == UPSTREAM_UNAVAILABLE_MESSAGE
+    assert "sign-in" in str(err)
+    assert "401" not in str(err)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
 
+### Fixed
+
+- HTTP 503 from the relayer is reported as a retryable upstream outage, not a sign-in failure. Empty-body 401s still point at `memwal_login`.
+
 ## 0.1.5
 
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- HTTP 503 from the relayer is reported as a retryable upstream outage, not a sign-in failure. Empty-body 401s still point at `memwal_login`.
+- HTTP 503 with `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` is reported as a retryable credential-verification outage, not a sign-in failure. Other 503s keep the generic sanitized body. Empty-body 401s still point at `memwal_login`.
 
 ## 0.1.5
 

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -889,14 +889,23 @@ export class MemWalManual {
             const clockDriftError = clockDriftErrorFromResponse(res);
             if (clockDriftError) throw clockDriftError;
 
-            const { message: sanitized, serverCode } = sanitizeServerError(res.status, raw);
+            const { message: sanitized, serverCode } = sanitizeServerError(
+                res.status,
+                raw,
+                res.headers.get("x-auth-error"),
+            );
             const err = new Error(sanitized) as Error & {
                 status?: number;
                 serverCode?: string;
+                retryAfterSeconds?: number;
                 cause?: string;
             };
             err.status = res.status;
             if (serverCode) err.serverCode = serverCode;
+            const retryAfter = Number(res.headers.get("retry-after"));
+            if (Number.isFinite(retryAfter) && retryAfter > 0) {
+                err.retryAfterSeconds = retryAfter;
+            }
             err.cause = raw;
             throw err;
         }

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -1293,14 +1293,23 @@ export class MemWal {
             const clockDriftError = clockDriftErrorFromResponse(res);
             if (clockDriftError) throw clockDriftError;
 
-            const { message, serverCode } = sanitizeServerError(res.status, raw);
+            const { message, serverCode } = sanitizeServerError(
+                res.status,
+                raw,
+                res.headers.get("x-auth-error"),
+            );
             const err = new Error(message) as Error & {
                 status?: number;
                 serverCode?: string;
+                retryAfterSeconds?: number;
                 cause?: string;
             };
             err.status = res.status;
             if (serverCode) err.serverCode = serverCode;
+            const retryAfter = Number(res.headers.get("retry-after"));
+            if (Number.isFinite(retryAfter) && retryAfter > 0) {
+                err.retryAfterSeconds = retryAfter;
+            }
             // Preserve raw body on `cause` for in-process debugging only.
             err.cause = raw;
             throw err;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -321,6 +321,18 @@ export function sanitizeServerError(
         };
     }
 
+    // Relayer 503 = Sui RPC/gRPC could not be consulted (WALM-429). This is
+    // retryable and is not a sign-in failure — do not send callers to
+    // memwal_login.
+    if (Number(status) === 503) {
+        return {
+            message:
+                "Walrus Memory temporarily cannot verify credentials (upstream unavailable). Retry; this is not a sign-in failure.",
+            raw: rawBody,
+            serverCode: "UPSTREAM_UNAVAILABLE",
+        };
+    }
+
     const MAX = 200;
     let serverCode: string | undefined;
     let text = rawBody;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -304,6 +304,7 @@ export function redactInternalUrls(text: string): string {
 export function sanitizeServerError(
     status: number,
     rawBody: string,
+    authError?: string | null,
 ): { message: string; raw: string; serverCode?: string } {
     // Number() so a string "401" (some MCP / HTTP paths) still hits this branch.
     if (Number(status) === 401) {
@@ -321,15 +322,15 @@ export function sanitizeServerError(
         };
     }
 
-    // Relayer 503 = Sui RPC/gRPC could not be consulted (WALM-429). This is
-    // retryable and is not a sign-in failure — do not send callers to
-    // memwal_login.
-    if (Number(status) === 503) {
+    // Auth-path 503 only: Sui could not be consulted (WALM-429). Other
+    // relayer 503s (Redis, rate limiter, LLM) keep the generic sanitizer
+    // so they are not mislabeled as a credential-verification failure.
+    if (Number(status) === 503 && authError === "AUTH_UPSTREAM_UNAVAILABLE") {
         return {
             message:
                 "Walrus Memory temporarily cannot verify credentials (upstream unavailable). Retry; this is not a sign-in failure.",
             raw: rawBody,
-            serverCode: "UPSTREAM_UNAVAILABLE",
+            serverCode: "AUTH_UPSTREAM_UNAVAILABLE",
         };
     }
 

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -35,16 +35,32 @@ test("non-401 empty bodies still use the <no message> placeholder", () => {
     assert.equal(message, "Walrus Memory server error (500): <no message>");
 });
 
-test("503 is retryable upstream unavailability, not a login hint", () => {
-    const { message, serverCode } = sanitizeServerError(503, "upstream unavailable");
-    assert.equal(serverCode, "UPSTREAM_UNAVAILABLE");
+test("auth 503 is retryable credential-verification unavailability, not a login hint", () => {
+    const { message, serverCode } = sanitizeServerError(
+        503,
+        "upstream unavailable",
+        "AUTH_UPSTREAM_UNAVAILABLE",
+    );
+    assert.equal(serverCode, "AUTH_UPSTREAM_UNAVAILABLE");
     assert.match(message, /not a sign-in failure/);
     assert.doesNotMatch(message, /memwal_login/);
 });
 
-test("empty-body 503 still avoids the memwal_login copy", () => {
+test("non-auth 503 keeps a generic retryable body, not credential copy", () => {
+    const { message, serverCode } = sanitizeServerError(
+        503,
+        "Rate limiter temporarily unavailable",
+    );
+    assert.equal(serverCode, undefined);
+    assert.match(message, /Rate limiter temporarily unavailable/);
+    assert.doesNotMatch(message, /cannot verify credentials/);
+    assert.doesNotMatch(message, /memwal_login/);
+});
+
+test("empty-body 503 without the auth header is generic", () => {
     const { message, serverCode } = sanitizeServerError(503, "");
-    assert.equal(serverCode, "UPSTREAM_UNAVAILABLE");
+    assert.equal(serverCode, undefined);
+    assert.equal(message, "Walrus Memory server error (503): <no message>");
     assert.doesNotMatch(message, /memwal_login/);
     assert.doesNotMatch(message, /isn't signed in/);
 });

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -35,6 +35,20 @@ test("non-401 empty bodies still use the <no message> placeholder", () => {
     assert.equal(message, "Walrus Memory server error (500): <no message>");
 });
 
+test("503 is retryable upstream unavailability, not a login hint", () => {
+    const { message, serverCode } = sanitizeServerError(503, "upstream unavailable");
+    assert.equal(serverCode, "UPSTREAM_UNAVAILABLE");
+    assert.match(message, /not a sign-in failure/);
+    assert.doesNotMatch(message, /memwal_login/);
+});
+
+test("empty-body 503 still avoids the memwal_login copy", () => {
+    const { message, serverCode } = sanitizeServerError(503, "");
+    assert.equal(serverCode, "UPSTREAM_UNAVAILABLE");
+    assert.doesNotMatch(message, /memwal_login/);
+    assert.doesNotMatch(message, /isn't signed in/);
+});
+
 test("localhost sidecar URLs are stripped from error text", () => {
     const { message } = sanitizeServerError(
         500,

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -93,8 +93,8 @@ pub(crate) fn upstream_unavailable() -> Response {
     (
         StatusCode::SERVICE_UNAVAILABLE,
         [
-            ("retry-after", "5"),
-            ("x-auth-error", AUTH_UPSTREAM_UNAVAILABLE),
+            ("retry-after", AUTH_UPSTREAM_RETRY_AFTER_SECS.to_string()),
+            ("x-auth-error", AUTH_UPSTREAM_UNAVAILABLE.to_string()),
         ],
         "upstream unavailable",
     )
@@ -975,11 +975,12 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some(AUTH_UPSTREAM_UNAVAILABLE),
         );
+        let retry_after = AUTH_UPSTREAM_RETRY_AFTER_SECS.to_string();
         assert_eq!(
             resp.headers()
                 .get("retry-after")
                 .and_then(|v| v.to_str().ok()),
-            Some("5"),
+            Some(retry_after.as_str()),
         );
         assert_eq!(AUTH_UPSTREAM_RETRY_AFTER_SECS, 5);
         let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
@@ -1003,6 +1004,15 @@ mod tests {
     #[test]
     fn resolve_account_cache_hit_key_not_found_evicts() {
         let action = cache_reverify_action(Err(OnchainVerifyError::KeyNotFound("gone".into())));
+        assert!(matches!(action, CacheReverifyAction::Evict { .. }));
+    }
+
+    #[test]
+    fn resolve_account_cache_hit_object_not_found_evicts() {
+        // Typo'd x-account-id / gRPC NOT_FOUND is a sign-in failure, not a 503.
+        let action = cache_reverify_action(Err(OnchainVerifyError::NotFound(
+            "gRPC GetObject failed: not found".into(),
+        )));
         assert!(matches!(action, CacheReverifyAction::Evict { .. }));
     }
 

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -73,6 +73,28 @@ fn unsupported_legacy_sdk() -> StatusCode {
     StatusCode::UPGRADE_REQUIRED
 }
 
+/// Matches the MCP proxy: Sui could not be consulted, so this is not a login
+/// failure. Empty 401 here is what made the SDK print memwal_login (WALM-429).
+fn upstream_unavailable() -> Response {
+    (StatusCode::SERVICE_UNAVAILABLE, "upstream unavailable").into_response()
+}
+
+/// Outcome of resolving a signed delegate key to a MemWal account.
+enum AccountResolveError {
+    /// Identity could not be established. Maps to a timing-normalized 401.
+    Unauthorized(String),
+    /// On-chain lookup could not be completed. Maps to 503 — retryable.
+    Unavailable(String),
+}
+
+impl std::fmt::Display for AccountResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unauthorized(msg) | Self::Unavailable(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
 /// Whether a request whose signed timestamp is `age` seconds old (negative =
 /// future-dated) is fresh, given the accepted drift window. The window is
 /// inclusive and symmetric: `|age| <= drift`. `drift == 0` requires an exact
@@ -326,12 +348,17 @@ pub async fn verify_signature(
     }
 
     // Step 2: Resolve account — cache → signed header hint/config fallback → registry scan
-    // Always use constant_time_reject so that timing of the resolution error
-    // ("account not found" vs "key not in account") cannot be observed by callers.
+    // Identity failures stay on constant_time_reject (bare 401) so "account not
+    // found" vs "key not in account" cannot be timed. RPC/scan unavailability
+    // is 503: a Sui 429 is not a revoke (WALM-429).
     let (account_id, owner) =
         match resolve_account(&state, &public_key_hex, &pk_array, account_id_hint).await {
             Ok(pair) => pair,
-            Err(e) => {
+            Err(AccountResolveError::Unavailable(e)) => {
+                tracing::warn!("Account resolution unavailable: {}", e);
+                return Ok(upstream_unavailable());
+            }
+            Err(AccountResolveError::Unauthorized(e)) => {
                 tracing::warn!("Account resolution failed: {}", e);
                 return Err(constant_time_reject().await);
             }
@@ -366,12 +393,14 @@ async fn resolve_account(
     public_key_hex: &str,
     pk_bytes: &[u8; 32],
     account_id_hint: Option<String>,
-) -> Result<(String, String), String> {
+) -> Result<(String, String), AccountResolveError> {
     // Strategy 1: Check PostgreSQL cache
-    if let Ok(Some((cached_account_id, _cached_owner))) =
+    if let Ok(Some((cached_account_id, cached_owner))) =
         state.db.get_cached_account(public_key_hex).await
     {
-        // Verify the cached mapping is still valid onchain
+        // Re-verify the cached mapping is still valid onchain when Sui is
+        // reachable. A transient RPC failure is *not* a revoke: keep the row
+        // and serve it so a Sui 429 does not 401 a still-registered key.
         match verify_delegate_key_onchain(
             &state.http_client,
             &state.config.sui_rpc_url,
@@ -386,14 +415,24 @@ async fn resolve_account(
                 tracing::debug!("account resolved from cache: {}", cached_account_id);
                 return Ok((cached_account_id, owner));
             }
-            Err(_) => {
-                // Key was revoked on-chain. Delete the stale cache row
-                // immediately so subsequent requests don't loop: cache-hit → RPC fail →
-                // fall-through, burning RPC quota and generating log noise on every call.
+            Err(e) if e.is_unavailable() => {
                 tracing::warn!(
-                    "delegate key {} revoked on-chain for account {}; evicting from cache",
+                    "on-chain re-verify unavailable for key {} on account {} ({}); serving cached mapping",
                     public_key_hex,
-                    cached_account_id
+                    cached_account_id,
+                    e
+                );
+                return Ok((cached_account_id, cached_owner));
+            }
+            Err(e) => {
+                // Definitive miss: key gone, account deactivated, or the
+                // cached object is not a MemWalAccount. Evict so later
+                // requests don't loop cache-hit → RPC → fall-through.
+                tracing::warn!(
+                    "cached delegate key {} is stale for account {} ({}); evicting from cache",
+                    public_key_hex,
+                    cached_account_id,
+                    e
                 );
                 let _ = state.db.delete_cached_key(public_key_hex).await;
             }
@@ -410,7 +449,7 @@ async fn resolve_account(
         .as_deref()
         .or(state.config.memwal_account_id.as_deref())
     {
-        let owner = verify_delegate_key_onchain(
+        match verify_delegate_key_onchain(
             &state.http_client,
             &state.config.sui_rpc_url,
             state.sui_grpc_client.as_ref(),
@@ -419,32 +458,41 @@ async fn resolve_account(
             &state.config.package_id,
         )
         .await
-        .map_err(|e| {
-            format!(
-                "exact account {} verification failed: {}",
-                exact_account_id, e
-            )
-        })?;
+        {
+            Ok(owner) => {
+                let _ = state
+                    .db
+                    .cache_delegate_key(public_key_hex, exact_account_id, &owner)
+                    .await;
 
-        let _ = state
-            .db
-            .cache_delegate_key(public_key_hex, exact_account_id, &owner)
-            .await;
-
-        tracing::debug!(
-            "account resolved from exact account id: {}",
-            exact_account_id
-        );
-        return Ok((exact_account_id.to_string(), owner));
+                tracing::debug!(
+                    "account resolved from exact account id: {}",
+                    exact_account_id
+                );
+                return Ok((exact_account_id.to_string(), owner));
+            }
+            Err(e) if e.is_unavailable() => {
+                return Err(AccountResolveError::Unavailable(format!(
+                    "exact account {} verification unavailable: {}",
+                    exact_account_id, e
+                )));
+            }
+            Err(e) => {
+                return Err(AccountResolveError::Unauthorized(format!(
+                    "exact account {} verification failed: {}",
+                    exact_account_id, e
+                )));
+            }
+        }
     }
 
     // Strategy 3: The legacy registry scan uses JSON-RPC. Testnet no longer
     // serves JSON-RPC, so fail closed when a modern signed x-account-id hint
     // is absent instead of silently contacting a retired endpoint.
     if state.config.sui_network == "testnet" {
-        return Err(
+        return Err(AccountResolveError::Unauthorized(
             "x-account-id is required for delegate-key authentication on testnet".to_string(),
-        );
+        ));
     }
 
     // Non-testnet compatibility path: scan AccountRegistry only when no exact
@@ -453,19 +501,20 @@ async fn resolve_account(
     // unknown-key floods can't stack unbounded scans, and a per-scan page
     // cap (MEMWAL_REGISTRY_SCAN_MAX_PAGES) inside the scan itself. Both
     // rejection messages name the x-account-id remediation, but they surface
-    // only in server logs: the middleware collapses every auth failure to a
-    // bare 401 (no oracle). A key past the page cap therefore cannot
-    // self-resolve — operators must diagnose the lockout from the warn logs
-    // and either raise the cap or have the client send the header hint,
-    // which Strategy 2 verifies directly without any scan.
+    // only in server logs: the middleware collapses identity failures to a
+    // bare 401 (no oracle) and RPC/scan unavailability to 503. A key past the
+    // page cap therefore cannot self-resolve — operators must diagnose the
+    // lockout from the warn logs and either raise the cap or have the client
+    // send the header hint, which Strategy 2 verifies directly without any
+    // scan.
     let _scan_permit = match state.registry_scan_semaphore.try_acquire() {
         Ok(permit) => permit,
         Err(_) => {
-            return Err(
+            return Err(AccountResolveError::Unavailable(
                 "registry scan concurrency limit reached; retry, or send the x-account-id \
                  header hint to skip the registry scan"
                     .to_string(),
-            );
+            ));
         }
     };
     match find_account_by_delegate_key(
@@ -486,19 +535,21 @@ async fn resolve_account(
                 .await;
             return Ok((account_id, owner));
         }
-        Err(e @ OnchainVerifyError::ScanCapExceeded(_)) => {
-            tracing::warn!("registry scan capped: {}", e);
-            return Err(format!(
+        Err(e) if e.is_unavailable() => {
+            tracing::warn!("registry scan unavailable: {}", e);
+            return Err(AccountResolveError::Unavailable(format!(
                 "{}; send the x-account-id header hint to authenticate without a scan",
                 e
-            ));
+            )));
         }
         Err(e) => {
             tracing::debug!("registry scan did not find key: {}", e);
         }
     }
 
-    Err("no account found: not in cache, exact account id, or registry".to_string())
+    Err(AccountResolveError::Unauthorized(
+        "no account found: not in cache, exact account id, or registry".to_string(),
+    ))
 }
 
 /// Combined auth dispatcher for `read_api_routes`: tries the owner-scoped
@@ -767,8 +818,14 @@ mod tests {
     fn reported_repro_45s_offset_is_within_default_window() {
         // The issue's repro used a +45s client offset; it is comfortably inside
         // the default 300s window and is accepted (i.e. does not reproduce).
-        assert!(is_timestamp_fresh(45, crate::types::DEFAULT_AUTH_CLOCK_DRIFT_SECS));
-        assert!(is_timestamp_fresh(-45, crate::types::DEFAULT_AUTH_CLOCK_DRIFT_SECS));
+        assert!(is_timestamp_fresh(
+            45,
+            crate::types::DEFAULT_AUTH_CLOCK_DRIFT_SECS
+        ));
+        assert!(is_timestamp_fresh(
+            -45,
+            crate::types::DEFAULT_AUTH_CLOCK_DRIFT_SECS
+        ));
     }
 
     #[test]
@@ -795,8 +852,14 @@ mod tests {
         // Pin the exact derivation at default and ceiling so it cannot regress:
         //   default: 2*300 + 300 = 900
         //   ceiling: 2*900 + 300 = 2100
-        assert_eq!(nonce_ttl_secs(crate::types::DEFAULT_AUTH_CLOCK_DRIFT_SECS), 900);
-        assert_eq!(nonce_ttl_secs(crate::types::MAX_AUTH_CLOCK_DRIFT_SECS), 2100);
+        assert_eq!(
+            nonce_ttl_secs(crate::types::DEFAULT_AUTH_CLOCK_DRIFT_SECS),
+            900
+        );
+        assert_eq!(
+            nonce_ttl_secs(crate::types::MAX_AUTH_CLOCK_DRIFT_SECS),
+            2100
+        );
     }
 
     // ── Timestamp-drift reason header (safe to distinguish) ──────
@@ -854,6 +917,31 @@ mod tests {
     async fn constant_time_reject_returns_unauthorized() {
         let status = constant_time_reject().await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn upstream_unavailable_is_503_not_401() {
+        let resp = upstream_unavailable();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            resp.headers().get("x-auth-error").is_none(),
+            "503 must not look like an identity reject"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
+        assert_eq!(&body[..], b"upstream unavailable");
+    }
+
+    #[test]
+    fn rpc_errors_are_unavailable_not_stale_cache() {
+        // WALM-429: a Sui 429 used to evict the cache and 401 a live key.
+        assert!(OnchainVerifyError::RpcError(
+            "gRPC GetObject failed: 429 Too Many Requests".into()
+        )
+        .is_unavailable());
+        assert!(OnchainVerifyError::ScanCapExceeded("cap".into()).is_unavailable());
+        assert!(!OnchainVerifyError::KeyNotFound("gone".into()).is_unavailable());
+        assert!(!OnchainVerifyError::AccountDeactivated("off".into()).is_unavailable());
+        assert!(!OnchainVerifyError::WrongObjectType("type".into()).is_unavailable());
     }
 
     #[test]

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -50,11 +50,10 @@ async fn constant_time_reject() -> StatusCode {
 
 /// Machine-readable reason for a stale/future-dated timestamp, surfaced on the
 /// `x-auth-error` header so a client can distinguish clock drift from a bad
-/// signature. Only emitted for the timestamp check: it depends solely on the
-/// client's own clock, not on whether the account or key exists, so exposing it
-/// leaks nothing about server-side identity state. Signature, nonce, and
-/// account-resolution failures keep the bare uniform 401 (no reason header) so
-/// they remain indistinguishable and cannot be used to enumerate accounts.
+/// signature. Identity 401s (signature, nonce, account-resolution) keep the
+/// bare uniform 401 so they cannot be used to enumerate accounts. 503 auth
+/// unavailability uses the same header with `AUTH_UPSTREAM_UNAVAILABLE` — that
+/// path does not leak whether the key exists.
 const ERR_TIMESTAMP_OUT_OF_BOUNDS: &str = "ERR_TIMESTAMP_OUT_OF_BOUNDS";
 
 /// 401 carrying `x-auth-error: <code>`, after the same constant delay as
@@ -73,10 +72,55 @@ fn unsupported_legacy_sdk() -> StatusCode {
     StatusCode::UPGRADE_REQUIRED
 }
 
+/// Machine-readable 503 from signed HTTP auth / MCP when Sui cannot be
+/// consulted. Distinct from other relayer 503s (Redis, rate limiter, LLM)
+/// so SDKs only print the credential-verification copy when this header is
+/// present (WALM-429 review).
+pub(crate) const AUTH_UPSTREAM_UNAVAILABLE: &str = "AUTH_UPSTREAM_UNAVAILABLE";
+
+/// Short Retry-After for auth 503. Callers must backoff rather than
+/// immediately re-hitting a 429ing Sui fullnode. Not a substitute for the
+/// 100 ms 401 timing pad — that path stays 401-only.
+pub(crate) const AUTH_UPSTREAM_RETRY_AFTER_SECS: u64 = 5;
+
 /// Matches the MCP proxy: Sui could not be consulted, so this is not a login
 /// failure. Empty 401 here is what made the SDK print memwal_login (WALM-429).
-fn upstream_unavailable() -> Response {
-    (StatusCode::SERVICE_UNAVAILABLE, "upstream unavailable").into_response()
+///
+/// Fail-closed: do not authenticate from a cached mapping while the chain
+/// is unreachable. Keep the cache row (do not evict), return 503 with
+/// `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` and `Retry-After`.
+pub(crate) fn upstream_unavailable() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [
+            ("retry-after", "5"),
+            ("x-auth-error", AUTH_UPSTREAM_UNAVAILABLE),
+        ],
+        "upstream unavailable",
+    )
+        .into_response()
+}
+
+/// What Strategy 1 does with a cache row after on-chain re-verify.
+/// WALM-429: an RPC failure must not evict the row *and* must not
+/// authenticate from it.
+#[derive(Debug)]
+enum CacheReverifyAction {
+    Authenticate { owner: String },
+    UnavailableKeepCache { reason: String },
+    Evict { reason: String },
+}
+
+fn cache_reverify_action(result: Result<String, OnchainVerifyError>) -> CacheReverifyAction {
+    match result {
+        Ok(owner) => CacheReverifyAction::Authenticate { owner },
+        Err(e) if e.is_unavailable() => CacheReverifyAction::UnavailableKeepCache {
+            reason: e.to_string(),
+        },
+        Err(e) => CacheReverifyAction::Evict {
+            reason: e.to_string(),
+        },
+    }
 }
 
 /// Outcome of resolving a signed delegate key to a MemWal account.
@@ -395,44 +439,46 @@ async fn resolve_account(
     account_id_hint: Option<String>,
 ) -> Result<(String, String), AccountResolveError> {
     // Strategy 1: Check PostgreSQL cache
-    if let Ok(Some((cached_account_id, cached_owner))) =
+    if let Ok(Some((cached_account_id, _cached_owner))) =
         state.db.get_cached_account(public_key_hex).await
     {
-        // Re-verify the cached mapping is still valid onchain when Sui is
-        // reachable. A transient RPC failure is *not* a revoke: keep the row
-        // and serve it so a Sui 429 does not 401 a still-registered key.
-        match verify_delegate_key_onchain(
-            &state.http_client,
-            &state.config.sui_rpc_url,
-            state.sui_grpc_client.as_ref(),
-            &cached_account_id,
-            pk_bytes,
-            &state.config.package_id,
-        )
-        .await
-        {
-            Ok(owner) => {
+        // Re-verify the cached mapping on-chain when Sui is reachable.
+        // A transient RPC failure is *not* a revoke: keep the row, but
+        // fail closed with 503 so a revoked key cannot ride a 24h cache
+        // through a Sui outage. Definitive misses evict.
+        match cache_reverify_action(
+            verify_delegate_key_onchain(
+                &state.http_client,
+                &state.config.sui_rpc_url,
+                state.sui_grpc_client.as_ref(),
+                &cached_account_id,
+                pk_bytes,
+                &state.config.package_id,
+            )
+            .await,
+        ) {
+            CacheReverifyAction::Authenticate { owner } => {
                 tracing::debug!("account resolved from cache: {}", cached_account_id);
                 return Ok((cached_account_id, owner));
             }
-            Err(e) if e.is_unavailable() => {
+            CacheReverifyAction::UnavailableKeepCache { reason } => {
                 tracing::warn!(
-                    "on-chain re-verify unavailable for key {} on account {} ({}); serving cached mapping",
+                    "on-chain re-verify unavailable for key {} on account {} ({}); keeping cached mapping, not authenticating from it",
                     public_key_hex,
                     cached_account_id,
-                    e
+                    reason
                 );
-                return Ok((cached_account_id, cached_owner));
+                return Err(AccountResolveError::Unavailable(format!(
+                    "on-chain re-verify unavailable for cached account {}: {}",
+                    cached_account_id, reason
+                )));
             }
-            Err(e) => {
-                // Definitive miss: key gone, account deactivated, or the
-                // cached object is not a MemWalAccount. Evict so later
-                // requests don't loop cache-hit → RPC → fall-through.
+            CacheReverifyAction::Evict { reason } => {
                 tracing::warn!(
                     "cached delegate key {} is stale for account {} ({}); evicting from cache",
                     public_key_hex,
                     cached_account_id,
-                    e
+                    reason
                 );
                 let _ = state.db.delete_cached_key(public_key_hex).await;
             }
@@ -923,25 +969,49 @@ mod tests {
     async fn upstream_unavailable_is_503_not_401() {
         let resp = upstream_unavailable();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-        assert!(
-            resp.headers().get("x-auth-error").is_none(),
-            "503 must not look like an identity reject"
+        assert_eq!(
+            resp.headers()
+                .get("x-auth-error")
+                .and_then(|v| v.to_str().ok()),
+            Some(AUTH_UPSTREAM_UNAVAILABLE),
         );
+        assert_eq!(
+            resp.headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok()),
+            Some("5"),
+        );
+        assert_eq!(AUTH_UPSTREAM_RETRY_AFTER_SECS, 5);
         let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
         assert_eq!(&body[..], b"upstream unavailable");
     }
 
     #[test]
-    fn rpc_errors_are_unavailable_not_stale_cache() {
+    fn resolve_account_cache_hit_rpc_error_keeps_row_without_authenticating() {
         // WALM-429: a Sui 429 used to evict the cache and 401 a live key.
-        assert!(OnchainVerifyError::RpcError(
-            "gRPC GetObject failed: 429 Too Many Requests".into()
-        )
-        .is_unavailable());
-        assert!(OnchainVerifyError::ScanCapExceeded("cap".into()).is_unavailable());
-        assert!(!OnchainVerifyError::KeyNotFound("gone".into()).is_unavailable());
-        assert!(!OnchainVerifyError::AccountDeactivated("off".into()).is_unavailable());
-        assert!(!OnchainVerifyError::WrongObjectType("type".into()).is_unavailable());
+        // Keep the row (so a later verify can succeed) but do not treat the
+        // cached mapping as authorization while the chain is unreachable.
+        let action = cache_reverify_action(Err(OnchainVerifyError::RpcError(
+            "gRPC GetObject failed: 429 Too Many Requests".into(),
+        )));
+        assert!(matches!(
+            action,
+            CacheReverifyAction::UnavailableKeepCache { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_account_cache_hit_key_not_found_evicts() {
+        let action = cache_reverify_action(Err(OnchainVerifyError::KeyNotFound("gone".into())));
+        assert!(matches!(action, CacheReverifyAction::Evict { .. }));
+    }
+
+    #[test]
+    fn resolve_account_cache_hit_ok_authenticates() {
+        match cache_reverify_action(Ok("0xowner".into())) {
+            CacheReverifyAction::Authenticate { owner } => assert_eq!(owner, "0xowner"),
+            other => panic!("expected authenticate, got {other:?}"),
+        }
     }
 
     #[test]

--- a/services/server/src/auth.rs
+++ b/services/server/src/auth.rs
@@ -75,7 +75,7 @@ fn unsupported_legacy_sdk() -> StatusCode {
 /// Machine-readable 503 from signed HTTP auth / MCP when Sui cannot be
 /// consulted. Distinct from other relayer 503s (Redis, rate limiter, LLM)
 /// so SDKs only print the credential-verification copy when this header is
-/// present (WALM-429 review).
+/// present (WALM-429).
 pub(crate) const AUTH_UPSTREAM_UNAVAILABLE: &str = "AUTH_UPSTREAM_UNAVAILABLE";
 
 /// Short Retry-After for auth 503. Callers must backoff rather than
@@ -101,8 +101,7 @@ pub(crate) fn upstream_unavailable() -> Response {
         .into_response()
 }
 
-/// What Strategy 1 does with a cache row after on-chain re-verify.
-/// WALM-429: an RPC failure must not evict the row *and* must not
+/// WALM-429: an RPC failure must not evict the cache row *and* must not
 /// authenticate from it.
 #[derive(Debug)]
 enum CacheReverifyAction {

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -60,11 +60,9 @@ fn security_delete_cors() -> CorsLayer {
 }
 
 /// CORS layer for the main relayer routes, scoped to the configured origins.
-/// `allow_headers` are the request headers a browser may send on a signed
-/// request; `expose_headers` lists the response headers a cross-origin client
-/// may read — Fetch hides everything else, so `x-auth-error` and `Retry-After`
-/// must be exposed for the browser SDK to read the machine-readable auth-failure
-/// reason (e.g. clock-drift vs. bad signature) and the 503 backoff.
+/// Fetch hides response headers unless listed in `expose_headers`, so
+/// `x-auth-error` and `Retry-After` must be exposed for the browser SDK
+/// (clock-drift vs bad signature, and 503 backoff).
 fn relayer_cors(origins: Vec<HeaderValue>) -> CorsLayer {
     CorsLayer::new()
         .allow_origin(AllowOrigin::list(origins))
@@ -177,10 +175,6 @@ mod cors_tests {
 
     #[tokio::test]
     async fn relayer_cors_exposes_x_auth_error_and_retry_after() {
-        // Browsers can only read response headers listed in
-        // Access-Control-Expose-Headers. The clock-drift reason (x-auth-error)
-        // and 503 backoff (Retry-After) must be exposed so the browser SDK can
-        // distinguish drift from a bad signature and honor auth 503s.
         let origin = "https://app.memwal.test";
         let app = Router::new()
             .route("/api/remember", post(|| async {}))

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -62,9 +62,9 @@ fn security_delete_cors() -> CorsLayer {
 /// CORS layer for the main relayer routes, scoped to the configured origins.
 /// `allow_headers` are the request headers a browser may send on a signed
 /// request; `expose_headers` lists the response headers a cross-origin client
-/// may read — Fetch hides everything else, so `x-auth-error` must be exposed
-/// for the browser SDK to read the machine-readable auth-failure reason (e.g.
-/// clock-drift vs. bad signature). Only that header is exposed.
+/// may read — Fetch hides everything else, so `x-auth-error` and `Retry-After`
+/// must be exposed for the browser SDK to read the machine-readable auth-failure
+/// reason (e.g. clock-drift vs. bad signature) and the 503 backoff.
 fn relayer_cors(origins: Vec<HeaderValue>) -> CorsLayer {
     CorsLayer::new()
         .allow_origin(AllowOrigin::list(origins))
@@ -90,7 +90,10 @@ fn relayer_cors(origins: Vec<HeaderValue>) -> CorsLayer {
             // so this custom header must be preflight-allowed)
             "x-admin-api-key".parse::<header::HeaderName>().unwrap(),
         ])
-        .expose_headers(["x-auth-error".parse::<header::HeaderName>().unwrap()])
+        .expose_headers([
+            "x-auth-error".parse::<header::HeaderName>().unwrap(),
+            header::RETRY_AFTER,
+        ])
 }
 
 #[cfg(test)]
@@ -173,11 +176,11 @@ mod cors_tests {
     }
 
     #[tokio::test]
-    async fn relayer_cors_exposes_only_x_auth_error() {
+    async fn relayer_cors_exposes_x_auth_error_and_retry_after() {
         // Browsers can only read response headers listed in
         // Access-Control-Expose-Headers. The clock-drift reason (x-auth-error)
-        // must be exposed so the browser SDK can distinguish drift from a bad
-        // signature; nothing else should cross origins.
+        // and 503 backoff (Retry-After) must be exposed so the browser SDK can
+        // distinguish drift from a bad signature and honor auth 503s.
         let origin = "https://app.memwal.test";
         let app = Router::new()
             .route("/api/remember", post(|| async {}))
@@ -208,10 +211,14 @@ mod cors_tests {
             names.iter().any(|n| n.eq_ignore_ascii_case("x-auth-error")),
             "x-auth-error must be exposed, got: {exposed}"
         );
+        assert!(
+            names.iter().any(|n| n.eq_ignore_ascii_case("retry-after")),
+            "retry-after must be exposed, got: {exposed}"
+        );
         assert_eq!(
             names.len(),
-            1,
-            "only x-auth-error should be exposed, got: {exposed}"
+            2,
+            "only x-auth-error and retry-after should be exposed, got: {exposed}"
         );
     }
 }
@@ -1394,8 +1401,7 @@ async fn main() {
             if let Err(e) = evict_state.db.prune_unconsumed_oauth_clients().await {
                 tracing::error!("MCP OAuth client pruning failed: {}", e);
             }
-            if let Err(e) = evict_state.db.sweep_expired_tombstones().await
-            {
+            if let Err(e) = evict_state.db.sweep_expired_tombstones().await {
                 tracing::error!("tombstone retention sweep failed: {}", e);
             }
         }

--- a/services/server/src/mcp_proxy.rs
+++ b/services/server/src/mcp_proxy.rs
@@ -186,9 +186,8 @@ async fn legacy_delegate_registered(
     .await
     {
         Ok(_) => McpAuthOutcome::Passthrough,
-        Err(crate::storage::sui::OnchainVerifyError::RpcError(msg))
-        | Err(crate::storage::sui::OnchainVerifyError::ScanCapExceeded(msg)) => {
-            tracing::warn!(error = %msg, "mcp delegate on-chain verify unavailable");
+        Err(err) if err.is_unavailable() => {
+            tracing::warn!(error = %err, "mcp delegate on-chain verify unavailable");
             McpAuthOutcome::Unavailable
         }
         Err(err) => {

--- a/services/server/src/mcp_proxy.rs
+++ b/services/server/src/mcp_proxy.rs
@@ -352,9 +352,7 @@ pub async fn sse_proxy(
         McpAuthOutcome::Unauthorized(err) => {
             return oauth_unauthorized_response(&state, err.as_ref())
         }
-        McpAuthOutcome::Unavailable => {
-            return (StatusCode::SERVICE_UNAVAILABLE, "upstream unavailable").into_response()
-        }
+        McpAuthOutcome::Unavailable => return crate::auth::upstream_unavailable(),
     };
     if let Err(code) = apply_internal_headers(
         &mut forwarded,
@@ -465,9 +463,7 @@ pub async fn messages_proxy(
         McpAuthOutcome::Unauthorized(err) => {
             return oauth_unauthorized_response(&state, err.as_ref())
         }
-        McpAuthOutcome::Unavailable => {
-            return (StatusCode::SERVICE_UNAVAILABLE, "upstream unavailable").into_response()
-        }
+        McpAuthOutcome::Unavailable => return crate::auth::upstream_unavailable(),
     };
     if let Err(code) = apply_internal_headers(
         &mut forwarded,
@@ -585,9 +581,7 @@ pub async fn streamable_proxy(
         McpAuthOutcome::Unauthorized(err) => {
             return oauth_unauthorized_response(&state, err.as_ref())
         }
-        McpAuthOutcome::Unavailable => {
-            return (StatusCode::SERVICE_UNAVAILABLE, "upstream unavailable").into_response()
-        }
+        McpAuthOutcome::Unavailable => return crate::auth::upstream_unavailable(),
     };
     if let Err(code) = apply_internal_headers(
         &mut forwarded,

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -2199,10 +2199,12 @@ impl VectorDb {
 
     /// Immediately remove a single stale/revoked delegate key from the cache.
     ///
-    /// Called when `verify_delegate_key_onchain` returns `Err` for a cached entry,
-    /// meaning the key has been revoked on-chain. Without this, every subsequent
-    /// request with the revoked key would hit the cache, fail the RPC verify, log
-    /// noise, and waste an RPC call — in an infinite loop until TTL expiry.
+    /// Called when a cached entry's on-chain re-verify returns a *definitive*
+    /// miss (`KeyNotFound` / `AccountDeactivated` / `WrongObjectType`). Do
+    /// **not** call this for `RpcError` / `ScanCapExceeded` — those mean Sui
+    /// could not be consulted (WALM-429). Evicting on a 429 made every later
+    /// request miss the cache, burn a second GetObject, and 401 a still-valid
+    /// key.
     pub async fn delete_cached_key(&self, public_key_hex: &str) -> Result<u64, AppError> {
         let result = sqlx::query("DELETE FROM delegate_key_cache WHERE public_key = $1")
             .bind(public_key_hex)

--- a/services/server/src/storage/sui.rs
+++ b/services/server/src/storage/sui.rs
@@ -998,6 +998,19 @@ impl std::fmt::Display for OnchainVerifyError {
 
 impl std::error::Error for OnchainVerifyError {}
 
+impl OnchainVerifyError {
+    /// True when the chain could not be consulted, as opposed to a definitive
+    /// "this key is not registered / this account is dead" answer.
+    ///
+    /// HTTP signed auth and the MCP proxy must not treat these as a revoke:
+    /// a Sui gRPC 429 is `RpcError`, and logging it as "revoked on-chain"
+    /// produced intermittent empty 401s that the SDK mapped to memwal_login
+    /// (WALM-429).
+    pub fn is_unavailable(&self) -> bool {
+        matches!(self, Self::RpcError(_) | Self::ScanCapExceeded(_))
+    }
+}
+
 /// Reject any object whose Move type is not
 /// `{type-origin-package}::account::MemWalAccount`. Sui preserves the original
 /// publish/type-origin id across package upgrades, so this must never be the
@@ -1316,6 +1329,11 @@ mod tests {
             OnchainVerifyError::AccountDeactivated(_)
         ));
         assert!(matches!(not_found, OnchainVerifyError::KeyNotFound(_)));
+        assert!(!deactivated.is_unavailable());
+        assert!(!not_found.is_unavailable());
+        assert!(OnchainVerifyError::RpcError("429".into()).is_unavailable());
+        assert!(OnchainVerifyError::ScanCapExceeded("cap".into()).is_unavailable());
+        assert!(!OnchainVerifyError::WrongObjectType("type".into()).is_unavailable());
     }
 
     // ── Deactivated account field parsing ────────────────────────

--- a/services/server/src/storage/sui.rs
+++ b/services/server/src/storage/sui.rs
@@ -97,13 +97,13 @@ pub async fn verify_delegate_key_onchain(
 
     let fields = content
         .fields
-        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no fields".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no fields".into()))?;
 
     // Extract owner address
     let owner = fields
         .get("owner")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'owner' field".into()))?
+        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'owner' field".into()))?
         .to_string();
 
     // Block deactivated accounts.
@@ -125,7 +125,7 @@ pub async fn verify_delegate_key_onchain(
     let delegate_keys = fields
         .get("delegate_keys")
         .and_then(|v| v.as_array())
-        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'delegate_keys' field".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'delegate_keys' field".into()))?;
 
     // Convert our public key to the same format as stored onchain (Vec<u8> as JSON array)
     let pk_as_numbers: Vec<serde_json::Value> = public_key_bytes
@@ -374,7 +374,7 @@ pub async fn list_delegate_keys_onchain(
 
     let fields = content
         .fields
-        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no fields".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no fields".into()))?;
 
     parse_delegate_keys(&fields)
 }
@@ -411,7 +411,7 @@ fn json_account_active(
     fields
         .get("active")
         .and_then(serde_json::Value::as_bool)
-        .ok_or_else(|| OnchainVerifyError::NotFound("Missing or malformed 'active' field".into()))
+        .ok_or_else(|| OnchainVerifyError::RpcError("Missing or malformed 'active' field".into()))
 }
 
 fn grpc_account_active(fields: &prost_types::Struct) -> Result<bool, OnchainVerifyError> {
@@ -419,7 +419,7 @@ fn grpc_account_active(fields: &prost_types::Struct) -> Result<bool, OnchainVeri
         .fields
         .get("active")
         .and_then(grpc_value_as_bool)
-        .ok_or_else(|| OnchainVerifyError::NotFound("Missing or malformed 'active' field".into()))
+        .ok_or_else(|| OnchainVerifyError::RpcError("Missing or malformed 'active' field".into()))
 }
 
 fn grpc_value_as_list(v: &prost_types::Value) -> Option<&[prost_types::Value]> {
@@ -517,15 +517,15 @@ async fn verify_delegate_key_onchain_grpc(
 
     let json = object
         .json
-        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no json content".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no json content".into()))?;
     let fields = grpc_value_as_struct(&json)
-        .ok_or_else(|| OnchainVerifyError::NotFound("Object json is not a struct".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Object json is not a struct".into()))?;
 
     let owner = fields
         .fields
         .get("owner")
         .and_then(grpc_value_as_str)
-        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'owner' field".into()))?
+        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'owner' field".into()))?
         .to_string();
 
     let active = grpc_account_active(fields)?;
@@ -544,7 +544,7 @@ async fn verify_delegate_key_onchain_grpc(
         .fields
         .get("delegate_keys")
         .and_then(grpc_value_as_list)
-        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'delegate_keys' field".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'delegate_keys' field".into()))?;
 
     for dk in delegate_keys {
         let Some(dk_fields) = grpc_value_as_struct(dk) else {
@@ -594,15 +594,15 @@ async fn list_delegate_keys_onchain_grpc(
 
     let json = object
         .json
-        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no json content".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no json content".into()))?;
     let fields = grpc_value_as_struct(&json)
-        .ok_or_else(|| OnchainVerifyError::NotFound("Object json is not a struct".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Object json is not a struct".into()))?;
 
     let delegate_keys = fields
         .fields
         .get("delegate_keys")
         .and_then(grpc_value_as_list)
-        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'delegate_keys' field".into()))?;
+        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'delegate_keys' field".into()))?;
 
     let mut out = Vec::with_capacity(delegate_keys.len());
     for dk in delegate_keys {
@@ -1414,7 +1414,10 @@ mod tests {
         assert!(json_account_active(&fields(r#"{"active":true}"#)).unwrap());
         assert!(!json_account_active(&fields(r#"{"active":false}"#)).unwrap());
         let missing = json_account_active(&fields(r#"{}"#)).unwrap_err();
-        assert!(!missing.is_unavailable());
+        assert!(
+            missing.is_unavailable(),
+            "omitted Move fields after a successful GetObject are RpcError, not NotFound"
+        );
         assert!(json_account_active(&fields(r#"{"active":"false"}"#)).is_err());
     }
 
@@ -1436,8 +1439,31 @@ mod tests {
 
         assert!(grpc_account_active(&fields(Some(Kind::BoolValue(true)))).unwrap());
         assert!(!grpc_account_active(&fields(Some(Kind::BoolValue(false)))).unwrap());
-        assert!(grpc_account_active(&fields(None)).is_err());
+        let missing = grpc_account_active(&fields(None)).unwrap_err();
+        assert!(
+            missing.is_unavailable(),
+            "omitted Move fields after a successful GetObject are RpcError, not NotFound"
+        );
         assert!(grpc_account_active(&fields(Some(Kind::StringValue("false".into())))).is_err());
+    }
+
+    #[test]
+    fn missing_move_fields_after_get_object_are_unavailable() {
+        // Object was returned; omitted json/owner/delegate_keys must 503 and
+        // keep the cache row, not 401+evict a live key (WALM-429).
+        for msg in [
+            "Missing 'owner' field",
+            "Missing 'delegate_keys' field",
+            "Object has no json content",
+            "Object json is not a struct",
+            "Object has no fields",
+        ] {
+            let err = OnchainVerifyError::RpcError(msg.into());
+            assert!(
+                err.is_unavailable(),
+                "{msg} must stay RpcError/unavailable, not NotFound"
+            );
+        }
     }
 
     // ── Delegate key matching — public key as JSON array ────────────────

--- a/services/server/src/storage/sui.rs
+++ b/services/server/src/storage/sui.rs
@@ -1007,7 +1007,10 @@ impl OnchainVerifyError {
     /// produced intermittent empty 401s that the SDK mapped to memwal_login
     /// (WALM-429).
     pub fn is_unavailable(&self) -> bool {
-        matches!(self, Self::RpcError(_) | Self::ScanCapExceeded(_))
+        match self {
+            Self::RpcError(_) | Self::ScanCapExceeded(_) => true,
+            Self::KeyNotFound(_) | Self::AccountDeactivated(_) | Self::WrongObjectType(_) => false,
+        }
     }
 }
 

--- a/services/server/src/storage/sui.rs
+++ b/services/server/src/storage/sui.rs
@@ -456,8 +456,6 @@ fn map_get_object_status(status: tonic::Status) -> OnchainVerifyError {
         tonic::Code::NotFound | tonic::Code::InvalidArgument => {
             OnchainVerifyError::NotFound(format!("gRPC GetObject failed: {status}"))
         }
-        // UNAVAILABLE / RESOURCE_EXHAUSTED (HTTP 429) / DEADLINE_EXCEEDED and
-        // any other transport failure: retryable, not a sign-in failure.
         _ => OnchainVerifyError::RpcError(format!("gRPC GetObject failed: {status}")),
     }
 }
@@ -1010,10 +1008,9 @@ impl OnchainVerifyError {
     /// not exist" answer.
     ///
     /// HTTP signed auth and the MCP proxy must not treat these as a revoke:
-    /// a Sui gRPC 429 is `RpcError` (`RESOURCE_EXHAUSTED`), and logging it as
-    /// "revoked on-chain" produced intermittent empty 401s that the SDK mapped
-    /// to memwal_login (WALM-429). `NotFound` / invalid object ids are
-    /// definitive and must not take this path.
+    /// a Sui gRPC 429 is `RpcError`, and logging it as "revoked on-chain"
+    /// produced intermittent empty 401s that the SDK mapped to memwal_login
+    /// (WALM-429).
     pub fn is_unavailable(&self) -> bool {
         match self {
             Self::RpcError(_) | Self::ScanCapExceeded(_) => true,
@@ -1333,11 +1330,8 @@ mod tests {
 
     #[test]
     fn test_error_variants_are_distinct() {
-        // Confirm AccountDeactivated is separate from KeyNotFound
-        // (different auth failure modes → different handling in resolve_account)
         let deactivated = OnchainVerifyError::AccountDeactivated("msg".into());
         let not_found = OnchainVerifyError::KeyNotFound("msg".into());
-        // Both are Err variants but must match differently:
         assert!(matches!(
             deactivated,
             OnchainVerifyError::AccountDeactivated(_)
@@ -1349,53 +1343,32 @@ mod tests {
         assert!(OnchainVerifyError::ScanCapExceeded("cap".into()).is_unavailable());
         assert!(!OnchainVerifyError::WrongObjectType("type".into()).is_unavailable());
         assert!(!OnchainVerifyError::NotFound("missing object".into()).is_unavailable());
-        assert!(!parse_object_id("not-a-valid-sui-address")
-            .unwrap_err()
-            .is_unavailable());
     }
 
     #[test]
-    fn get_object_status_not_found_is_definitive() {
-        let err = map_get_object_status(tonic::Status::not_found("no such object"));
-        assert!(matches!(err, OnchainVerifyError::NotFound(_)));
-        assert!(!err.is_unavailable());
-    }
-
-    #[test]
-    fn get_object_status_invalid_argument_is_definitive() {
-        let err = map_get_object_status(tonic::Status::invalid_argument("bad object id"));
-        assert!(matches!(err, OnchainVerifyError::NotFound(_)));
-        assert!(!err.is_unavailable());
-    }
-
-    #[test]
-    fn get_object_status_resource_exhausted_is_unavailable() {
-        let err = map_get_object_status(tonic::Status::resource_exhausted("429 Too Many Requests"));
-        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
-        assert!(err.is_unavailable());
-    }
-
-    #[test]
-    fn get_object_status_unavailable_is_unavailable() {
-        let err = map_get_object_status(tonic::Status::unavailable("fullnode down"));
-        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
-        assert!(err.is_unavailable());
-    }
-
-    #[test]
-    fn get_object_status_deadline_exceeded_is_unavailable() {
-        let err = map_get_object_status(tonic::Status::deadline_exceeded("timeout"));
-        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
-        assert!(err.is_unavailable());
-    }
-
-    #[test]
-    fn get_object_does_not_treat_not_found_in_message_as_absent() {
-        let err = map_get_object_status(tonic::Status::internal(
-            "internal error: object not found while loading state",
-        ));
-        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
-        assert!(err.is_unavailable());
+    fn get_object_status_classifies_by_grpc_code() {
+        for (status, unavailable) in [
+            (tonic::Status::not_found("no such object"), false),
+            (tonic::Status::invalid_argument("bad object id"), false),
+            (
+                tonic::Status::resource_exhausted("429 Too Many Requests"),
+                true,
+            ),
+            (tonic::Status::unavailable("fullnode down"), true),
+            (tonic::Status::deadline_exceeded("timeout"), true),
+            (
+                tonic::Status::internal("internal error: object not found while loading state"),
+                true,
+            ),
+        ] {
+            let err = map_get_object_status(status);
+            assert_eq!(err.is_unavailable(), unavailable, "{err}");
+            if unavailable {
+                assert!(matches!(err, OnchainVerifyError::RpcError(_)), "{err}");
+            } else {
+                assert!(matches!(err, OnchainVerifyError::NotFound(_)), "{err}");
+            }
+        }
     }
 
     #[test]
@@ -1414,10 +1387,7 @@ mod tests {
         assert!(json_account_active(&fields(r#"{"active":true}"#)).unwrap());
         assert!(!json_account_active(&fields(r#"{"active":false}"#)).unwrap());
         let missing = json_account_active(&fields(r#"{}"#)).unwrap_err();
-        assert!(
-            missing.is_unavailable(),
-            "omitted Move fields after a successful GetObject are RpcError, not NotFound"
-        );
+        assert!(missing.is_unavailable());
         assert!(json_account_active(&fields(r#"{"active":"false"}"#)).is_err());
     }
 
@@ -1440,30 +1410,8 @@ mod tests {
         assert!(grpc_account_active(&fields(Some(Kind::BoolValue(true)))).unwrap());
         assert!(!grpc_account_active(&fields(Some(Kind::BoolValue(false)))).unwrap());
         let missing = grpc_account_active(&fields(None)).unwrap_err();
-        assert!(
-            missing.is_unavailable(),
-            "omitted Move fields after a successful GetObject are RpcError, not NotFound"
-        );
+        assert!(missing.is_unavailable());
         assert!(grpc_account_active(&fields(Some(Kind::StringValue("false".into())))).is_err());
-    }
-
-    #[test]
-    fn missing_move_fields_after_get_object_are_unavailable() {
-        // Object was returned; omitted json/owner/delegate_keys must 503 and
-        // keep the cache row, not 401+evict a live key (WALM-429).
-        for msg in [
-            "Missing 'owner' field",
-            "Missing 'delegate_keys' field",
-            "Object has no json content",
-            "Object json is not a struct",
-            "Object has no fields",
-        ] {
-            let err = OnchainVerifyError::RpcError(msg.into());
-            assert!(
-                err.is_unavailable(),
-                "{msg} must stay RpcError/unavailable, not NotFound"
-            );
-        }
     }
 
     // ── Delegate key matching — public key as JSON array ────────────────

--- a/services/server/src/storage/sui.rs
+++ b/services/server/src/storage/sui.rs
@@ -80,12 +80,12 @@ pub async fn verify_delegate_key_onchain(
 
     let result = rpc_response
         .result
-        .ok_or_else(|| OnchainVerifyError::RpcError("No result in RPC response".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("No result in RPC response".into()))?;
 
     let content = result
         .data
         .and_then(|d| d.content)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no content".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no content".into()))?;
 
     // #398: reject foreign/lookalike objects — verify the Move type against the
     // configured immutable type-origin package id before trusting any field.
@@ -97,13 +97,13 @@ pub async fn verify_delegate_key_onchain(
 
     let fields = content
         .fields
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no fields".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no fields".into()))?;
 
     // Extract owner address
     let owner = fields
         .get("owner")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'owner' field".into()))?
+        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'owner' field".into()))?
         .to_string();
 
     // Block deactivated accounts.
@@ -125,7 +125,7 @@ pub async fn verify_delegate_key_onchain(
     let delegate_keys = fields
         .get("delegate_keys")
         .and_then(|v| v.as_array())
-        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'delegate_keys' field".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'delegate_keys' field".into()))?;
 
     // Convert our public key to the same format as stored onchain (Vec<u8> as JSON array)
     let pk_as_numbers: Vec<serde_json::Value> = public_key_bytes
@@ -360,11 +360,11 @@ pub async fn list_delegate_keys_onchain(
 
     let result = rpc_response
         .result
-        .ok_or_else(|| OnchainVerifyError::RpcError("No result in RPC response".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("No result in RPC response".into()))?;
     let content = result
         .data
         .and_then(|d| d.content)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no content".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no content".into()))?;
 
     ensure_memwal_account_type(
         content.object_type.as_deref(),
@@ -374,7 +374,7 @@ pub async fn list_delegate_keys_onchain(
 
     let fields = content
         .fields
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no fields".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no fields".into()))?;
 
     parse_delegate_keys(&fields)
 }
@@ -411,7 +411,7 @@ fn json_account_active(
     fields
         .get("active")
         .and_then(serde_json::Value::as_bool)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Missing or malformed 'active' field".into()))
+        .ok_or_else(|| OnchainVerifyError::NotFound("Missing or malformed 'active' field".into()))
 }
 
 fn grpc_account_active(fields: &prost_types::Struct) -> Result<bool, OnchainVerifyError> {
@@ -419,7 +419,7 @@ fn grpc_account_active(fields: &prost_types::Struct) -> Result<bool, OnchainVeri
         .fields
         .get("active")
         .and_then(grpc_value_as_bool)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Missing or malformed 'active' field".into()))
+        .ok_or_else(|| OnchainVerifyError::NotFound("Missing or malformed 'active' field".into()))
 }
 
 fn grpc_value_as_list(v: &prost_types::Value) -> Option<&[prost_types::Value]> {
@@ -441,23 +441,32 @@ fn grpc_value_as_u64(v: &prost_types::Value) -> Option<u64> {
     }
 }
 
-/// gRPC counterpart of `verify_delegate_key_onchain` above — same checks
-/// (owner, active, delegate_keys membership), fetched via
-/// LedgerService.GetObject instead of JSON-RPC's `sui_getObject`.
-///
-/// The gRPC `.json` object representation is flatter than JSON-RPC's
-/// `.fields` shape and encodes delegate key `public_key` as base64 (not a
-/// byte-array) — verified live against real testnet objects while migrating
-/// the sidecar and web app to gRPC for this same JSON-RPC sunset.
-async fn verify_delegate_key_onchain_grpc(
+fn parse_object_id(account_object_id: &str) -> Result<sui_sdk_types::Address, OnchainVerifyError> {
+    account_object_id
+        .parse()
+        .map_err(|error| OnchainVerifyError::NotFound(format!("invalid object id: {error}")))
+}
+
+/// Classify LedgerService.GetObject failures by gRPC *code*, never by message
+/// text. tonic's Display embeds the code's English name, so matching "not found"
+/// in the string would also fire on INTERNAL errors that merely mention a
+/// missing object.
+fn map_get_object_status(status: tonic::Status) -> OnchainVerifyError {
+    match status.code() {
+        tonic::Code::NotFound | tonic::Code::InvalidArgument => {
+            OnchainVerifyError::NotFound(format!("gRPC GetObject failed: {status}"))
+        }
+        // UNAVAILABLE / RESOURCE_EXHAUSTED (HTTP 429) / DEADLINE_EXCEEDED and
+        // any other transport failure: retryable, not a sign-in failure.
+        _ => OnchainVerifyError::RpcError(format!("gRPC GetObject failed: {status}")),
+    }
+}
+
+async fn grpc_get_object(
     mut client: sui_rpc::Client,
     account_object_id: &str,
-    public_key_bytes: &[u8],
-    expected_type_origin_package_id: &str,
-) -> Result<String, OnchainVerifyError> {
-    let address: sui_sdk_types::Address = account_object_id
-        .parse()
-        .map_err(|e| OnchainVerifyError::RpcError(format!("invalid object id: {}", e)))?;
+) -> Result<sui_rpc::proto::sui::rpc::v2::Object, OnchainVerifyError> {
+    let address = parse_object_id(account_object_id)?;
     let mut request = sui_rpc::proto::sui::rpc::v2::GetObjectRequest::new(&address);
     request.read_mask = Some(prost_types::FieldMask {
         paths: vec!["json".to_string(), "object_type".to_string()],
@@ -476,11 +485,28 @@ async fn verify_delegate_key_onchain_grpc(
         started.elapsed(),
     );
 
-    let object = response
-        .map_err(|e| OnchainVerifyError::RpcError(format!("gRPC GetObject failed: {}", e)))?
+    response
+        .map_err(map_get_object_status)?
         .into_inner()
         .object
-        .ok_or_else(|| OnchainVerifyError::RpcError("gRPC response missing object".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("gRPC response missing object".into()))
+}
+
+/// gRPC counterpart of `verify_delegate_key_onchain` above — same checks
+/// (owner, active, delegate_keys membership), fetched via
+/// LedgerService.GetObject instead of JSON-RPC's `sui_getObject`.
+///
+/// The gRPC `.json` object representation is flatter than JSON-RPC's
+/// `.fields` shape and encodes delegate key `public_key` as base64 (not a
+/// byte-array) — verified live against real testnet objects while migrating
+/// the sidecar and web app to gRPC for this same JSON-RPC sunset.
+async fn verify_delegate_key_onchain_grpc(
+    client: sui_rpc::Client,
+    account_object_id: &str,
+    public_key_bytes: &[u8],
+    expected_type_origin_package_id: &str,
+) -> Result<String, OnchainVerifyError> {
+    let object = grpc_get_object(client, account_object_id).await?;
 
     // #398: verify the Move type before trusting any field (gRPC path).
     ensure_memwal_account_type(
@@ -491,15 +517,15 @@ async fn verify_delegate_key_onchain_grpc(
 
     let json = object
         .json
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no json content".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no json content".into()))?;
     let fields = grpc_value_as_struct(&json)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object json is not a struct".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object json is not a struct".into()))?;
 
     let owner = fields
         .fields
         .get("owner")
         .and_then(grpc_value_as_str)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'owner' field".into()))?
+        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'owner' field".into()))?
         .to_string();
 
     let active = grpc_account_active(fields)?;
@@ -518,7 +544,7 @@ async fn verify_delegate_key_onchain_grpc(
         .fields
         .get("delegate_keys")
         .and_then(grpc_value_as_list)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'delegate_keys' field".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'delegate_keys' field".into()))?;
 
     for dk in delegate_keys {
         let Some(dk_fields) = grpc_value_as_struct(dk) else {
@@ -554,36 +580,11 @@ async fn verify_delegate_key_onchain_grpc(
 /// representation (unlike JSON-RPC's array-of-numbers), but `/agents`
 /// doesn't need the key bytes at all — only `sui_address`/`label`/`created_at`.
 async fn list_delegate_keys_onchain_grpc(
-    mut client: sui_rpc::Client,
+    client: sui_rpc::Client,
     account_object_id: &str,
     expected_type_origin_package_id: &str,
 ) -> Result<Vec<DelegateKeyInfo>, OnchainVerifyError> {
-    let address: sui_sdk_types::Address = account_object_id
-        .parse()
-        .map_err(|e| OnchainVerifyError::RpcError(format!("invalid object id: {}", e)))?;
-    let mut request = sui_rpc::proto::sui::rpc::v2::GetObjectRequest::new(&address);
-    request.read_mask = Some(prost_types::FieldMask {
-        paths: vec!["json".to_string(), "object_type".to_string()],
-    });
-
-    let started = std::time::Instant::now();
-    let response = client.ledger_client().get_object(request).await;
-    let status_label = match &response {
-        Ok(_) => "200".to_string(),
-        Err(status) => status.code().to_string(),
-    };
-    crate::observability::observe_external(
-        "sui_grpc",
-        "GetObject",
-        &status_label,
-        started.elapsed(),
-    );
-
-    let object = response
-        .map_err(|e| OnchainVerifyError::RpcError(format!("gRPC GetObject failed: {}", e)))?
-        .into_inner()
-        .object
-        .ok_or_else(|| OnchainVerifyError::RpcError("gRPC response missing object".into()))?;
+    let object = grpc_get_object(client, account_object_id).await?;
 
     ensure_memwal_account_type(
         object.object_type.as_deref(),
@@ -593,15 +594,15 @@ async fn list_delegate_keys_onchain_grpc(
 
     let json = object
         .json
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object has no json content".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object has no json content".into()))?;
     let fields = grpc_value_as_struct(&json)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Object json is not a struct".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Object json is not a struct".into()))?;
 
     let delegate_keys = fields
         .fields
         .get("delegate_keys")
         .and_then(grpc_value_as_list)
-        .ok_or_else(|| OnchainVerifyError::RpcError("Missing 'delegate_keys' field".into()))?;
+        .ok_or_else(|| OnchainVerifyError::NotFound("Missing 'delegate_keys' field".into()))?;
 
     let mut out = Vec::with_capacity(delegate_keys.len());
     for dk in delegate_keys {
@@ -842,7 +843,7 @@ pub async fn find_account_by_delegate_key(
                     );
                     return Ok((account_id.to_string(), owner));
                 }
-                Err(OnchainVerifyError::KeyNotFound(_)) => {
+                Err(OnchainVerifyError::KeyNotFound(_) | OnchainVerifyError::NotFound(_)) => {
                     continue;
                 }
                 Err(e) => {
@@ -966,6 +967,10 @@ struct ObjectContent {
 pub enum OnchainVerifyError {
     RpcError(String),
     KeyNotFound(String),
+    /// The named object does not exist, the id is unparseable, or GetObject
+    /// returned no object. Distinct from `KeyNotFound` (the account exists
+    /// but this key is not in `delegate_keys`).
+    NotFound(String),
     /// Returned when MemWalAccount.active == false.
     /// Prevents deactivated accounts from authenticating.
     AccountDeactivated(String),
@@ -983,6 +988,7 @@ impl std::fmt::Display for OnchainVerifyError {
         match self {
             OnchainVerifyError::RpcError(msg) => write!(f, "Sui RPC error: {}", msg),
             OnchainVerifyError::KeyNotFound(msg) => write!(f, "Key not found: {}", msg),
+            OnchainVerifyError::NotFound(msg) => write!(f, "Object not found: {}", msg),
             OnchainVerifyError::AccountDeactivated(msg) => {
                 write!(f, "Account deactivated: {}", msg)
             }
@@ -1000,16 +1006,21 @@ impl std::error::Error for OnchainVerifyError {}
 
 impl OnchainVerifyError {
     /// True when the chain could not be consulted, as opposed to a definitive
-    /// "this key is not registered / this account is dead" answer.
+    /// "this key is not registered / this account is dead / this object does
+    /// not exist" answer.
     ///
     /// HTTP signed auth and the MCP proxy must not treat these as a revoke:
-    /// a Sui gRPC 429 is `RpcError`, and logging it as "revoked on-chain"
-    /// produced intermittent empty 401s that the SDK mapped to memwal_login
-    /// (WALM-429).
+    /// a Sui gRPC 429 is `RpcError` (`RESOURCE_EXHAUSTED`), and logging it as
+    /// "revoked on-chain" produced intermittent empty 401s that the SDK mapped
+    /// to memwal_login (WALM-429). `NotFound` / invalid object ids are
+    /// definitive and must not take this path.
     pub fn is_unavailable(&self) -> bool {
         match self {
             Self::RpcError(_) | Self::ScanCapExceeded(_) => true,
-            Self::KeyNotFound(_) | Self::AccountDeactivated(_) | Self::WrongObjectType(_) => false,
+            Self::NotFound(_)
+            | Self::KeyNotFound(_)
+            | Self::AccountDeactivated(_)
+            | Self::WrongObjectType(_) => false,
         }
     }
 }
@@ -1337,6 +1348,61 @@ mod tests {
         assert!(OnchainVerifyError::RpcError("429".into()).is_unavailable());
         assert!(OnchainVerifyError::ScanCapExceeded("cap".into()).is_unavailable());
         assert!(!OnchainVerifyError::WrongObjectType("type".into()).is_unavailable());
+        assert!(!OnchainVerifyError::NotFound("missing object".into()).is_unavailable());
+        assert!(!parse_object_id("not-a-valid-sui-address")
+            .unwrap_err()
+            .is_unavailable());
+    }
+
+    #[test]
+    fn get_object_status_not_found_is_definitive() {
+        let err = map_get_object_status(tonic::Status::not_found("no such object"));
+        assert!(matches!(err, OnchainVerifyError::NotFound(_)));
+        assert!(!err.is_unavailable());
+    }
+
+    #[test]
+    fn get_object_status_invalid_argument_is_definitive() {
+        let err = map_get_object_status(tonic::Status::invalid_argument("bad object id"));
+        assert!(matches!(err, OnchainVerifyError::NotFound(_)));
+        assert!(!err.is_unavailable());
+    }
+
+    #[test]
+    fn get_object_status_resource_exhausted_is_unavailable() {
+        let err = map_get_object_status(tonic::Status::resource_exhausted("429 Too Many Requests"));
+        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
+        assert!(err.is_unavailable());
+    }
+
+    #[test]
+    fn get_object_status_unavailable_is_unavailable() {
+        let err = map_get_object_status(tonic::Status::unavailable("fullnode down"));
+        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
+        assert!(err.is_unavailable());
+    }
+
+    #[test]
+    fn get_object_status_deadline_exceeded_is_unavailable() {
+        let err = map_get_object_status(tonic::Status::deadline_exceeded("timeout"));
+        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
+        assert!(err.is_unavailable());
+    }
+
+    #[test]
+    fn get_object_does_not_treat_not_found_in_message_as_absent() {
+        let err = map_get_object_status(tonic::Status::internal(
+            "internal error: object not found while loading state",
+        ));
+        assert!(matches!(err, OnchainVerifyError::RpcError(_)));
+        assert!(err.is_unavailable());
+    }
+
+    #[test]
+    fn invalid_object_id_is_not_unavailable() {
+        let err = parse_object_id("not-a-sui-object-id").unwrap_err();
+        assert!(matches!(err, OnchainVerifyError::NotFound(_)));
+        assert!(!err.is_unavailable());
     }
 
     // ── Deactivated account field parsing ────────────────────────
@@ -1347,7 +1413,8 @@ mod tests {
 
         assert!(json_account_active(&fields(r#"{"active":true}"#)).unwrap());
         assert!(!json_account_active(&fields(r#"{"active":false}"#)).unwrap());
-        assert!(json_account_active(&fields(r#"{}"#)).is_err());
+        let missing = json_account_active(&fields(r#"{}"#)).unwrap_err();
+        assert!(!missing.is_unavailable());
         assert!(json_account_active(&fields(r#"{"active":"false"}"#)).is_err());
     }
 
@@ -1873,6 +1940,9 @@ mod tests {
             "0xcf6ad755a1cdff7217865c796778fabe5aa399cb0cf2eba986f4b582047229c6",
         )
         .await;
-        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(OnchainVerifyError::NotFound(_))),
+            "missing object must be NotFound, not unavailable RpcError, got: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Signed HTTP auth treated **every** `verify_delegate_key_onchain` error as a revoke, including Sui gRPC `GetObject` 429s. That evicted a still-valid cache row, retried RPC, and returned an empty 401.
- Empty 401s made the SDK print `Walrus Memory isn't signed in. Call the memwal_login tool` even though the key was still on-chain. Recall looked intermittent.
- HTTP `/api/recall` now matches MCP SSE on classification: `RpcError` / `ScanCapExceeded` are unavailability, not a revoke.
- **Fail-closed on cache hit + RPC failure:** keep the cached mapping (do not evict) but return 503. We do **not** authenticate from a stale 24h cache while Sui is unreachable, so a revoked key cannot ride an outage. 503 carries `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` and `Retry-After: 5`.
- Cache miss + unavailability → 503. Evict only on `KeyNotFound` / `AccountDeactivated` / `WrongObjectType`.
- Registry-scan semaphore exhaustion (`try_acquire` fail) is also 503. That is not an RPC error — it is retryable saturation, previously a timing-normalized 401, and is now externally observable as unavailable. Called out because it is a behavior change beyond the PR title.
- TS SDK 0.1.6 and Python SDK 0.1.9 report **auth** 503 (header present) as retryable credential-verification unavailability, not a sign-in failure. Other relayer 503s (Redis, rate limiter, LLM) keep the generic sanitized body. Versions and changelogs dumped by hand (no changeset).

## Test plan
- [x] `cargo test --bin memwal-server` filters: `resolve_account_cache_hit_*`, `upstream_unavailable_is_503_not_401`, `test_error_variants_are_distinct`
- [x] SDK `sanitize-server-error` tests (auth 503 vs generic 503)
- [x] Python `test_auth_rejected_message` (3/3)
- [ ] After merge: watch prod `POST /api/recall` during Sui 429 bursts — should be 503 with `AUTH_UPSTREAM_UNAVAILABLE`, not empty 401 + `revoked on-chain`

Linear: WALM-429