### PR TITLE
fix(chatbot): return 404 when deleting a nonexistent document (WALM-422)

### DIFF
--- a/apps/chatbot/app/(chat)/api/document/document-route.unit.test.ts
+++ b/apps/chatbot/app/(chat)/api/document/document-route.unit.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression test for WALM-422: DELETE /api/document read `.userId` off the
+// first row without checking that a row came back, so an id matching no
+// document threw TypeError and the request 500s with an empty body. The GET
+// handler in the same file already had the guard, so the two disagreed on the
+// same missing document.
+//
+// The DB query layer is mocked so no Postgres connection is needed.
+
+const OWNER_ID = "11111111-1111-1111-1111-111111111111";
+const OTHER_ID = "22222222-2222-2222-2222-222222222222";
+const DOC_ID = "33333333-3333-3333-3333-333333333333";
+const MISSING_ID = "44444444-4444-4444-4444-444444444444";
+const TIMESTAMP = "2026-01-01T00:00:00.000Z";
+
+function makeDoc(userId = OWNER_ID) {
+  return {
+    id: DOC_ID,
+    userId,
+    title: "A document",
+    content: "body",
+    kind: "text" as const,
+    createdAt: new Date(),
+  };
+}
+
+const getDocumentsById = vi.fn(async ({ id }: { id: string }) =>
+  id === DOC_ID ? [makeDoc()] : []
+);
+const deleteDocumentsByIdAfterTimestamp = vi.fn(async () => [makeDoc()]);
+const saveDocument = vi.fn(async () => makeDoc());
+
+vi.mock("@/lib/db/queries", () => ({
+  getDocumentsById,
+  deleteDocumentsByIdAfterTimestamp,
+  saveDocument,
+}));
+
+const auth = vi.fn(async () => ({ user: { id: OWNER_ID }, expires: "" }));
+vi.mock("@/app/(auth)/auth", () => ({ auth }));
+
+function deleteRequest(id: string, timestamp = TIMESTAMP) {
+  return new Request(
+    `http://localhost/api/document?id=${id}&timestamp=${timestamp}`,
+    { method: "DELETE" }
+  );
+}
+
+async function callDelete(id: string) {
+  const { DELETE } = await import("./route");
+  return DELETE(deleteRequest(id));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getDocumentsById.mockImplementation(async ({ id }: { id: string }) =>
+    id === DOC_ID ? [makeDoc()] : []
+  );
+  auth.mockResolvedValue({ user: { id: OWNER_ID }, expires: "" });
+});
+
+describe("DELETE /api/document", () => {
+  it("returns 404 for an id that matches no document", async () => {
+    const response = await callDelete(MISSING_ID);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "not_found:document",
+    });
+    // Nothing may be deleted on the way to reporting the miss.
+    expect(deleteDocumentsByIdAfterTimestamp).not.toHaveBeenCalled();
+  });
+
+  it("agrees with GET on the same missing document", async () => {
+    const { GET } = await import("./route");
+    const getResponse = await GET(
+      new Request(`http://localhost/api/document?id=${MISSING_ID}`)
+    );
+    const deleteResponse = await callDelete(MISSING_ID);
+
+    expect(deleteResponse.status).toBe(getResponse.status);
+  });
+
+  it("returns 403 for a document owned by someone else", async () => {
+    getDocumentsById.mockResolvedValue([makeDoc(OTHER_ID)]);
+
+    const response = await callDelete(DOC_ID);
+
+    expect(response.status).toBe(403);
+    expect(deleteDocumentsByIdAfterTimestamp).not.toHaveBeenCalled();
+  });
+
+  it("deletes the caller's own document", async () => {
+    const response = await callDelete(DOC_ID);
+
+    expect(response.status).toBe(200);
+    expect(deleteDocumentsByIdAfterTimestamp).toHaveBeenCalledWith({
+      id: DOC_ID,
+      timestamp: new Date(TIMESTAMP),
+    });
+  });
+
+  it("rejects a missing timestamp before reaching the database", async () => {
+    const { DELETE } = await import("./route");
+    const response = await DELETE(
+      new Request(`http://localhost/api/document?id=${DOC_ID}`, {
+        method: "DELETE",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(getDocumentsById).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller before reaching the database", async () => {
+    auth.mockResolvedValue(null as never);
+
+    const response = await callDelete(DOC_ID);
+
+    expect(response.status).toBe(401);
+    expect(getDocumentsById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/chatbot/app/(chat)/api/document/route.ts
+++ b/apps/chatbot/app/(chat)/api/document/route.ts
@@ -113,6 +113,12 @@ export async function DELETE(request: Request) {
 
   const [document] = documents;
 
+  // Same guard the GET handler above runs. Without it an id that matches no row
+  // reads `.userId` off undefined and the request 500s with an empty body.
+  if (!document) {
+    return new ChatbotError("not_found:document").toResponse();
+  }
+
   if (document.userId !== session.user.id) {
     return new ChatbotError("forbidden:document").toResponse();
   }

--- a/apps/chatbot/app/(chat)/api/document/route.ts
+++ b/apps/chatbot/app/(chat)/api/document/route.ts
@@ -113,8 +113,6 @@ export async function DELETE(request: Request) {
 
   const [document] = documents;
 
-  // Same guard the GET handler above runs. Without it an id that matches no row
-  // reads `.userId` off undefined and the request 500s with an empty body.
   if (!document) {
     return new ChatbotError("not_found:document").toResponse();
   }


### PR DESCRIPTION
## Summary

DELETE /api/document answered an empty HTTP 500 for a document id that matches no row. It now returns 404 not_found:document, the same answer GET already gave for that id. A route-level test pins the behavior.

## Problem

### What happened

DELETE /api/document with an unused UUID threw an unhandled exception instead of reporting a normal not-found error, so the client received a 500 with an empty body.

### Root cause

The handler destructured the first row out of getDocumentsById and read .userId off it without checking that a row came back. For an unknown id the array is empty, so the read landed on undefined:

TypeError: Cannot read properties of undefined (reading 'userId')

### Why GET was unaffected

GET in the same file already ran the `if (!document)` check before the ownership comparison. The two handlers therefore disagreed on the same missing document.

### Fix

Add that same guard to DELETE, placed before the ownership comparison so an unknown id is never reported as 403 or 500.

### Scope of the audit

DELETE was the only unguarded case in the app. auth.ts checks users.length before destructuring, POST in this file checks documents.length, and the suggestions route and chat actions already guard.

## Verification

- [x] pnpm --filter @memwal/chatbot test:unit: 21 pass, 6 of them new
- [x] Removing the guard turns 2 of the new tests red with the exact TypeError from the report
- [x] pnpm exec next build passes, which covers the type-check
- [x] Live reproduction from the report: DELETE returns 404 not_found:document and matches GET on the same id

## Out of scope

- The chatbot lint step already fails on dev because ultracite 7.3.0 passes a --skip flag that biome 2.3.11 rejects. CI marks it continue-on-error, and this branch does not change it.
- lib/ai/models.test.ts matches neither the vitest include nor the Playwright testDir, so no runner executes it today.