### PR TITLE
docs(ops): migration completion artifact schema (COMG-718)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
             script: scripts/check-docs-freshness.mjs
           - name: SEAL cross-account synthetic parser
             script: scripts/synthetic-seal-cross-account.test.mjs
+          - name: Migration / Completion artifact
+            script: scripts/write-migration-completion-artifact.mjs --self-test
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/ops/migration-completion-artifact.md
+++ b/docs/ops/migration-completion-artifact.md
@@ -4,7 +4,8 @@ After a security migration, write a completion artifact that records the target
 package, reviewed manifest digest, imported counts, verification result, and
 approver. Keep the file with the operator record. This is not a full release
 checklist and it is not the in-cluster completion-report consumed as
-`COMPLETION_EVIDENCE_JSON`.
+`COMPLETION_EVIDENCE_JSON`. Security RC classification and review are in
+`docs/ops/security-rc-workflow.md`.
 
 `scripts/build-finalize-tx.ts` still requires `MANIFEST_SHA256` and a fresh
 completion-report. Ceremony GitHub Environments are checked by

--- a/docs/ops/migration-completion-artifact.md
+++ b/docs/ops/migration-completion-artifact.md
@@ -1,0 +1,62 @@
+# Migration completion artifact
+
+After a security migration, write a completion artifact that records the target
+package, reviewed manifest digest, imported counts, verification result, and
+approver. Keep the file with the operator record. This is not a full release
+checklist and it is not the in-cluster completion-report consumed as
+`COMPLETION_EVIDENCE_JSON`.
+
+`scripts/build-finalize-tx.ts` still requires `MANIFEST_SHA256` and a fresh
+completion-report. Ceremony GitHub Environments are checked by
+`scripts/verify-migration-environments.sh` and
+`.github/workflows/verify-migration-environments.yml`.
+
+## Schema
+
+```json
+{
+  "packageId": "0x…",
+  "manifestSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "imported": 12,
+  "skipped": 0,
+  "verified": true,
+  "approver": "user:alice",
+  "timestamp": "2026-08-31T12:00:00.000Z"
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `packageId` | Target (destination) package id |
+| `manifestSha256` | Independently reviewed migration manifest digest (same value as `MANIFEST_SHA256` for finalize-tx) |
+| `imported` | Count of imported records |
+| `skipped` | Count of skipped records |
+| `verified` | Verification result (`true` if checks passed) |
+| `approver` | Reviewer who approved the ceremony |
+| `timestamp` | UTC time the artifact was written (ISO-8601) |
+
+## How to fill
+
+1. Confirm ceremony environments still match the reviewer allowlist (`scripts/verify-migration-environments.sh`).
+2. Copy `packageId` from the destination package used with `scripts/build-finalize-tx.ts` (`PACKAGE_ID`).
+3. Copy `manifestSha256` from the independently reviewed digest (`MANIFEST_SHA256`).
+4. Set `imported` and `skipped` from the import totals.
+5. Set `verified` from the verification result.
+6. Set `approver` to the reviewer who approved the ceremony (not the initiator).
+7. Write the file:
+
+```bash
+node scripts/write-migration-completion-artifact.mjs \
+  --package-id "$PACKAGE_ID" \
+  --manifest-sha256 "$MANIFEST_SHA256" \
+  --imported "$IMPORTED" \
+  --skipped "$SKIPPED" \
+  --verified true \
+  --approver "user:harrymove-ctrl" \
+  --out ./migration-completion-artifact.json
+```
+
+Flags override env of the same name (`PACKAGE_ID`, `MANIFEST_SHA256`,
+`IMPORTED`, `SKIPPED`, `VERIFIED`, `APPROVER`, `OUT`). Missing required fields
+exit 1. Signing and submitting finalize-tx remains a separate offline step;
+see `scripts/build-finalize-tx.ts` and `.github/workflows/finalize-tx.yml`.

--- a/docs/ops/migration-completion-artifact.md
+++ b/docs/ops/migration-completion-artifact.md
@@ -1,4 +1,4 @@
-# Migration completion artifact
+## Migration completion artifact
 
 After a security migration, write a completion artifact that records the target
 package, reviewed manifest digest, imported counts, verification result, and

--- a/docs/ops/migration-completion-artifact.md
+++ b/docs/ops/migration-completion-artifact.md
@@ -59,7 +59,8 @@ node scripts/write-migration-completion-artifact.mjs \
 
 Flags override env of the same name (`PACKAGE_ID`, `MANIFEST_SHA256`,
 `IMPORTED`, `SKIPPED`, `VERIFIED`, `APPROVER`, `OUT`). Missing required fields
-exit 1.
+exit 1, and so does an unrecognized flag: a misspelled `--approver` would
+otherwise fall back to `APPROVER` and record an approver nobody typed.
 
 The writer rejects a `packageId` that `scripts/build-finalize-tx.ts` would
 reject, and records it in the same normalized form, so the artifact and the

--- a/docs/ops/migration-completion-artifact.md
+++ b/docs/ops/migration-completion-artifact.md
@@ -28,7 +28,7 @@ completion-report. Ceremony GitHub Environments are checked by
 
 | Field | Meaning |
 | --- | --- |
-| `packageId` | Target (destination) package id |
+| `packageId` | Target (destination) package id, in the form `build-finalize-tx.ts` normalizes `PACKAGE_ID` to: lowercase, `0x`-prefixed, 32 bytes of hex |
 | `manifestSha256` | Independently reviewed migration manifest digest (same value as `MANIFEST_SHA256` for finalize-tx) |
 | `imported` | Count of imported records |
 | `skipped` | Count of skipped records |
@@ -59,5 +59,19 @@ node scripts/write-migration-completion-artifact.mjs \
 
 Flags override env of the same name (`PACKAGE_ID`, `MANIFEST_SHA256`,
 `IMPORTED`, `SKIPPED`, `VERIFIED`, `APPROVER`, `OUT`). Missing required fields
-exit 1. Signing and submitting finalize-tx remains a separate offline step;
-see `scripts/build-finalize-tx.ts` and `.github/workflows/finalize-tx.yml`.
+exit 1.
+
+The writer rejects a `packageId` that `scripts/build-finalize-tx.ts` would
+reject, and records it in the same normalized form, so the artifact and the
+transaction name the target package identically. It also refuses to overwrite an
+existing `--out` file: pass `--force` to replace one deliberately. `--force` is
+a flag only, with no env equivalent.
+
+The artifact is an operator record, not a control the tooling enforces. Nothing checks that
+`approver` is a real reviewer or that it differs from the operator running the
+command; step 6 is a procedure the ceremony follows, and the ceremony
+environments in `scripts/verify-migration-environments.sh` are what actually
+prevent self-review.
+
+Signing and submitting finalize-tx remains a separate offline step; see
+`scripts/build-finalize-tx.ts` and `.github/workflows/finalize-tx.yml`.

--- a/docs/ops/security-rc-workflow.md
+++ b/docs/ops/security-rc-workflow.md
@@ -1,0 +1,39 @@
+# Security RC review workflow
+
+Every release-candidate batch gets Security review capacity (human, AI, or
+combined) before it ships. Classify the change set, keep one candidate in one
+PR, and request Security review when it is required.
+
+## One candidate per PR
+
+One candidate release, or one security-sensitive change set, is one PR. Do not
+mix contract, demo, and docs work in an RC.
+
+## Classification
+
+**Security review required** — request Security review on the PR:
+
+- Move contract / SEAL policy
+- Relayer auth
+- Sidecar SEAL encrypt / decrypt
+- Migration ceremony (manifest, finalize-tx, environments)
+- Anything that changes who can decrypt
+
+**Security review not required** — normal Eng review:
+
+- Docs-only changes
+- Demo apps
+- Changelog / version dump
+- Tests that do not change production policy
+
+## How
+
+Request review from Security (or the postmortem Security owners) on that single
+PR. When the change is a security migration, record the approver on the
+migration completion artifact (`docs/ops/migration-completion-artifact.md`).
+
+## TDD bar
+
+The PR body lists test proof, method, and reproduction (existing Commandoss PR
+template). Prefer unit tests plus connected-surface integration / e2e over
+coverage slogans.

--- a/docs/ops/security-rc-workflow.md
+++ b/docs/ops/security-rc-workflow.md
@@ -1,4 +1,4 @@
-# Security RC review workflow
+## Security RC review workflow
 
 Every release-candidate batch gets Security review capacity (human, AI, or
 combined) before it ships. Classify the change set, keep one candidate in one
@@ -11,7 +11,7 @@ mix contract, demo, and docs work in an RC.
 
 ## Classification
 
-**Security review required** — request Security review on the PR:
+**Security review required:** request Security review on the PR:
 
 - Move contract / SEAL policy
 - Relayer auth
@@ -19,7 +19,7 @@ mix contract, demo, and docs work in an RC.
 - Migration ceremony (manifest, finalize-tx, environments)
 - Anything that changes who can decrypt
 
-**Security review not required** — normal Eng review:
+**Security review not required:** normal Eng review:
 
 - Docs-only changes
 - Demo apps

--- a/docs/ops/security-rc-workflow.md
+++ b/docs/ops/security-rc-workflow.md
@@ -34,6 +34,5 @@ migration completion artifact (`docs/ops/migration-completion-artifact.md`).
 
 ## TDD bar
 
-The PR body lists test proof, method, and reproduction (existing Commandoss PR
-template). Prefer unit tests plus connected-surface integration / e2e over
-coverage slogans.
+The PR body lists test proof, method, and reproduction. Prefer unit tests plus
+connected-surface integration / e2e over coverage slogans.

--- a/docs/ops/security-rc-workflow.md
+++ b/docs/ops/security-rc-workflow.md
@@ -2,7 +2,7 @@
 
 Every release-candidate batch gets Security review capacity (human, AI, or
 combined) before it ships. Classify the change set, keep one candidate in one
-PR, and request Security review when it is required.
+PR, and request Security review when the change requires it.
 
 ## One candidate per PR
 

--- a/scripts/build-finalize-tx.ts
+++ b/scripts/build-finalize-tx.ts
@@ -14,6 +14,7 @@
  * Burning the spent MigrationCap is a separate tx signed by the wallet that owns
  * the cap (the controller's), not this one.
  * A fresh completion report from the in-cluster one-shot Job is mandatory.
+ * After a security migration, write the operator completion artifact with scripts/write-migration-completion-artifact.mjs (docs/ops/migration-completion-artifact.md).
  *
  * Gas is auto-selected by build(): address balance when available, otherwise an
  * owned SUI coin. The transaction is chain-bound to the current Sui epoch. Sui

--- a/scripts/write-migration-completion-artifact.mjs
+++ b/scripts/write-migration-completion-artifact.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * Write a migration completion artifact JSON file.
+ *
+ *   node scripts/write-migration-completion-artifact.mjs \
+ *     --package-id 0x… --manifest-sha256 <64-hex> \
+ *     --imported N --skipped N --verified true \
+ *     --approver user:alice --out artifact.json
+ *
+ * Flags override env of the same name. Missing required fields exit 1.
+ * See docs/ops/migration-completion-artifact.md.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const USAGE = `Write a migration completion artifact JSON file.
+
+Usage:
+  node scripts/write-migration-completion-artifact.mjs \\
+    --package-id <id> --manifest-sha256 <64-hex> \\
+    --imported <n> --skipped <n> --verified <true|false> \\
+    --approver <who> --out <file>
+
+Flags (override env):
+  --package-id        PACKAGE_ID         target package id
+  --manifest-sha256   MANIFEST_SHA256    reviewed manifest digest
+  --imported          IMPORTED           imported count
+  --skipped           SKIPPED            skipped count
+  --verified          VERIFIED           verification result (true|false)
+  --approver          APPROVER           ceremony approver
+  --out               OUT                output JSON path
+
+  --help, -h          print this help
+  --self-test         write/read round-trip and missing-field checks
+`;
+
+const REQUIRED = [
+    ["package-id", "PACKAGE_ID", "packageId"],
+    ["manifest-sha256", "MANIFEST_SHA256", "manifestSha256"],
+    ["imported", "IMPORTED", "imported"],
+    ["skipped", "SKIPPED", "skipped"],
+    ["verified", "VERIFIED", "verified"],
+    ["approver", "APPROVER", "approver"],
+    ["out", "OUT", "out"],
+];
+
+function main(argv = process.argv.slice(2), env = process.env) {
+    const flags = parseArgv(argv);
+    if (flags.has("help") || flags.has("h")) {
+        process.stdout.write(USAGE);
+        return 0;
+    }
+    if (flags.has("self-test")) {
+        selfTest();
+        return 0;
+    }
+
+    const raw = Object.fromEntries(
+        REQUIRED.map(([flag, envName]) => [flag, valueOf(flags, env, flag, envName)]),
+    );
+    const missing = REQUIRED.filter(([flag]) => raw[flag] === "").map(
+        ([flag, envName]) => `--${flag} (or ${envName})`,
+    );
+    if (missing.length > 0) {
+        process.stderr.write(`missing required fields: ${missing.join(", ")}\n`);
+        return 1;
+    }
+
+    let artifact;
+    try {
+        artifact = buildArtifact(raw);
+    } catch (error) {
+        process.stderr.write(`${error.message}\n`);
+        return 1;
+    }
+
+    const outPath = path.resolve(raw.out);
+    mkdirSync(path.dirname(outPath), { recursive: true });
+    writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`);
+    process.stdout.write(`wrote ${outPath}\n`);
+    return 0;
+}
+
+function parseArgv(argv) {
+    const flags = new Map();
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === "--help" || arg === "-h") {
+            flags.set("help", "true");
+            continue;
+        }
+        if (arg === "--self-test") {
+            flags.set("self-test", "true");
+            continue;
+        }
+        if (!arg.startsWith("--")) {
+            throw new Error(`unexpected argument: ${arg}`);
+        }
+        const eq = arg.indexOf("=");
+        if (eq !== -1) {
+            flags.set(arg.slice(2, eq), arg.slice(eq + 1));
+            continue;
+        }
+        const name = arg.slice(2);
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith("--")) {
+            flags.set(name, "");
+            continue;
+        }
+        flags.set(name, next);
+        i += 1;
+    }
+    return flags;
+}
+
+function valueOf(flags, env, flag, envName) {
+    if (flags.has(flag)) return String(flags.get(flag) ?? "").trim();
+    return String(env[envName] ?? "").trim();
+}
+
+function buildArtifact(raw) {
+    const packageId = raw["package-id"];
+    if (!packageId) throw new Error("packageId is required");
+
+    const manifestSha256 = parseManifestSha256(raw["manifest-sha256"]);
+    const imported = parseCount(raw.imported, "imported");
+    const skipped = parseCount(raw.skipped, "skipped");
+    const verified = parseBoolean(raw.verified, "verified");
+    const approver = raw.approver;
+    if (!approver) throw new Error("approver is required");
+
+    return {
+        packageId,
+        manifestSha256,
+        imported,
+        skipped,
+        verified,
+        approver,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+function parseManifestSha256(value) {
+    if (!/^[0-9a-fA-F]{64}$/.test(value)) {
+        throw new Error("manifestSha256 must be a 64-character hex digest");
+    }
+    return value.toLowerCase();
+}
+
+function parseCount(value, field) {
+    if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+        throw new Error(`${field} must be a non-negative integer`);
+    }
+    const n = Number(value);
+    if (!Number.isSafeInteger(n)) {
+        throw new Error(`${field} must be a non-negative integer`);
+    }
+    return n;
+}
+
+function parseBoolean(value, field) {
+    const normalized = value.toLowerCase();
+    if (normalized === "true" || normalized === "1" || normalized === "yes") return true;
+    if (normalized === "false" || normalized === "0" || normalized === "no") return false;
+    throw new Error(`${field} must be true or false`);
+}
+
+function selfTest() {
+    const self = fileURLToPath(import.meta.url);
+    const env = { ...process.env };
+    for (const [, envName] of REQUIRED) delete env[envName];
+
+    const help = spawnSync(process.execPath, [self, "--help"], {
+        encoding: "utf8",
+        env,
+    });
+    assert(help.status === 0, `help exit ${help.status}: ${help.stderr}`);
+    assert(help.stdout.includes("--package-id"), "help missing --package-id");
+    assert(help.stdout.includes("--manifest-sha256"), "help missing --manifest-sha256");
+
+    const missing = spawnSync(process.execPath, [self], { encoding: "utf8", env });
+    assert(missing.status === 1, `missing fields exit ${missing.status}`);
+    assert(
+        missing.stderr.includes("missing required fields"),
+        `missing-field stderr: ${missing.stderr}`,
+    );
+
+    const dir = mkdtempSync(path.join(tmpdir(), "migration-completion-artifact-"));
+    try {
+        const out = path.join(dir, "artifact.json");
+        const packageId = `0x${"ab".repeat(32)}`;
+        const manifestSha256 = "a".repeat(64);
+        const write = spawnSync(
+            process.execPath,
+            [
+                self,
+                "--package-id",
+                packageId,
+                "--manifest-sha256",
+                manifestSha256,
+                "--imported",
+                "3",
+                "--skipped",
+                "1",
+                "--verified",
+                "true",
+                "--approver",
+                "user:alice",
+                "--out",
+                out,
+            ],
+            { encoding: "utf8", env },
+        );
+        assert(write.status === 0, `write exit ${write.status}: ${write.stderr}`);
+        const artifact = JSON.parse(readFileSync(out, "utf8"));
+        assert(artifact.packageId === packageId, "packageId mismatch");
+        assert(artifact.manifestSha256 === manifestSha256, "manifestSha256 mismatch");
+        assert(artifact.imported === 3, "imported mismatch");
+        assert(artifact.skipped === 1, "skipped mismatch");
+        assert(artifact.verified === true, "verified mismatch");
+        assert(artifact.approver === "user:alice", "approver mismatch");
+        assert(
+            typeof artifact.timestamp === "string" &&
+                /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(artifact.timestamp),
+            `timestamp invalid: ${artifact.timestamp}`,
+        );
+        assert(
+            JSON.stringify(Object.keys(artifact).sort()) ===
+                JSON.stringify([
+                    "approver",
+                    "imported",
+                    "manifestSha256",
+                    "packageId",
+                    "skipped",
+                    "timestamp",
+                    "verified",
+                ]),
+            `unexpected keys: ${Object.keys(artifact)}`,
+        );
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+
+    process.stdout.write("self-test OK\n");
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error(`self-test failed: ${message}`);
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+    try {
+        process.exit(main());
+    } catch (error) {
+        process.stderr.write(`${error.message}\n`);
+        process.exit(1);
+    }
+}

--- a/scripts/write-migration-completion-artifact.mjs
+++ b/scripts/write-migration-completion-artifact.mjs
@@ -12,7 +12,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -41,14 +41,25 @@ Flags (override env):
 `;
 
 const REQUIRED = [
-    ["package-id", "PACKAGE_ID", "packageId"],
-    ["manifest-sha256", "MANIFEST_SHA256", "manifestSha256"],
-    ["imported", "IMPORTED", "imported"],
-    ["skipped", "SKIPPED", "skipped"],
-    ["verified", "VERIFIED", "verified"],
-    ["approver", "APPROVER", "approver"],
-    ["out", "OUT", "out"],
+    ["package-id", "PACKAGE_ID"],
+    ["manifest-sha256", "MANIFEST_SHA256"],
+    ["imported", "IMPORTED"],
+    ["skipped", "SKIPPED"],
+    ["verified", "VERIFIED"],
+    ["approver", "APPROVER"],
+    ["out", "OUT"],
 ];
+
+// Every flag the parser accepts. An unrecognized --flag is a typo, and a typo
+// on a value flag would otherwise fall through to the env var of the same name
+// and record something the operator never typed.
+const KNOWN_FLAGS = new Set([
+    ...REQUIRED.map(([flag]) => flag),
+    "force",
+    "help",
+    "h",
+    "self-test",
+]);
 
 function main(argv = process.argv.slice(2), env = process.env) {
     const flags = parseArgv(argv);
@@ -81,6 +92,12 @@ function main(argv = process.argv.slice(2), env = process.env) {
     }
 
     const outPath = path.resolve(raw.out);
+    if (statSync(outPath, { throwIfNoEntry: false })?.isDirectory()) {
+        // "wx" reports EEXIST for a directory, so without this the operator is
+        // told to pass --force, which then fails with EISDIR.
+        process.stderr.write(`--out is a directory, not a file: ${outPath}\n`);
+        return 1;
+    }
     mkdirSync(path.dirname(outPath), { recursive: true });
     try {
         // "wx" fails if the path exists: a completion artifact is an audit
@@ -121,10 +138,11 @@ function parseArgv(argv) {
         }
         const eq = arg.indexOf("=");
         if (eq !== -1) {
-            flags.set(arg.slice(2, eq), arg.slice(eq + 1));
+            const name = assertKnown(arg.slice(2, eq));
+            flags.set(name, arg.slice(eq + 1));
             continue;
         }
-        const name = arg.slice(2);
+        const name = assertKnown(arg.slice(2));
         const next = argv[i + 1];
         if (next === undefined || next.startsWith("--")) {
             flags.set(name, "");
@@ -134,6 +152,13 @@ function parseArgv(argv) {
         i += 1;
     }
     return flags;
+}
+
+function assertKnown(name) {
+    if (!KNOWN_FLAGS.has(name)) {
+        throw new Error(`unknown flag: --${name}`);
+    }
+    return name;
 }
 
 function valueOf(flags, env, flag, envName) {
@@ -322,6 +347,24 @@ function selfTest() {
         assert(
             JSON.parse(readFileSync(out, "utf8")).skipped === 2,
             "--force did not replace the artifact",
+        );
+
+        // A typo in a value flag must not fall through to the env var of the
+        // same name and record something the operator never typed.
+        const unknown = run(["--out", path.join(dir, "unknown.json"), "--aprover", "user:bob"]);
+        assert(unknown.status === 1, `unknown flag exit ${unknown.status}`);
+        assert(
+            unknown.stderr.includes("unknown flag: --aprover"),
+            `unknown flag stderr: ${unknown.stderr}`,
+        );
+
+        // A directory --out is caught before the overwrite check, which would
+        // otherwise tell the operator to pass --force.
+        const dirOut = run(["--out", dir]);
+        assert(dirOut.status === 1, `directory --out exit ${dirOut.status}`);
+        assert(
+            dirOut.stderr.includes("--out is a directory"),
+            `directory --out stderr: ${dirOut.stderr}`,
         );
 
         // packageId mirrors assertObjectId: reject non-ids and wrong lengths.

--- a/scripts/write-migration-completion-artifact.mjs
+++ b/scripts/write-migration-completion-artifact.mjs
@@ -34,6 +34,8 @@ Flags (override env):
   --approver          APPROVER           ceremony approver
   --out               OUT                output JSON path
 
+  --force             replace an existing --out file (flag only, no env)
+
   --help, -h          print this help
   --self-test         write/read round-trip and missing-field checks
 `;
@@ -80,7 +82,20 @@ function main(argv = process.argv.slice(2), env = process.env) {
 
     const outPath = path.resolve(raw.out);
     mkdirSync(path.dirname(outPath), { recursive: true });
-    writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`);
+    try {
+        // "wx" fails if the path exists: a completion artifact is an audit
+        // record, so replacing one has to be deliberate.
+        writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`, {
+            flag: flags.has("force") ? "w" : "wx",
+        });
+    } catch (error) {
+        if (error.code !== "EEXIST") throw error;
+        process.stderr.write(
+            `refusing to overwrite existing artifact: ${outPath}\n` +
+                "pass --force to replace it\n",
+        );
+        return 1;
+    }
     process.stdout.write(`wrote ${outPath}\n`);
     return 0;
 }
@@ -95,6 +110,10 @@ function parseArgv(argv) {
         }
         if (arg === "--self-test") {
             flags.set("self-test", "true");
+            continue;
+        }
+        if (arg === "--force") {
+            flags.set("force", "true");
             continue;
         }
         if (!arg.startsWith("--")) {
@@ -123,8 +142,7 @@ function valueOf(flags, env, flag, envName) {
 }
 
 function buildArtifact(raw) {
-    const packageId = raw["package-id"];
-    if (!packageId) throw new Error("packageId is required");
+    const packageId = parsePackageId(raw["package-id"]);
 
     const manifestSha256 = parseManifestSha256(raw["manifest-sha256"]);
     const imported = parseCount(raw.imported, "imported");
@@ -142,6 +160,26 @@ function buildArtifact(raw) {
         approver,
         timestamp: new Date().toISOString(),
     };
+}
+
+/**
+ * Mirrors assertObjectId() in scripts/assertions.ts, which is
+ * isValidSuiObjectId() + normalizeSuiAddress() from @mysten/sui/utils: a Sui
+ * object id is exactly 32 bytes of hex, optionally 0x-prefixed, and normalizes
+ * to lowercase with the prefix. Reimplemented rather than imported because the
+ * CI job runs this under bare `node` with no install step. An artifact whose
+ * packageId does not round-trip to what build-finalize-tx.ts used is not
+ * evidence of anything, so reject instead of recording it verbatim.
+ */
+function parsePackageId(value) {
+    const hex = /^0[xX]/.test(value) ? value.slice(2) : value;
+    if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+        throw new Error(
+            "packageId must be a Sui object id: 32 bytes of hex (64 characters),"
+                + " optionally 0x-prefixed",
+        );
+    }
+    return `0x${hex.toLowerCase()}`;
 }
 
 function parseManifestSha256(value) {
@@ -216,7 +254,8 @@ function selfTest() {
             { encoding: "utf8", env },
         );
         assert(write.status === 0, `write exit ${write.status}: ${write.stderr}`);
-        const artifact = JSON.parse(readFileSync(out, "utf8"));
+        const before = readFileSync(out, "utf8");
+        const artifact = JSON.parse(before);
         assert(artifact.packageId === packageId, "packageId mismatch");
         assert(artifact.manifestSha256 === manifestSha256, "manifestSha256 mismatch");
         assert(artifact.imported === 3, "imported mismatch");
@@ -240,6 +279,77 @@ function selfTest() {
                     "verified",
                 ]),
             `unexpected keys: ${Object.keys(artifact)}`,
+        );
+
+        // Same valid inputs as above, with per-case overrides appended.
+        const run = (extra) =>
+            spawnSync(
+                process.execPath,
+                [
+                    self,
+                    "--package-id",
+                    packageId,
+                    "--manifest-sha256",
+                    manifestSha256,
+                    "--imported",
+                    "3",
+                    "--skipped",
+                    "1",
+                    "--verified",
+                    "true",
+                    "--approver",
+                    "user:alice",
+                    ...extra,
+                ],
+                { encoding: "utf8", env },
+            );
+
+        // A second write to the same path must not clobber the record.
+        const clobber = run(["--out", out]);
+        assert(clobber.status === 1, `clobber exit ${clobber.status}`);
+        assert(
+            clobber.stderr.includes("refusing to overwrite existing artifact"),
+            `clobber stderr: ${clobber.stderr}`,
+        );
+        assert(
+            readFileSync(out, "utf8") === before,
+            "refused write still modified the artifact",
+        );
+
+        // --force is the deliberate replace.
+        const forced = run(["--out", out, "--skipped", "2", "--force"]);
+        assert(forced.status === 0, `force exit ${forced.status}: ${forced.stderr}`);
+        assert(
+            JSON.parse(readFileSync(out, "utf8")).skipped === 2,
+            "--force did not replace the artifact",
+        );
+
+        // packageId mirrors assertObjectId: reject non-ids and wrong lengths.
+        const badIds = ["not-a-package-id", "0x2", `0x${"ab".repeat(31)}`, `0x${"a".repeat(65)}`];
+        for (const bad of badIds) {
+            const rejected = run(["--package-id", bad, "--out", path.join(dir, "bad.json")]);
+            assert(rejected.status === 1, `bad packageId ${bad} exit ${rejected.status}`);
+            assert(
+                rejected.stderr.includes("packageId must be a Sui object id"),
+                `bad packageId ${bad} stderr: ${rejected.stderr}`,
+            );
+        }
+
+        // ...and normalizes case and the 0x prefix the way finalize-tx does.
+        const normOut = path.join(dir, "normalized.json");
+        const normalized = run([
+            "--package-id",
+            "AB".repeat(32),
+            "--out",
+            normOut,
+        ]);
+        assert(
+            normalized.status === 0,
+            `normalize exit ${normalized.status}: ${normalized.stderr}`,
+        );
+        assert(
+            JSON.parse(readFileSync(normOut, "utf8")).packageId === `0x${"ab".repeat(32)}`,
+            "packageId was not normalized to lowercase 0x form",
         );
     } finally {
         rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Adds the remaining COMG-718 operator completion artifact: a small JSON record of the target package, reviewed manifest digest, imported/skipped counts, verification result, approver, and timestamp.

This is not the in-cluster `COMPLETION_EVIDENCE_JSON` consumed by `finalize-tx`. It is a durable operator record written after a security migration.

## Changes

- `docs/ops/migration-completion-artifact.md` — schema and how to fill, pointing at `scripts/build-finalize-tx.ts` and `verify-migration-environments`
- `scripts/write-migration-completion-artifact.mjs` — CLI/env writer (`--package-id --manifest-sha256 --imported --skipped --verified --approver --out`); exits 1 on missing required fields
- `--help` / `--self-test` smoke, wired into `test.yml`
- One-line pointer from the `build-finalize-tx.ts` header

## Test plan

- [x] `node scripts/write-migration-completion-artifact.mjs --help`
- [x] `node scripts/write-migration-completion-artifact.mjs --self-test`
- [x] missing flags exit 1
- [x] `node scripts/check-docs-freshness.mjs` and `node scripts/check-docs-code-sync.mjs`