### PR TITLE
fix(python-sdk): reject misaligned remember_bulk job_ids (WALM-453)

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,12 +29,20 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.8. It adds `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset, and hardens hex decoding and error redaction. 0.1.7 added deterministic mock clients and idempotency keys.
+  The latest Python SDK release is 0.1.9. It rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
 
 For the latest version, see the [PyPI project page](https://pypi.org/project/memwal/).
+
+## 0.1.9
+
+This release aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids.
+
+### Fixed
+
+- `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
 
 ## 0.1.8
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # memwal
 
+## 0.1.9
+
+### Fixed
+
+- `remember_bulk_async` rejects an empty `items` list before the request and raises when the relayer returns a `job_ids` length that does not match the batch.
+
 ## 0.1.8
 
 ### Added

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -122,4 +122,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -463,6 +463,9 @@ class MemWal:
         capped at ``MAX_REMEMBER_TEXT_BYTES`` (= 64 KiB).
         """
 
+        if not items:
+            raise ValueError("remember_bulk_async: items must be a non-empty array")
+
         payload_items: List[Dict[str, Any]] = [
             {
                 "text": item.text,
@@ -476,8 +479,15 @@ class MemWal:
             {"items": payload_items},
             accepted_statuses=(200, 202),
         )
+        job_ids = data.get("job_ids")
+        returned = len(job_ids) if job_ids else 0
+        if not job_ids or returned != len(payload_items):
+            raise ValueError(
+                f"remember_bulk_async: server returned {returned} job_ids for "
+                f"{len(payload_items)} items"
+            )
         return RememberBulkAcceptedResult(
-            job_ids=list(data.get("job_ids", [])),
+            job_ids=list(job_ids),
             total=int(data.get("total", len(payload_items))),
             status=data.get("status", "pending"),
         )

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.8"
+version = "0.1.9"
 description = "Python SDK for Walrus Memory — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -27,6 +27,8 @@ from memwal.client import (
 from memwal.types import (
     RecallManualOptions,
     RecallParams,
+    RememberBulkAcceptedResult,
+    RememberBulkItem,
     RememberManualOptions,
     ScoringWeights,
 )
@@ -340,6 +342,90 @@ class TestRemember:
         body = json.loads(route.calls[0].request.content)
         assert body["namespace"] == "custom-ns"
         assert result.job_id == "job-2"
+        assert result.status == "pending"
+
+
+# ============================================================
+# remember_bulk_async() tests
+# ============================================================
+
+
+class TestRememberBulkAsync:
+    @respx.mock
+    async def test_empty_items_raises_without_http(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
+        route = respx.post(f"{_TEST_SERVER}/api/remember/bulk").mock(
+            return_value=httpx.Response(
+                202,
+                json={"job_ids": [], "total": 0, "status": "pending"},
+            )
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="remember_bulk_async: items must be a non-empty array",
+        ):
+            await memwal_client.remember_bulk_async([])
+
+        assert not route.called
+
+    @respx.mock
+    async def test_mismatched_job_ids_raises(self, memwal_client: MemWal) -> None:
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/remember/bulk").mock(
+            return_value=httpx.Response(
+                202,
+                json={
+                    "job_ids": ["job-1"],
+                    "total": 1,
+                    "status": "pending",
+                },
+            )
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="remember_bulk_async: server returned 1 job_ids for 2 items",
+        ):
+            await memwal_client.remember_bulk_async(
+                [
+                    RememberBulkItem(text="I love coffee"),
+                    RememberBulkItem(text="I live in Tokyo"),
+                ]
+            )
+
+    @respx.mock
+    async def test_matching_job_ids_returns_accepted(
+        self, memwal_client: MemWal
+    ) -> None:
+        mock_seal_session_prereqs()
+        route = respx.post(f"{_TEST_SERVER}/api/remember/bulk").mock(
+            return_value=httpx.Response(
+                202,
+                json={
+                    "job_ids": ["job-1", "job-2"],
+                    "total": 2,
+                    "status": "pending",
+                },
+            )
+        )
+
+        result = await memwal_client.remember_bulk_async(
+            [
+                RememberBulkItem(text="I love coffee"),
+                RememberBulkItem(text="I live in Tokyo", namespace="profile"),
+            ]
+        )
+
+        assert route.called
+        body = json.loads(route.calls[0].request.content)
+        assert body["items"] == [
+            {"text": "I love coffee", "namespace": "default"},
+            {"text": "I live in Tokyo", "namespace": "profile"},
+        ]
+        assert isinstance(result, RememberBulkAcceptedResult)
+        assert result.job_ids == ["job-1", "job-2"]
+        assert result.total == 2
         assert result.status == "pending"
 
 

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -11,7 +11,7 @@ const releases = [
     },
     {
         name: "Python SDK",
-        version: "0.1.8",
+        version: "0.1.9",
         manifests: [
             ["packages/python-sdk-memwal/pyproject.toml", "toml-version"],
             ["packages/python-sdk-memwal/memwal/__init__.py", "python-version"],


### PR DESCRIPTION
## Ticket

WALM-453 — https://linear.app/mysten-labs/issue/WALM-453
GH #750 — https://github.com/MystenLabs/MemWal/issues/750

## What changed?

- Python `remember_bulk_async` now rejects an empty `items` list before the network call.
- After accept, it requires `len(job_ids) == len(items)` instead of treating a truncated relayer response as success.
- Python SDK patch bump 0.1.8 → 0.1.9.

## Why is this needed?

A misaligned bulk response silently under-tracked writes. The TypeScript SDK already refused that shape.

## Scope

Python `remember_bulk_async` (and the `remember_bulk` alias).

### Out of scope

- `remember_facts_async`
- TypeScript SDK (already has the guards)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `pytest tests/test_client.py::TestRememberBulkAsync tests/test_client.py::TestRemember` (7 passed); `node scripts/verify-manual-sdk-release.mjs`

## How can the reviewer verify it?

1. Compare `remember_bulk_async` in `packages/python-sdk-memwal/memwal/client.py` to `rememberBulkAsync` in `packages/sdk/src/memwal.ts`.
2. Run `pytest packages/python-sdk-memwal/tests/test_client.py::TestRememberBulkAsync`.
3. Confirm `node scripts/verify-manual-sdk-release.mjs` passes.

## Risks and dependencies

Conflicts with PR #836 on the Python 0.1.9 version files (both bump 0.1.8→0.1.9 from `dev`). Merge #836 first, then rebase this and keep the Fixed bullet under `## 0.1.9` without bumping to 0.1.10.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
