### PR TITLE
fix(sdk): use typed tx.pure helpers in account and manual PTBs (WALM-442)

### DIFF
--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,12 +28,12 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures, and stops telling headless SDK clients to call `memwal_login` on empty-body 401s.
+This release adds `failed` on `restore()` results, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
 
 ### Added
 
@@ -42,6 +42,7 @@ This release adds `failed` on `restore()` results for permanent decrypt and UTF-
 ### Fixed
 
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
+- `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
 
 ## 0.1.6
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
+- `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
 
 ## 0.1.6
 

--- a/packages/sdk/src/account.ts
+++ b/packages/sdk/src/account.ts
@@ -287,8 +287,8 @@ export async function addDelegateKey(
         arguments: [
             tx.object(opts.accountId),
             tx.object(opts.registryId),
-            tx.pure("vector<u8>", Array.from(pkBytes)),
-            tx.pure("string", opts.label),
+            tx.pure.vector("u8", Array.from(pkBytes)),
+            tx.pure.string(opts.label),
             tx.object(SUI_CLOCK),
         ],
     });
@@ -338,7 +338,7 @@ export async function removeDelegateKey(
         arguments: [
             tx.object(opts.accountId),
             tx.object(opts.registryId),
-            tx.pure("vector<u8>", Array.from(pkBytes)),
+            tx.pure.vector("u8", Array.from(pkBytes)),
         ],
     });
 

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -505,7 +505,7 @@ export class MemWalManual {
                 tx.moveCall({
                     target: `${this.config.sealPolicyPackageId ?? this.config.packageId}::account::seal_approve`,
                     arguments: [
-                        tx.pure("vector<u8>", idBytes),
+                        tx.pure.vector("u8", idBytes),
                         tx.object(this.config.registryId),
                         tx.object(this.config.accountId),
                     ],

--- a/packages/sdk/test/typed-pure-args.test.mjs
+++ b/packages/sdk/test/typed-pure-args.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// WALM-442 / GH #799: account.ts and manual.ts used the legacy two-arg
+// `tx.pure("vector<u8>", …)` form. Modern `@mysten/sui` documents the typed
+// helpers (`tx.pure.vector("u8", …)`, `tx.pure.string(…)`). Pin the call
+// sites so the legacy form cannot land again.
+
+const FILES = ["account.ts", "manual.ts"];
+
+test("account.ts and manual.ts use typed tx.pure helpers, not legacy two-arg form", () => {
+    for (const file of FILES) {
+        const src = readFileSync(new URL(`../src/${file}`, import.meta.url), "utf8");
+        assert.equal(
+            src.includes('tx.pure("'),
+            false,
+            `${file} still contains legacy tx.pure("type", value)`,
+        );
+        assert.equal(
+            src.includes("tx.pure('"),
+            false,
+            `${file} still contains legacy tx.pure('type', value)`,
+        );
+        assert.match(
+            src,
+            /tx\.pure\.vector\(\s*["']u8["']/,
+            `${file} must pass vector<u8> via tx.pure.vector`,
+        );
+    }
+});
+
+test("addDelegateKey / removeDelegateKey labels use tx.pure.string", () => {
+    const src = readFileSync(new URL("../src/account.ts", import.meta.url), "utf8");
+    assert.match(src, /tx\.pure\.string\(\s*opts\.label\s*\)/);
+});


### PR DESCRIPTION
## Summary
- `account.ts` and `manual.ts` built Move call args with legacy two-arg `tx.pure`.
- SDK peer-depends on `@mysten/sui` 2.5+, which documents `tx.pure.vector` / `tx.pure.string`.
- Switch the three call sites and pin them with a source regression test.

Fixes WALM-442 / GH #799.

## Test plan
- [x] `npm test` in `packages/sdk` (includes typed-pure-args regression)
