### PR TITLE
fix(researcher): check the destination before fetching a source file url (WAKM-419)

### DIFF
--- a/apps/researcher/lib/rag/ingest/index.ts
+++ b/apps/researcher/lib/rag/ingest/index.ts
@@ -4,6 +4,7 @@ import { chunkDocument, estimateTokens } from "./chunking";
 import { batchEmbed } from "./embeddings";
 import { extractFromUrl, extractFromPdf } from "./extract";
 import { generateSourceMetadata } from "./metadata";
+import { fetchPublicUrl } from "./safe-fetch";
 import { createSource, createSourceChunks } from "@/lib/db/queries";
 import { ChatbotError } from "@/lib/errors";
 import type { SourceInput } from "@/lib/ai/source-processing";
@@ -39,8 +40,9 @@ export async function processSource({
     rawText = await extractFromPdf(source.file);
   } else {
     type = "pdf";
-    // Download the PDF from the uploaded file URL
-    const response = await fetch(source.fileUrl);
+    // Download the PDF from the uploaded file URL. The URL arrives from the
+    // request body, so the destination is checked before anything is sent.
+    const response = await fetchPublicUrl(source.fileUrl);
     if (!response.ok) {
       throw new ChatbotError(
         "bad_request:api",

--- a/apps/researcher/lib/rag/ingest/safe-fetch.ts
+++ b/apps/researcher/lib/rag/ingest/safe-fetch.ts
@@ -1,0 +1,277 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+import { ChatbotError } from "@/lib/errors";
+
+// No "server-only" marker here, matching every other unit-tested module in lib:
+// the import throws under `node --test`. The node:dns import above keeps this out
+// of a client bundle regardless.
+
+// Outbound fetches for user-supplied source URLs. A file part in a chat request
+// names a URL that the server then downloads, so without a destination check the
+// request doubles as a probe of whatever the server can reach: loopback services,
+// RFC1918 neighbours, and the cloud metadata endpoint on 169.254.169.254.
+//
+// extractUrlsFromText has a prefix-matching denylist for URLs found in chat text,
+// but it only recognises literal 127.0.0.1 and friends at the very start of the
+// string. That misses userinfo (http://x@127.0.0.1), IPv6, 127.x outside .0.1,
+// hostnames that resolve into a private range, and redirects. This module resolves
+// the host and checks every address instead.
+
+const MAX_REDIRECTS = 5;
+
+// [network, prefix length]. Everything a request has no business reaching from a
+// URL a user typed: loopback, the private ranges, link-local (which carries the
+// metadata service), plus the unspecified, multicast, and reserved blocks.
+const BLOCKED_V4_RANGES: [string, number][] = [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+];
+
+const BLOCKED_V6_RANGES: [string, number][] = [
+  ["::", 128],
+  ["::1", 128],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  // NAT64 addresses carry an IPv4 destination in their low 32 bits, so they are a
+  // way back into the ranges above.
+  ["64:ff9b::", 96],
+];
+
+function ipv4ToBytes(address: string): number[] | null {
+  const groups = address.split(".");
+
+  if (groups.length !== 4) {
+    return null;
+  }
+
+  const bytes = groups.map((group) =>
+    /^\d{1,3}$/.test(group) ? Number(group) : Number.NaN
+  );
+
+  return bytes.every((byte) => byte >= 0 && byte <= 255) ? bytes : null;
+}
+
+function ipv6GroupsToBytes(part: string): number[] | null {
+  if (part === "") {
+    return [];
+  }
+
+  const groups = part.split(":");
+  const bytes: number[] = [];
+
+  for (const [index, group] of groups.entries()) {
+    // A trailing dotted-quad (::ffff:127.0.0.1) stands for the last four bytes.
+    if (group.includes(".")) {
+      const embedded = index === groups.length - 1 ? ipv4ToBytes(group) : null;
+
+      if (!embedded) {
+        return null;
+      }
+      bytes.push(...embedded);
+      continue;
+    }
+
+    if (!/^[0-9a-f]{1,4}$/i.test(group)) {
+      return null;
+    }
+    const value = Number.parseInt(group, 16);
+    bytes.push(value >> 8, value & 0xff);
+  }
+
+  return bytes;
+}
+
+function ipv6ToBytes(address: string): number[] | null {
+  // Drop any zone id: fe80::1%eth0 addresses the same interface-local target.
+  const [plain] = address.split("%");
+  const halves = plain.split("::");
+
+  if (halves.length > 2) {
+    return null;
+  }
+
+  const head = ipv6GroupsToBytes(halves[0]);
+  const tail = halves.length === 2 ? ipv6GroupsToBytes(halves[1]) : [];
+
+  if (!head || !tail) {
+    return null;
+  }
+
+  if (halves.length === 1) {
+    return head.length === 16 ? head : null;
+  }
+
+  const zeroes = 16 - head.length - tail.length;
+
+  return zeroes < 0
+    ? null
+    : [...head, ...new Array<number>(zeroes).fill(0), ...tail];
+}
+
+function withinRange(
+  address: number[],
+  network: number[],
+  prefixLength: number
+): boolean {
+  let remaining = prefixLength;
+
+  for (let i = 0; i < address.length && remaining > 0; i++) {
+    const bits = Math.min(8, remaining);
+    const mask = (0xff << (8 - bits)) & 0xff;
+
+    if ((address[i] & mask) !== (network[i] & mask)) {
+      return false;
+    }
+    remaining -= bits;
+  }
+
+  return true;
+}
+
+function isMappedIpv4(bytes: number[]): boolean {
+  return (
+    bytes.slice(0, 10).every((byte) => byte === 0) &&
+    bytes[10] === 0xff &&
+    bytes[11] === 0xff
+  );
+}
+
+/**
+ * Whether an IP literal names something outside the public internet. Anything
+ * unparseable counts as blocked: a value this code cannot reason about must not
+ * be handed to fetch.
+ */
+export function isBlockedAddress(address: string): boolean {
+  const version = isIP(address);
+
+  if (version === 4) {
+    const bytes = ipv4ToBytes(address);
+
+    return bytes
+      ? BLOCKED_V4_RANGES.some(([network, prefix]) =>
+          withinRange(bytes, ipv4ToBytes(network) as number[], prefix)
+        )
+      : true;
+  }
+
+  if (version === 6) {
+    const bytes = ipv6ToBytes(address);
+
+    if (!bytes) {
+      return true;
+    }
+    if (isMappedIpv4(bytes)) {
+      return BLOCKED_V4_RANGES.some(([network, prefix]) =>
+        withinRange(bytes.slice(12), ipv4ToBytes(network) as number[], prefix)
+      );
+    }
+
+    return BLOCKED_V6_RANGES.some(([network, prefix]) =>
+      withinRange(bytes, ipv6ToBytes(network) as number[], prefix)
+    );
+  }
+
+  return true;
+}
+
+/**
+ * Parse a user-supplied URL and confirm it names a public HTTP(S) destination.
+ * Hostnames are resolved and every returned address has to be public, so a name
+ * pointing at 127.0.0.1 is rejected as surely as the literal is.
+ */
+export async function assertPublicUrl(rawUrl: string): Promise<URL> {
+  let url: URL;
+
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new ChatbotError("bad_request:api", "Invalid URL format");
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new ChatbotError(
+      "bad_request:api",
+      `Unsupported URL scheme: ${url.protocol.replace(":", "")}`
+    );
+  }
+
+  // URL keeps the brackets on an IPv6 host; isIP does not want them.
+  const host = url.hostname.replace(/^\[|\]$/g, "");
+
+  if (isIP(host)) {
+    if (isBlockedAddress(host)) {
+      throw new ChatbotError(
+        "bad_request:api",
+        "URL points at a private or reserved address"
+      );
+    }
+
+    return url;
+  }
+
+  let addresses: { address: string }[];
+
+  try {
+    addresses = await lookup(host, { all: true });
+  } catch {
+    throw new ChatbotError(
+      "bad_request:api",
+      `Could not resolve host: ${host}`
+    );
+  }
+
+  if (
+    addresses.length === 0 ||
+    addresses.some((entry) => isBlockedAddress(entry.address))
+  ) {
+    throw new ChatbotError(
+      "bad_request:api",
+      "URL resolves to a private or reserved address"
+    );
+  }
+
+  return url;
+}
+
+/**
+ * fetch for user-supplied URLs, with the destination checked before the request
+ * leaves and again at every redirect. Redirects are followed by hand because
+ * fetch's own following would skip the check on each new target.
+ *
+ * A host that answers with a public address and then a private one on the next
+ * resolution (DNS rebinding) is not covered; that needs the connection pinned to
+ * the address that was checked, which fetch does not expose.
+ */
+export async function fetchPublicUrl(
+  rawUrl: string,
+  init?: RequestInit
+): Promise<Response> {
+  let target = rawUrl;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const url = await assertPublicUrl(target);
+    const response = await fetch(url, { ...init, redirect: "manual" });
+    const location = response.headers.get("location");
+
+    if (response.status < 300 || response.status >= 400 || !location) {
+      return response;
+    }
+
+    target = new URL(location, url).toString();
+  }
+
+  throw new ChatbotError(
+    "bad_request:api",
+    "Too many redirects while fetching the URL"
+  );
+}

--- a/apps/researcher/lib/rag/ingest/safe-fetch.ts
+++ b/apps/researcher/lib/rag/ingest/safe-fetch.ts
@@ -286,7 +286,11 @@ export async function fetchPublicUrl(
       return response;
     }
 
-    target = new URL(location, url).toString();
+    try {
+      target = new URL(location, url).toString();
+    } catch {
+      throw new ChatbotError("bad_request:api", "Invalid URL format");
+    }
   }
 
   throw new ChatbotError(

--- a/apps/researcher/lib/rag/ingest/safe-fetch.ts
+++ b/apps/researcher/lib/rag/ingest/safe-fetch.ts
@@ -45,6 +45,8 @@ const BLOCKED_V6_RANGES: [string, number][] = [
   // NAT64 addresses carry an IPv4 destination in their low 32 bits, so they are a
   // way back into the ranges above.
   ["64:ff9b::", 96],
+  // IPv4 already blocks 224.0.0.0/4; the v6 multicast range is the counterpart.
+  ["ff00::", 8],
 ];
 
 function ipv4ToBytes(address: string): number[] | null {
@@ -138,12 +140,32 @@ function withinRange(
   return true;
 }
 
+function isBlockedIpv4Bytes(bytes: number[]): boolean {
+  return BLOCKED_V4_RANGES.some(([network, prefix]) =>
+    withinRange(bytes, ipv4ToBytes(network) as number[], prefix)
+  );
+}
+
 function isMappedIpv4(bytes: number[]): boolean {
   return (
     bytes.slice(0, 10).every((byte) => byte === 0) &&
     bytes[10] === 0xff &&
     bytes[11] === 0xff
   );
+}
+
+function isSiitIpv4(bytes: number[]): boolean {
+  return (
+    bytes.slice(0, 8).every((byte) => byte === 0) &&
+    bytes[8] === 0xff &&
+    bytes[9] === 0xff &&
+    bytes[10] === 0 &&
+    bytes[11] === 0
+  );
+}
+
+function isIpv4Compatible(bytes: number[]): boolean {
+  return bytes.slice(0, 12).every((byte) => byte === 0);
 }
 
 /**
@@ -157,11 +179,7 @@ export function isBlockedAddress(address: string): boolean {
   if (version === 4) {
     const bytes = ipv4ToBytes(address);
 
-    return bytes
-      ? BLOCKED_V4_RANGES.some(([network, prefix]) =>
-          withinRange(bytes, ipv4ToBytes(network) as number[], prefix)
-        )
-      : true;
+    return bytes ? isBlockedIpv4Bytes(bytes) : true;
   }
 
   if (version === 6) {
@@ -170,10 +188,11 @@ export function isBlockedAddress(address: string): boolean {
     if (!bytes) {
       return true;
     }
-    if (isMappedIpv4(bytes)) {
-      return BLOCKED_V4_RANGES.some(([network, prefix]) =>
-        withinRange(bytes.slice(12), ipv4ToBytes(network) as number[], prefix)
-      );
+    // Mapped, deprecated IPv4-compatible (::/96), and SIIT stash IPv4 in the
+    // last 32 bits. Check that payload against the v4 table so ::7f00:1 and
+    // ::ffff:0:7f00:1 cannot skip a denylist that already unwraps ::ffff:7f00:1.
+    if (isMappedIpv4(bytes) || isSiitIpv4(bytes) || isIpv4Compatible(bytes)) {
+      return isBlockedIpv4Bytes(bytes.slice(12));
     }
 
     return BLOCKED_V6_RANGES.some(([network, prefix]) =>

--- a/apps/researcher/lib/rag/ingest/safe-fetch.unit.test.ts
+++ b/apps/researcher/lib/rag/ingest/safe-fetch.unit.test.ts
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { resolve } from "node:path";
+import test from "node:test";
+import { ChatbotError } from "@/lib/errors";
+import { assertPublicUrl, fetchPublicUrl, isBlockedAddress } from "./safe-fetch";
+
+// Regression tests for issue #778: a PDF file part named a URL that the server
+// downloaded with a bare fetch, so a chat request could make the server call
+// loopback services, RFC1918 neighbours, or the metadata endpoint. The addresses
+// below are the ones an SSRF probe reaches for, plus the encodings that walked
+// straight through the old prefix-matching denylist in extractUrlsFromText.
+
+const BLOCKED = [
+  // The address from the report.
+  "127.0.0.1",
+  // Loopback outside .0.1, which a prefix match on "127.0.0.1" misses.
+  "127.1.2.3",
+  "0.0.0.0",
+  // Cloud metadata, absent from the old denylist altogether.
+  "169.254.169.254",
+  "169.254.0.1",
+  "10.0.0.1",
+  "172.16.0.1",
+  "172.31.255.255",
+  "192.168.1.1",
+  "100.64.0.1",
+  "192.0.0.1",
+  "198.18.0.1",
+  "224.0.0.1",
+  "255.255.255.255",
+  // IPv6 loopback, in both the compressed and the written-out form.
+  "::1",
+  "0:0:0:0:0:0:0:1",
+  "::",
+  "fd00::1",
+  "fc00::1",
+  "fe80::1",
+  // Zone ids still name an interface-local target.
+  "fe80::1%eth0",
+  // IPv4-mapped and NAT64 forms both carry a blocked IPv4 destination.
+  "::ffff:127.0.0.1",
+  "::ffff:169.254.169.254",
+  "64:ff9b::7f00:1",
+];
+
+const ALLOWED = [
+  "8.8.8.8",
+  "1.1.1.1",
+  "93.184.216.34",
+  "172.32.0.1",
+  "172.15.255.255",
+  "128.0.0.1",
+  "2606:4700:4700::1111",
+  "::ffff:8.8.8.8",
+];
+
+// ChatbotError puts the caller-facing detail in `cause` and leaves `message` as
+// the generic copy for the error code, so assertions read `cause`.
+async function rejectionOf(
+  call: () => Promise<unknown>
+): Promise<ChatbotError> {
+  try {
+    await call();
+  } catch (error) {
+    assert.ok(error instanceof ChatbotError, `unexpected error type: ${error}`);
+    return error;
+  }
+
+  throw new Error("expected the call to reject");
+}
+
+async function assertRejectedWith(
+  call: () => Promise<unknown>,
+  detail: RegExp
+): Promise<void> {
+  const error = await rejectionOf(call);
+
+  assert.equal(error.statusCode, 400);
+  assert.match(String(error.cause), detail);
+}
+
+test("isBlockedAddress rejects loopback, private, link-local, and reserved addresses", () => {
+  for (const address of BLOCKED) {
+    assert.equal(isBlockedAddress(address), true, `expected blocked: ${address}`);
+  }
+});
+
+test("isBlockedAddress allows public addresses", () => {
+  for (const address of ALLOWED) {
+    assert.equal(isBlockedAddress(address), false, `expected allowed: ${address}`);
+  }
+});
+
+test("isBlockedAddress treats anything unparseable as blocked", () => {
+  for (const address of ["", "not-an-ip", "127.0.0.256", "1.2.3", "gg::1", "::1::2"]) {
+    assert.equal(isBlockedAddress(address), true, `expected blocked: ${address}`);
+  }
+});
+
+test("assertPublicUrl rejects the URL from the report", async () => {
+  await assertRejectedWith(
+    () => assertPublicUrl("http://127.0.0.1:9999/ssrf-proof-token-abc123"),
+    /private or reserved address/
+  );
+});
+
+test("assertPublicUrl rejects a loopback host hidden behind userinfo", async () => {
+  // The old denylist anchored on "http://127.0.0.1", so a username in front of
+  // the host was enough to slip past it.
+  await assertRejectedWith(
+    () => assertPublicUrl("http://user@127.0.0.1/admin"),
+    /private or reserved address/
+  );
+});
+
+test("assertPublicUrl rejects bracketed IPv6 loopback", async () => {
+  await assertRejectedWith(
+    () => assertPublicUrl("http://[::1]:9999/probe"),
+    /private or reserved address/
+  );
+});
+
+test("assertPublicUrl rejects the metadata endpoint", async () => {
+  await assertRejectedWith(
+    () => assertPublicUrl("http://169.254.169.254/latest/meta-data/"),
+    /private or reserved address/
+  );
+});
+
+test("assertPublicUrl rejects a hostname that resolves to loopback", async () => {
+  // localhost is a name, not a literal, so only resolution catches it.
+  await assertRejectedWith(
+    () => assertPublicUrl("http://localhost:3000/probe"),
+    /private or reserved address/
+  );
+});
+
+test("assertPublicUrl rejects non-HTTP schemes", async () => {
+  for (const url of [
+    "file:///etc/passwd",
+    "ftp://example.com/x",
+    "gopher://example.com/",
+  ]) {
+    await assertRejectedWith(() => assertPublicUrl(url), /Unsupported URL scheme/);
+  }
+});
+
+test("assertPublicUrl rejects a malformed URL", async () => {
+  await assertRejectedWith(
+    () => assertPublicUrl("not a url"),
+    /Invalid URL format/
+  );
+});
+
+test("assertPublicUrl accepts a public literal without touching DNS", async () => {
+  const url = await assertPublicUrl("https://8.8.8.8/file.pdf");
+
+  assert.equal(url.hostname, "8.8.8.8");
+  assert.equal(url.pathname, "/file.pdf");
+});
+
+test("fetchPublicUrl sends nothing to a loopback listener", async () => {
+  // The report proved the bug by watching a listener log "CAPTURED REQUEST".
+  // Asserting on the listener, rather than only on the rejection, is what shows
+  // the request is refused before it leaves rather than after.
+  const captured: string[] = [];
+  const server = createServer((request, response) => {
+    captured.push(request.url ?? "");
+    response.end("ok");
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    await assertRejectedWith(
+      () => fetchPublicUrl(`http://127.0.0.1:${address.port}/ssrf-proof-token`),
+      /private or reserved address/
+    );
+    assert.deepEqual(captured, []);
+  } finally {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+});
+
+// The guard only helps where it is wired in, and the module that had the bug
+// cannot be imported here: it pulls in chunking.ts, whose "server-only" import
+// throws under node --test. Reading the source is what pins the call site, so
+// restoring the bare fetch fails a test rather than passing quietly.
+test("ingest downloads the PDF through the guard rather than bare fetch", () => {
+  const ingest = readFileSync(resolve("lib/rag/ingest/index.ts"), "utf8");
+
+  assert.match(ingest, /await fetchPublicUrl\(source\.fileUrl\)/);
+  assert.doesNotMatch(ingest, /await fetch\(/);
+});
+
+test("fetchPublicUrl refuses a redirect into a blocked range", async () => {
+  // fetch would follow a redirect itself, skipping the check on the new target,
+  // so fetchPublicUrl follows by hand and re-checks each hop. Stubbing fetch is
+  // the only way to stage a public first hop from a test.
+  const originalFetch = globalThis.fetch;
+  const requested: string[] = [];
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    requested.push(String(input));
+
+    return new Response(null, {
+      status: 302,
+      headers: { location: "http://169.254.169.254/latest/meta-data/" },
+    });
+  }) as typeof fetch;
+
+  try {
+    await assertRejectedWith(
+      () => fetchPublicUrl("https://8.8.8.8/file.pdf"),
+      /private or reserved address/
+    );
+    // Only the first, allowed hop was ever requested.
+    assert.deepEqual(requested, ["https://8.8.8.8/file.pdf"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/researcher/lib/rag/ingest/safe-fetch.unit.test.ts
+++ b/apps/researcher/lib/rag/ingest/safe-fetch.unit.test.ts
@@ -41,8 +41,14 @@ const BLOCKED = [
   "fe80::1%eth0",
   // IPv4-mapped and NAT64 forms both carry a blocked IPv4 destination.
   "::ffff:127.0.0.1",
+  "::ffff:7f00:1",
   "::ffff:169.254.169.254",
   "64:ff9b::7f00:1",
+  // Deprecated IPv4-compatible and SIIT embeddings of loopback.
+  "::7f00:1",
+  "::ffff:0:7f00:1",
+  // IPv6 multicast; v4 multicast 224.0.0.1 is already in the list above.
+  "ff02::1",
 ];
 
 const ALLOWED = [
@@ -54,6 +60,9 @@ const ALLOWED = [
   "128.0.0.1",
   "2606:4700:4700::1111",
   "::ffff:8.8.8.8",
+  // Unwrap, do not blanket-block: public IPv4 via compatible / SIIT stays public.
+  "::8.8.8.8",
+  "::ffff:0:8.8.8.8",
 ];
 
 // ChatbotError puts the caller-facing detail in `cause` and leaves `message` as

--- a/apps/researcher/lib/rag/ingest/safe-fetch.unit.test.ts
+++ b/apps/researcher/lib/rag/ingest/safe-fetch.unit.test.ts
@@ -238,3 +238,30 @@ test("fetchPublicUrl refuses a redirect into a blocked range", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("fetchPublicUrl maps a malformed redirect Location to ChatbotError", async () => {
+  // new URL(location, url) throws TypeError on a broken Location. Without a
+  // catch, chat's generic handler turns that into offline:chat (503) instead
+  // of the same 400 assertPublicUrl uses for a bad user-supplied URL.
+  const originalFetch = globalThis.fetch;
+  const requested: string[] = [];
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    requested.push(String(input));
+
+    return new Response(null, {
+      status: 302,
+      headers: { location: "http://[" },
+    });
+  }) as typeof fetch;
+
+  try {
+    await assertRejectedWith(
+      () => fetchPublicUrl("https://8.8.8.8/file.pdf"),
+      /Invalid URL format/
+    );
+    assert.deepEqual(requested, ["https://8.8.8.8/file.pdf"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- route the PDF file-part download through a destination check instead of a bare `fetch`
- reject loopback, private, link-local, and reserved targets, by literal or by hostname resolution
- re-check the destination at every redirect hop rather than letting `fetch` follow blindly

Closes #778

## Problem

### The server fetched whatever url the request named

`processSource` handled a `file` part with `mediaType: application/pdf` by calling `fetch(source.fileUrl)` on the url from the request body. Nothing looked at where that url pointed, so an authenticated chat request turned the server into a probe of its own network. The report proved it with a listener on `127.0.0.1:9999` that logged the incoming request.

### The existing filter did not apply, and would not have been enough

`extractUrlsFromText` has a denylist for urls found in chat text, but it never ran on file parts, and `postRequestBodySchema` only required `z.string().url()`.

That denylist is also prefix matching on a few literals, which misses:

- userinfo in front of the host, as in `http://user@127.0.0.1/`
- loopback outside `127.0.0.1`, such as `127.1.2.3`
- IPv6 forms: `::1`, `0:0:0:0:0:0:0:1`, `::ffff:127.0.0.1`
- link-local and the metadata address `169.254.169.254`, absent from the list
- hostnames that resolve into a blocked range
- redirects, which `fetch` follows on its own

## Fix

`lib/rag/ingest/safe-fetch.ts` holds the check, and ingest calls it:

- `assertPublicUrl` parses the url, requires http or https, and rejects blocked IPv4 and IPv6 ranges. IP literals are checked directly; hostnames are resolved and every returned address has to be public. IPv4-mapped and NAT64 forms are unwrapped so they cannot smuggle a blocked IPv4 destination. Anything unparseable counts as blocked.
- `fetchPublicUrl` runs that check, then fetches with `redirect: "manual"` and re-checks each hop, up to five.

The text-url path is untouched: it reaches its target through Jina Reader rather than from this server, so it is not a request from our network.

## Validation

- `pnpm --filter researcher test:unit` — 31 pass, 12 of them new
- reverting ingest to the bare `fetch` fails the call-site test, so the wiring is pinned rather than assumed
- one test asserts a real loopback listener records nothing, which shows the request is refused before it leaves, not after
- `pnpm exec tsc --noEmit` clean

## Out of scope

- DNS rebinding, where a host answers with a public address for the check and a private one for the connection. Closing it means pinning the connection to the address that was checked, which `fetch` does not expose.
- the prefix denylist in `extractUrlsFromText`, left as is since that path does not fetch from this server
- `/api/research/process-source` with a url body, which applies no denylist at all and reaches the target through Jina for the same reason
