### PR TITLE
fix(noter): bind getSession and logout to the caller's own session (WALM-420)

### DIFF
--- a/apps/noter/package/feature/auth/api/input.ts
+++ b/apps/noter/package/feature/auth/api/input.ts
@@ -8,24 +8,10 @@
  */
 
 import { z } from "zod";
-import {
-  uuidv7Schema,
-  walletSessionInsertSchema,
-} from "@/shared/db/type";
+import { walletSessionInsertSchema } from "@/shared/db/type";
 
-// ═══════════════════════════════════════════════════════════════
-// Session Management Inputs
-// ═══════════════════════════════════════════════════════════════
-
-/**
- * Input for validating existing session
- * Uses common idInputSchema pattern, aliased as sessionId
- */
-export const validateSessionInput = z.object({
-  sessionId: uuidv7Schema, // Same as idInputSchema.shape.id
-});
-
-export type ValidateSessionInput = z.infer<typeof validateSessionInput>;
+// Session id is deliberately absent here: getSession and logout take it from the
+// x-session-id header via the tRPC context, so it can never be supplied as input.
 
 // ═══════════════════════════════════════════════════════════════
 // Wallet Auth Inputs

--- a/apps/noter/package/feature/auth/api/route.ts
+++ b/apps/noter/package/feature/auth/api/route.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { verifyPersonalMessageSignature } from "@mysten/sui/verify";
 import { normalizeSuiAddress } from "@mysten/sui/utils";
 import { uuidv7 } from "uuidv7";
-import { validateSessionInput, connectWalletInput } from "./input";
+import { connectWalletInput } from "./input";
 import { AUTH_ERRORS } from "../constant";
 import { walletSessions } from "@/shared/db/schema";
 import * as authService from "../domain/service";
@@ -38,24 +38,29 @@ const suiAddressSchema = z
 
 export const authRouter = router({
   /**
-   * Get current session (for resuming auth state).
+   * Get the caller's own session (for resuming auth state).
    * Resolves wallet / enoki sessions only; the legacy zkLogin table is not trusted.
+   *
+   * The session id is read from the x-session-id header via ctx, never from the
+   * input, so a caller cannot read a session it does not already hold. Returns
+   * null for a missing, unknown, or expired session, which is how the client
+   * detects a stale stored session and clears it.
    */
-  getSession: procedure
-    .input(validateSessionInput)
-    .query(({ ctx, input }) =>
-      authService.getActiveSession(ctx.db, input.sessionId)
-    ),
+  getSession: procedure.query(({ ctx }) =>
+    ctx.sessionId ? authService.getActiveSession(ctx.db, ctx.sessionId) : null
+  ),
 
   /**
-   * Logout - clear session (works for both zkLogin and wallet)
+   * Logout - clear the caller's own session (works for both zkLogin and wallet).
+   * Like getSession, the id comes from the header, so knowing another user's
+   * session id is not enough to end their session.
    */
-  logout: procedure
-    .input(validateSessionInput)
-    .mutation(async ({ ctx, input }) => {
-      await authService.deleteSession(ctx.db, input.sessionId);
-      return { success: true };
-    }),
+  logout: procedure.mutation(async ({ ctx }) => {
+    if (ctx.sessionId) {
+      await authService.deleteSession(ctx.db, ctx.sessionId);
+    }
+    return { success: true };
+  }),
 
   /**
    * Connect wallet - authenticate with Sui wallet (Slush, Sui Wallet)

--- a/apps/noter/package/feature/auth/api/route.ts
+++ b/apps/noter/package/feature/auth/api/route.ts
@@ -51,9 +51,9 @@ export const authRouter = router({
   ),
 
   /**
-   * Logout - clear the caller's own session (works for both zkLogin and wallet).
-   * Like getSession, the id comes from the header, so knowing another user's
-   * session id is not enough to end their session.
+   * Logout - end only the session presented in x-session-id (zkLogin and wallet).
+   * A body/input id is ignored. The header value is still a bearer credential:
+   * presenting a session id there is enough to delete that session.
    */
   logout: procedure.mutation(async ({ ctx }) => {
     if (ctx.sessionId) {

--- a/apps/noter/package/feature/auth/api/session-binding.unit.test.ts
+++ b/apps/noter/package/feature/auth/api/session-binding.unit.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Route-layer binding tests for getSession / logout (issue #779). Both used to
+// take a sessionId as procedure input and act on it, so anyone who learned an id
+// could read that session's user and address or delete the session, without ever
+// presenting the id as a credential. Both now read the id from ctx.sessionId,
+// which createContext fills from the x-session-id header.
+//
+// These call the REAL authRouter through createCaller and pass a victim id as
+// input anyway, cast past the types, to prove the input cannot steer either
+// procedure. The service layer is mocked so no DB is needed.
+
+vi.mock("server-only", () => ({}));
+
+const CALLER_SESSION = "0192f0a0-0000-7000-8000-000000000001";
+const VICTIM_SESSION = "0192f0a0-0000-7000-8000-000000000002";
+
+const VICTIM_SESSION_ROW = {
+  user: { id: "victim", suiAddress: `0x${"b".repeat(64)}` },
+  sessionId: VICTIM_SESSION,
+  suiAddress: `0x${"b".repeat(64)}`,
+  expiresAt: new Date(Date.now() + 60_000),
+};
+
+const CALLER_SESSION_ROW = {
+  user: { id: "caller", suiAddress: `0x${"a".repeat(64)}` },
+  sessionId: CALLER_SESSION,
+  suiAddress: `0x${"a".repeat(64)}`,
+  expiresAt: new Date(Date.now() + 60_000),
+};
+
+const getActiveSession = vi.fn(async (_db: unknown, sessionId: string) => {
+  if (sessionId === CALLER_SESSION) return CALLER_SESSION_ROW;
+  if (sessionId === VICTIM_SESSION) return VICTIM_SESSION_ROW;
+  return null;
+});
+const deleteSession = vi.fn(async () => undefined);
+
+vi.mock("../domain/service", () => ({
+  getActiveSession,
+  deleteSession,
+  toSafeUser: (u: unknown) => u,
+  DelegateCredentialConflictError: class extends Error {},
+}));
+
+vi.mock("../lib/enoki-challenge", () => ({
+  issueEnokiChallenge: vi.fn(),
+  verifyAndConsumeEnokiChallenge: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/shared-redis", () => ({
+  SharedRedisUnavailableError: class extends Error {},
+}));
+
+// sessionId mirrors what createContext read from x-session-id; null means the
+// caller presented no usable session header.
+async function callerFor(sessionId: string | null) {
+  const { authRouter } = await import("./route");
+  const ctx = {
+    db: {},
+    request: new Request("http://localhost/api/trpc/auth"),
+    sessionId,
+    userId: sessionId === CALLER_SESSION ? "caller" : null,
+  };
+  return authRouter.createCaller(ctx as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getSession — bound to the caller's own session", () => {
+  it("returns null when the caller presents no session header", async () => {
+    const caller = await callerFor(null);
+
+    await expect(caller.getSession()).resolves.toBeNull();
+    expect(getActiveSession).not.toHaveBeenCalled();
+  });
+
+  it("ignores a victim session id passed as input", async () => {
+    const caller = await callerFor(null);
+
+    // The exact request from the report: a valid id, no credential for it.
+    const result = await (
+      caller.getSession as unknown as (input: unknown) => Promise<unknown>
+    )({ sessionId: VICTIM_SESSION });
+
+    expect(result).toBeNull();
+    expect(getActiveSession).not.toHaveBeenCalledWith(
+      expect.anything(),
+      VICTIM_SESSION
+    );
+  });
+
+  it("reads the header session even when the input names another one", async () => {
+    const caller = await callerFor(CALLER_SESSION);
+
+    const result = await (
+      caller.getSession as unknown as (input: unknown) => Promise<unknown>
+    )({ sessionId: VICTIM_SESSION });
+
+    expect(result).toEqual(CALLER_SESSION_ROW);
+    expect(getActiveSession).toHaveBeenCalledWith(
+      expect.anything(),
+      CALLER_SESSION
+    );
+  });
+
+  it("returns null for a header session that no longer resolves", async () => {
+    const caller = await callerFor("0192f0a0-0000-7000-8000-00000000dead");
+
+    await expect(caller.getSession()).resolves.toBeNull();
+  });
+});
+
+describe("logout — ends only the caller's own session", () => {
+  it("deletes nothing when the caller presents no session header", async () => {
+    const caller = await callerFor(null);
+
+    await expect(caller.logout()).resolves.toEqual({ success: true });
+    expect(deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("ignores a victim session id passed as input", async () => {
+    const caller = await callerFor(null);
+
+    await (
+      caller.logout as unknown as (input: unknown) => Promise<unknown>
+    )({ sessionId: VICTIM_SESSION });
+
+    expect(deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("deletes the header session even when the input names another one", async () => {
+    const caller = await callerFor(CALLER_SESSION);
+
+    await (
+      caller.logout as unknown as (input: unknown) => Promise<unknown>
+    )({ sessionId: VICTIM_SESSION });
+
+    expect(deleteSession).toHaveBeenCalledTimes(1);
+    expect(deleteSession).toHaveBeenCalledWith(
+      expect.anything(),
+      CALLER_SESSION
+    );
+  });
+});

--- a/apps/noter/package/feature/auth/hook/use-auth.ts
+++ b/apps/noter/package/feature/auth/hook/use-auth.ts
@@ -27,20 +27,33 @@ export function useAuth() {
   // Wallet disconnect (clears dapp-kit autoConnect state)
   const { mutateAsync: disconnectWallet } = useDisconnectWallet();
 
+  const utils = trpc.useUtils();
+
   // tRPC mutations
   const connectEnokiMutation = trpc.auth.connectEnoki.useMutation();
   const connectDelegateKeyMutation = trpc.auth.connectDelegateKey.useMutation();
   const logoutMutation = trpc.auth.logout.useMutation();
 
-  // Session validation query
-  const sessionQuery = trpc.auth.getSession.useQuery(
-    { sessionId: session?.sessionId || "" },
-    {
-      enabled: !!session?.sessionId,
-      retry: false,
-      refetchOnWindowFocus: false,
-      refetchOnMount: true,
-    }
+  // Session validation query. It takes no input: the server reads the session id
+  // from the x-session-id header that TRPCProvider attaches, so the cache key no
+  // longer varies per session and every session change has to reset it — see
+  // resetSessionQuery below.
+  const sessionQuery = trpc.auth.getSession.useQuery(undefined, {
+    enabled: !!session?.sessionId,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+  });
+
+  /**
+   * Drop the cached session lookup so a result fetched for one session is never
+   * read as the answer for the next one. Without this a cached null (a session
+   * that had expired) would make the effect below clear the session that was
+   * just established.
+   */
+  const resetSessionQuery = useCallback(
+    () => utils.auth.getSession.reset(),
+    [utils]
   );
 
   /** Initialize authentication from persisted session. */
@@ -79,6 +92,7 @@ export function useAuth() {
 
         if (result.sessionData) {
           setSession(result.sessionData);
+          await resetSessionQuery();
         }
 
         if (result.user) {
@@ -96,7 +110,7 @@ export function useAuth() {
         throw error;
       }
     },
-    [connectEnokiMutation, setSession, setAuthenticated]
+    [connectEnokiMutation, setSession, setAuthenticated, resetSessionQuery]
   );
 
   /** Connect with delegate key (manual key + account ID). */
@@ -106,6 +120,7 @@ export function useAuth() {
         const result = await connectDelegateKeyMutation.mutateAsync(params);
 
         setSession(result.sessionData);
+        await resetSessionQuery();
 
         setAuthenticated({
           isAuthenticated: true,
@@ -120,14 +135,20 @@ export function useAuth() {
         throw error;
       }
     },
-    [connectDelegateKeyMutation, setSession, setAuthenticated]
+    [
+      connectDelegateKeyMutation,
+      setSession,
+      setAuthenticated,
+      resetSessionQuery,
+    ]
   );
 
   /** Logout — clear session, auth state, and disconnect wallet (prevents autoConnect). */
   const logout = useCallback(async () => {
     try {
       if (session?.sessionId) {
-        await logoutMutation.mutateAsync({ sessionId: session.sessionId });
+        // No argument: the server ends the session behind the request header.
+        await logoutMutation.mutateAsync();
       }
     } catch (error) {
       console.error("Logout failed:", error);
@@ -139,7 +160,14 @@ export function useAuth() {
       // Wallet may already be disconnected
     }
     clearAuth();
-  }, [session, logoutMutation, disconnectWallet, clearAuth]);
+    await resetSessionQuery();
+  }, [
+    session,
+    logoutMutation,
+    disconnectWallet,
+    clearAuth,
+    resetSessionQuery,
+  ]);
 
   return {
     ...auth,

--- a/apps/noter/package/feature/auth/index.ts
+++ b/apps/noter/package/feature/auth/index.ts
@@ -21,10 +21,7 @@ export {
 } from "./api/form";
 
 // API Input Schemas (if needed by external features)
-export type {
-  ValidateSessionInput,
-  ConnectWalletInput,
-} from "./api/input";
+export type { ConnectWalletInput } from "./api/input";
 
 // Types
 export type {

--- a/apps/noter/package/shared/lib/trpc/create-context.unit.test.ts
+++ b/apps/noter/package/shared/lib/trpc/create-context.unit.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
+
+// createContext is where the malformed-header guard lives (issue #779). A
+// non-uuid x-session-id used to reach eq(walletSessions.id, …) and make
+// Postgres raise. The route-layer session-binding tests inject ctx.sessionId
+// already parsed, so they cannot catch a regression here. These call the real
+// createContext with the db mocked and assert the lookup is skipped unless the
+// header is a uuid.
+
+const VALID_SESSION = "0192f0a0-0000-7000-8000-000000000001";
+const USER_ID = "user-1";
+
+const { select, from, where, limit } = vi.hoisted(() => ({
+  select: vi.fn(),
+  from: vi.fn(),
+  where: vi.fn(),
+  limit: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/db", () => ({
+  db: {
+    select: (...args: unknown[]) => select(...args),
+  },
+}));
+
+function requestOpts(headers?: HeadersInit): FetchCreateContextFnOptions {
+  return {
+    req: new Request("http://localhost/api/trpc", { headers }),
+    resHeaders: new Headers(),
+    info: {} as FetchCreateContextFnOptions["info"],
+  };
+}
+
+async function load() {
+  return import("./init");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  select.mockReturnValue({ from });
+  from.mockReturnValue({ where });
+  where.mockReturnValue({ limit });
+  limit.mockResolvedValue([]);
+});
+
+describe("createContext — x-session-id UUID guard", () => {
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["non-uuid", "not-a-uuid"],
+  ] as const)(
+    "treats a %s header as no credential and skips the session lookup",
+    async (_label, header) => {
+      const { createContext } = await load();
+      const ctx = await createContext(
+        requestOpts(
+          header === undefined ? undefined : { "x-session-id": header }
+        )
+      );
+
+      expect(ctx.sessionId).toBeNull();
+      expect(ctx.userId).toBeNull();
+      expect(select).not.toHaveBeenCalled();
+    }
+  );
+
+  it("looks up an expired uuid session but does not authenticate it", async () => {
+    limit.mockResolvedValueOnce([
+      {
+        id: VALID_SESSION,
+        userId: USER_ID,
+        expiresAt: new Date(Date.now() - 60_000),
+      },
+    ]);
+    const { createContext } = await load();
+    const ctx = await createContext(
+      requestOpts({ "x-session-id": VALID_SESSION })
+    );
+
+    expect(select).toHaveBeenCalledOnce();
+    expect(ctx.sessionId).toBe(VALID_SESSION);
+    expect(ctx.userId).toBeNull();
+  });
+
+  it("authenticates a valid uuid session", async () => {
+    limit.mockResolvedValueOnce([
+      {
+        id: VALID_SESSION,
+        userId: USER_ID,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ]);
+    const { createContext } = await load();
+    const ctx = await createContext(
+      requestOpts({ "x-session-id": VALID_SESSION })
+    );
+
+    expect(select).toHaveBeenCalledOnce();
+    expect(ctx.sessionId).toBe(VALID_SESSION);
+    expect(ctx.userId).toBe(USER_ID);
+  });
+});

--- a/apps/noter/package/shared/lib/trpc/init.ts
+++ b/apps/noter/package/shared/lib/trpc/init.ts
@@ -8,22 +8,42 @@ import { eq } from "drizzle-orm";
 export type Context = {
   db: typeof db;
   request: Request;
+  /**
+   * The session id the caller presented in x-session-id, whether or not it
+   * resolves to a live session. Procedures that act on a session must read it
+   * from here rather than from their input, so holding the credential is what
+   * grants access instead of merely knowing the id.
+   */
+  sessionId: string | null;
   userId: string | null;
 };
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function getSessionIdFromRequest(req: Request): string | null {
-  return req.headers.get("x-session-id");
+  const sessionId = req.headers.get("x-session-id")?.trim();
+
+  // Session ids are compared against uuid columns, where a malformed value makes
+  // Postgres raise rather than simply miss. Anything that is not a uuid cannot
+  // name a session, so treat it as no credential at all.
+  if (!sessionId || !UUID_REGEX.test(sessionId)) {
+    return null;
+  }
+
+  return sessionId;
 }
 
 export const createContext = async (
   opts: FetchCreateContextFnOptions
 ): Promise<Context> => {
+  const sessionId = getSessionIdFromRequest(opts.req);
   const noAuth: Context = {
     db,
     request: opts.req,
+    sessionId,
     userId: null,
   };
-  const sessionId = getSessionIdFromRequest(opts.req);
   if (!sessionId) return noAuth;
 
   // Sessions are resolved only from wallet/enoki sessions, which require proof
@@ -37,7 +57,7 @@ export const createContext = async (
     .limit(1);
 
   if (walletSession?.userId && walletSession.expiresAt > new Date()) {
-    return { db, request: opts.req, userId: walletSession.userId };
+    return { db, request: opts.req, sessionId, userId: walletSession.userId };
   }
 
   return noAuth;


### PR DESCRIPTION
Fixes #779

## Summary

auth.getSession and auth.logout took a sessionId as procedure input and acted on it. Both now take the id from the x-session-id header through the tRPC context, the way protectedProcedure and the memory REST routes already do, so the input can no longer steer either call.

## Problem

### What happened

Both procedures are public and read input.sessionId, ignoring ctx entirely. A caller with no session of its own could read another session's user and Sui address through getSession, or delete that session through logout, purely by naming the id.

### Why the id is not a secret in practice

getSession is a query, so the id travelled in the request URL on every page load and landed in access logs and browser history. The report notes the exploit depends on the id leaking through exactly such a channel, so the input was both the hole and a way to widen it.

### Fix

Context gains a sessionId field, filled from the header whether or not the session is still live, and both procedures read that. The sessionId input and its schema are removed, so there is nothing left to forge. getSession still answers null for a missing, unknown, or expired session, which is how the client detects a stale stored session and clears it.

### Malformed header

The zod input schema used to reject a non-uuid id before it reached a uuid column, where Postgres raises instead of simply not matching. createContext now applies that check to the header, so a malformed value means no credential rather than a 500.

### Client

The getSession query key no longer varies per session, so useAuth resets the cached lookup whenever the stored session changes. Without it a cached null left by an expired session would be read as the answer for the session just established, and the effect that clears stale sessions would wipe a fresh login.

### Scope of the audit

These two were the only procedures in noter taking a sessionId or userId as input. The note router works from ctx.userId and filters on ownership, and the memory REST routes already authenticate from the header only.

## Verification

- [x] pnpm --filter @memwal/noter test:unit: 40 pass, 7 of them new
- [x] Restoring the input-based version turns all 7 new tests red
- [x] Playwright e2e on a fresh database: 8 auth tests and 14 app, memory, and note tests pass
- [x] pnpm exec tsc --noEmit and pnpm exec next build both pass

## Out of scope

- Session ids remain bearer credentials in sessionStorage rather than httpOnly cookies, so possession still grants access. Changing that touches every request path in the app and contradicts the documented header-based design, so it needs its own decision.
- The delegate fixture pool can only be registered once per database, and Playwright recycles fixture indices when it restarts a worker after a failure, so a local rerun against a used database fails on provisioning rather than on the code.