### PR TITLE
fix(chatbot): scope getSuggestions to the calling user (WALM-438)

### DIFF
--- a/apps/chatbot/app/(chat)/api/suggestions/route.ts
+++ b/apps/chatbot/app/(chat)/api/suggestions/route.ts
@@ -1,5 +1,5 @@
 import { auth } from "@/app/(auth)/auth";
-import { getSuggestionsByDocumentId } from "@/lib/db/queries";
+import { getSuggestionsByDocumentIdForUser } from "@/lib/db/queries";
 import { ChatbotError } from "@/lib/errors";
 
 export async function GET(request: Request) {
@@ -14,22 +14,20 @@ export async function GET(request: Request) {
   }
 
   const session = await auth();
+  const userId = session?.user?.id;
 
-  if (!session?.user) {
+  if (!userId) {
     return new ChatbotError("unauthorized:suggestions").toResponse();
   }
 
-  const suggestions = await getSuggestionsByDocumentId({
+  const suggestions = await getSuggestionsByDocumentIdForUser({
     documentId,
+    userId,
   });
 
-  const [suggestion] = suggestions;
-
-  if (!suggestion) {
-    return Response.json([], { status: 200 });
-  }
-
-  if (suggestion.userId !== session.user.id) {
+  // Owner-scoped lookup already dropped other users' rows. Re-assert so a
+  // future query refactor cannot leak suggestion text through this route.
+  if (suggestions.some((suggestion) => suggestion.userId !== userId)) {
     return new ChatbotError("forbidden:api").toResponse();
   }
 

--- a/apps/chatbot/artifacts/actions.ts
+++ b/apps/chatbot/artifacts/actions.ts
@@ -1,8 +1,23 @@
 "use server";
 
-import { getSuggestionsByDocumentId } from "@/lib/db/queries";
+import { auth } from "@/app/(auth)/auth";
+import { getSuggestionsByDocumentIdForUser } from "@/lib/db/queries";
 
 export async function getSuggestions({ documentId }: { documentId: string }) {
-  const suggestions = await getSuggestionsByDocumentId({ documentId });
-  return suggestions ?? [];
+  const session = await auth();
+  const userId = session?.user?.id;
+  // No authenticated user id → same empty shape as a missing document, so
+  // existence of another user's suggestions is not disclosed.
+  if (!userId) {
+    return [];
+  }
+
+  const suggestions = await getSuggestionsByDocumentIdForUser({
+    documentId,
+    userId,
+  });
+  // Defense in depth: even though the lookup is owner-scoped, drop any row
+  // that somehow isn't the caller's so a future query refactor cannot
+  // silently reopen the IDOR.
+  return (suggestions ?? []).filter((row) => row.userId === userId);
 }

--- a/apps/chatbot/artifacts/get-suggestions-ownership.unit.test.ts
+++ b/apps/chatbot/artifacts/get-suggestions-ownership.unit.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression test for the getSuggestions IDOR (WALM-438 / GH #786).
+// The server action used to call an unscoped by-documentId lookup with no
+// session check, so guest B could read guest A's suggestion text. The HTTP
+// route already rejected that; the action did not.
+//
+// Two layers, both proven here:
+//   1. Auth guard — no session / no user id returns [] and never queries.
+//   2. Call-site re-check — even if the DB layer returns a victim row, the
+//      action strips it so existence/text is not disclosed.
+
+const OWNER_ID = "11111111-1111-1111-1111-111111111111";
+const ATTACKER_ID = "22222222-2222-2222-2222-222222222222";
+const DOC_ID = "33333333-3333-3333-3333-333333333333";
+
+const ownerRow = {
+  documentId: DOC_ID,
+  originalText: "secret draft paragraph",
+  suggestedText: "rewritten secret draft",
+  userId: OWNER_ID,
+};
+
+const auth = vi.fn();
+const getSuggestionsByDocumentIdForUser = vi.fn();
+
+vi.mock("@/app/(auth)/auth", () => ({ auth }));
+vi.mock("@/lib/db/queries", () => ({
+  getSuggestionsByDocumentIdForUser,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSuggestionsByDocumentIdForUser.mockResolvedValue([]);
+});
+
+describe("getSuggestions ownership", () => {
+  it("returns [] and does not query when there is no session", async () => {
+    auth.mockResolvedValue(null);
+    const { getSuggestions } = await import("./actions");
+
+    await expect(getSuggestions({ documentId: DOC_ID })).resolves.toEqual([]);
+    expect(getSuggestionsByDocumentIdForUser).not.toHaveBeenCalled();
+  });
+
+  it("returns [] and does not query when the session has no user id", async () => {
+    auth.mockResolvedValue({ user: {}, expires: "" });
+    const { getSuggestions } = await import("./actions");
+
+    await expect(getSuggestions({ documentId: DOC_ID })).resolves.toEqual([]);
+    expect(getSuggestionsByDocumentIdForUser).not.toHaveBeenCalled();
+  });
+
+  it("returns the caller's rows", async () => {
+    auth.mockResolvedValue({ user: { id: OWNER_ID }, expires: "" });
+    getSuggestionsByDocumentIdForUser.mockResolvedValue([ownerRow]);
+    const { getSuggestions } = await import("./actions");
+
+    await expect(getSuggestions({ documentId: DOC_ID })).resolves.toEqual([
+      ownerRow,
+    ]);
+    expect(getSuggestionsByDocumentIdForUser).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      userId: OWNER_ID,
+    });
+  });
+
+  it("does not return another user's suggestion text even if the query leaks it", async () => {
+    auth.mockResolvedValue({ user: { id: ATTACKER_ID }, expires: "" });
+    getSuggestionsByDocumentIdForUser.mockResolvedValue([ownerRow]);
+    const { getSuggestions } = await import("./actions");
+
+    await expect(getSuggestions({ documentId: DOC_ID })).resolves.toEqual([]);
+    expect(getSuggestionsByDocumentIdForUser).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      userId: ATTACKER_ID,
+    });
+  });
+});

--- a/apps/chatbot/lib/db/queries.ts
+++ b/apps/chatbot/lib/db/queries.ts
@@ -443,16 +443,26 @@ export async function saveSuggestions({
   }
 }
 
-export async function getSuggestionsByDocumentId({
+// Owner-scoped lookup: filters on both documentId AND userId so a caller can
+// never resolve another user's suggestion text. An unscoped by-documentId
+// lookup was the footgun behind the getSuggestions IDOR (WALM-438 / GH #786).
+export async function getSuggestionsByDocumentIdForUser({
   documentId,
+  userId,
 }: {
   documentId: string;
+  userId: string;
 }) {
   try {
     return await db
       .select()
       .from(suggestion)
-      .where(eq(suggestion.documentId, documentId));
+      .where(
+        and(
+          eq(suggestion.documentId, documentId),
+          eq(suggestion.userId, userId)
+        )
+      );
   } catch (_error) {
     throw new ChatbotError(
       "bad_request:database",

--- a/apps/chatbot/lib/db/suggestion-query-scope.unit.test.ts
+++ b/apps/chatbot/lib/db/suggestion-query-scope.unit.test.ts
@@ -1,0 +1,54 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression test for the DB-layer owner scoping of
+// getSuggestionsByDocumentIdForUser (WALM-438 / GH #786).
+//
+// The action-level suite mocks the query module, so it never executes the
+// real SQL. This suite runs the REAL query body against a mocked drizzle
+// builder, captures the WHERE clause, and asserts it filters on BOTH
+// documentId AND userId. Dropping the userId predicate reopens the IDOR.
+
+const DOC_VAL = "44444444-4444-4444-4444-444444444444";
+const USER_VAL = "55555555-5555-5555-5555-555555555555";
+
+let capturedWhere: unknown;
+
+const where = vi.fn((clause: unknown) => {
+  capturedWhere = clause;
+  return Promise.resolve([]);
+});
+const from = vi.fn(() => ({ where }));
+const select = vi.fn(() => ({ from }));
+
+vi.mock("server-only", () => ({}));
+vi.mock("postgres", () => ({ default: () => ({}) }));
+vi.mock("drizzle-orm/postgres-js", () => ({
+  drizzle: () => ({ select }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedWhere = undefined;
+});
+
+describe("getSuggestionsByDocumentIdForUser DB-layer scoping", () => {
+  it("filters on both documentId and the owner userId", async () => {
+    const { getSuggestionsByDocumentIdForUser } = await import("./queries");
+
+    await getSuggestionsByDocumentIdForUser({
+      documentId: DOC_VAL,
+      userId: USER_VAL,
+    });
+
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(capturedWhere).toBeDefined();
+
+    const { sql, params } = new PgDialect().sqlToQuery(capturedWhere as never);
+
+    expect(sql).toMatch(/"documentId"/);
+    expect(sql).toMatch(/"userId"/);
+    expect(params).toContain(DOC_VAL);
+    expect(params).toContain(USER_VAL);
+  });
+});


### PR DESCRIPTION
## Summary
- `getSuggestions` server action queried suggestions by `documentId` with no session check. Guest B could read guest A's suggestion text.
- The HTTP route already rejected that; the action did not.
- Same class as WALM-309: owner-scoped DB lookup (`documentId` AND `userId`) plus a call-site filter. Unscoped by-documentId lookup is removed.
- Example chatbot only — not the relayer.

Fixes WALM-438 / GH #786.

## Test plan
- [x] `pnpm --filter @memwal/chatbot test:unit` (ownership + SQL-scope suites)
