### PR TITLE
fix(chatbot): restore chat, titles and artifacts after upstream model retirements (WALM-354)

### DIFF
--- a/.github/workflows/check-model-ids.yml
+++ b/.github/workflows/check-model-ids.yml
@@ -1,0 +1,57 @@
+name: Check model ids
+
+# Verifies the OpenRouter ids apps/chatbot can send still exist upstream.
+#
+# Its own workflow rather than a job in test.yml because the failure it catches
+# arrives with no commit attached: OpenRouter retires ids on its own timetable,
+# which is how a retired title model reached production unnoticed. test.yml has
+# no schedule trigger, so a weekly job there would mean guarding every other job
+# in the file against a scheduled run.
+#
+# The catalog endpoint is public, so this needs no key and no environment.
+
+on:
+  pull_request:
+    # Only when the curated list or the check itself moves. Every other PR would
+    # be taking a network dependency on OpenRouter for nothing.
+    paths:
+      - "apps/chatbot/lib/ai/models.ts"
+      - "apps/chatbot/scripts/check-model-ids.ts"
+      - ".github/workflows/check-model-ids.yml"
+  schedule:
+    # Reads nothing shared, so it does not need the bench-account offsets the
+    # other weekly suites coordinate around.
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: check-model-ids-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  model-ids:
+    name: Model ids live on OpenRouter
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Check curated model ids against the live catalog
+        run: pnpm --filter @memwal/chatbot check:models

--- a/apps/chatbot/app/(chat)/actions.ts
+++ b/apps/chatbot/app/(chat)/actions.ts
@@ -3,6 +3,7 @@
 import { generateText, type UIMessage } from "ai";
 import { cookies } from "next/headers";
 import type { VisibilityType } from "@/components/visibility-selector";
+import { MAX_TITLE_OUTPUT_TOKENS } from "@/lib/ai/models";
 import { titlePrompt } from "@/lib/ai/prompts";
 import { getTitleModel } from "@/lib/ai/providers";
 import {
@@ -35,6 +36,7 @@ export async function generateTitleFromUserMessage({
     model: getTitleModel(),
     system: titlePrompt,
     prompt: getTextFromMessage(message),
+    maxOutputTokens: MAX_TITLE_OUTPUT_TOKENS,
   });
   return text
     .replace(/^[#*"\s]+/, "")

--- a/apps/chatbot/app/(chat)/api/chat/route.ts
+++ b/apps/chatbot/app/(chat)/api/chat/route.ts
@@ -16,7 +16,12 @@ import { createResumableStreamContext } from "resumable-stream";
 import { auth, type UserType } from "@/app/(auth)/auth";
 import { entitlementsByUserType } from "@/lib/ai/entitlements";
 import { memoryNamespaceForUser } from "@/lib/ai/memory-namespace";
-import { allowedModelIds, isReasoningModelId } from "@/lib/ai/models";
+import {
+  allowedModelIds,
+  isReasoningModelId,
+  MAX_OUTPUT_TOKENS,
+  MAX_REASONING_OUTPUT_TOKENS,
+} from "@/lib/ai/models";
 import { type RequestHints, systemPrompt } from "@/lib/ai/prompts";
 import { getLanguageModel, getMemWalModel } from "@/lib/ai/providers";
 import { createDocument } from "@/lib/ai/tools/create-document";
@@ -194,6 +199,9 @@ export async function POST(request: Request) {
             : getLanguageModel(selectedChatModel),
           system: systemPrompt({ selectedChatModel, requestHints }),
           messages: modelMessages,
+          maxOutputTokens: isReasoningModel
+            ? MAX_REASONING_OUTPUT_TOKENS
+            : MAX_OUTPUT_TOKENS,
           stopWhen: stepCountIs(5),
           experimental_activeTools: isReasoningModel
             ? []

--- a/apps/chatbot/app/(chat)/api/chat/route.ts
+++ b/apps/chatbot/app/(chat)/api/chat/route.ts
@@ -16,7 +16,7 @@ import { createResumableStreamContext } from "resumable-stream";
 import { auth, type UserType } from "@/app/(auth)/auth";
 import { entitlementsByUserType } from "@/lib/ai/entitlements";
 import { memoryNamespaceForUser } from "@/lib/ai/memory-namespace";
-import { allowedModelIds } from "@/lib/ai/models";
+import { allowedModelIds, isReasoningModelId } from "@/lib/ai/models";
 import { type RequestHints, systemPrompt } from "@/lib/ai/prompts";
 import { getLanguageModel, getMemWalModel } from "@/lib/ai/providers";
 import { createDocument } from "@/lib/ai/tools/create-document";
@@ -177,10 +177,7 @@ export async function POST(request: Request) {
       });
     }
 
-    const isReasoningModel =
-      selectedChatModel.endsWith("-thinking") ||
-      (selectedChatModel.includes("reasoning") &&
-        !selectedChatModel.includes("non-reasoning"));
+    const isReasoningModel = isReasoningModelId(selectedChatModel);
 
     const modelMessages = await convertToModelMessages(uiMessages);
 

--- a/apps/chatbot/app/(chat)/chat/[id]/page.tsx
+++ b/apps/chatbot/app/(chat)/chat/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from "react";
 import { auth } from "@/app/(auth)/auth";
 import { Chat } from "@/components/chat";
 import { DataStreamHandler } from "@/components/data-stream-handler";
-import { DEFAULT_CHAT_MODEL } from "@/lib/ai/models";
+import { resolveChatModelId } from "@/lib/ai/models";
 import { getChatById, getMessagesByChatId } from "@/lib/db/queries";
 import { convertToUIMessages } from "@/lib/utils";
 
@@ -48,30 +48,15 @@ async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
   const uiMessages = convertToUIMessages(messagesFromDb);
 
   const cookieStore = await cookies();
-  const chatModelFromCookie = cookieStore.get("chat-model");
-
-  if (!chatModelFromCookie) {
-    return (
-      <>
-        <Chat
-          autoResume={true}
-          id={chat.id}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialMessages={uiMessages}
-          initialVisibilityType={chat.visibility}
-          isReadonly={session?.user?.id !== chat.userId}
-        />
-        <DataStreamHandler />
-      </>
-    );
-  }
 
   return (
     <>
       <Chat
         autoResume={true}
         id={chat.id}
-        initialChatModel={chatModelFromCookie.value}
+        initialChatModel={resolveChatModelId(
+          cookieStore.get("chat-model")?.value
+        )}
         initialMessages={uiMessages}
         initialVisibilityType={chat.visibility}
         isReadonly={session?.user?.id !== chat.userId}

--- a/apps/chatbot/app/(chat)/page.tsx
+++ b/apps/chatbot/app/(chat)/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { Suspense } from "react";
 import { Chat } from "@/components/chat";
 import { DataStreamHandler } from "@/components/data-stream-handler";
-import { DEFAULT_CHAT_MODEL } from "@/lib/ai/models";
+import { resolveChatModelId } from "@/lib/ai/models";
 import { generateUUID } from "@/lib/utils";
 
 export default function Page() {
@@ -15,32 +15,16 @@ export default function Page() {
 
 async function NewChatPage() {
   const cookieStore = await cookies();
-  const modelIdFromCookie = cookieStore.get("chat-model");
   const id = generateUUID();
-
-  if (!modelIdFromCookie) {
-    return (
-      <>
-        <Chat
-          autoResume={false}
-          id={id}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialMessages={[]}
-          initialVisibilityType="private"
-          isReadonly={false}
-          key={id}
-        />
-        <DataStreamHandler />
-      </>
-    );
-  }
 
   return (
     <>
       <Chat
         autoResume={false}
         id={id}
-        initialChatModel={modelIdFromCookie.value}
+        initialChatModel={resolveChatModelId(
+          cookieStore.get("chat-model")?.value
+        )}
         initialMessages={[]}
         initialVisibilityType="private"
         isReadonly={false}

--- a/apps/chatbot/artifacts/code/server.ts
+++ b/apps/chatbot/artifacts/code/server.ts
@@ -1,5 +1,6 @@
 import { streamObject } from "ai";
 import { z } from "zod";
+import { MAX_OUTPUT_TOKENS } from "@/lib/ai/models";
 import { codePrompt, updateDocumentPrompt } from "@/lib/ai/prompts";
 import { getArtifactModel } from "@/lib/ai/providers";
 import { createDocumentHandler } from "@/lib/artifacts/server";
@@ -12,6 +13,7 @@ export const codeDocumentHandler = createDocumentHandler<"code">({
     const { fullStream } = streamObject({
       model: getArtifactModel(),
       system: codePrompt,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
       prompt: title,
       schema: z.object({
         code: z.string(),
@@ -45,6 +47,7 @@ export const codeDocumentHandler = createDocumentHandler<"code">({
     const { fullStream } = streamObject({
       model: getArtifactModel(),
       system: updateDocumentPrompt(document.content, "code"),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
       prompt: description,
       schema: z.object({
         code: z.string(),

--- a/apps/chatbot/artifacts/sheet/server.ts
+++ b/apps/chatbot/artifacts/sheet/server.ts
@@ -1,5 +1,6 @@
 import { streamObject } from "ai";
 import { z } from "zod";
+import { MAX_OUTPUT_TOKENS } from "@/lib/ai/models";
 import { sheetPrompt, updateDocumentPrompt } from "@/lib/ai/prompts";
 import { getArtifactModel } from "@/lib/ai/providers";
 import { createDocumentHandler } from "@/lib/artifacts/server";
@@ -12,6 +13,7 @@ export const sheetDocumentHandler = createDocumentHandler<"sheet">({
     const { fullStream } = streamObject({
       model: getArtifactModel(),
       system: sheetPrompt,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
       prompt: title,
       schema: z.object({
         csv: z.string().describe("CSV data"),
@@ -51,6 +53,7 @@ export const sheetDocumentHandler = createDocumentHandler<"sheet">({
     const { fullStream } = streamObject({
       model: getArtifactModel(),
       system: updateDocumentPrompt(document.content, "sheet"),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
       prompt: description,
       schema: z.object({
         csv: z.string(),

--- a/apps/chatbot/artifacts/text/server.ts
+++ b/apps/chatbot/artifacts/text/server.ts
@@ -1,4 +1,5 @@
 import { smoothStream, streamText } from "ai";
+import { MAX_OUTPUT_TOKENS } from "@/lib/ai/models";
 import { updateDocumentPrompt } from "@/lib/ai/prompts";
 import { getArtifactModel } from "@/lib/ai/providers";
 import { createDocumentHandler } from "@/lib/artifacts/server";
@@ -13,6 +14,7 @@ export const textDocumentHandler = createDocumentHandler<"text">({
       system:
         "Write about the given topic. Markdown is supported. Use headings wherever appropriate.",
       experimental_transform: smoothStream({ chunking: "word" }),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
       prompt: title,
     });
 
@@ -41,6 +43,7 @@ export const textDocumentHandler = createDocumentHandler<"text">({
       model: getArtifactModel(),
       system: updateDocumentPrompt(document.content, "text"),
       experimental_transform: smoothStream({ chunking: "word" }),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
       prompt: description,
       providerOptions: {
         openai: {

--- a/apps/chatbot/components/document-preview.tsx
+++ b/apps/chatbot/components/document-preview.tsx
@@ -102,7 +102,7 @@ export function DocumentPreview({
   }
 
   return (
-    <div className="relative w-full max-w-[450px] cursor-pointer">
+    <div className="relative w-full max-w-[450px] cursor-pointer" data-testid="document-preview">
       <HitboxLayer
         hitboxRef={hitboxRef}
         result={result}

--- a/apps/chatbot/components/document.tsx
+++ b/apps/chatbot/components/document.tsx
@@ -38,6 +38,7 @@ function PureDocumentToolResult({
   return (
     <button
       className="flex w-fit cursor-pointer flex-row items-start gap-3 rounded-xl border bg-background px-3 py-2"
+      data-testid="artifact-create-result"
       onClick={(event) => {
         if (isReadonly) {
           toast.error(

--- a/apps/chatbot/lib/ai/models.mock.ts
+++ b/apps/chatbot/lib/ai/models.mock.ts
@@ -11,17 +11,56 @@ const mockUsage = {
   outputTokens: { total: 20, text: 20, reasoning: 0 },
 };
 
-function getResponseForPrompt(prompt: unknown): string {
-  const promptStr = JSON.stringify(prompt).toLowerCase();
+const GREETING_REGEX = /\b(hello|hi|hey)\b/;
 
-  if (promptStr.includes("weather") || promptStr.includes("temperature")) {
+type ModelMessage = {
+  role?: string;
+  content?: unknown;
+};
+
+/**
+ * Read the newest user turn only. Matching the serialised prompt as a whole
+ * swept in the system prompt, whose prose contains "hi" inside ordinary words
+ * like "this", so every request looked like a greeting and the branches below
+ * could never be told apart from a test.
+ */
+function lastUserText(prompt: unknown): string {
+  if (!Array.isArray(prompt)) {
+    return "";
+  }
+
+  const userMessages = (prompt as ModelMessage[]).filter(
+    (message) => message?.role === "user"
+  );
+  const latest = userMessages.at(-1);
+
+  if (!latest) {
+    return "";
+  }
+  if (typeof latest.content === "string") {
+    return latest.content.toLowerCase();
+  }
+  if (!Array.isArray(latest.content)) {
+    return "";
+  }
+
+  return latest.content
+    .map((part: unknown) =>
+      part && typeof part === "object" && "text" in part
+        ? String((part as { text: unknown }).text)
+        : ""
+    )
+    .join(" ")
+    .toLowerCase();
+}
+
+function getResponseForPrompt(prompt: unknown): string {
+  const text = lastUserText(prompt);
+
+  if (text.includes("weather") || text.includes("temperature")) {
     return mockResponses.weather;
   }
-  if (
-    promptStr.includes("hello") ||
-    promptStr.includes("hi") ||
-    promptStr.includes("hey")
-  ) {
+  if (GREETING_REGEX.test(text)) {
     return mockResponses.greeting;
   }
 

--- a/apps/chatbot/lib/ai/models.mock.ts
+++ b/apps/chatbot/lib/ai/models.mock.ts
@@ -54,6 +54,44 @@ function lastUserText(prompt: unknown): string {
     .toLowerCase();
 }
 
+const DOCUMENT_PROMPT_REGEX = /\b(essay|create a document|write a document)\b/;
+const CREATE_DOCUMENT_CALL_ID = "call_doc";
+const CREATE_DOCUMENT_INPUT = JSON.stringify({
+  title: "Test Artifact",
+  kind: "text",
+});
+
+function promptAlreadyCalledTools(prompt: unknown): boolean {
+  if (!Array.isArray(prompt)) {
+    return false;
+  }
+  for (const message of prompt as ModelMessage[]) {
+    if (message?.role === "tool") {
+      return true;
+    }
+    if (!Array.isArray(message?.content)) {
+      continue;
+    }
+    for (const part of message.content as Array<{ type?: string }>) {
+      if (
+        part?.type === "tool-call" ||
+        part?.type === "tool-result" ||
+        part?.type === "tool-createDocument"
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function shouldCreateDocument(prompt: unknown): boolean {
+  return (
+    !promptAlreadyCalledTools(prompt) &&
+    DOCUMENT_PROMPT_REGEX.test(lastUserText(prompt))
+  );
+}
+
 function getResponseForPrompt(prompt: unknown): string {
   const text = lastUserText(prompt);
 
@@ -67,6 +105,34 @@ function getResponseForPrompt(prompt: unknown): string {
   return mockResponses.default;
 }
 
+function enqueueCreateDocument(controller: ReadableStreamDefaultController) {
+  controller.enqueue({
+    type: "tool-input-start",
+    id: CREATE_DOCUMENT_CALL_ID,
+    toolName: "createDocument",
+  });
+  controller.enqueue({
+    type: "tool-input-delta",
+    id: CREATE_DOCUMENT_CALL_ID,
+    delta: CREATE_DOCUMENT_INPUT,
+  });
+  controller.enqueue({
+    type: "tool-input-end",
+    id: CREATE_DOCUMENT_CALL_ID,
+  });
+  controller.enqueue({
+    type: "tool-call",
+    toolCallId: CREATE_DOCUMENT_CALL_ID,
+    toolName: "createDocument",
+    input: CREATE_DOCUMENT_INPUT,
+  });
+  controller.enqueue({
+    type: "finish",
+    finishReason: "tool-calls",
+    usage: mockUsage,
+  });
+}
+
 const createMockModel = (): LanguageModel => {
   return {
     specificationVersion: "v3",
@@ -74,13 +140,44 @@ const createMockModel = (): LanguageModel => {
     modelId: "mock-model",
     defaultObjectGenerationMode: "tool",
     supportedUrls: {},
-    doGenerate: async ({ prompt }: { prompt: unknown }) => ({
-      finishReason: "stop",
-      usage: mockUsage,
-      content: [{ type: "text", text: getResponseForPrompt(prompt) }],
-      warnings: [],
-    }),
+    doGenerate: async ({ prompt }: { prompt: unknown }) => {
+      if (shouldCreateDocument(prompt)) {
+        return {
+          finishReason: "tool-calls",
+          usage: mockUsage,
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: CREATE_DOCUMENT_CALL_ID,
+              toolName: "createDocument",
+              input: CREATE_DOCUMENT_INPUT,
+            },
+          ],
+          warnings: [],
+        };
+      }
+      return {
+        finishReason: "stop",
+        usage: mockUsage,
+        content: [{ type: "text", text: getResponseForPrompt(prompt) }],
+        warnings: [],
+      };
+    },
     doStream: ({ prompt }: { prompt: unknown }) => {
+      if (shouldCreateDocument(prompt)) {
+        return {
+          stream: new ReadableStream({
+            async start(controller) {
+              await new Promise((resolve) => {
+                setTimeout(resolve, 500);
+              });
+              enqueueCreateDocument(controller);
+              controller.close();
+            },
+          }),
+        };
+      }
+
       const response = getResponseForPrompt(prompt);
       const words = response.split(" ");
 

--- a/apps/chatbot/lib/ai/models.ts
+++ b/apps/chatbot/lib/ai/models.ts
@@ -86,6 +86,17 @@ export function isReasoningModelId(modelId: string): boolean {
   );
 }
 
+// Every id the app can send upstream. OpenRouter retires ids on its own
+// schedule and answers a retired one with a 404 at request time, so keep the
+// full set in one place for check-model-ids.ts to verify against the catalog.
+export const openRouterModelIds = [
+  ...new Set([
+    ...chatModels.map((m) => baseOpenRouterId(m.id)),
+    TITLE_MODEL,
+    ARTIFACT_MODEL,
+  ]),
+];
+
 // Group models by provider for UI
 export const allowedModelIds = new Set(chatModels.map((m) => m.id));
 

--- a/apps/chatbot/lib/ai/models.ts
+++ b/apps/chatbot/lib/ai/models.ts
@@ -24,21 +24,21 @@ export const chatModels: ChatModel[] = [
   },
   // Anthropic
   {
-    id: "anthropic/claude-3.5-haiku",
-    name: "Claude 3.5 Haiku",
+    id: "anthropic/claude-haiku-4.5",
+    name: "Claude Haiku 4.5",
     provider: "anthropic",
     description: "Fast and affordable, great for everyday tasks",
   },
   {
-    id: "anthropic/claude-3.5-sonnet",
-    name: "Claude 3.5 Sonnet",
+    id: "anthropic/claude-sonnet-4.5",
+    name: "Claude Sonnet 4.5",
     provider: "anthropic",
     description: "Best balance of speed and intelligence",
   },
   // Google
   {
-    id: "google/gemini-2.0-flash-001",
-    name: "Gemini 2.0 Flash",
+    id: "google/gemini-2.5-flash",
+    name: "Gemini 2.5 Flash",
     provider: "google",
     description: "Ultra fast and affordable",
   },
@@ -49,14 +49,42 @@ export const chatModels: ChatModel[] = [
     provider: "deepseek",
     description: "Strong open-source model",
   },
-  // Reasoning models
+  // Reasoning models. The -thinking suffix is ours, not OpenRouter's:
+  // getLanguageModel strips it and wraps the base id (see providers.ts).
   {
-    id: "anthropic/claude-3.5-sonnet-thinking",
-    name: "Claude 3.5 Sonnet (Thinking)",
+    id: "anthropic/claude-sonnet-4.5-thinking",
+    name: "Claude Sonnet 4.5 (Thinking)",
     provider: "reasoning",
     description: "Extended thinking for complex problems",
   },
 ];
+
+/**
+ * Models for the two background calls the picker never covers: chat titles and
+ * artifact content.
+ *
+ * Declared beside the curated list rather than hardcoded at the call site. The
+ * previous inline ids ("google/gemini-2.0-flash-001" for titles,
+ * "anthropic/claude-3.5-haiku" for artifacts) were retired upstream and 404'd
+ * on every request, and nothing tied them back to the models the app maintains.
+ * Keep both pointing at an id present in `chatModels`.
+ */
+export const TITLE_MODEL = "google/gemini-2.5-flash";
+export const ARTIFACT_MODEL = "anthropic/claude-haiku-4.5";
+
+const THINKING_SUFFIX_REGEX = /-thinking$/;
+
+// "-thinking" is our own marker, not part of any OpenRouter id.
+export function baseOpenRouterId(modelId: string): string {
+  return modelId.replace(THINKING_SUFFIX_REGEX, "");
+}
+
+export function isReasoningModelId(modelId: string): boolean {
+  return (
+    THINKING_SUFFIX_REGEX.test(modelId) ||
+    (modelId.includes("reasoning") && !modelId.includes("non-reasoning"))
+  );
+}
 
 // Group models by provider for UI
 export const allowedModelIds = new Set(chatModels.map((m) => m.id));
@@ -71,4 +99,3 @@ export const modelsByProvider = chatModels.reduce(
   },
   {} as Record<string, ChatModel[]>
 );
-

--- a/apps/chatbot/lib/ai/models.ts
+++ b/apps/chatbot/lib/ai/models.ts
@@ -111,6 +111,21 @@ export const openRouterModelIds = [
 // Group models by provider for UI
 export const allowedModelIds = new Set(chatModels.map((m) => m.id));
 
+/**
+ * Coerce a persisted `chat-model` cookie to a model the app still supports.
+ *
+ * The cookie outlives the curated list: anyone who had a since-retired model
+ * selected keeps sending that id, and `/api/chat` rejects unknown ids with a
+ * 400. The picker's own fallback is display-only — it renders the default name
+ * while `initialChatModel` still carries the stale id into the request body —
+ * so the coercion has to happen where the cookie is read.
+ */
+export function resolveChatModelId(cookieValue: string | undefined): string {
+  return cookieValue && allowedModelIds.has(cookieValue)
+    ? cookieValue
+    : DEFAULT_CHAT_MODEL;
+}
+
 export const modelsByProvider = chatModels.reduce(
   (acc, model) => {
     if (!acc[model.provider]) {

--- a/apps/chatbot/lib/ai/models.ts
+++ b/apps/chatbot/lib/ai/models.ts
@@ -72,6 +72,17 @@ export const chatModels: ChatModel[] = [
 export const TITLE_MODEL = "google/gemini-2.5-flash";
 export const ARTIFACT_MODEL = "anthropic/claude-haiku-4.5";
 
+// An uncapped request is billed as if it will emit the model's whole output
+// window, and OpenRouter reserves that much credit up front for Anthropic and
+// Google models. Left unset, picking one of those rejects the turn outright
+// ("requires more credits ... you requested up to 65535 tokens") however short
+// the answer would have been.
+export const MAX_OUTPUT_TOKENS = 4096;
+// Has to clear the thinking budget the chat route asks for, or the answer is
+// truncated before any of it reaches the reply.
+export const MAX_REASONING_OUTPUT_TOKENS = 12_000;
+export const MAX_TITLE_OUTPUT_TOKENS = 64;
+
 const THINKING_SUFFIX_REGEX = /-thinking$/;
 
 // "-thinking" is our own marker, not part of any OpenRouter id.

--- a/apps/chatbot/lib/ai/models.ts
+++ b/apps/chatbot/lib/ai/models.ts
@@ -136,3 +136,4 @@ export const modelsByProvider = chatModels.reduce(
   },
   {} as Record<string, ChatModel[]>
 );
+

--- a/apps/chatbot/lib/ai/models.unit.test.ts
+++ b/apps/chatbot/lib/ai/models.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  allowedModelIds,
+  ARTIFACT_MODEL,
+  baseOpenRouterId,
+  chatModels,
+  DEFAULT_CHAT_MODEL,
+  isReasoningModelId,
+  TITLE_MODEL,
+} from "./models";
+
+// apps/researcher hit this in 2026-08: getTitleModel() hardcoded
+// "google/gemini-2.0-flash-001", OpenRouter retired it, and every title call
+// 404'd. The chatbot carried the same three ids. Nothing here can tell that a
+// model was retired upstream — that needs a live call — but these assertions do
+// catch the structural cause: an id drifting away from the curated set.
+const RETIRED_IDS = [
+  "google/gemini-2.0-flash-001",
+  "anthropic/claude-3.5-haiku",
+  "anthropic/claude-3.5-sonnet",
+];
+
+describe("curated model list", () => {
+  it("points the background models at models the app also offers", () => {
+    // Titles and artifacts are generated outside the picker, so a bad id here
+    // breaks those features for everyone rather than only whoever selects it.
+    expect(allowedModelIds.has(TITLE_MODEL)).toBe(true);
+    expect(allowedModelIds.has(ARTIFACT_MODEL)).toBe(true);
+    expect(allowedModelIds.has(DEFAULT_CHAT_MODEL)).toBe(true);
+  });
+
+  it("never reintroduces a retired id", () => {
+    for (const id of RETIRED_IDS) {
+      expect(allowedModelIds.has(id)).toBe(false);
+      expect(TITLE_MODEL).not.toBe(id);
+      expect(ARTIFACT_MODEL).not.toBe(id);
+      expect(DEFAULT_CHAT_MODEL).not.toBe(id);
+    }
+  });
+
+  it("keeps entries unique and provider-qualified", () => {
+    expect(allowedModelIds.size).toBe(chatModels.length);
+    for (const model of chatModels) {
+      expect(model.id).toContain("/");
+      expect(model.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("strips the -thinking marker before a request leaves the app", () => {
+    // OpenRouter has no "-thinking" id; sending one unstripped is a 404.
+    expect(isReasoningModelId("anthropic/claude-sonnet-4.5-thinking")).toBe(true);
+    expect(isReasoningModelId("openai/gpt-4o-mini")).toBe(false);
+    expect(baseOpenRouterId("anthropic/claude-sonnet-4.5-thinking")).toBe(
+      "anthropic/claude-sonnet-4.5"
+    );
+  });
+});

--- a/apps/chatbot/lib/ai/models.unit.test.ts
+++ b/apps/chatbot/lib/ai/models.unit.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   allowedModelIds,
@@ -8,6 +8,8 @@ import {
   chatModels,
   DEFAULT_CHAT_MODEL,
   isReasoningModelId,
+  MAX_OUTPUT_TOKENS,
+  MAX_REASONING_OUTPUT_TOKENS,
   openRouterModelIds,
   resolveChatModelId,
   TITLE_MODEL,
@@ -91,4 +93,59 @@ describe("chat-model cookie resolution", () => {
       expect(source).not.toMatch(/initialChatModel=\{\w*[Cc]ookie\w*\.value\}/);
     }
   );
+});
+
+const MODEL_CALL_REGEX = /\b(streamText|streamObject|generateText|generateObject)\(/g;
+const MAX_OUTPUT_TOKENS_REGEX = /maxOutputTokens:/g;
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return sourceFiles(path);
+    }
+    if (entry.name.includes(".test.") || !/\.tsx?$/.test(extname(path))) {
+      return [];
+    }
+    return [path];
+  });
+}
+
+describe("output token caps", () => {
+  it("keeps the reasoning cap above the thinking budget the chat route asks for", () => {
+    const route = readFileSync(resolve("app/(chat)/api/chat/route.ts"), "utf8");
+    const budget = route.match(/budgetTokens:\s*([\d_]+)/);
+
+    expect(budget).not.toBeNull();
+    expect(MAX_REASONING_OUTPUT_TOKENS).toBeGreaterThan(
+      Number((budget?.[1] ?? "0").replace(/_/g, ""))
+    );
+  });
+
+  // An uncapped call is quoted against the model's whole output window, which
+  // Anthropic and Google reject for credit up front. Counting call sites rather
+  // than naming them is deliberate: the by-hand sweep that introduced the caps
+  // missed requestSuggestions, and a named list would have missed it again.
+  it("caps every model call in the app", () => {
+    const uncapped = ["app", "artifacts", "lib"]
+      .flatMap((dir) => sourceFiles(resolve(dir)))
+      .map((path) => {
+        const source = readFileSync(path, "utf8");
+        return {
+          path,
+          calls: source.match(MODEL_CALL_REGEX)?.length ?? 0,
+          caps: source.match(MAX_OUTPUT_TOKENS_REGEX)?.length ?? 0,
+        };
+      })
+      .filter((file) => file.calls > file.caps)
+      .map((file) => `${file.path} (${file.calls} calls, ${file.caps} capped)`);
+
+    expect(uncapped).toEqual([]);
+  });
+
+  it("keeps the caps small enough to be the point of having them", () => {
+    expect(MAX_OUTPUT_TOKENS).toBeLessThan(32_000);
+    expect(MAX_REASONING_OUTPUT_TOKENS).toBeLessThan(32_000);
+  });
 });

--- a/apps/chatbot/lib/ai/models.unit.test.ts
+++ b/apps/chatbot/lib/ai/models.unit.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   allowedModelIds,
@@ -7,6 +9,7 @@ import {
   DEFAULT_CHAT_MODEL,
   isReasoningModelId,
   openRouterModelIds,
+  resolveChatModelId,
   TITLE_MODEL,
 } from "./models";
 
@@ -59,4 +62,33 @@ describe("curated model list", () => {
       expect(id.endsWith("-thinking")).toBe(false);
     }
   });
+});
+
+describe("chat-model cookie resolution", () => {
+  it("keeps ids the chat API still accepts", () => {
+    for (const model of chatModels) {
+      expect(resolveChatModelId(model.id)).toBe(model.id);
+    }
+  });
+
+  it("falls back to the default for missing, empty or retired ids", () => {
+    for (const value of [...RETIRED_IDS, "not-a-model", "", "  "]) {
+      expect(resolveChatModelId(value)).toBe(DEFAULT_CHAT_MODEL);
+    }
+    expect(resolveChatModelId(undefined)).toBe(DEFAULT_CHAT_MODEL);
+  });
+
+  // Both chat pages read the cookie server-side and hand it to <Chat>, which
+  // sends it as selectedChatModel, so passing cookie.value straight through is
+  // what made a retired id reject every send. Guard the call sites too.
+  it.each([["app/(chat)/page.tsx"], ["app/(chat)/chat/[id]/page.tsx"]])(
+    "routes the cookie through the resolver in %s",
+    (page) => {
+      const source = readFileSync(resolve(page), "utf8");
+      expect(source).toMatch(
+        /resolveChatModelId\(\s*cookieStore\.get\("chat-model"\)\?\.value\s*\)/
+      );
+      expect(source).not.toMatch(/initialChatModel=\{\w*[Cc]ookie\w*\.value\}/);
+    }
+  );
 });

--- a/apps/chatbot/lib/ai/models.unit.test.ts
+++ b/apps/chatbot/lib/ai/models.unit.test.ts
@@ -6,6 +6,7 @@ import {
   chatModels,
   DEFAULT_CHAT_MODEL,
   isReasoningModelId,
+  openRouterModelIds,
   TITLE_MODEL,
 } from "./models";
 
@@ -35,6 +36,7 @@ describe("curated model list", () => {
       expect(TITLE_MODEL).not.toBe(id);
       expect(ARTIFACT_MODEL).not.toBe(id);
       expect(DEFAULT_CHAT_MODEL).not.toBe(id);
+      expect(openRouterModelIds).not.toContain(id);
     }
   });
 
@@ -53,5 +55,8 @@ describe("curated model list", () => {
     expect(baseOpenRouterId("anthropic/claude-sonnet-4.5-thinking")).toBe(
       "anthropic/claude-sonnet-4.5"
     );
+    for (const id of openRouterModelIds) {
+      expect(id.endsWith("-thinking")).toBe(false);
+    }
   });
 });

--- a/apps/chatbot/lib/ai/providers.ts
+++ b/apps/chatbot/lib/ai/providers.ts
@@ -6,8 +6,12 @@ import {
 } from "ai";
 import { withMemWal } from "@mysten-incubation/memwal/ai";
 import { isTestEnvironment } from "../constants";
-
-const THINKING_SUFFIX_REGEX = /-thinking$/;
+import {
+  ARTIFACT_MODEL,
+  baseOpenRouterId,
+  isReasoningModelId,
+  TITLE_MODEL,
+} from "./models";
 
 // OpenRouter provider (OpenAI-compatible)
 const openrouter = createOpenAI({
@@ -39,15 +43,9 @@ export function getLanguageModel(modelId: string) {
     return myProvider.languageModel(modelId);
   }
 
-  const isReasoningModel =
-    modelId.endsWith("-thinking") ||
-    (modelId.includes("reasoning") && !modelId.includes("non-reasoning"));
-
-  if (isReasoningModel) {
-    const gatewayModelId = modelId.replace(THINKING_SUFFIX_REGEX, "");
-
+  if (isReasoningModelId(modelId)) {
     return wrapLanguageModel({
-      model: openrouter.chat(gatewayModelId),
+      model: openrouter.chat(baseOpenRouterId(modelId)),
       middleware: extractReasoningMiddleware({ tagName: "thinking" }),
     });
   }
@@ -59,14 +57,14 @@ export function getTitleModel() {
   if (isTestEnvironment && myProvider) {
     return myProvider.languageModel("title-model");
   }
-  return openrouter.chat("google/gemini-2.0-flash-001");
+  return openrouter.chat(TITLE_MODEL);
 }
 
 export function getArtifactModel() {
   if (isTestEnvironment && myProvider) {
     return myProvider.languageModel("artifact-model");
   }
-  return openrouter.chat("anthropic/claude-3.5-haiku");
+  return openrouter.chat(ARTIFACT_MODEL);
 }
 
 /**

--- a/apps/chatbot/lib/ai/providers.ts
+++ b/apps/chatbot/lib/ai/providers.ts
@@ -39,8 +39,13 @@ export const myProvider = isTestEnvironment
   : null;
 
 export function getLanguageModel(modelId: string) {
+  // The mock provider registers behaviours, not catalog ids, so every real id
+  // has to land on one of its aliases — asking it for "openai/gpt-4o-mini"
+  // throws NoSuchModelError and fails the turn.
   if (isTestEnvironment && myProvider) {
-    return myProvider.languageModel(modelId);
+    return myProvider.languageModel(
+      isReasoningModelId(modelId) ? "chat-model-reasoning" : "chat-model"
+    );
   }
 
   if (isReasoningModelId(modelId)) {

--- a/apps/chatbot/lib/ai/tools/request-suggestions.ts
+++ b/apps/chatbot/lib/ai/tools/request-suggestions.ts
@@ -5,6 +5,7 @@ import { getDocumentByIdForUser, saveSuggestions } from "@/lib/db/queries";
 import type { Suggestion } from "@/lib/db/schema";
 import type { ChatMessage } from "@/lib/types";
 import { generateUUID } from "@/lib/utils";
+import { MAX_OUTPUT_TOKENS } from "../models";
 import { getArtifactModel } from "../providers";
 
 type RequestSuggestionsProps = {
@@ -63,6 +64,7 @@ export const requestSuggestions = ({
         model: getArtifactModel(),
         system:
           "You are a help writing assistant. Given a piece of writing, please offer suggestions to improve the piece of writing and describe the change. It is very important for the edits to contain full sentences instead of just words. Max 5 suggestions.",
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
         prompt: document.content,
         output: Output.array({
           element: z.object({

--- a/apps/chatbot/package.json
+++ b/apps/chatbot/package.json
@@ -20,7 +20,8 @@
     "test:e2e": "PLAYWRIGHT=True playwright test",
     "test:e2e:ui": "PLAYWRIGHT=True playwright test --ui",
     "test": "pnpm test:e2e",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "check:models": "tsx scripts/check-model-ids.ts"
   },
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.15",

--- a/apps/chatbot/playwright.config.ts
+++ b/apps/chatbot/playwright.config.ts
@@ -34,7 +34,8 @@ export default defineConfig({
     screenshot: "only-on-failure",
     actionTimeout: 10_000,
     // 30s to tolerate cold Next.js/Turbopack compile on 2-vCPU CI runners;
-    // globalSetup also warms `/` to make first-nav fast on the happy path.
+    // globalSetup also warms every route the suite reaches, so a first-nav
+    // should already be hitting a compiled route.
     navigationTimeout: 30_000,
   },
 

--- a/apps/chatbot/scripts/check-model-ids.ts
+++ b/apps/chatbot/scripts/check-model-ids.ts
@@ -1,0 +1,48 @@
+/**
+ * Verify every OpenRouter id the app can send still exists upstream.
+ *
+ * OpenRouter retires ids on its own schedule and answers a retired one with a
+ * 404 ("No endpoints found for <id>") only at request time. Nothing in the type
+ * system or the e2e suite notices, so a dead id surfaces as a generic "Oops, an
+ * error occurred!" for whoever picks it — and for the title and artifact models,
+ * which are hardcoded, it silently breaks those features for everyone.
+ *
+ * The catalog endpoint is public, so this needs no OPENROUTER_API_KEY.
+ */
+import { openRouterModelIds } from "../lib/ai/models";
+
+const CATALOG_URL = "https://openrouter.ai/api/v1/models";
+
+async function main(): Promise<void> {
+  const response = await fetch(CATALOG_URL, {
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not read the OpenRouter catalog: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const catalog = (await response.json()) as { data: { id: string }[] };
+  const live = new Set(catalog.data.map((model) => model.id));
+  const retired = openRouterModelIds.filter((id) => !live.has(id));
+
+  for (const id of openRouterModelIds) {
+    console.log(`${live.has(id) ? "ok     " : "retired"} ${id}`);
+  }
+
+  if (retired.length > 0) {
+    throw new Error(
+      `${retired.length} model id(s) no longer exist on OpenRouter: ${retired.join(", ")}. ` +
+        "Update lib/ai/models.ts — requests using these ids fail with a 404."
+    );
+  }
+
+  console.log(`\nAll ${openRouterModelIds.length} model ids are live.`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/apps/chatbot/tests/playwright/e2e/conversation.test.ts
+++ b/apps/chatbot/tests/playwright/e2e/conversation.test.ts
@@ -93,6 +93,26 @@ test.describe("Conversation", () => {
     });
   });
 
+  test("creates a text artifact through the retired-id-safe artifact model", async ({
+    page,
+  }) => {
+    // ARTIFACT_MODEL used to be a retired OpenRouter id, so createDocument
+    // 404'd before any panel opened. The mock emits the same tool call the
+    // chat model would, then the artifact model fills the document.
+    await page.goto("/");
+    await page
+      .getByTestId("multimodal-input")
+      .fill("Create a document about Silicon Valley");
+    await page.getByTestId("send-button").click();
+
+    const preview = page.getByTestId("document-preview");
+    await expect(preview).toBeVisible({ timeout: 20_000 });
+    await expect(preview).toContainText("Test Artifact");
+
+    await preview.click();
+    await expect(page.getByTestId("artifact")).toBeVisible();
+  });
+
   test("recovers when the chat-model cookie holds a retired id", async ({
     page,
     context,

--- a/apps/chatbot/tests/playwright/e2e/conversation.test.ts
+++ b/apps/chatbot/tests/playwright/e2e/conversation.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+
+// The mock provider answers a greeting with "Hello! How can I help you today?",
+// a weather question with a fixed forecast, and anything else with "This is a
+// mock response for testing." (lib/ai/models.mock.ts).
+const MOCK_GREETING = /How can I help you today/i;
+const MOCK_DEFAULT = /mock response for testing/i;
+const MOCK_WEATHER = /sunny and 72/i;
+const MODEL_BUTTON_REGEX = /Gemini|Claude|GPT|Grok/i;
+
+test.describe("Conversation", () => {
+  test("streams an assistant reply back into the thread", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("multimodal-input").fill("Hello there");
+    await page.getByTestId("send-button").click();
+
+    const assistantMessage = page
+      .locator('[data-role="assistant"]')
+      .getByTestId("message-content")
+      .first();
+
+    await expect(assistantMessage).toContainText(MOCK_GREETING, {
+      timeout: 20_000,
+    });
+  });
+
+  test("keeps the reply after reloading the chat", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("multimodal-input").fill("Tell me something");
+    await page.getByTestId("send-button").click();
+
+    const assistantMessage = page
+      .locator('[data-role="assistant"]')
+      .getByTestId("message-content")
+      .first();
+    await expect(assistantMessage).toContainText(MOCK_DEFAULT, {
+      timeout: 20_000,
+    });
+
+    // Sending redirects `/` to /chat/<id>; both the user turn and the assistant
+    // turn have to come back from the database on a cold load.
+    await expect(page).toHaveURL(/\/chat\/[0-9a-f-]{36}/, { timeout: 20_000 });
+    await page.reload();
+
+    await expect(page.getByTestId("message-content").first()).toContainText(
+      "Tell me something"
+    );
+    await expect(
+      page.locator('[data-role="assistant"]').getByTestId("message-content").first()
+    ).toContainText(MOCK_DEFAULT);
+  });
+
+  test("routes the question to the model instead of a fixed reply", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page
+      .getByTestId("multimodal-input")
+      .fill("What is the weather in San Francisco?");
+    await page.getByTestId("send-button").click();
+
+    await expect(
+      page.locator('[data-role="assistant"]').getByTestId("message-content").first()
+    ).toContainText(MOCK_WEATHER, { timeout: 20_000 });
+  });
+
+  test("titles the chat in the sidebar", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("multimodal-input").fill("Hello there");
+    await page.getByTestId("send-button").click();
+
+    // The title comes from its own model call, separate from the reply. When
+    // that model id was retired upstream every chat stayed named "New chat".
+    await expect(
+      page.getByRole("link", { name: /Test Conversation/i })
+    ).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("streams reasoning for a thinking model", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .locator("button")
+      .filter({ hasText: MODEL_BUTTON_REGEX })
+      .first()
+      .click();
+    await page.getByText(/Claude Sonnet [\d.]+ \(Thinking\)/i).first().click();
+
+    await page.getByTestId("multimodal-input").fill("Solve this puzzle");
+    await page.getByTestId("send-button").click();
+
+    await expect(page.getByTestId("message-reasoning").first()).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+
+  test("recovers when the chat-model cookie holds a retired id", async ({
+    page,
+    context,
+  }) => {
+    // Ids leave chatModels whenever OpenRouter retires a model, but a returning
+    // reader still carries the old one. Passing it through made /api/chat reject
+    // every send as a bad request while the picker showed a valid model.
+    await context.addCookies([
+      {
+        name: "chat-model",
+        value: "anthropic/claude-3.5-sonnet",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+
+    await page.goto("/");
+    await page.getByTestId("multimodal-input").fill("Hello there");
+    await page.getByTestId("send-button").click();
+
+    await expect(
+      page.locator('[data-role="assistant"]').getByTestId("message-content").first()
+    ).toContainText(MOCK_GREETING, { timeout: 20_000 });
+  });
+});

--- a/apps/chatbot/tests/playwright/global-setup.ts
+++ b/apps/chatbot/tests/playwright/global-setup.ts
@@ -115,6 +115,7 @@ async function warmRoutes(): Promise<void> {
     ["/register"],
     ["/api/history?limit=1"],
     ["/api/chat", { method: "POST", body: "{}" }],
+    [`/api/document?id=${randomUUID()}`],
     [`/chat/${randomUUID()}`],
   ];
 

--- a/apps/chatbot/tests/playwright/global-setup.ts
+++ b/apps/chatbot/tests/playwright/global-setup.ts
@@ -58,15 +58,13 @@ function storeCookies(response: Response): void {
  * nothing. Redirects are followed as GET, matching how the proxy sends a
  * would-be POST through the guest handshake first.
  */
-async function fetchFollowing(url: string): Promise<Response> {
+async function fetchFollowing(
+  url: string,
+  init: { method?: string; body?: string } = {}
+): Promise<Response> {
   let target = url;
-  let method = "GET";
-  let body: string | undefined;
-
-  if (url.includes("/api/chat")) {
-    method = "POST";
-    body = "{}";
-  }
+  let method = init.method ?? "GET";
+  let body = init.body;
 
   for (let hop = 0; hop < 5; hop++) {
     const response: Response = await fetch(target, {
@@ -111,19 +109,19 @@ async function fetchFollowing(url: string): Promise<Response> {
 async function warmRoutes(): Promise<void> {
   const port = process.env.PORT ?? "3001";
   const base = `http://localhost:${port}`;
-  const paths = [
-    "/",
-    "/login",
-    "/register",
-    "/api/history?limit=1",
-    "/api/chat",
-    `/chat/${randomUUID()}`,
+  const routes: [string, { method?: string; body?: string }?][] = [
+    ["/"],
+    ["/login"],
+    ["/register"],
+    ["/api/history?limit=1"],
+    ["/api/chat", { method: "POST", body: "{}" }],
+    [`/chat/${randomUUID()}`],
   ];
 
-  for (const path of paths) {
+  for (const [path, init] of routes) {
     const started = Date.now();
     try {
-      const response = await fetchFollowing(`${base}${path}`);
+      const response = await fetchFollowing(`${base}${path}`, init);
       console.log(
         `[playwright] Warmed ${path} in ${Date.now() - started}ms (status ${response.status})`
       );

--- a/apps/chatbot/tests/playwright/global-setup.ts
+++ b/apps/chatbot/tests/playwright/global-setup.ts
@@ -4,11 +4,11 @@
  * Runs once before any test (after the webServer is spawned). Responsible for:
  *   1. Applying Drizzle migrations so chat/user tables exist.
  *   2. Failing fast with a clear error if POSTGRES_URL is missing in CI.
- *   3. Warming the `/` route so the first `page.goto("/")` in the suite
- *      doesn't race Turbopack's lazy cold compile against the 15s
- *      navigationTimeout on CI runners.
+ *   3. Warming the routes the suite exercises so no test races Turbopack's lazy
+ *      cold compile against the navigationTimeout on CI runners.
  */
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 
 export default async function globalSetup(): Promise<void> {
   const url = process.env.POSTGRES_URL;
@@ -33,23 +33,102 @@ export default async function globalSetup(): Promise<void> {
     throw new Error(`[playwright] Migration failed with exit code ${result.status}`);
   }
 
-  // Prime Next.js/Turbopack's per-route compile cache for `/`. On a cold
-  // CI runner the first `page.goto("/")` can take 15-30s (the route is
-  // compiled lazily on first hit), which exceeds the default 15s
-  // navigationTimeout and flakes tests until retries kick in. Fetching
-  // here moves the cost to setup time so the first real test navigation
-  // hits a warm cache.
-  const port = process.env.PORT ?? "3001";
-  const target = `http://localhost:${port}/`;
-  console.log(`[playwright] Warming ${target} ...`);
-  try {
-    const started = Date.now();
-    const res = await fetch(target, {
-      redirect: "manual", // `/` may 307 to /api/auth/guest; we just want the compile
-      signal: AbortSignal.timeout(60_000),
+  await warmRoutes();
+}
+
+const jar = new Map<string, string>();
+
+function storeCookies(response: Response): void {
+  for (const header of response.headers.getSetCookie()) {
+    const [pair] = header.split(";");
+    const separator = pair.indexOf("=");
+
+    if (separator > 0) {
+      jar.set(pair.slice(0, separator).trim(), pair.slice(separator + 1).trim());
+    }
+  }
+}
+
+/**
+ * Fetch a route the way a browser reaches it: following redirects and keeping
+ * the cookies they set.
+ *
+ * Unauthenticated requests are bounced to /api/auth/guest by the proxy, so a
+ * single non-following request never renders the route it names and compiles
+ * nothing. Redirects are followed as GET, matching how the proxy sends a
+ * would-be POST through the guest handshake first.
+ */
+async function fetchFollowing(url: string): Promise<Response> {
+  let target = url;
+  let method = "GET";
+  let body: string | undefined;
+
+  if (url.includes("/api/chat")) {
+    method = "POST";
+    body = "{}";
+  }
+
+  for (let hop = 0; hop < 5; hop++) {
+    const response: Response = await fetch(target, {
+      method,
+      body,
+      headers: jar.size > 0 ? { cookie: [...jar].map(([k, v]) => `${k}=${v}`).join("; ") } : {},
+      redirect: "manual",
+      // Matches the webServer budget. A 2-vCPU runner compiles slower than a
+      // dev laptop, where `/` alone took 39s from a cleared .next.
+      signal: AbortSignal.timeout(120_000),
     });
-    console.log(`[playwright] Warm-up done in ${Date.now() - started}ms (status ${res.status})`);
-  } catch (err) {
-    console.warn("[playwright] Warm-up failed, continuing:", err);
+
+    storeCookies(response);
+    const location = response.headers.get("location");
+
+    if (response.status < 300 || response.status >= 400 || !location) {
+      return response;
+    }
+
+    target = new URL(location, target).toString();
+    method = "GET";
+    body = undefined;
+  }
+
+  throw new Error(`Too many redirects while warming ${url}`);
+}
+
+/**
+ * Prime Turbopack's per-route compile cache before the first test runs.
+ *
+ * Routes compile lazily on first hit, and on a cold cache that first hit costs
+ * seconds to tens of seconds. Warming `/` alone was not enough: sending a
+ * message still paid for `/api/chat` and `/chat/[id]` mid-test, overrunning both
+ * the 30s navigationTimeout and the 60s test timeout. Retries hid it, since by
+ * the second attempt the routes were warm.
+ *
+ * Each request is shaped to compile its route without writing anything: an
+ * unparseable chat body is rejected before it reaches the database, and a random
+ * chat id belongs to nobody. Failures are not fatal — a slow first test beats a
+ * suite that cannot start.
+ */
+async function warmRoutes(): Promise<void> {
+  const port = process.env.PORT ?? "3001";
+  const base = `http://localhost:${port}`;
+  const paths = [
+    "/",
+    "/login",
+    "/register",
+    "/api/history?limit=1",
+    "/api/chat",
+    `/chat/${randomUUID()}`,
+  ];
+
+  for (const path of paths) {
+    const started = Date.now();
+    try {
+      const response = await fetchFollowing(`${base}${path}`);
+      console.log(
+        `[playwright] Warmed ${path} in ${Date.now() - started}ms (status ${response.status})`
+      );
+    } catch (err) {
+      console.warn(`[playwright] Warming ${path} failed, continuing:`, err);
+    }
   }
 }


### PR DESCRIPTION
Closes WALM-354.

## Summary

Restores chat, titles and artifacts after OpenRouter retired four of the seven curated model ids. Replaces those ids, caps `maxOutputTokens` on every model call, resolves a stale `chat-model` cookie to the default instead of forwarding it to `/api/chat`, and points the Playwright mock at the ids the app actually sends. Adds six conversation e2e tests, a guard that counts model calls against capped calls, and a weekly workflow checking the curated ids still exist upstream.

## Problem

### Four of the seven curated model ids no longer exist

OpenRouter answers a retired id with a 404 at request time, so picking one produced only "Oops, an error occurred!". Two were also hardcoded at their call sites: `getTitleModel` used `google/gemini-2.0-flash-001`, so every chat stayed named "New chat", and `getArtifactModel` used `anthropic/claude-3.5-haiku`, so document creation broke for everyone rather than only whoever picked it.

### No call site capped the output tokens

Every request was quoted against the model's whole output window. OpenRouter reserves that credit up front for Anthropic and Google, and rejected those turns with "requires more credits, you requested up to 65535 tokens" however short the answer would have been. OpenAI and DeepSeek do not reserve, which is why only part of the picker looked broken.

The by-hand sweep that added the caps then missed `requestSuggestions`, which streams through `getArtifactModel` from `lib/ai/tools` rather than beside the artifact handlers. That call is capped here too, and the guard below counts call sites instead of naming them so the next one cannot slip through the same way.

### A stale cookie rejected every send

Both chat pages forwarded `chat-model` verbatim, and `/api/chat` rejects an id missing from `chatModels`. Anyone holding a since-retired selection had every send fail as a 400, with nothing to explain it: the picker's fallback is display-only, so it rendered a valid model name while the request body still carried the dead id.

### The mock provider could not answer a real model id

Under `PLAYWRIGHT`, `getLanguageModel` passed catalog ids to a provider that registers behaviours rather than ids, so every turn threw `NoSuchModelError`. The suite stayed green because no test asserted that a reply arrives. The mock also matched keywords across the whole serialised prompt, where the system prompt contains "hi" inside "this", so it always answered with the greeting.

### The Playwright warm-up compiled nothing

`global-setup.ts` fetched with `redirect: "manual"`, so the proxy's guest redirect ended each request in under 60ms without rendering the route it named. Tests then paid the compile themselves: from a cleared `.next`, 4 to 14 of them failed on first-hit navigations of 40s to 1.3m against a 30s navigation timeout. CI never reported it because by the second of its two retries the routes were warm.

## CI

- `Chatbot / Playwright E2E` already existed on `dev`, so no new e2e job was needed. It now runs the conversation tests (including createDocument artifacts), confirmed in this PR's job log rather than only locally
- `Model ids live on OpenRouter` is new, in `.github/workflows/check-model-ids.yml`, running weekly and on pull requests that touch the curated list
- it gets its own workflow because the failure it catches arrives with no commit attached, and `test.yml` has no schedule trigger to hang a weekly run off
- the catalog endpoint is public, so it needs no key and no environment, and the paths filter keeps unrelated pull requests from taking a network dependency on OpenRouter
- `Chatbot / Lint + Build` picks up the new unit tests, including the guard that counts model calls against capped calls
- the lint step in that job is `continue-on-error: true` on `dev`, because `ultracite` passes a flag the bundled biome rejects, so it is not a gate for this branch either
- the warm-up fix matters most in CI: with two retries configured, a cold runner was passing on the second attempt rather than the first, so the failures were absorbed rather than reported

## Verification

- [x] `test:unit`: 26 pass, covering the retired ids, the `-thinking` strip, cookie resolution, both page call sites, and every capped model call
- [x] the cap guard fails as intended: removing the `requestSuggestions` cap turns it red, restoring it turns it green
- [x] `test:e2e` from a cleared `.next`: 29 pass, 1 skipped, including a new createDocument artifact test. The same cleared-cache run failed 4 to 14 before the warm-up fix
- [x] `check:models`: all 6 ids live on the public catalog
- [x] `next build` in `apps/chatbot`: clean
- [x] CI on this PR: Chatbot Lint + Build, Chatbot Playwright E2E and Model ids live on OpenRouter all pass

## Out of scope

- e2e always runs against the mock provider, so CI never calls OpenRouter. A live smoke test would need a key and a spend decision
- `saveMemory` and the MemWal path have no CI coverage, which needs a relayer and credentials
- whether `providerOptions.anthropic.thinking` is applied through OpenRouter's OpenAI-compatible endpoint is unverified, so reasoning may not behave as designed even though it streams
