### PR TITLE
ci(contract): gate SEAL cross-account deny invariant (COMG-714)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -551,3 +551,7 @@ jobs:
       - name: Run Move unit tests
         working-directory: services/contract
         run: sui move test
+
+      - name: Require SEAL cross-account deny invariant
+        working-directory: services/contract
+        run: sui move test --filter seal_approve_delegate_requires_matching_owner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -554,4 +554,7 @@ jobs:
 
       - name: Require SEAL cross-account deny invariant
         working-directory: services/contract
-        run: sui move test --filter seal_approve_delegate_requires_matching_owner
+        run: |
+          set -o pipefail
+          sui move test seal_approve_delegate_requires_matching_owner | tee /tmp/seal-invariant.log
+          grep -q 'test_seal_approve_delegate_requires_matching_owner' /tmp/seal-invariant.log

--- a/docs/relayer/versioning-and-compatibility.md
+++ b/docs/relayer/versioning-and-compatibility.md
@@ -120,5 +120,6 @@ CI runs `pnpm check:compatibility`, which verifies that:
 - SDK/MCP compatibility baselines match the relayer's minimum supported versions
 - SDK/MCP package versions are not older than the compatibility baseline they advertise
 - this policy document contains the current API version and compatibility matrix values
+- `test_seal_approve_delegate_requires_matching_owner` (`ENoAccess`) remains in the Move suite; CI also runs that test by name so deleting it fails the gate
 
 If a public compatibility value changes, update the implementation, this document, and the relevant changelog/deprecation notes together.

--- a/scripts/check-compatibility-contract.mjs
+++ b/scripts/check-compatibility-contract.mjs
@@ -126,4 +126,16 @@ for (const value of [
     assertContains("versioning policy doc", policyDoc, value);
 }
 
+const sealInvariantTest = read("services/contract/tests/account_tests.move");
+assertContains(
+    "SEAL cross-account deny invariant (COMG-714): services/contract/tests/account_tests.move",
+    sealInvariantTest,
+    "fun test_seal_approve_delegate_requires_matching_owner",
+);
+assertContains(
+    "SEAL cross-account deny invariant abort code (COMG-714): services/contract/tests/account_tests.move",
+    sealInvariantTest,
+    "ENoAccess",
+);
+
 console.log("compatibility contract OK");


### PR DESCRIPTION
## Summary
CI now fails if the SEAL cross-account deny invariant is deleted.

`sui move test` still runs the full suite, but deleting `test_seal_approve_delegate_requires_matching_owner` would still go green. This gate requires that test to exist and pass.

## Changes
- `scripts/check-compatibility-contract.mjs` asserts `services/contract/tests/account_tests.move` contains `fun test_seal_approve_delegate_requires_matching_owner` and `ENoAccess`.
- `move-contract` job runs `sui move test --filter seal_approve_delegate_requires_matching_owner` after the full suite.
- One-line note in `docs/relayer/versioning-and-compatibility.md`.

COMG-714