### PR TITLE
fix(server): return 400 for oversized recall embeddings (WALM-423)

### DIFF
--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -26,6 +26,18 @@ pub const EMBEDDING_MODEL: &str = "openai/text-embedding-3-small";
 /// on the manual write path are validated against it.
 pub const EMBEDDING_DIMS: usize = 1536;
 
+/// 16384 = 8192 tokens × 2 chars/token under cl100k; do not use admin 64KiB.
+const MAX_EMBED_INPUT_BYTES: usize = 16384;
+
+fn reject_oversized_embed_input(text: &str) -> Result<(), AppError> {
+    if text.len() > MAX_EMBED_INPUT_BYTES {
+        return Err(AppError::BadRequest(format!(
+            "input is over the embedding input limit of {MAX_EMBED_INPUT_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
 #[async_trait]
 pub trait Embedder: Send + Sync {
     /// Embed a single text into a vector. Returns the vector or an error if
@@ -55,6 +67,7 @@ impl OpenAiEmbedder {
 impl Embedder for OpenAiEmbedder {
     #[tracing::instrument(name = "embedder.embed", skip_all, fields(text_len = text.len()))]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, AppError> {
+        reject_oversized_embed_input(text)?;
         match &self.config.openai_api_key {
             Some(api_key) => {
                 // Real embedding via OpenRouter/OpenAI-compatible API
@@ -92,15 +105,17 @@ impl Embedder for OpenAiEmbedder {
                 if !resp.status().is_success() {
                     let status = resp.status();
                     let body = resp.text().await.unwrap_or_default();
-                    // Same transient-vs-permanent split as the
-                    // extractor: 429 + 5xx → 503 (retryable); other
-                    // 4xx → 500 (genuine bug). See
-                    // `extractor::is_upstream_status_transient`.
                     if crate::services::extractor::is_upstream_status_transient(status) {
                         return Err(AppError::UpstreamUnavailable(format!(
                             "Embedding API upstream error ({}): {}",
                             status, body
                         )));
+                    }
+                    if status == reqwest::StatusCode::BAD_REQUEST {
+                        tracing::warn!(%status, body, "embedding API returned 400");
+                        return Err(AppError::BadRequest(
+                            "embedding input exceeds the model context limit".into(),
+                        ));
                     }
                     return Err(AppError::Internal(format!(
                         "Embedding API error ({}): {}",
@@ -206,5 +221,34 @@ mod tests {
             .expect("embedder must be able to detect the same envelope shape as the extractor");
         assert_eq!(envelope.code, 504);
         assert_eq!(envelope.message, "The operation was aborted");
+    }
+
+    fn assert_bad_request(result: Result<(), crate::types::AppError>, needle: &str) {
+        match result {
+            Err(crate::types::AppError::BadRequest(msg)) => {
+                assert!(
+                    msg.contains(needle),
+                    "expected error mentioning {needle:?}, got: {msg}"
+                );
+            }
+            other => panic!("expected BadRequest containing {needle:?}, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn embed_input_at_byte_limit_is_accepted() {
+        super::reject_oversized_embed_input(&"q".repeat(super::MAX_EMBED_INPUT_BYTES)).unwrap();
+    }
+
+    #[test]
+    fn embed_input_over_byte_limit_is_bad_request() {
+        assert_bad_request(
+            super::reject_oversized_embed_input(&"q".repeat(16400)),
+            "input is over the embedding input limit",
+        );
+        assert_bad_request(
+            super::reject_oversized_embed_input(&"q".repeat(16385)),
+            "input is over the embedding input limit",
+        );
     }
 }


### PR DESCRIPTION
## Ticket

WALM-423 — https://linear.app/mysten-labs/issue/WALM-423
GH #785 — https://github.com/MystenLabs/MemWal/issues/785

## What changed?

- Embedder rejects input over 16384 bytes with HTTP 400 before calling the embedding provider.
- Provider HTTP 400 is mapped to a generic client 400 (`embedding input exceeds the model context limit`) instead of Internal 500. The provider body is logged server-side only.
- 429 / 5xx still surface as 503. Other 4xx stay Internal.

## Why is this needed?

A recall/ask query just over `text-embedding-3-small`'s 8192-token limit made OpenAI return 400 `context_length_exceeded`, which the relayer turned into HTTP 500.

## Scope

Embedder input cap + 400 mapping. Relayer only.

### Out of scope

- Tokenizer-accurate token counts (no tiktoken)
- Changing extractor 4xx mapping globally

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `cargo test --manifest-path services/server/Cargo.toml --lib embed` (7 passed)

## How can the reviewer verify it?

1. Read `reject_oversized_embed_input` and the 400 arm in `services/server/src/services/embedder.rs`.
2. Run `cargo test --manifest-path services/server/Cargo.toml --lib embed`.
3. Confirm `"q".repeat(16384)` is accepted and `"q".repeat(16400)` is BadRequest.

## Risks and dependencies

Recall/analyze/admin embed callers now 400 at 16KiB instead of forwarding huge payloads. Admin's 64KiB route cap is no longer reachable for embed.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
