### PR TITLE
fix(server): reject control characters in recall namespace with 400 (WALM-439)

### DIFF
--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -291,6 +291,7 @@ pub async fn ask(
     if body.question.is_empty() {
         return Err(AppError::BadRequest("Question cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     // Validate scoring_weights up front — fail fast on malformed input
     // before we burn an embed + vector search + Walrus + SEAL round-trip.

--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -157,6 +157,7 @@ pub async fn recall(
     if body.query.trim().is_empty() {
         return Err(AppError::BadRequest("Query cannot be empty".into()));
     }
+    validate_namespace(&body.namespace)?;
 
     // Validate scoring_weights up front — fail fast on malformed input
     // (NaN, out-of-range, sub-floor half-life) BEFORE we spend an embed +
@@ -326,6 +327,7 @@ pub async fn recall_manual(
     // opaque 500; reject it here with an actionable 400. (No upload/gas on this
     // read path, unlike remember_manual — this is purely a clearer-error improvement.)
     validate_embedding_vector(&body.vector)?;
+    validate_namespace(&body.namespace)?;
 
     // Validate scoring_weights up front (NaN / out-of-range / sub-floor
     // half-life) before the vector search, mirroring `recall`. Previously

--- a/services/server/src/routes/remember.rs
+++ b/services/server/src/routes/remember.rs
@@ -1268,18 +1268,16 @@ pub async fn remember_bulk(
                 i, MAX_REMEMBER_TEXT_BYTES
             )));
         }
-        if item.namespace.is_empty() {
-            return Err(AppError::BadRequest(format!(
-                "items[{}].namespace cannot be empty",
-                i
-            )));
-        }
-        if item.namespace.len() > MAX_NAMESPACE_BYTES {
-            return Err(AppError::BadRequest(format!(
-                "items[{}].namespace exceeds maximum length of {} bytes",
-                i, MAX_NAMESPACE_BYTES
-            )));
-        }
+        // Delegate to the shared validator rather than re-checking empty and
+        // length inline, so bulk inherits every namespace rule the single-item
+        // paths enforce (notably the NUL rejection — a `\0` bound into the
+        // `remember_jobs` insert below is an opaque 500). Its messages all
+        // start with "namespace ", so prefixing with the item index reproduces
+        // the previous `items[{i}].namespace ...` wording verbatim.
+        validate_namespace(&item.namespace).map_err(|e| match e {
+            AppError::BadRequest(msg) => AppError::BadRequest(format!("items[{}].{}", i, msg)),
+            other => other,
+        })?;
     }
 
     let owner = &auth.owner;

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1293,6 +1293,14 @@ pub fn validate_namespace(namespace: &str) -> Result<(), AppError> {
             MAX_NAMESPACE_BYTES
         )));
     }
+    // NUL (and other control chars) must not reach PostgreSQL: a `\0` in a
+    // text bind makes libpq/pg reject the query as an opaque 500. Reject here
+    // so recall/ask match remember and return HTTP 400 (WALM-439 / GH #787).
+    if namespace.chars().any(char::is_control) {
+        return Err(AppError::BadRequest(
+            "namespace contains invalid control characters".into(),
+        ));
+    }
     Ok(())
 }
 
@@ -3075,6 +3083,14 @@ mod tests {
         assert!(validate_namespace(&"n".repeat(MAX_NAMESPACE_BYTES)).is_ok());
         assert!(validate_namespace("").is_err());
         assert!(validate_namespace(&"n".repeat(MAX_NAMESPACE_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn namespace_validation_rejects_nul_and_other_control_characters() {
+        assert!(validate_namespace("default\0evil").is_err());
+        assert!(validate_namespace("has\nnewline").is_err());
+        assert!(validate_namespace("has\ttab").is_err());
+        assert!(validate_namespace("normal-ns_01").is_ok());
     }
 
     // ── HealthResponse.prompt_versions wire shape ────────────────

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1283,6 +1283,14 @@ fn default_namespace() -> String {
     "default".to_string()
 }
 
+/// Shared namespace validation for every request that carries a namespace.
+///
+/// API-compatibility note: this rejects the empty string, and the read paths
+/// (`recall`, `recall_manual`, `ask`) call it, so an explicit
+/// `"namespace": ""` returns HTTP 400 where it previously returned HTTP 200
+/// with an empty result set. That matches the write paths, but it is
+/// client-visible: a caller that sends `""` to mean "unset" must omit the
+/// field instead and let `default_namespace` apply.
 pub fn validate_namespace(namespace: &str) -> Result<(), AppError> {
     if namespace.is_empty() {
         return Err(AppError::BadRequest("namespace cannot be empty".into()));
@@ -1293,12 +1301,18 @@ pub fn validate_namespace(namespace: &str) -> Result<(), AppError> {
             MAX_NAMESPACE_BYTES
         )));
     }
-    // NUL (and other control chars) must not reach PostgreSQL: a `\0` in a
-    // text bind makes libpq/pg reject the query as an opaque 500. Reject here
-    // so recall/ask match remember and return HTTP 400 (WALM-439 / GH #787).
-    if namespace.chars().any(char::is_control) {
+    // NUL must not reach PostgreSQL: a `\0` in a text bind makes libpq/pg
+    // reject the query as an opaque 500. Reject here so recall/ask match
+    // remember and return HTTP 400 (WALM-439 / GH #787).
+    //
+    // Deliberately NUL-only, not every Unicode Cc character: `\t`, `\n`, `\r`,
+    // DEL and C1 are all valid Postgres `text` and stored fine before this
+    // check existed. Because this validator also guards the read and delete
+    // paths, rejecting them here would strand any namespace already written
+    // with one — unreadable via recall/ask/stats and undeletable via forget.
+    if namespace.contains('\0') {
         return Err(AppError::BadRequest(
-            "namespace contains invalid control characters".into(),
+            "namespace contains a NUL byte".into(),
         ));
     }
     Ok(())
@@ -3086,11 +3100,14 @@ mod tests {
     }
 
     #[test]
-    fn namespace_validation_rejects_nul_and_other_control_characters() {
+    fn namespace_validation_rejects_nul_bytes() {
         assert!(validate_namespace("default\0evil").is_err());
-        assert!(validate_namespace("has\nnewline").is_err());
-        assert!(validate_namespace("has\ttab").is_err());
         assert!(validate_namespace("normal-ns_01").is_ok());
+        // Other control characters stay accepted: Postgres stores them without
+        // complaint, and this validator also gates recall/ask/stats/forget, so
+        // rejecting them would strand namespaces written before the NUL check.
+        assert!(validate_namespace("has\nnewline").is_ok());
+        assert!(validate_namespace("has\ttab").is_ok());
     }
 
     // ── HealthResponse.prompt_versions wire shape ────────────────


### PR DESCRIPTION
## Summary
- `validate_namespace` only checked empty / over-length. Write paths called it; `recall`, `recall_manual`, and `ask` did not.
- A NUL in `namespace` reached PostgreSQL and returned HTTP 500.
- NUL is now rejected in the shared validator, and the three read paths call it before touching the DB.
- `remember_bulk` hand-rolled its own empty/length checks, so it did not inherit the new rejection — it now delegates to `validate_namespace` too, keeping its `items[{i}].namespace ...` error wording unchanged.

Fixes WALM-439 / GH #787.

## Behavior change — `"namespace": ""` on read paths now returns 400

Because `validate_namespace` also rejects the empty string, wiring it into the read paths changes the response for an **explicitly empty** namespace:

| Request | Before | After |
| --- | --- | --- |
| `POST /api/recall` with `"namespace": ""` | 200, empty result set | **400** `namespace cannot be empty` |
| `namespace` field omitted | 200 (`default` namespace) | 200 (`default` namespace) — unchanged |

This matches what `remember` / `forget` / `stats` have always done, and no in-repo caller or SDK sends `"namespace": ""`, so nothing in this repo is affected. But it is client-visible: a deployed client or UI that sends an empty string to mean "unset" will start getting a 400 instead of degrading to no results. Such callers should **omit the field** and let the `default_namespace` serde default apply.

## Why NUL-only rather than all control characters

An earlier revision rejected every Unicode `Cc` character. That was reverted to a NUL-only check: `\t`, `\n`, `\r`, DEL and C1 are all valid Postgres `text` and were accepted by the write path before this check existed. Since the same validator now also gates the read and delete paths, rejecting them would strand any namespace already written with one — unreadable via `recall`/`ask`/`stats` and undeletable via `forget` (only the blob-level security-delete flow, which takes no namespace, would still reach it). The issue's acceptance criteria only require NUL.

## Test plan
- [x] `cargo test --bin memwal-server namespace_validation`
