### PR TITLE
fix(researcher): validate AUTH_SECRET before signing or verifying a session

### DIFF
--- a/apps/researcher/lib/auth/auth-secret.ts
+++ b/apps/researcher/lib/auth/auth-secret.ts
@@ -1,0 +1,36 @@
+// One rule for AUTH_SECRET across the app. session.ts and proxy.ts used to read
+// the variable raw, which had two silent failure modes:
+//
+//   - unset: `new TextEncoder().encode(undefined)` returns zero bytes, and jose
+//     signs and verifies HS256 with an empty key without complaining. The app
+//     then hands out and accepts cookies signed with a key every attacker
+//     already has, so forging a session for any user id takes no secret at all.
+//   - too short: a placeholder is brute-forceable offline from one captured
+//     cookie.
+//
+// enoki-challenge.ts already refused anything under 32 characters for the same
+// variable, so the session path was the odd one out.
+
+const MIN_AUTH_SECRET_LENGTH = 32;
+
+/**
+ * The validated AUTH_SECRET. Reading is deliberately lazy: validating at module
+ * scope would run during `next build`, where the Dockerfile supplies a short
+ * build-time placeholder, and fail the image build rather than a request.
+ */
+export function getAuthSecret(): string {
+  const value = process.env.AUTH_SECRET;
+
+  if (!value || value.length < MIN_AUTH_SECRET_LENGTH) {
+    throw new Error(
+      `AUTH_SECRET must contain at least ${MIN_AUTH_SECRET_LENGTH} characters`
+    );
+  }
+
+  return value;
+}
+
+/** The validated secret as a signing key, for jose. */
+export function getAuthSecretKey(): Uint8Array {
+  return new TextEncoder().encode(getAuthSecret());
+}

--- a/apps/researcher/lib/auth/auth-secret.unit.test.ts
+++ b/apps/researcher/lib/auth/auth-secret.unit.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import { SignJWT, jwtVerify } from "jose";
+import { getAuthSecret, getAuthSecretKey } from "./auth-secret";
+
+// Regression tests for issue #781: session.ts and proxy.ts signed and verified
+// session cookies with the raw AUTH_SECRET value, while enoki-challenge.ts in the
+// same folder already required at least 32 characters for that same variable.
+
+const THIRTY_TWO = "0123456789012345678901234567890a";
+
+function withSecret<T>(value: string | undefined, body: () => T): T {
+  const previous = process.env.AUTH_SECRET;
+
+  if (value === undefined) {
+    delete process.env.AUTH_SECRET;
+  } else {
+    process.env.AUTH_SECRET = value;
+  }
+
+  try {
+    return body();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.AUTH_SECRET;
+    } else {
+      process.env.AUTH_SECRET = previous;
+    }
+  }
+}
+
+test("getAuthSecret rejects a missing secret", () => {
+  withSecret(undefined, () => {
+    assert.throws(getAuthSecret, /at least 32 characters/);
+  });
+});
+
+test("getAuthSecret rejects an empty secret", () => {
+  // .env.example ships AUTH_SECRET= with no value, so this is the shape a
+  // copied config actually has.
+  withSecret("", () => {
+    assert.throws(getAuthSecret, /at least 32 characters/);
+  });
+});
+
+test("getAuthSecret rejects a secret one character short", () => {
+  withSecret("0123456789012345678901234567890", () => {
+    assert.throws(getAuthSecret, /at least 32 characters/);
+  });
+});
+
+test("getAuthSecret rejects the short placeholder from the report", () => {
+  withSecret("short", () => {
+    assert.throws(getAuthSecret, /at least 32 characters/);
+  });
+});
+
+test("getAuthSecret accepts a secret at the minimum length", () => {
+  withSecret(THIRTY_TWO, () => {
+    assert.equal(getAuthSecret().length, 32);
+    assert.equal(getAuthSecret(), THIRTY_TWO);
+  });
+});
+
+test("getAuthSecretKey encodes the validated secret", () => {
+  withSecret(THIRTY_TWO, () => {
+    assert.deepEqual(
+      getAuthSecretKey(),
+      new TextEncoder().encode(THIRTY_TWO)
+    );
+  });
+});
+
+test("getAuthSecretKey refuses the empty key that an unset secret used to produce", async () => {
+  // Why the guard exists at all: encoding an absent value yields zero bytes, and
+  // jose will sign and verify HS256 with that key. A deployment missing the
+  // variable therefore issued and accepted cookies signed with a key anyone can
+  // reproduce, so forging a session for any user id needed no secret.
+  const emptyKey = new TextEncoder().encode(process.env.AUTH_SECRET_UNSET);
+  assert.equal(emptyKey.length, 0);
+
+  const forged = await new SignJWT({ userId: "victim" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime("1h")
+    .sign(emptyKey);
+  const { payload } = await jwtVerify(forged, emptyKey);
+  assert.equal(payload.userId, "victim");
+
+  withSecret(undefined, () => {
+    assert.throws(getAuthSecretKey, /at least 32 characters/);
+  });
+});
+
+// The guard only helps where it is wired in. These modules cannot be imported
+// here (next/headers, the db client), so their source is what pins the call
+// sites: reintroducing a raw read fails a test rather than passing quietly.
+for (const path of ["lib/auth/session.ts", "proxy.ts"]) {
+  test(`${path} reads the secret through the guard`, () => {
+    const source = readFileSync(resolve(path), "utf8");
+
+    assert.match(source, /getAuthSecretKey\(\)/);
+    assert.doesNotMatch(source, /process\.env\.AUTH_SECRET/);
+  });
+}
+
+test("enoki-challenge.ts shares the one guard rather than its own copy", () => {
+  const source = readFileSync(resolve("lib/auth/enoki-challenge.ts"), "utf8");
+
+  assert.match(source, /getAuthSecretKey\(\)/);
+  assert.doesNotMatch(source, /process\.env\.AUTH_SECRET/);
+});
+
+test("the guard stays lazy so a build-time placeholder cannot break the image", () => {
+  // The Dockerfile builder stage sets a 22-character AUTH_SECRET so `next build`
+  // can prerender. Validating at module scope would fail the build instead of a
+  // request, so no module may compute the key while being imported.
+  for (const path of ["lib/auth/session.ts", "proxy.ts"]) {
+    const source = readFileSync(resolve(path), "utf8");
+    const moduleScopeCall = /^const \w+ = getAuthSecretKey\(\)/m;
+
+    assert.doesNotMatch(source, moduleScopeCall);
+  }
+});

--- a/apps/researcher/lib/auth/auth-secret.unit.test.ts
+++ b/apps/researcher/lib/auth/auth-secret.unit.test.ts
@@ -105,6 +105,21 @@ for (const path of ["lib/auth/session.ts", "proxy.ts"]) {
   });
 }
 
+test("session.ts and enoki-challenge.ts read the key before the verify try", () => {
+  // jwtVerify's try treats every throw as a bad cookie / failed ownership
+  // check. The key must be read outside that catch so a missing AUTH_SECRET
+  // fails loud instead of looking like "not authenticated".
+  for (const path of ["lib/auth/session.ts", "lib/auth/enoki-challenge.ts"]) {
+    const source = readFileSync(resolve(path), "utf8");
+
+    assert.match(source, /const secret = getAuthSecretKey\(\);/);
+    assert.doesNotMatch(
+      source,
+      /jwtVerify\(\s*\w+\s*,\s*getAuthSecretKey\(\)/
+    );
+  }
+});
+
 test("enoki-challenge.ts shares the one guard rather than its own copy", () => {
   const source = readFileSync(resolve("lib/auth/enoki-challenge.ts"), "utf8");
 

--- a/apps/researcher/lib/auth/enoki-challenge.ts
+++ b/apps/researcher/lib/auth/enoki-challenge.ts
@@ -5,6 +5,7 @@ import { normalizeSuiAddress } from "@mysten/sui/utils";
 import { verifyPersonalMessageSignature } from "@mysten/sui/verify";
 import { jwtVerify, SignJWT } from "jose";
 import { cookies } from "next/headers";
+import { getAuthSecretKey } from "@/lib/auth/auth-secret";
 import {
   requireSharedRedisClient,
   SharedRedisUnavailableError,
@@ -15,14 +16,6 @@ const CHALLENGE_TTL_SECONDS = 5 * 60;
 const CHALLENGE_REDIS_PREFIX = "enoki-auth:challenge:";
 
 type SuiNetwork = "mainnet" | "testnet";
-
-function getSecret(): Uint8Array {
-  const value = process.env.AUTH_SECRET;
-  if (!value || value.length < 32) {
-    throw new Error("AUTH_SECRET must contain at least 32 characters");
-  }
-  return new TextEncoder().encode(value);
-}
 
 function getNetwork(): SuiNetwork {
   return process.env.NEXT_PUBLIC_SUI_NETWORK === "mainnet"
@@ -56,7 +49,7 @@ export async function issueEnokiChallenge(rawAddress: string): Promise<string> {
     .setJti(nonce)
     .setIssuedAt()
     .setExpirationTime(`${CHALLENGE_TTL_SECONDS}s`)
-    .sign(getSecret());
+    .sign(getAuthSecretKey());
 
   try {
     const redis = await requireSharedRedisClient();
@@ -111,7 +104,7 @@ export async function verifyAndConsumeEnokiChallenge({
 
   try {
     const address = normalizeSuiAddress(rawAddress);
-    const { payload } = await jwtVerify(token, getSecret(), {
+    const { payload } = await jwtVerify(token, getAuthSecretKey(), {
       algorithms: ["HS256"],
       audience: "enoki-auth",
       issuer: "walrus-memory-researcher",

--- a/apps/researcher/lib/auth/enoki-challenge.ts
+++ b/apps/researcher/lib/auth/enoki-challenge.ts
@@ -102,9 +102,12 @@ export async function verifyAndConsumeEnokiChallenge({
     return false;
   }
 
+  // A missing/short AUTH_SECRET must not look like a failed ownership check.
+  const secret = getAuthSecretKey();
+
   try {
     const address = normalizeSuiAddress(rawAddress);
-    const { payload } = await jwtVerify(token, getAuthSecretKey(), {
+    const { payload } = await jwtVerify(token, secret, {
       algorithms: ["HS256"],
       audience: "enoki-auth",
       issuer: "walrus-memory-researcher",

--- a/apps/researcher/lib/auth/session.ts
+++ b/apps/researcher/lib/auth/session.ts
@@ -3,13 +3,13 @@ import "server-only";
 import { jwtVerify } from "jose";
 import { cookies } from "next/headers";
 import { getUserById } from "@/lib/db/queries";
+import { getAuthSecretKey } from "@/lib/auth/auth-secret";
 import {
   SESSION_MAX_AGE_SECONDS,
   signSessionIdentity,
 } from "@/lib/auth/session-token";
 
 const COOKIE_NAME = "session";
-const secret = new TextEncoder().encode(process.env.AUTH_SECRET);
 
 type SessionUser = {
   id: string;
@@ -28,7 +28,7 @@ export async function getSession(): Promise<{ user: SessionUser } | null> {
   if (!token) return null;
 
   try {
-    const { payload } = await jwtVerify(token, secret);
+    const { payload } = await jwtVerify(token, getAuthSecretKey());
     if (typeof payload.userId !== "string") return null;
 
     const user = await getUserById(payload.userId);
@@ -55,7 +55,7 @@ export async function createSession(
 ): Promise<void> {
   const token = await signSessionIdentity(
     { userId, publicKey, accountId },
-    secret
+    getAuthSecretKey()
   );
   const cookieStore = await cookies();
   cookieStore.set(COOKIE_NAME, token, {

--- a/apps/researcher/lib/auth/session.ts
+++ b/apps/researcher/lib/auth/session.ts
@@ -27,8 +27,13 @@ export async function getSession(): Promise<{ user: SessionUser } | null> {
   const token = cookieStore.get(COOKIE_NAME)?.value;
   if (!token) return null;
 
+  // Same order as proxy.ts: a missing/short AUTH_SECRET must throw, not look
+  // like an invalid cookie. /api/auth/* skips the proxy guard, so this is the
+  // path GET /api/auth/profile takes.
+  const secret = getAuthSecretKey();
+
   try {
-    const { payload } = await jwtVerify(token, getAuthSecretKey());
+    const { payload } = await jwtVerify(token, secret);
     if (typeof payload.userId !== "string") return null;
 
     const user = await getUserById(payload.userId);

--- a/apps/researcher/proxy.ts
+++ b/apps/researcher/proxy.ts
@@ -1,8 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { jwtVerify } from "jose";
+import { getAuthSecretKey } from "@/lib/auth/auth-secret";
 import { isTestEnvironment } from "@/lib/constants";
-
-const secret = new TextEncoder().encode(process.env.AUTH_SECRET);
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -21,6 +20,10 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Read the secret whether or not a cookie came with the request. Deferring it
+  // until a token shows up would let a deployment with no AUTH_SECRET serve the
+  // login page as if nothing were wrong.
+  const secret = getAuthSecretKey();
   const token = request.cookies.get("session")?.value;
   let isAuthenticated = false;
 


### PR DESCRIPTION
## Summary

- validate `AUTH_SECRET` before it is used to sign or verify a session cookie, matching the 32 character rule the app already applied to Enoki challenges
- cover both raw readers, `lib/auth/session.ts` and `proxy.ts`, and drop the duplicate guard in `lib/auth/enoki-challenge.ts` so one rule covers every caller
- keep the check inside the functions so `next build` with the short Docker placeholder still succeeds

Closes #781

## Problem

### The session path trusted whatever the variable held

`lib/auth/session.ts` and `proxy.ts` both did `new TextEncoder().encode(process.env.AUTH_SECRET)` at module scope. `lib/auth/enoki-challenge.ts`, in the same folder, already rejected anything under 32 characters for that same variable, so the session path was the odd one out.

### A short secret is brute-forceable

The reported 5 character value signs valid HS256 cookies. One captured cookie is enough to recover the secret offline and mint sessions.

### An unset variable is worse, and was not in the report

`new TextEncoder().encode(undefined)` returns zero bytes, and jose signs and verifies HS256 with an empty key without complaint. A deployment that never set the variable therefore issued and accepted cookies signed with a key anyone can reproduce, so forging a session for any user id needed no secret at all.

That state is reachable by accident rather than in theory:

- `.env.example` ships `AUTH_SECRET=` with no value
- the runtime image starts from a fresh base, so it does not inherit the builder stage placeholder

### The report named only part of the surface

It cited `session.ts` and `session-token.ts`. `proxy.ts` carried the identical raw read and gates every page.

## Fix

`lib/auth/auth-secret.ts` holds the rule:

- `getAuthSecret` returns the value only when it is present and at least 32 characters, and throws otherwise
- `getAuthSecretKey` returns that value encoded, for jose
- `session.ts`, `proxy.ts`, and `enoki-challenge.ts` all call it, so the threshold lives in one place

Two deliberate choices:

- Validation happens when the secret is used, not at module scope. The Dockerfile builder stage sets a 22 character `AUTH_SECRET` so `next build` can prerender, and a module scope check would fail the image build instead of a request.
- `proxy.ts` reads the secret whether or not a cookie arrived. Deferring it until a token appears would let a deployment with no secret serve the login page as though the caller were merely signed out.

## Validation

- `pnpm --filter researcher test:unit` — 28 pass, 12 of them new, covering unset, empty, 31 characters, exactly 32, and the reported `short`
- one test signs and verifies a JWT with an empty key to record why the guard exists, then asserts the guard refuses that case
- source-level tests pin the call sites, so reintroducing a raw read or hoisting the check to module scope fails a test rather than passing quietly
- `AUTH_SECRET=build-time-placeholder pnpm next build` succeeds, so the image build is unaffected
- `pnpm exec tsc --noEmit` clean

## Out of scope

- `apps/chatbot`, where open PR #644 adds the same guard through its own `lib/auth-secret.ts`. Touching those files here would collide with that branch.
- promoting the check to startup rather than first use, which would need a boot-time entry point that also runs before `next build` prerendering
- `.env.example` still ships an empty `AUTH_SECRET`; with this change a local run fails loudly instead of accepting an empty key, but generating a value is left to the operator