### PR TITLE
fix(analyze): skip the pre-extraction embed on inputs the API will reject [WALM-411]

### DIFF
--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -106,6 +106,34 @@ const EMBED_TIMEOUT_MS: u64 = 800;
 const SEARCH_TIMEOUT_MS: u64 = 300;
 const FETCH_TIMEOUT_MS: u64 = 500;
 
+/// Largest input handed straight to the embedder for the pre-extraction dedup
+/// query. `text-embedding-3-small` caps at 8192 tokens and the embedder does
+/// not truncate, so oversized input is rejected outright with
+/// `Invalid 'input': maximum context length is 8192` — after the request has
+/// already cost a round-trip (~560ms observed in production).
+///
+/// Measured bytes-per-token over representative corpora runs ~1.4 (base64)
+/// to ~4.5 (English prose), so the byte length at which 8192 tokens is
+/// reached varies from ~11 KiB to ~36 KiB depending on content. No single
+/// byte threshold is exact; this one sits below the densest case so the
+/// guard never lets a doomed call through.
+///
+/// Deliberately a separate constant from `remember`'s
+/// `SUMMARIZE_THRESHOLD_BYTES`, which holds the same value today. That one
+/// decides when to pay for an LLM summary before storing a *permanent*
+/// embedding; this one decides when to abandon a *throwaway* dedup query
+/// vector. Different trade-offs, so they are free to diverge.
+const MAX_PRE_EXTRACT_EMBED_BYTES: usize = 8 * 1024;
+
+/// Whether to skip the pre-extraction dedup embed for an input of this size.
+///
+/// Skipping costs the extractor its dedup context, which is why the boundary
+/// is inclusive: input of exactly `MAX_PRE_EXTRACT_EMBED_BYTES` is still
+/// handed to the embedder.
+fn should_skip_pre_extract_embed(text_len: usize) -> bool {
+    text_len > MAX_PRE_EXTRACT_EMBED_BYTES
+}
+
 /// One fact that has finished embed + SEAL encrypt and is ready to enqueue:
 /// `(plaintext, importance, embedding, ciphertext)`.
 type PreparedFact = (String, f32, Vec<f32>, Vec<u8>);
@@ -200,6 +228,19 @@ pub async fn analyze(
 
     let related_memories: Vec<crate::engine::HydratedMemory> = if !namespace_has_memories {
         pre_extract_status = "skipped_empty_namespace";
+        Vec::new()
+    } else if should_skip_pre_extract_embed(body.text.len()) {
+        // Oversized input (task WALM-411): the embedding API rejects anything
+        // past its 8192-token ceiling and the embedder does not truncate, so
+        // this call cannot succeed. Skip it rather than spend the round-trip
+        // (~560ms observed in production) to arrive at the same empty context.
+        //
+        // The consequence is that large inputs extract without dedup context.
+        // Recovering it would need summarize-before-embed, the way
+        // `remember` does it — not affordable here, where pre-extraction is
+        // inline on the caller's request under a ~1.6s total budget while
+        // `remember` summarizes inside a spawned job.
+        pre_extract_status = "skipped_oversized";
         Vec::new()
     } else {
         // Embed the input as a query. On embed failure, log + degrade —
@@ -914,8 +955,8 @@ pub async fn analyze(
 #[cfg(test)]
 mod tests {
     use super::{
-        analyze_fact_idempotency_key, classify_analyze_job_reuse, AnalyzeJobReuse,
-        ANALYZE_CONCURRENCY, MAX_ANALYZE_TEXT_BYTES,
+        analyze_fact_idempotency_key, classify_analyze_job_reuse, should_skip_pre_extract_embed,
+        AnalyzeJobReuse, ANALYZE_CONCURRENCY, MAX_ANALYZE_TEXT_BYTES, MAX_PRE_EXTRACT_EMBED_BYTES,
     };
     use crate::routes::remember::MAX_REMEMBER_TEXT_BYTES;
     use crate::services::extractor::MAX_ANALYZE_FACTS;
@@ -932,6 +973,48 @@ mod tests {
         // Analyze does fact extraction in a single LLM call without
         // chunking, so its ceiling must stay below remember's.
         const { assert!(MAX_ANALYZE_TEXT_BYTES < MAX_REMEMBER_TEXT_BYTES) }
+    }
+
+    // ── Pre-extraction embed size guard (WALM-411) ───────────────
+
+    #[test]
+    fn max_pre_extract_embed_bytes_is_8kb() {
+        assert_eq!(MAX_PRE_EXTRACT_EMBED_BYTES, 8 * 1024);
+    }
+
+    #[test]
+    fn pre_extract_guard_is_reachable_below_the_accepted_input_ceiling() {
+        // If the guard sat at or above the endpoint's own cap it could never
+        // fire, and the skip would be dead code.
+        const { assert!(MAX_PRE_EXTRACT_EMBED_BYTES < MAX_ANALYZE_TEXT_BYTES) }
+    }
+
+    #[test]
+    fn embed_is_attempted_at_and_below_the_threshold() {
+        assert!(!should_skip_pre_extract_embed(0));
+        assert!(!should_skip_pre_extract_embed(1));
+        assert!(!should_skip_pre_extract_embed(
+            MAX_PRE_EXTRACT_EMBED_BYTES - 1
+        ));
+        // Boundary: exactly at the limit is still handed to the embedder.
+        assert!(!should_skip_pre_extract_embed(MAX_PRE_EXTRACT_EMBED_BYTES));
+    }
+
+    #[test]
+    fn embed_is_skipped_above_the_threshold() {
+        assert!(should_skip_pre_extract_embed(
+            MAX_PRE_EXTRACT_EMBED_BYTES + 1
+        ));
+        assert!(should_skip_pre_extract_embed(MAX_ANALYZE_TEXT_BYTES));
+    }
+
+    #[test]
+    fn observed_production_rejection_would_now_be_skipped() {
+        // Regression anchor: a real 31,782-byte /api/analyze input was
+        // rejected by the embedding API on 2026-08-27 with
+        // `Invalid 'input': maximum context length is 8192`, after burning
+        // 564ms. That request must not reach the embedder again.
+        assert!(should_skip_pre_extract_embed(31_782));
     }
 
     // ── Analyze concurrency + weight ────────────────────

--- a/services/server/src/routes/analyze.rs
+++ b/services/server/src/routes/analyze.rs
@@ -106,24 +106,15 @@ const EMBED_TIMEOUT_MS: u64 = 800;
 const SEARCH_TIMEOUT_MS: u64 = 300;
 const FETCH_TIMEOUT_MS: u64 = 500;
 
-/// Largest input handed straight to the embedder for the pre-extraction dedup
-/// query. `text-embedding-3-small` caps at 8192 tokens and the embedder does
-/// not truncate, so oversized input is rejected outright with
-/// `Invalid 'input': maximum context length is 8192` — after the request has
-/// already cost a round-trip (~560ms observed in production).
+/// Largest input handed to the embedder for the pre-extraction dedup query.
+/// Matches the embedder's local byte cap: larger inputs already fail before
+/// any HTTP request. Skipping them here reports an expected skip instead of
+/// an embed failure, while preserving dedup attempts for inputs up to 16 KiB.
 ///
-/// Measured bytes-per-token over representative corpora runs ~1.4 (base64)
-/// to ~4.5 (English prose), so the byte length at which 8192 tokens is
-/// reached varies from ~11 KiB to ~36 KiB depending on content. No single
-/// byte threshold is exact; this one sits below the densest case so the
-/// guard never lets a doomed call through.
-///
-/// Deliberately a separate constant from `remember`'s
-/// `SUMMARIZE_THRESHOLD_BYTES`, which holds the same value today. That one
-/// decides when to pay for an LLM summary before storing a *permanent*
-/// embedding; this one decides when to abandon a *throwaway* dedup query
-/// vector. Different trade-offs, so they are free to diverge.
-const MAX_PRE_EXTRACT_EMBED_BYTES: usize = 8 * 1024;
+/// This is a byte limit, not a token guarantee: dense inputs below it can
+/// still exceed the provider's token limit and fall back to plain extraction.
+/// It is independent of `remember`'s summarize-before-store cost threshold.
+const MAX_PRE_EXTRACT_EMBED_BYTES: usize = 16 * 1024;
 
 /// Whether to skip the pre-extraction dedup embed for an input of this size.
 ///
@@ -230,10 +221,9 @@ pub async fn analyze(
         pre_extract_status = "skipped_empty_namespace";
         Vec::new()
     } else if should_skip_pre_extract_embed(body.text.len()) {
-        // Oversized input (task WALM-411): the embedding API rejects anything
-        // past its 8192-token ceiling and the embedder does not truncate, so
-        // this call cannot succeed. Skip it rather than spend the round-trip
-        // (~560ms observed in production) to arrive at the same empty context.
+        // The embedder already rejects inputs above its byte cap locally.
+        // Classify this expected outcome as a skip instead of logging an
+        // embed failure; no network round-trip would occur either way.
         //
         // The consequence is that large inputs extract without dedup context.
         // Recovering it would need summarize-before-embed, the way
@@ -978,8 +968,8 @@ mod tests {
     // ── Pre-extraction embed size guard (WALM-411) ───────────────
 
     #[test]
-    fn max_pre_extract_embed_bytes_is_8kb() {
-        assert_eq!(MAX_PRE_EXTRACT_EMBED_BYTES, 8 * 1024);
+    fn max_pre_extract_embed_bytes_is_16kb() {
+        assert_eq!(MAX_PRE_EXTRACT_EMBED_BYTES, 16 * 1024);
     }
 
     #[test]
@@ -987,12 +977,18 @@ mod tests {
         // If the guard sat at or above the endpoint's own cap it could never
         // fire, and the skip would be dead code.
         const { assert!(MAX_PRE_EXTRACT_EMBED_BYTES < MAX_ANALYZE_TEXT_BYTES) }
+        // Lowering the embedder cap must not leave analyze attempting inputs
+        // that are guaranteed to fail its local validation.
+        const { assert!(MAX_PRE_EXTRACT_EMBED_BYTES <= crate::services::embedder::MAX_EMBED_INPUT_BYTES) }
     }
 
     #[test]
     fn embed_is_attempted_at_and_below_the_threshold() {
         assert!(!should_skip_pre_extract_embed(0));
         assert!(!should_skip_pre_extract_embed(1));
+        // Preserve dedup attempts in the band the original 8 KiB guard skipped.
+        assert!(!should_skip_pre_extract_embed(8 * 1024 + 1));
+        assert!(!should_skip_pre_extract_embed(12 * 1024));
         assert!(!should_skip_pre_extract_embed(
             MAX_PRE_EXTRACT_EMBED_BYTES - 1
         ));
@@ -1013,7 +1009,8 @@ mod tests {
         // Regression anchor: a real 31,782-byte /api/analyze input was
         // rejected by the embedding API on 2026-08-27 with
         // `Invalid 'input': maximum context length is 8192`, after burning
-        // 564ms. That request must not reach the embedder again.
+        // 564ms. Since #837, the embedder rejects it locally; analyze should
+        // classify it as skipped_oversized instead of embed_failed.
         assert!(should_skip_pre_extract_embed(31_782));
     }
 

--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -27,7 +27,7 @@ pub const EMBEDDING_MODEL: &str = "openai/text-embedding-3-small";
 pub const EMBEDDING_DIMS: usize = 1536;
 
 /// 16384 = 8192 tokens × 2 chars/token under cl100k; do not use admin 64KiB.
-const MAX_EMBED_INPUT_BYTES: usize = 16384;
+pub(crate) const MAX_EMBED_INPUT_BYTES: usize = 16384;
 
 fn reject_oversized_embed_input(text: &str) -> Result<(), AppError> {
     if text.len() > MAX_EMBED_INPUT_BYTES {


### PR DESCRIPTION
Closes WALM-411.

`/api/analyze` accepts up to 64 KiB and uses the full input for its pre-extraction dedup query. Since #837 (WALM-423), `OpenAiEmbedder::embed` rejects inputs over 16 KiB locally, before any HTTP request. Analyze currently logs that expected rejection as a warning with `pre_extract_status = "embed_failed"`, then continues with plain extraction.

This change skips that query above 16 KiB and reports `skipped_oversized`. It preserves dedup attempts for inputs at or below 16 KiB, including the 8–16 KiB range that the original version of this PR would have skipped. The empty-namespace check still takes precedence and reports `skipped_empty_namespace`.

The analyze threshold matches `MAX_EMBED_INPUT_BYTES`, now `pub(crate)`. A compile-time assertion alongside the guard-reachability assertion prevents the analyze threshold from exceeding the embedder cap. This threshold is independent of remember's summarize-before-store threshold. Byte length is not an exact token count: dense inputs at or below 16 KiB can still exceed the provider's token limit and use the existing failure fallback.

The 31,782-byte production input from 2026-08-27 remains a regression case. Its observed 564 ms API rejection predates #837; current dev rejects it in-process already. This PR improves classification and warning noise for that case and does not claim a network-latency saving over current dev.

Large inputs continue extracting without dedup context. Summarization, fetch timeouts, timeout tuning, and per-fact embeddings are outside this change.

Validation:
- Rebased onto latest `origin/dev` (`b11f0c07`).
- Five guard tests cover the 16 KiB value, reachability and cap drift, eligibility through the boundary (including 8–16 KiB), sizes above the boundary, and the historical production input.
- Targeted tests: all 15 analyze tests and all 3 embedder tests pass.
- `rustfmt --check` on both changed files and `git diff --check` pass.
- `cargo clippy --bins --tests` passes with repository warnings.
- Full library suite: 437 passed, 23 ignored, 17 failed because database-backed job tests time out acquiring a PostgreSQL connection (`PoolTimedOut`). Full binary suite: 648 passed, 37 ignored, 42 failed with PostgreSQL connection timeouts in database-backed tests; targeted tests above pass.
