### PR TITLE
fix(python-sdk): warn on plaintext remote server_url (WALM-452)

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,7 +29,7 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, and aligns restore `truncated` docs with WALM-431 retryable semantics. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
+  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
@@ -38,13 +38,14 @@ For the latest version, see the [PyPI project page](https://pypi.org/project/mem
 
 ## 0.1.9
 
-This release reports HTTP 503 as a retryable upstream outage and aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids.
+This release reports HTTP 503 as a retryable upstream outage, aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids, and warns when `server_url` uses plaintext HTTP on a non-localhost host.
 
 ### Fixed
 
 - HTTP 503 from the relayer is reported as a retryable upstream outage, not a credential failure.
 - `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 - restore `truncated` docs now match WALM-431 retryable semantics.
+- Warn when `server_url` uses plaintext `http://` against a non-localhost host, matching the TypeScript SDK `normalizeServerUrl` guard. Localhost, `127.0.0.1`, `::1`, and `*.localhost` are exempt; invalid URLs are left for the HTTP client to surface.
 
 ## 0.1.8
 

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,7 +29,7 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
+  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
@@ -45,7 +45,7 @@ This release reports HTTP 503 as a retryable upstream outage, aligns Python bulk
 - HTTP 503 from the relayer is reported as a retryable upstream outage, not a credential failure.
 - `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 - restore `truncated` docs now match WALM-431 retryable semantics.
-- Warn when `server_url` uses plaintext `http://` against a non-localhost host, matching the TypeScript SDK `normalizeServerUrl` guard. Localhost, `127.0.0.1`, `::1`, and `*.localhost` are exempt; invalid URLs are left for the HTTP client to surface.
+- Warn when `server_url` uses plaintext `http://` against a non-localhost host, matching the TypeScript SDK `normalizeServerUrl` guard. Localhost, `127.0.0.1`, `::1`, and `*.localhost` are exempt; invalid URLs are left for the HTTP client to surface. The warning logs only scheme, host, and port so URL userinfo is not written to logs.
 
 ## 0.1.8
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -7,7 +7,7 @@
 - HTTP 503 with `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` is reported as a retryable credential-verification outage, not a sign-in failure. Other 503s keep the generic sanitized body.
 - `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 - restore `truncated` docs now match WALM-431 retryable semantics.
-- Warn when `server_url` uses plaintext `http://` against a non-localhost host, matching the TypeScript SDK `normalizeServerUrl` guard. Localhost, `127.0.0.1`, `::1`, and `*.localhost` are exempt; invalid URLs are left for the HTTP client to surface.
+- Warn when `server_url` uses plaintext `http://` against a non-localhost host, matching the TypeScript SDK `normalizeServerUrl` guard. Localhost, `127.0.0.1`, `::1`, and `*.localhost` are exempt; invalid URLs are left for the HTTP client to surface. The warning logs only scheme, host, and port so URL userinfo is not written to logs.
 
 ## 0.1.8
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -7,6 +7,7 @@
 - HTTP 503 with `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` is reported as a retryable credential-verification outage, not a sign-in failure. Other 503s keep the generic sanitized body.
 - `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 - restore `truncated` docs now match WALM-431 retryable semantics.
+- Warn when `server_url` uses plaintext `http://` against a non-localhost host, matching the TypeScript SDK `normalizeServerUrl` guard. Localhost, `127.0.0.1`, `::1`, and `*.localhost` are exempt; invalid URLs are left for the HTTP client to surface.
 
 ## 0.1.8
 

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -35,7 +35,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 import httpx
 import nacl.signing
@@ -108,12 +108,27 @@ UPSTREAM_UNAVAILABLE_MESSAGE = (
 logger = logging.getLogger("memwal")
 
 
+def _server_url_for_log(parsed: ParseResult) -> str:
+    """Scheme/host/port only — never userinfo, path, query, or fragment."""
+
+    host = parsed.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed.port is not None:
+        return f"{parsed.scheme}://{host}:{parsed.port}"
+    return f"{parsed.scheme}://{host}"
+
+
 def normalize_server_url(url: str) -> str:
     """Strip a trailing slash and warn on plaintext HTTP to a remote host.
 
     Ports the TypeScript ``normalizeServerUrl`` helper: localhost,
     ``127.0.0.1``, ``::1``, and ``*.localhost`` are exempt. Invalid URLs
     are returned trimmed so the HTTP client can surface the error later.
+
+    The warning logs only scheme/host/port so URL userinfo (HTTPX
+    credentials) and other sensitive components are not written to logs.
+    The returned URL is otherwise unchanged and still used for transport.
     """
 
     trimmed = url.rstrip("/")
@@ -131,7 +146,7 @@ def normalize_server_url(url: str) -> str:
                 '[memwal] serverUrl "%s" uses plaintext HTTP on a non-localhost host. '
                 "Signed requests and any bearer material will be visible to the network. "
                 "Use https:// in production.",
-                trimmed,
+                _server_url_for_log(parsed),
             )
     except ValueError:
         # invalid URL — let the HTTP call surface the error at request time

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -35,6 +35,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
+from urllib.parse import urlparse
 
 import httpx
 import nacl.signing
@@ -105,6 +106,37 @@ UPSTREAM_UNAVAILABLE_MESSAGE = (
 
 
 logger = logging.getLogger("memwal")
+
+
+def normalize_server_url(url: str) -> str:
+    """Strip a trailing slash and warn on plaintext HTTP to a remote host.
+
+    Ports the TypeScript ``normalizeServerUrl`` helper: localhost,
+    ``127.0.0.1``, ``::1``, and ``*.localhost`` are exempt. Invalid URLs
+    are returned trimmed so the HTTP client can surface the error later.
+    """
+
+    trimmed = url.rstrip("/")
+    try:
+        parsed = urlparse(trimmed)
+        host = (parsed.hostname or "").lower()
+        is_local = (
+            host == "localhost"
+            or host == "127.0.0.1"
+            or host == "::1"
+            or host.endswith(".localhost")
+        )
+        if parsed.scheme == "http" and host and not is_local:
+            logger.warning(
+                '[memwal] serverUrl "%s" uses plaintext HTTP on a non-localhost host. '
+                "Signed requests and any bearer material will be visible to the network. "
+                "Use https:// in production.",
+                trimmed,
+            )
+    except ValueError:
+        # invalid URL — let the HTTP call surface the error at request time
+        pass
+    return trimmed
 
 
 # ============================================================
@@ -234,7 +266,7 @@ class MemWal:
         self._private_key_hex = normalize_private_key(config.key)
         self._signing_key = build_signing_key(self._private_key_hex)
         self._account_id = config.account_id
-        self._server_url = config.server_url.rstrip("/")
+        self._server_url = normalize_server_url(config.server_url)
         self._namespace = config.namespace
         self._client: Optional[httpx.AsyncClient] = None
         self._server_config: Optional[Dict[str, str]] = None

--- a/packages/python-sdk-memwal/tests/test_normalize_server_url.py
+++ b/packages/python-sdk-memwal/tests/test_normalize_server_url.py
@@ -1,0 +1,62 @@
+"""Tests for plaintext HTTP server_url guarding (WALM-452 / #748).
+
+No network: ``MemWal.create`` only stores config, and
+``normalize_server_url`` is a pure parse + log helper.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from memwal.client import MemWal, normalize_server_url
+
+_KEY = "ab" * 32
+_ACCOUNT = "0xdummy"
+
+
+def test_plaintext_remote_warns_and_strips(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING, logger="memwal")
+    assert (
+        normalize_server_url("http://relayer.example.com/")
+        == "http://relayer.example.com"
+    )
+    assert "plaintext" in caplog.text
+
+
+def test_https_remote_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING, logger="memwal")
+    assert (
+        normalize_server_url("https://relayer.memory.walrus.xyz")
+        == "https://relayer.memory.walrus.xyz"
+    )
+    assert caplog.text == ""
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8000",
+        "http://127.0.0.1:8000",
+        "http://foo.localhost",
+        "http://[::1]:8000",
+    ],
+)
+def test_plaintext_local_does_not_warn(
+    url: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING, logger="memwal")
+    assert normalize_server_url(url) == url
+    assert caplog.text == ""
+
+
+def test_create_warns_on_plaintext_remote(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING, logger="memwal")
+    client = MemWal.create(
+        key=_KEY,
+        account_id=_ACCOUNT,
+        server_url="http://relayer.example.com/",
+    )
+    assert client._server_url == "http://relayer.example.com"
+    assert "plaintext" in caplog.text

--- a/packages/python-sdk-memwal/tests/test_normalize_server_url.py
+++ b/packages/python-sdk-memwal/tests/test_normalize_server_url.py
@@ -60,3 +60,37 @@ def test_create_warns_on_plaintext_remote(caplog: pytest.LogCaptureFixture) -> N
     )
     assert client._server_url == "http://relayer.example.com"
     assert "plaintext" in caplog.text
+
+
+def test_plaintext_remote_warning_omits_url_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """HTTPX userinfo must stay on the transport URL and out of the warning."""
+
+    caplog.set_level(logging.WARNING, logger="memwal")
+    url = "http://alice:example-secret@relayer.example.com/?token=super-secret"
+    assert (
+        normalize_server_url(url)
+        == "http://alice:example-secret@relayer.example.com/?token=super-secret"
+    )
+    assert "plaintext" in caplog.text
+    assert "http://relayer.example.com" in caplog.text
+    assert "alice" not in caplog.text
+    assert "example-secret" not in caplog.text
+    assert "super-secret" not in caplog.text
+    for rec in caplog.records:
+        assert "example-secret" not in rec.getMessage()
+        assert "example-secret" not in str(rec.args)
+        assert "super-secret" not in rec.getMessage()
+        assert "super-secret" not in str(rec.args)
+
+
+def test_create_preserves_url_credentials_and_redacts_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="memwal")
+    url = "http://alice:example-secret@relayer.example.com/"
+    client = MemWal.create(key=_KEY, account_id=_ACCOUNT, server_url=url)
+    assert client._server_url == "http://alice:example-secret@relayer.example.com"
+    assert "plaintext" in caplog.text
+    assert "example-secret" not in caplog.text


### PR DESCRIPTION
## Ticket

WALM-452 — https://linear.app/mysten-labs/issue/WALM-452
GH #748 — https://github.com/MystenLabs/MemWal/issues/748

## What changed?

- Python SDK `normalize_server_url` now matches the TS `normalizeServerUrl` guard: warn (do not raise) when `server_url` is plaintext `http://` on a non-localhost host.
- Localhost / `127.0.0.1` / `::1` / `*.localhost` stay silent. Trailing slash still stripped.
- Python SDK patch bump 0.1.8 → 0.1.9 (changelogs + verify-script pin).

## Why is this needed?

A remote `http://` relayer silently sent signed headers and any bearer material in cleartext. The TS SDK already warned; Python did not.

## Scope

Python SDK client construction warning. Same semantics as TS LOW-22.

### Out of scope

- Raising / refusing the URL
- TypeScript SDK (already has the guard)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `python3 -m pytest tests/test_normalize_server_url.py tests/test_client.py tests/test_env_presets.py tests/test_signing.py tests/test_auth_rejected_message.py -m "not integration"` (102 passed); `node scripts/verify-manual-sdk-release.mjs` (pass)

## How can the reviewer verify it?

1. Read `normalize_server_url` in `packages/python-sdk-memwal/memwal/client.py` against `packages/sdk/src/utils.ts` `normalizeServerUrl`.
2. Run the new tests in `packages/python-sdk-memwal/tests/test_normalize_server_url.py`.
3. Confirm `node scripts/verify-manual-sdk-release.mjs` still passes.

## Risks and dependencies

Warning only; no request is blocked. Operators who rely on remote HTTP will see a log line.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
