### PR TITLE
fix(sdk): stop telling headless clients to call memwal_login (WALM-454)

### DIFF
--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,16 +28,20 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures.
+This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures, and stops telling headless SDK clients to call `memwal_login` on empty-body 401s.
 
 ### Added
 
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+
+### Fixed
+
+- Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 
 ## 0.1.6
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
+### Fixed
+
+- Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
+
 ## 0.1.6
 
 ### Added

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -308,15 +308,11 @@ export function sanitizeServerError(
 ): { message: string; raw: string; serverCode?: string } {
     // Number() so a string "401" (some MCP / HTTP paths) still hits this branch.
     if (Number(status) === 401) {
-        // Empty body = no-session / bare relayer 401. Non-empty keeps
-        // the AUTH_REJECTED triage (wrong key / account / network).
-        const empty = !String(rawBody ?? "").trim();
         return {
-            message: empty
-                ? "Walrus Memory isn't signed in. Call the memwal_login tool, then retry."
-                : "401 from relayer: typically wrong private key, key not registered on this account, " +
-                  "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
-                  "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",
+            message:
+                "401 from relayer: typically wrong private key, key not registered on this account, " +
+                "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
+                "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",
             raw: rawBody,
             serverCode: "AUTH_REJECTED",
         };

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -3,30 +3,31 @@ import test from "node:test";
 
 import { sanitizeServerError } from "../dist/utils.js";
 
-const LOGIN =
-    "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.";
+const AUTH_REJECTED =
+    "401 from relayer: typically wrong private key, key not registered on this account, " +
+    "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
+    "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors";
 
-test("empty-body 401 points at memwal_login instead of <no message>", () => {
+test("empty-body 401 uses AUTH_REJECTED troubleshooting instead of memwal_login", () => {
     const { message, serverCode } = sanitizeServerError(401, "");
     assert.equal(serverCode, "AUTH_REJECTED");
-    assert.equal(message, LOGIN);
+    assert.equal(message, AUTH_REJECTED);
     assert.doesNotMatch(message, /<no message>/);
+    assert.doesNotMatch(message, /memwal_login/);
 });
 
-test("string status \"401\" with an empty body uses the login hint", () => {
+test("string status \"401\" with an empty body uses AUTH_REJECTED troubleshooting", () => {
     const { message, serverCode } = sanitizeServerError("401", "   ");
     assert.equal(serverCode, "AUTH_REJECTED");
-    assert.equal(message, LOGIN);
+    assert.equal(message, AUTH_REJECTED);
     assert.doesNotMatch(message, /<no message>/);
+    assert.doesNotMatch(message, /memwal_login/);
 });
 
 test("non-empty 401 keeps the AUTH_REJECTED troubleshooting URL", () => {
     const { message, serverCode } = sanitizeServerError(401, "auth rejected");
     assert.equal(serverCode, "AUTH_REJECTED");
-    assert.match(
-        message,
-        /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
-    );
+    assert.equal(message, AUTH_REJECTED);
     assert.doesNotMatch(message, /memwal_login/);
 });
 


### PR DESCRIPTION
## Ticket

WALM-454 — https://linear.app/mysten-labs/issue/WALM-454
GH #829 — https://github.com/MystenLabs/MemWal/issues/829

## What changed?

- Empty HTTP 401s from the TypeScript SDK now use the same AUTH_REJECTED troubleshooting copy as non-empty 401s.
- That copy no longer tells callers to run `memwal_login` (an MCP tool). MCP keeps its own signed-out message.
- TypeScript SDK patch bump 0.1.5 → 0.1.6.

## Why is this needed?

Headless SDK users with a private key and account ID were told to call an MCP login tool they do not have.

## Scope

TS SDK `sanitizeServerError` 401 copy.

### Out of scope

- MCP signed-out instructions
- Relayer 401 vs 503 classification (WALM-429 / PR #811)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `node --test packages/sdk/test/sanitize-server-error.test.mjs` (5 passed); `node scripts/verify-manual-sdk-release.mjs`

## How can the reviewer verify it?

1. Read `sanitizeServerError` in `packages/sdk/src/utils.ts`.
2. Run `node --test packages/sdk/test/sanitize-server-error.test.mjs` from the SDK package after `tsc`.
3. Confirm the message does not contain `memwal_login` and still links the 401 troubleshooting doc.

## Risks and dependencies

Conflicts with PR #811 on the TypeScript 0.1.6 version files. Merge #811 first, then rebase this and keep the Fixed bullet under `## 0.1.6` without bumping to 0.1.7. MCP clients still get `memwal_login` from the MCP package itself.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
