### PR TITLE
fix(server): report restore decrypt failures instead of skipped (COMG-719)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.12"
+      "version": "0.0.13"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "memwal",
       "source": "./packages/mcp/plugin",
       "description": "Automatic Walrus Memory — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
-      "version": "0.0.12"
+      "version": "0.0.13"
     }
   ]
 }

--- a/SKILL.md
+++ b/SKILL.md
@@ -365,7 +365,7 @@ Cross-namespace and cross-owner reads are not just filtered out of results — t
 |---|---|---|
 | `restored` | Blobs the relayer just rebuilt this call | Pulled from Walrus → SEAL decrypted → re-embedded → inserted as a new row |
 | `skipped` | On-chain blobs already in the local **success** index | No work needed; relayer left them as-is. Does not include decrypt/UTF-8 failures. |
-| `failed` | Permanent decrypt/UTF-8 failures | Negative cache for this owner+namespace plus new permanent failures this call. Older relayers omit the field; SDKs default it to `0`. |
+| `failed` | Permanent decrypt/UTF-8 failures | On-chain blobs in this page that are negative-cached, plus new permanent failures this call. Older relayers omit the field; SDKs default it to `0`. |
 | `total` | All on-chain blobs the relayer saw for `(owner, namespace)` | Before the limit was applied |
 | `namespace` | Echo of the request | |
 | `owner` | Resolved owner address | |
@@ -373,7 +373,7 @@ Cross-namespace and cross-owner reads are not just filtered out of results — t
 
 `truncated=true` means this restore is **known-retryable-incomplete**: more missing blobs than `limit` allowed this call to restore, **or** the sidecar's owner-wide candidate fetch hit its cap **and** raising `limit` can still expand that fetch (`limit < 20`). Once the sidecar cap is saturated (`limit >= 20`, cap pinned at 100), truncation follows this call's missing-blob page length, not onchain `total`. A fully restored namespace does not loop. `truncated=false` is **not** proof the sidecar saw every onchain blob; blobs beyond the owner-wide sidecar candidate cap can still be missing. WALM-451 tracks a `sourceCapped` field for that case. Relayers older than WALM-319 omit `truncated`; SDKs default it to `false`.
 
-Permanent decrypt or invalid-UTF-8 failures count in `failed`, not `skipped`. Transient download/decrypt/embed errors are still not counted in `restored`, `skipped`, or `failed` and may be retried. `restored + skipped + failed` is therefore a lower bound on inspected blobs, not a strict equality with `total`.
+Permanent decrypt or invalid-UTF-8 failures count in `failed`, not `skipped`. Transient download/decrypt/embed errors are still not counted in `restored`, `skipped`, or `failed` and may be retried (`truncated=true` when a page yields only those). `restored + skipped + failed` therefore never exceeds `total`, and falls short of it whenever transient errors leave blobs uncounted.
 
 #### Default and limit
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -155,7 +155,7 @@ const stored = await memwal.waitForRememberJob(accepted.job_id, {
 | `recall({ query, limit?, topK?, namespace?, maxDistance? })` *(preferred)* or `recall(query, limit?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
 | `analyze(text, namespace?)` | Extract facts and accept one memory job per fact | `{ job_ids, facts, fact_count, status, owner }` |
 | `analyzeAndWait(text, namespace?, opts?)` | Extract facts and wait for all fact jobs to complete | `{ results, facts, total, succeeded, failed, owner }` |
-| `restore(namespace, limit?)` | Rebuild missing index entries from Walrus | `{ restored, skipped, total, namespace, owner, truncated }` |
+| `restore(namespace, limit?)` | Rebuild missing index entries from Walrus | `{ restored, skipped, failed, total, namespace, owner, truncated }` |
 | `health()` | Check relayer health | `{ status, version }` |
 | `getPublicKeyHex()` | Get hex-encoded public key | `string` |
 
@@ -271,6 +271,7 @@ interface EmbedResult {
 interface RestoreResult {
   restored: number;
   skipped: number;
+  failed?: number;
   total: number;
   namespace: string;
   owner: string;
@@ -363,7 +364,8 @@ Cross-namespace and cross-owner reads are not just filtered out of results — t
 | Field | Counts | Notes |
 |---|---|---|
 | `restored` | Blobs the relayer just rebuilt this call | Pulled from Walrus → SEAL decrypted → re-embedded → inserted as a new row |
-| `skipped` | On-chain blobs already in the local index | No work needed; relayer left them as-is |
+| `skipped` | On-chain blobs already in the local **success** index | No work needed; relayer left them as-is. Does not include decrypt/UTF-8 failures. |
+| `failed` | Permanent decrypt/UTF-8 failures | Negative cache for this owner+namespace plus new permanent failures this call. Older relayers omit the field; SDKs default it to `0`. |
 | `total` | All on-chain blobs the relayer saw for `(owner, namespace)` | Before the limit was applied |
 | `namespace` | Echo of the request | |
 | `owner` | Resolved owner address | |
@@ -371,7 +373,7 @@ Cross-namespace and cross-owner reads are not just filtered out of results — t
 
 `truncated=true` means this restore is **known-retryable-incomplete**: more missing blobs than `limit` allowed this call to restore, **or** the sidecar's owner-wide candidate fetch hit its cap **and** raising `limit` can still expand that fetch (`limit < 20`). Once the sidecar cap is saturated (`limit >= 20`, cap pinned at 100), truncation follows this call's missing-blob page length, not onchain `total`. A fully restored namespace does not loop. `truncated=false` is **not** proof the sidecar saw every onchain blob; blobs beyond the owner-wide sidecar candidate cap can still be missing. WALM-451 tracks a `sourceCapped` field for that case. Relayers older than WALM-319 omit `truncated`; SDKs default it to `false`.
 
-**Silent drops.** A blob that *cannot* be decrypted or embedded (e.g. wrong delegate key, malformed ciphertext, embedding API down) is dropped without counting in `restored` *or* `skipped`. `restored + skipped` is therefore a lower bound on healthy entries, not a strict equality with `total`.
+Permanent decrypt or invalid-UTF-8 failures count in `failed`, not `skipped`. Transient download/decrypt/embed errors are still not counted in `restored`, `skipped`, or `failed` and may be retried. `restored + skipped + failed` is therefore a lower bound on inspected blobs, not a strict equality with `total`.
 
 #### Default and limit
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -271,7 +271,7 @@ interface EmbedResult {
 interface RestoreResult {
   restored: number;
   skipped: number;
-  failed?: number;
+  failed: number;
   total: number;
   namespace: string;
   owner: string;

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -151,7 +151,8 @@ Returns:
 ```ts
 {
   restored: number;   // Entries newly indexed
-  skipped: number;    // Entries already in DB
+  skipped: number;    // On-chain blobs already in the local success index
+  failed?: number;    // Permanent decrypt/UTF-8 failures (defaults to 0)
   total: number;      // Total blobs found on-chain
   namespace: string;
   owner: string;

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -152,7 +152,7 @@ Returns:
 {
   restored: number;   // Entries newly indexed
   skipped: number;    // On-chain blobs already in the local success index
-  failed?: number;    // Permanent decrypt/UTF-8 failures (defaults to 0)
+  failed: number;     // Permanent decrypt/UTF-8 failures (defaults to 0)
   total: number;      // Total blobs found on-chain
   namespace: string;
   owner: string;

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,8 +28,16 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.12. It forwards the MCP client's initialize.clientInfo to the relayer so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, and others) on each session and tool call, and it resolves the credential directory on every access so MEMWAL_CREDS_DIR can override it. Version 0.0.11 makes memwal_logout cut the running bridge session so memory tools stop after sign-out.
+  The latest MCP package release is 0.0.13. `memwal_restore` reports `failed` and retries the same page when truncation is a download or embed blip, instead of always telling the agent to raise `limit`. Version 0.0.12 forwards the MCP client's initialize.clientInfo to the relayer so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, and others) on each session and tool call, and it resolves the credential directory on every access so MEMWAL_CREDS_DIR can override it.
 ---
+
+## 0.0.13
+
+This release reports restore `failed` counts and retries the same page when truncation is a transient download or embed blip.
+
+### Fixed
+
+- `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
 
 ## 0.0.12
 
@@ -43,7 +51,6 @@ This release forwards the MCP client's identity to the relayer so sidecar logs c
 ### Fixed
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
-- `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
 - When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -43,6 +43,7 @@ This release forwards the MCP client's identity to the relayer so sidecar logs c
 ### Fixed
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
+- `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
 - When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 

--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -174,7 +174,7 @@ AskResult(
 Rebuild missing indexed entries for one namespace from Walrus. Incremental.
 
 - `limit` defaults to `10` and caps the inspected blob set, newest-first
-- `restored` counts blobs re-indexed in this call; `skipped` counts on-chain blobs already in the local success index; `failed` counts permanent decrypt/UTF-8 failures (defaults to `0`)
+- `restored` counts blobs re-indexed in this call; `skipped` counts onchain blobs already in the local success index; `failed` counts permanent decrypt/UTF-8 failures (defaults to `0`)
 - There is no pagination cursor; use a larger `limit` for larger one-shot restores
 
 ```python

--- a/docs/python-sdk/api-reference.md
+++ b/docs/python-sdk/api-reference.md
@@ -174,11 +174,11 @@ AskResult(
 Rebuild missing indexed entries for one namespace from Walrus. Incremental.
 
 - `limit` defaults to `10` and caps the inspected blob set, newest-first
-- `restored` counts blobs re-indexed in this call; `skipped` counts blobs already in the local index
+- `restored` counts blobs re-indexed in this call; `skipped` counts on-chain blobs already in the local success index; `failed` counts permanent decrypt/UTF-8 failures (defaults to `0`)
 - There is no pagination cursor; use a larger `limit` for larger one-shot restores
 
 ```python
-RestoreResult(restored: int, skipped: int, total: int, namespace: str, owner: str, truncated: bool = False)
+RestoreResult(restored: int, skipped: int, total: int, namespace: str, owner: str, truncated: bool = False, failed: int = 0)
 ```
 
 `truncated=true` is known-retryable-incomplete (this call's `limit`, or a still-expandable sidecar candidate fetch); `truncated=false` is not proof the sidecar saw every onchain blob (WALM-451 `sourceCapped`).

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,7 +29,7 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
+  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials. `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
@@ -39,6 +39,10 @@ For the latest version, see the [PyPI project page](https://pypi.org/project/mem
 ## 0.1.9
 
 This release reports HTTP 503 as a retryable upstream outage, aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids, and warns when `server_url` uses plaintext HTTP on a non-localhost host.
+
+### Added
+
+- `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,20 +29,24 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.9. It reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials. `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.8 added `dropped_count` on recall results, `write_ready` on health, `MemWalClockDriftError` for clock-drift 401s, and the `dev` relayer preset.
+  The latest Python SDK release is 0.1.10. `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.9 reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
 
 For the latest version, see the [PyPI project page](https://pypi.org/project/memwal/).
 
-## 0.1.9
+## 0.1.10
 
-This release reports HTTP 503 as a retryable upstream outage, aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids, and warns when `server_url` uses plaintext HTTP on a non-localhost host.
+This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures.
 
 ### Added
 
 - `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+
+## 0.1.9
+
+This release reports HTTP 503 as a retryable upstream outage, aligns Python bulk remember with the TypeScript SDK by refusing empty batches and mismatched job ids, and warns when `server_url` uses plaintext HTTP on a non-localhost host.
 
 ### Fixed
 

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -470,7 +470,7 @@ Rebuild missing vector entries for one namespace. Queries onchain blobs by owner
 }
 ```
 
-`skipped` is on-chain blobs already in the local success index. `failed` is permanent decrypt/UTF-8 failures: the owner+namespace negative cache plus any new permanent failures this call. Transient download, decrypt, or embed errors are not counted in `failed` and may be retried.
+`skipped` is onchain blobs already in the local success index. `failed` is permanent decrypt/UTF-8 failures: the owner+namespace negative cache plus any new permanent failures this call. Transient download, decrypt, or embed errors are not counted in `failed` and might be retried.
 
 `truncated=true` means this restore is **known-retryable-incomplete**: more missing blobs than `limit` allowed this call to restore, **or** the sidecar's owner-wide candidate fetch hit its cap **and** raising `limit` can still expand that fetch (`limit < 20`). Once the sidecar cap is saturated (`limit >= 20`, cap pinned at 100), truncation follows this call's missing-blob page length, not onchain `total`. A fully restored namespace does not loop. `truncated=false` is **not** proof the sidecar saw every onchain blob; blobs beyond the owner-wide sidecar candidate cap can still be missing. WALM-451 tracks a `sourceCapped` field for that case ([WALM-451](https://linear.app/mysten-labs/issue/WALM-451)). Relayers older than WALM-319 omit `truncated`; SDKs default it to `false`.
 

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -470,7 +470,7 @@ Rebuild missing vector entries for one namespace. Queries onchain blobs by owner
 }
 ```
 
-`skipped` is onchain blobs already in the local success index. `failed` is permanent decrypt/UTF-8 failures: the owner+namespace negative cache plus any new permanent failures this call. Transient download, decrypt, or embed errors are not counted in `failed` and might be retried.
+`skipped` is onchain blobs already in the local success index. `failed` is permanent decrypt/UTF-8 failures on this onchain page (negative-cache hits plus new permanent failures this call), so it never exceeds `total`. Transient download, decrypt, or embed errors are not counted in `failed`; when a page yields only those, `truncated` is true so the caller retries.
 
 `truncated=true` means this restore is **known-retryable-incomplete**: more missing blobs than `limit` allowed this call to restore, **or** the sidecar's owner-wide candidate fetch hit its cap **and** raising `limit` can still expand that fetch (`limit < 20`). Once the sidecar cap is saturated (`limit >= 20`, cap pinned at 100), truncation follows this call's missing-blob page length, not onchain `total`. A fully restored namespace does not loop. `truncated=false` is **not** proof the sidecar saw every onchain blob; blobs beyond the owner-wide sidecar candidate cap can still be missing. WALM-451 tracks a `sourceCapped` field for that case ([WALM-451](https://linear.app/mysten-labs/issue/WALM-451)). Relayers older than WALM-319 omit `truncated`; SDKs default it to `false`.
 

--- a/docs/relayer/api-reference.md
+++ b/docs/relayer/api-reference.md
@@ -462,12 +462,15 @@ Rebuild missing vector entries for one namespace. Queries onchain blobs by owner
 {
   "restored": 3,
   "skipped": 7,
+  "failed": 0,
   "total": 10,
   "namespace": "demo",
   "owner": "0x...",
   "truncated": false
 }
 ```
+
+`skipped` is on-chain blobs already in the local success index. `failed` is permanent decrypt/UTF-8 failures: the owner+namespace negative cache plus any new permanent failures this call. Transient download, decrypt, or embed errors are not counted in `failed` and may be retried.
 
 `truncated=true` means this restore is **known-retryable-incomplete**: more missing blobs than `limit` allowed this call to restore, **or** the sidecar's owner-wide candidate fetch hit its cap **and** raising `limit` can still expand that fetch (`limit < 20`). Once the sidecar cap is saturated (`limit >= 20`, cap pinned at 100), truncation follows this call's missing-blob page length, not onchain `total`. A fully restored namespace does not loop. `truncated=false` is **not** proof the sidecar saw every onchain blob; blobs beyond the owner-wide sidecar candidate cap can still be missing. WALM-451 tracks a `sourceCapped` field for that case ([WALM-451](https://linear.app/mysten-labs/issue/WALM-451)). Relayers older than WALM-319 omit `truncated`; SDKs default it to `false`.
 

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -262,7 +262,8 @@ Rebuild missing indexed entries for one namespace from Walrus. Incremental — o
 ```ts
 {
   restored: number;   // Entries newly indexed
-  skipped: number;    // Entries already in DB
+  skipped: number;    // On-chain blobs already in the local success index
+  failed?: number;    // Permanent decrypt/UTF-8 failures (defaults to 0)
   total: number;      // Total blobs found on-chain
   namespace: string;
   owner: string;

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -263,7 +263,7 @@ Rebuild missing indexed entries for one namespace from Walrus. Incremental — o
 {
   restored: number;   // Entries newly indexed
   skipped: number;    // On-chain blobs already in the local success index
-  failed?: number;    // Permanent decrypt/UTF-8 failures (defaults to 0)
+  failed: number;     // Permanent decrypt/UTF-8 failures (defaults to 0)
   total: number;      // Total blobs found on-chain
   namespace: string;
   owner: string;

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,7 +28,7 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.6. It adds optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`. HTTP 503 from the relayer is reported as a retryable upstream outage instead of a sign-in failure. `restore()` results include optional `failed` for permanent decrypt/UTF-8 failures. 0.1.5 added `dropped_count` on recall results and `write_ready` on health, switched `rememberManual` to sending `encryptedData`, and hardened hex decoding and error redaction.
+  The latest TypeScript SDK release is 0.1.6. It adds optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`. HTTP 503 from the relayer is reported as a retryable upstream outage instead of a sign-in failure. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures. 0.1.5 added `dropped_count` on recall results and `write_ready` on health, switched `rememberManual` to sending `encryptedData`, and hardened hex decoding and error redaction.
 ---
 
 ## 0.1.6
@@ -39,7 +39,7 @@ This release adds write-time on recall results, lets callers sort by recency or 
 
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
-- `restore()` results include optional `failed` for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+- `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,7 +28,7 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.6. It adds optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`. HTTP 503 from the relayer is reported as a retryable upstream outage instead of a sign-in failure. 0.1.5 added `dropped_count` on recall results and `write_ready` on health, switched `rememberManual` to sending `encryptedData`, and hardened hex decoding and error redaction.
+  The latest TypeScript SDK release is 0.1.6. It adds optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`. HTTP 503 from the relayer is reported as a retryable upstream outage instead of a sign-in failure. `restore()` results include optional `failed` for permanent decrypt/UTF-8 failures. 0.1.5 added `dropped_count` on recall results and `write_ready` on health, switched `rememberManual` to sending `encryptedData`, and hardened hex decoding and error redaction.
 ---
 
 ## 0.1.6
@@ -39,6 +39,7 @@ This release adds write-time on recall results, lets callers sort by recency or 
 
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
+- `restore()` results include optional `failed` for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,8 +28,16 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.6. It adds optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`. HTTP 503 from the relayer is reported as a retryable upstream outage instead of a sign-in failure. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures. 0.1.5 added `dropped_count` on recall results and `write_ready` on health, switched `rememberManual` to sending `encryptedData`, and hardened hex decoding and error redaction.
+  The latest TypeScript SDK release is 0.1.7. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
+
+## 0.1.7
+
+This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures.
+
+### Added
+
+- `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ## 0.1.6
 
@@ -39,7 +47,6 @@ This release adds write-time on recall results, lets callers sort by recency or 
 
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
-- `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
+- `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
 - When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mysten-incubation/memwal-mcp
 
+## 0.0.13
+
+### Fixed
+
+- `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
+
 ## 0.0.12
 
 ### Added
@@ -10,7 +16,6 @@
 ### Fixed
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
-- `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
 - When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal-mcp",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "Walrus Memory MCP client — single-binary stdio MCP server that bridges Cursor / Claude Desktop / Antigravity / Claude Code to the Walrus Memory relayer. Handles browser-based wallet login on first run.",
     "type": "module",
     "engines": {

--- a/packages/mcp/plugin/.claude-plugin/plugin.json
+++ b/packages/mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Automatic Walrus Memory for Claude Code — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": {
     "name": "Mysten Labs"

--- a/packages/mcp/plugin/.codex-plugin/plugin.json
+++ b/packages/mcp/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Persistent Walrus Memory for Codex. Remembers decisions, preferences, and project context across sessions.",
   "author": {
     "name": "Mysten Labs",

--- a/packages/mcp/plugin/.cursor-plugin/plugin.json
+++ b/packages/mcp/plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memwal",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Automatic Walrus Memory for Cursor — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/plugin/plugin.json
+++ b/packages/mcp/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "memwal",
   "name": "memwal",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Automatic Walrus Memory for Antigravity — proactive recall and durable-fact saving via the MemWal MCP + lifecycle hooks.",
   "author": { "name": "Mysten Labs" },
   "homepage": "https://memory.walrus.xyz",

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -130,7 +130,7 @@ function buildToolDefinitions(proactive: boolean) {
         title: "Restore Memory Index",
         annotations: { readOnlyHint: false, destructiveHint: false },
         description:
-            "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index \u2014 use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns restored/skipped/failed/total plus truncated \u2014 does not return memory texts. truncated=true is known-retryable-incomplete: retry the same limit when restored=0 and skipped+failed < total (download/embed blip); raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
+            "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index \u2014 use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns restored/skipped/failed/total plus truncated \u2014 does not return memory texts. truncated=true is known-retryable-incomplete: retry the same limit on a download/embed blip; raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
         inputSchema: {
             type: "object",
             properties: {

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -130,7 +130,7 @@ function buildToolDefinitions(proactive: boolean) {
         title: "Restore Memory Index",
         annotations: { readOnlyHint: false, destructiveHint: false },
         description:
-            "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index \u2014 use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status \u2014 does not return memory texts. truncated=true is known-retryable-incomplete: raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
+            "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index \u2014 use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns restored/skipped/failed/total plus truncated \u2014 does not return memory texts. truncated=true is known-retryable-incomplete: retry the same limit when restored=0 and skipped+failed < total (download/embed blip); raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
         inputSchema: {
             type: "object",
             properties: {

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,10 +1,12 @@
 # memwal
 
-## 0.1.9
+## 0.1.10
 
 ### Added
 
 - `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+
+## 0.1.9
 
 ### Fixed
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.1.9
 
+### Added
+
+- `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+
 ### Fixed
 
 - HTTP 503 with `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` is reported as a retryable credential-verification outage, not a sign-in failure. Other 503s keep the generic sanitized body.

--- a/packages/python-sdk-memwal/memwal/__init__.py
+++ b/packages/python-sdk-memwal/memwal/__init__.py
@@ -122,4 +122,4 @@ __all__ = [
     "RecallManualResult",
 ]
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -908,11 +908,12 @@ class MemWal:
         * ``skipped`` — on-chain blobs already present in the local success
           index (no work needed). Does not include permanent decrypt/UTF-8
           failures.
-        * ``failed`` — permanent decrypt/UTF-8 failures: the owner+namespace
-          negative cache plus any new permanent failures this call.
-          Transient download/decrypt/embed errors are not counted here and
-          may be retried. Defaults to ``0`` when talking to a relayer older
-          than COMG-719 that omits the field.
+        * ``failed`` — permanent decrypt/UTF-8 failures on this on-chain page:
+          negative-cache hits plus any new permanent failures this call.
+          Transient download/decrypt/embed errors are not counted here; when
+          a page yields only those, ``truncated`` is true so the caller
+          retries. Defaults to ``0`` when talking to a relayer older than
+          COMG-719 that omits the field.
         * ``total`` — count of on-chain blobs the relayer saw for
           ``(owner, namespace)`` before the limit was applied.
         * ``truncated`` — True when this restore is known-incomplete (limit

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -905,9 +905,14 @@ class MemWal:
 
         * ``restored`` — blobs that completed the full
           download → decrypt → embed → DB insert pipeline this call.
-        * ``skipped`` — on-chain blobs already present in the local index
-          (no work needed). Decrypt / embed failures are dropped silently and
-          do **not** count as either restored or skipped.
+        * ``skipped`` — on-chain blobs already present in the local success
+          index (no work needed). Does not include permanent decrypt/UTF-8
+          failures.
+        * ``failed`` — permanent decrypt/UTF-8 failures: the owner+namespace
+          negative cache plus any new permanent failures this call.
+          Transient download/decrypt/embed errors are not counted here and
+          may be retried. Defaults to ``0`` when talking to a relayer older
+          than COMG-719 that omits the field.
         * ``total`` — count of on-chain blobs the relayer saw for
           ``(owner, namespace)`` before the limit was applied.
         * ``truncated`` — True when this restore is known-incomplete (limit
@@ -952,6 +957,8 @@ class MemWal:
             # treat "not present" as "not known to be truncated" rather
             # than require every relayer version to send it.
             truncated=data.get("truncated", False),
+            # Relayers older than COMG-719 omit `failed`; default to 0.
+            failed=data.get("failed", 0),
         )
 
     async def health(self) -> HealthResult:

--- a/packages/python-sdk-memwal/memwal/mock.py
+++ b/packages/python-sdk-memwal/memwal/mock.py
@@ -341,6 +341,7 @@ class MemWalMock:
             namespace=namespace,
             owner=self._owner,
             truncated=False,
+            failed=0,
         )
 
     async def health(self) -> HealthResult:

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -212,7 +212,8 @@ class RestoreResult:
     #: ``limit`` can still expand that fetch (``limit < 20``). Once the cap
     #: is saturated, truncation follows this call's missing-blob page, not
     #: on-chain ``total``, so a fully restored namespace does not loop
-    #: (WALM-431 / GH #762).
+    #: (WALM-431 / GH #762). Also true when an inspected page produced only
+    #: transients (download/decrypt/embed) so the caller retries (WALM-480).
     #:
     #: ``truncated=False`` is not proof the sidecar saw every on-chain blob.
     #: Blobs beyond the owner-wide sidecar candidate cap can still be
@@ -221,8 +222,8 @@ class RestoreResult:
     #: Relayers older than WALM-319 don't send this field at all; the SDK
     #: defaults it to ``False`` in that case rather than requiring it.
     truncated: bool = False
-    #: Permanent decrypt/UTF-8 failures: the owner+namespace negative cache
-    #: plus any new permanent failures this call. Relayers older than
+    #: Permanent decrypt/UTF-8 failures on this on-chain page: negative-cache
+    #: hits plus any new permanent failures this call. Relayers older than
     #: COMG-719 omit this field; the SDK defaults it to ``0``.
     failed: int = 0
 

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -221,6 +221,10 @@ class RestoreResult:
     #: Relayers older than WALM-319 don't send this field at all; the SDK
     #: defaults it to ``False`` in that case rather than requiring it.
     truncated: bool = False
+    #: Permanent decrypt/UTF-8 failures: the owner+namespace negative cache
+    #: plus any new permanent failures this call. Relayers older than
+    #: COMG-719 omit this field; the SDK defaults it to ``0``.
+    failed: int = 0
 
 
 @dataclass

--- a/packages/python-sdk-memwal/pyproject.toml
+++ b/packages/python-sdk-memwal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "memwal"
-version = "0.1.9"
+version = "0.1.10"
 description = "Python SDK for Walrus Memory — Privacy-first AI memory with Ed25519 signing"
 readme = "README.md"
 license = "MIT"

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -854,6 +854,7 @@ class TestRestore:
         assert body["limit"] == 100
         assert result.restored == 5
         assert result.skipped == 2
+        assert result.failed == 0
         assert result.truncated is False
 
     @respx.mock
@@ -905,6 +906,55 @@ class TestRestore:
         result = await memwal_client.restore("my-app", limit=100)
 
         assert result.truncated is False
+
+    @respx.mock
+    async def test_restore_preserves_failed(
+        self, memwal_client: MemWal
+    ) -> None:
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/restore").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "restored": 5,
+                    "skipped": 2,
+                    "failed": 3,
+                    "total": 10,
+                    "namespace": "my-app",
+                    "owner": "0xowner",
+                    "truncated": False,
+                },
+            )
+        )
+
+        result = await memwal_client.restore("my-app", limit=100)
+
+        assert result.failed == 3
+
+    @respx.mock
+    async def test_restore_failed_defaults_zero_when_omitted(
+        self, memwal_client: MemWal
+    ) -> None:
+        """Relayers older than COMG-719 omit `failed` — the SDK must
+        default it to 0 rather than requiring the field."""
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/restore").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "restored": 5,
+                    "skipped": 2,
+                    "total": 7,
+                    "namespace": "my-app",
+                    "owner": "0xowner",
+                    "truncated": False,
+                },
+            )
+        )
+
+        result = await memwal_client.restore("my-app", limit=100)
+
+        assert result.failed == 0
 
 
 class TestHealth:

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,12 +1,17 @@
 # @mysten-incubation/memwal
 
+## 0.1.7
+
+### Added
+
+- `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+
 ## 0.1.6
 
 ### Added
 
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
-- `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
+- `restore()` results include optional `failed` for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `recall()` results include optional `created_at` (RFC3339 write-time of the stored fact).
 - `RecallOptions` accepts `sort: "relevance" | "recent"` and `scoringWeights`. `sort: "recent"` over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`.
-- `restore()` results include optional `failed` for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+- `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mysten-incubation/memwal",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -932,6 +932,11 @@ export class MemWalManual {
         // Relayers older than WALM-319 omit `truncated` entirely — treat
         // "not present" as "not known to be truncated" rather than drop
         // the field or require every relayer version to send it.
-        return { ...result, truncated: result.truncated ?? false };
+        // Relayers older than COMG-719 omit `failed`; default to 0.
+        return {
+            ...result,
+            truncated: result.truncated ?? false,
+            failed: result.failed ?? 0,
+        };
     }
 }

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -877,8 +877,11 @@ export class MemWal {
      * **Response semantics**:
      * - `restored` — blobs that completed the full
      *   download → decrypt → embed → DB insert pipeline this call.
-     * - `skipped` — on-chain blobs already in the local index (no work needed).
-     *   Decrypt / embed failures are dropped silently and count as neither.
+     * - `skipped` — on-chain blobs already in the local success index
+     *   (no work needed). Does not include permanent decrypt/UTF-8 failures.
+     * - `failed` — permanent decrypt/UTF-8 failures: the owner+namespace
+     *   negative cache plus any new permanent failures this call. Transient
+     *   download/decrypt/embed errors are not counted here and may be retried.
      * - `total` — on-chain blobs the relayer saw for `(owner, namespace)`
      *   before the limit was applied.
      *
@@ -899,12 +902,12 @@ export class MemWal {
      *
      * @param namespace - Namespace to restore (exact match; no prefix/hierarchy)
      * @param limit - Max blobs to inspect this call (default: 10)
-     * @returns RestoreResult with restored / skipped / total counts
+     * @returns RestoreResult with restored / skipped / failed / total counts
      *
      * @example
      * ```typescript
      * const result = await memwal.restore("my-app");
-     * console.log(`restored=${result.restored} skipped=${result.skipped} total=${result.total}`);
+     * console.log(`restored=${result.restored} skipped=${result.skipped} failed=${result.failed} total=${result.total}`);
      * ```
      */
     async restore(namespace: string, limit: number = 10): Promise<RestoreResult> {
@@ -915,7 +918,12 @@ export class MemWal {
         // Relayers older than WALM-319 omit `truncated` entirely — treat
         // "not present" as "not known to be truncated" rather than drop
         // the field or require every relayer version to send it.
-        return { ...result, truncated: result.truncated ?? false };
+        // Relayers older than COMG-719 omit `failed`; default to 0.
+        return {
+            ...result,
+            truncated: result.truncated ?? false,
+            failed: result.failed ?? 0,
+        };
     }
 
     /**

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -879,9 +879,10 @@ export class MemWal {
      *   download → decrypt → embed → DB insert pipeline this call.
      * - `skipped` — on-chain blobs already in the local success index
      *   (no work needed). Does not include permanent decrypt/UTF-8 failures.
-     * - `failed` — permanent decrypt/UTF-8 failures: the owner+namespace
-     *   negative cache plus any new permanent failures this call. Transient
-     *   download/decrypt/embed errors are not counted here and may be retried.
+     * - `failed` — permanent decrypt/UTF-8 failures on this on-chain page:
+     *   negative-cache hits plus any new permanent failures this call.
+     *   Transient download/decrypt/embed errors are not counted here; when
+     *   a page yields only those, `truncated` is true so the caller retries.
      * - `total` — on-chain blobs the relayer saw for `(owner, namespace)`
      *   before the limit was applied.
      *

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -377,6 +377,7 @@ export class MemWalMock {
         return {
             restored: 0,
             skipped: 0,
+            failed: 0,
             total: 0,
             namespace,
             owner: this.owner,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -449,6 +449,12 @@ export interface ListNamespacesOptions {
 export interface RestoreResult {
     restored: number;
     skipped: number;
+    /**
+     * Permanent decrypt/UTF-8 failures: the owner+namespace negative cache
+     * plus any new permanent failures this call. Relayers older than
+     * COMG-719 omit this field; the SDK defaults it to `0`.
+     */
+    failed?: number;
     total: number;
     namespace: string;
     owner: string;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -450,11 +450,11 @@ export interface RestoreResult {
     restored: number;
     skipped: number;
     /**
-     * Permanent decrypt/UTF-8 failures: the owner+namespace negative cache
-     * plus any new permanent failures this call. Relayers older than
+     * Permanent decrypt/UTF-8 failures on this on-chain page: negative-cache
+     * hits plus any new permanent failures this call. Relayers older than
      * COMG-719 omit this field; the SDK defaults it to `0`.
      */
-    failed?: number;
+    failed: number;
     total: number;
     namespace: string;
     owner: string;
@@ -465,7 +465,8 @@ export interface RestoreResult {
      * `limit` can still expand that fetch (`limit < 20`). Once the cap is
      * saturated, truncation follows this call's missing-blob page, not
      * on-chain `total`, so a fully restored namespace does not loop
-     * (WALM-431 / GH #762).
+     * (WALM-431 / GH #762). Also true when an inspected page produced only
+     * transients (download/decrypt/embed) so the caller retries (WALM-480).
      *
      * `truncated=false` is not proof the sidecar saw every on-chain blob.
      * Blobs beyond the owner-wide sidecar candidate cap can still be

--- a/packages/sdk/test/restore-truncated.test.mjs
+++ b/packages/sdk/test/restore-truncated.test.mjs
@@ -60,6 +60,26 @@ test("MemWal.restore() defaults truncated to false when an older relayer omits i
     assert.equal(result.truncated, false);
 });
 
+test("MemWal.restore() preserves failed from the relayer response", async () => {
+    const memwal = client();
+    memwal.signedRequest = async () => baseResponse({ failed: 4 });
+
+    const result = await memwal.restore("demo");
+
+    assert.equal(result.failed, 4);
+});
+
+test("MemWal.restore() defaults failed to 0 when an older relayer omits it", async () => {
+    const memwal = client();
+    const raw = baseResponse();
+    delete raw.failed;
+    memwal.signedRequest = async () => raw;
+
+    const result = await memwal.restore("demo");
+
+    assert.equal(result.failed, 0);
+});
+
 test("MemWalManual.restore() preserves truncated=true from the relayer response", async () => {
     const manual = manualClient();
     manual.signedRequest = async () => baseResponse({ truncated: true });
@@ -78,4 +98,24 @@ test("MemWalManual.restore() defaults truncated to false when an older relayer o
     const result = await manual.restore("demo");
 
     assert.equal(result.truncated, false);
+});
+
+test("MemWalManual.restore() preserves failed from the relayer response", async () => {
+    const manual = manualClient();
+    manual.signedRequest = async () => baseResponse({ failed: 4 });
+
+    const result = await manual.restore("demo");
+
+    assert.equal(result.failed, 4);
+});
+
+test("MemWalManual.restore() defaults failed to 0 when an older relayer omits it", async () => {
+    const manual = manualClient();
+    const raw = baseResponse();
+    delete raw.failed;
+    manual.signedRequest = async () => raw;
+
+    const result = await manual.restore("demo");
+
+    assert.equal(result.failed, 0);
 });

--- a/scripts/verify-manual-sdk-release.mjs
+++ b/scripts/verify-manual-sdk-release.mjs
@@ -5,13 +5,13 @@ import { readFileSync } from "node:fs";
 const releases = [
     {
         name: "TypeScript SDK",
-        version: "0.1.6",
+        version: "0.1.7",
         manifests: [["packages/sdk/package.json", "version"]],
         changelogs: ["packages/sdk/CHANGELOG.md", "docs/sdk/changelog.mdx"],
     },
     {
         name: "Python SDK",
-        version: "0.1.9",
+        version: "0.1.10",
         manifests: [
             ["packages/python-sdk-memwal/pyproject.toml", "toml-version"],
             ["packages/python-sdk-memwal/memwal/__init__.py", "python-version"],
@@ -23,7 +23,7 @@ const releases = [
     },
     {
         name: "MCP package",
-        version: "0.0.12",
+        version: "0.0.13",
         manifests: [
             ["packages/mcp/package.json", "version"],
             [".claude-plugin/marketplace.json", "plugin-version"],

--- a/services/server/scripts/mcp/__tests__/restore.test.ts
+++ b/services/server/scripts/mcp/__tests__/restore.test.ts
@@ -68,3 +68,69 @@ test("memwal_restore treats an omitted legacy truncated field as false", () => {
     assert.match(text, /truncated=false/);
     assert.match(text, /not proof the sidecar saw every blob/);
 });
+
+test("memwal_restore prints failed next to the other counts", () => {
+    const text = formatRestoreResult({
+        namespace: "my-app",
+        total: 10,
+        restored: 7,
+        skipped: 0,
+        failed: 3,
+        truncated: false,
+    });
+
+    assert.match(text, /failed=3/);
+    assert.match(text, /restored=7/);
+    assert.match(text, /skipped=0/);
+});
+
+test("memwal_restore defaults omitted failed to 0", () => {
+    const text = formatRestoreResult({
+        namespace: "legacy",
+        total: 1,
+        restored: 1,
+        skipped: 0,
+        truncated: false,
+    });
+
+    assert.match(text, /failed=0/);
+});
+
+test("memwal_restore hints retry not raise-limit when the page is only transients", () => {
+    const text = formatRestoreResult(
+        {
+            namespace: "my-app",
+            total: 10,
+            restored: 0,
+            skipped: 0,
+            failed: 0,
+            truncated: true,
+        },
+        10,
+    );
+
+    assert.match(text, /^Restore partially complete/);
+    assert.match(text, /failed=0/);
+    assert.match(text, /download\/embed blip/);
+    assert.match(text, /retry the same limit/);
+    assert.doesNotMatch(text, /increase limit and call again/);
+});
+
+test("memwal_restore still tells agents to raise limit for WALM-431 cap truncation", () => {
+    // Empty namespace, sidecar cap still expandable (limit < 20): skipped+failed
+    // is not short of total, so this is page/cap truncation, not an embed blip.
+    const text = formatRestoreResult(
+        {
+            namespace: "my-app",
+            total: 0,
+            restored: 0,
+            skipped: 0,
+            failed: 0,
+            truncated: true,
+        },
+        10,
+    );
+
+    assert.match(text, /increase limit and call again/);
+    assert.doesNotMatch(text, /download\/embed blip/);
+});

--- a/services/server/scripts/mcp/tools/restore.ts
+++ b/services/server/scripts/mcp/tools/restore.ts
@@ -36,19 +36,29 @@ export function formatRestoreResult(
         total: number;
         restored: number;
         skipped: number;
+        failed?: number;
         truncated?: boolean;
     },
     limit = 10,
 ): string {
     const truncated = result.truncated === true;
+    const failed = result.failed ?? 0;
+    // WALM-480: truncated + no success + uncounted blobs → transients
+    // (download/embed blip). Raising limit does not fix that; retry does.
+    const transientPage =
+        truncated &&
+        result.restored === 0 &&
+        result.skipped + failed < result.total;
     const hint = !truncated
         ? "\n  truncated=false is not proof the sidecar saw every blob."
-        : limit < SIDECAR_CAP_SATURATES_AT_LIMIT
-          ? "\n  ⚠️ More blobs remain to restore — increase limit and call again."
-          : "\n  ⚠️ Sidecar cap is saturated — truncation follows this call's missing-blob page; truncated is not completeness (WALM-451 sourceCapped).";
+        : transientPage
+          ? "\n  ⚠️ This page did not restore (download/embed blip) — retry the same limit."
+          : limit < SIDECAR_CAP_SATURATES_AT_LIMIT
+            ? "\n  ⚠️ More blobs remain to restore — increase limit and call again."
+            : "\n  ⚠️ Sidecar cap is saturated — truncation follows this call's missing-blob page; truncated is not completeness (WALM-451 sourceCapped).";
     return (
         `${truncated ? "Restore partially complete" : "Restore page finished"} for namespace "${result.namespace}":\n` +
-        `  total=${result.total}  restored=${result.restored}  skipped=${result.skipped}  truncated=${truncated}` +
+        `  total=${result.total}  restored=${result.restored}  skipped=${result.skipped}  failed=${failed}  truncated=${truncated}` +
         hint
     );
 }
@@ -62,7 +72,7 @@ export function registerRestoreTool(
         {
             ...TOOL_METADATA.memwal_restore,
             description:
-                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. truncated=true is known-retryable-incomplete: raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
+                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns restored/skipped/failed/total plus truncated — does not return memory texts. truncated=true is known-retryable-incomplete: retry the same limit when restored=0 and skipped+failed < total (download/embed blip); raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
             inputSchema: RESTORE_INPUT,
         },
         wrapTool<{ namespace: string; limit: number }>(session, "memwal_restore", async ({ namespace, limit }) => {

--- a/services/server/scripts/mcp/tools/restore.ts
+++ b/services/server/scripts/mcp/tools/restore.ts
@@ -72,7 +72,7 @@ export function registerRestoreTool(
         {
             ...TOOL_METADATA.memwal_restore,
             description:
-                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns restored/skipped/failed/total plus truncated — does not return memory texts. truncated=true is known-retryable-incomplete: retry the same limit when restored=0 and skipped+failed < total (download/embed blip); raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
+                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns restored/skipped/failed/total plus truncated — does not return memory texts. truncated=true is known-retryable-incomplete: retry the same limit on a download/embed blip; raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
             inputSchema: RESTORE_INPUT,
         },
         wrapTool<{ namespace: string; limit: number }>(session, "memwal_restore", async ({ namespace, limit }) => {

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -587,21 +587,16 @@ fn restore_truncated_after_page(
     truncated || (restored == 0 && newly_failed == 0 && transient_unresolved > 0)
 }
 
-/// One restore decrypt attempt. Permanent failures are negative-cached and
-/// counted in `RestoreResponse.failed`; transients are retried next call.
 enum RestoreDecrypt {
     Ok(String, String),
     PermanentFail,
     TransientFail,
 }
 
-/// Per-blob restore inspection stage. Download/embed are never permanent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RestoreFailStage {
     InvalidUtf8,
     Decrypt,
-    Download,
-    Embed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -610,8 +605,8 @@ enum RestoreFailClass {
     Transient,
 }
 
-/// Classify a restore inspection failure. Swapping permanent/transient
-/// here would negative-cache blobs during a SEAL/embedder blip.
+/// Classify a restore decrypt/UTF-8 failure. Swapping permanent/transient
+/// here would negative-cache blobs during a SEAL infra blip.
 fn restore_fail_class(stage: RestoreFailStage, decrypt_err: Option<&str>) -> RestoreFailClass {
     match stage {
         RestoreFailStage::InvalidUtf8 => RestoreFailClass::Permanent,
@@ -621,7 +616,6 @@ fn restore_fail_class(stage: RestoreFailStage, decrypt_err: Option<&str>) -> Res
             }
             _ => RestoreFailClass::Transient,
         },
-        RestoreFailStage::Download | RestoreFailStage::Embed => RestoreFailClass::Transient,
     }
 }
 
@@ -1025,7 +1019,6 @@ async fn restore_unbounded(
                     Ok(vector) => Some((blob_id, vector)),
                     Err(e) => {
                         tracing::warn!("restore: embedding failed for {}: {}", blob_id, e);
-                        // Embed failures are transient: do not negative-cache.
                         None
                     }
                 }
@@ -1355,25 +1348,17 @@ mod tests {
     }
 
     #[test]
-    fn restore_truncated_true_when_page_is_only_transients() {
+    fn restore_truncated_after_page_signals_retry_on_transients_only() {
         // Embedder down / download blip: inspected page yielded neither a
         // restore nor a permanent failure. source_capped=false would otherwise
         // leave truncated=false and the caller would not retry (WALM-480).
         assert!(super::restore_truncated_after_page(false, 0, 0, 10));
         assert!(super::restore_truncated_after_page(false, 0, 0, 1));
-    }
-
-    #[test]
-    fn restore_truncated_false_when_page_has_success_or_permanent_fail() {
+        assert!(super::restore_truncated_after_page(true, 5, 0, 0));
         assert!(!super::restore_truncated_after_page(false, 1, 0, 9));
         assert!(!super::restore_truncated_after_page(false, 0, 10, 0));
         assert!(!super::restore_truncated_after_page(false, 0, 1, 9));
         assert!(!super::restore_truncated_after_page(false, 0, 0, 0));
-    }
-
-    #[test]
-    fn restore_truncated_after_page_preserves_existing_true() {
-        assert!(super::restore_truncated_after_page(true, 5, 0, 0));
     }
 
     #[test]
@@ -1407,15 +1392,6 @@ mod tests {
             ),
             RestoreFailClass::Transient,
             "SEAL infra blips must not be negative-cached"
-        );
-        assert_eq!(
-            restore_fail_class(RestoreFailStage::Download, None),
-            RestoreFailClass::Transient
-        );
-        assert_eq!(
-            restore_fail_class(RestoreFailStage::Embed, None),
-            RestoreFailClass::Transient,
-            "embedder-down is transient; do not negative-cache"
         );
     }
 

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -546,27 +546,45 @@ fn clamp_restore_limit(limit: usize) -> usize {
     limit.clamp(1, 100)
 }
 
-/// Count restore `skipped` / `failed`.
+/// Count restore `skipped` / `failed` over the on-chain page.
 ///
 /// `skipped` is on-chain blobs already in the local **success** index
 /// (`existing_blob_ids`). Negative-cached blob IDs are not skipped.
 ///
-/// `failed` is `failed_blob_ids.len()` (the owner+namespace negative cache)
-/// plus `newly_failed` permanent failures from this call. Callers must not
-/// include blobs already in `failed_blob_ids` in `newly_failed`.
+/// `failed` is on-chain blobs in `failed_blob_ids` (the owner+namespace
+/// negative cache). Both counts share `on_chain_blob_ids` as their domain,
+/// so neither can exceed `total`. New permanent failures this call are
+/// added by the caller after inspection.
 fn restore_skip_fail_counts(
     on_chain_blob_ids: &[String],
     existing_blob_ids: &[String],
     failed_blob_ids: &[String],
-    newly_failed: usize,
 ) -> (usize, usize) {
     let existing_set: std::collections::HashSet<&str> =
         existing_blob_ids.iter().map(|s| s.as_str()).collect();
+    let failed_set: std::collections::HashSet<&str> =
+        failed_blob_ids.iter().map(|s| s.as_str()).collect();
     let skipped = on_chain_blob_ids
         .iter()
         .filter(|id| existing_set.contains(id.as_str()))
         .count();
-    (skipped, failed_blob_ids.len() + newly_failed)
+    let failed = on_chain_blob_ids
+        .iter()
+        .filter(|id| failed_set.contains(id.as_str()))
+        .count();
+    (skipped, failed)
+}
+
+/// Force `truncated` when an inspected page produced only transients
+/// (download / SEAL infra / embed). Permanent failures are counted in
+/// `failed` and must not be retried; embed failures are not negative-cached.
+fn restore_truncated_after_page(
+    truncated: bool,
+    restored: usize,
+    newly_failed: usize,
+    transient_unresolved: usize,
+) -> bool {
+    truncated || (restored == 0 && newly_failed == 0 && transient_unresolved > 0)
 }
 
 /// One restore decrypt attempt. Permanent failures are negative-cached and
@@ -575,6 +593,42 @@ enum RestoreDecrypt {
     Ok(String, String),
     PermanentFail,
     TransientFail,
+}
+
+/// Per-blob restore inspection stage. Download/embed are never permanent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RestoreFailStage {
+    InvalidUtf8,
+    Decrypt,
+    Download,
+    Embed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RestoreFailClass {
+    Permanent,
+    Transient,
+}
+
+/// Classify a restore inspection failure. Swapping permanent/transient
+/// here would negative-cache blobs during a SEAL/embedder blip.
+fn restore_fail_class(stage: RestoreFailStage, decrypt_err: Option<&str>) -> RestoreFailClass {
+    match stage {
+        RestoreFailStage::InvalidUtf8 => RestoreFailClass::Permanent,
+        RestoreFailStage::Decrypt => match decrypt_err {
+            Some(err) if seal::DecryptOutcome::permanent_from_error(err) => {
+                RestoreFailClass::Permanent
+            }
+            _ => RestoreFailClass::Transient,
+        },
+        RestoreFailStage::Download | RestoreFailStage::Embed => RestoreFailClass::Transient,
+    }
+}
+
+enum RestoreDownload {
+    Ok(String, Vec<u8>),
+    Expired,
+    Transient,
 }
 
 /// POST /api/restore
@@ -726,7 +780,7 @@ async fn restore_unbounded(
         limit,
     );
     let (skipped, failed) =
-        restore_skip_fail_counts(&all_blob_ids, &existing_blob_ids, &failed_blob_ids, 0);
+        restore_skip_fail_counts(&all_blob_ids, &existing_blob_ids, &failed_blob_ids);
     tracing::info!(
         "restore: total={} on-chain, existing={}, negative-cached={}, skipped={}, failed={}, missing={} (limited to {}, truncated={}, source_capped={}) for ns={}",
         total,
@@ -776,7 +830,7 @@ async fn restore_unbounded(
                 )
                 .await
                 {
-                    Ok(data) => Some((blob_id, data)),
+                    Ok(data) => RestoreDownload::Ok(blob_id, data),
                     Err(AppError::BlobNotFound(msg)) => {
                         tracing::warn!("restore: blob expired, skipping: {}", msg);
                         cleanup_expired_blob(
@@ -786,11 +840,11 @@ async fn restore_unbounded(
                             &namespace_for_cleanup,
                         )
                         .await;
-                        None
+                        RestoreDownload::Expired
                     }
                     Err(e) => {
                         tracing::warn!("restore: download failed for {}: {}", blob_id, e);
-                        None
+                        RestoreDownload::Transient
                     }
                 }
             }
@@ -801,11 +855,19 @@ async fn restore_unbounded(
     // OOM when restoring large namespaces. join_all() with hundreds of blobs
     // would spawn all downloads simultaneously → memory spike.
     // We use buffer_unordered(10) to cap parallelism at 10 concurrent downloads.
-    let downloaded: Vec<(String, Vec<u8>)> = stream::iter(download_tasks)
+    let download_results: Vec<RestoreDownload> = stream::iter(download_tasks)
         .buffer_unordered(10)
-        .filter_map(|opt| async move { opt })
         .collect()
         .await;
+    let mut downloaded = Vec::with_capacity(download_results.len());
+    let mut transient_unresolved = 0usize;
+    for result in download_results {
+        match result {
+            RestoreDownload::Ok(blob_id, data) => downloaded.push((blob_id, data)),
+            RestoreDownload::Transient => transient_unresolved += 1,
+            RestoreDownload::Expired => {}
+        }
+    }
 
     // Preserve encrypted blob sizes so restored rows still contribute to storage quota.
     let blob_sizes: std::collections::HashMap<String, i64> = downloaded
@@ -814,6 +876,7 @@ async fn restore_unbounded(
         .collect();
 
     if downloaded.is_empty() {
+        let truncated = restore_truncated_after_page(truncated, 0, 0, transient_unresolved);
         return Ok(Json(RestoreResponse {
             restored: 0,
             skipped,
@@ -865,17 +928,27 @@ async fn restore_unbounded(
                             // Decrypt already succeeded here, so invalid UTF-8
                             // is inherently deterministic for this blob — always
                             // safe to negative-cache (GH #501 / WALM-299).
-                            if let Err(db_err) = db
-                                .record_restore_failure(&owner, &namespace, &blob_id, "invalid_utf8")
-                                .await
-                            {
-                                tracing::warn!(
-                                    "restore: failed to record invalid-UTF-8 negative cache for {}: {}",
-                                    blob_id,
-                                    db_err
-                                );
+                            match restore_fail_class(RestoreFailStage::InvalidUtf8, None) {
+                                RestoreFailClass::Permanent => {
+                                    if let Err(db_err) = db
+                                        .record_restore_failure(
+                                            &owner,
+                                            &namespace,
+                                            &blob_id,
+                                            "invalid_utf8",
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "restore: failed to record invalid-UTF-8 negative cache for {}: {}",
+                                            blob_id,
+                                            db_err
+                                        );
+                                    }
+                                    RestoreDecrypt::PermanentFail
+                                }
+                                RestoreFailClass::Transient => RestoreDecrypt::TransientFail,
                             }
-                            RestoreDecrypt::PermanentFail
                         }
                     },
                     Err(e) => {
@@ -886,25 +959,29 @@ async fn restore_unbounded(
                         // rate limit) must keep being retried; caching those
                         // could permanently and wrongly blacklist a
                         // legitimate blob during an infra blip.
-                        if seal::DecryptOutcome::permanent_from_error(&e.to_string()) {
-                            if let Err(db_err) = db
-                                .record_restore_failure(
-                                    &owner,
-                                    &namespace,
-                                    &blob_id,
-                                    "decrypt_permanent",
-                                )
-                                .await
-                            {
-                                tracing::warn!(
-                                    "restore: failed to record decrypt-permanent negative cache for {}: {}",
-                                    blob_id,
-                                    db_err
-                                );
+                        match restore_fail_class(
+                            RestoreFailStage::Decrypt,
+                            Some(&e.to_string()),
+                        ) {
+                            RestoreFailClass::Permanent => {
+                                if let Err(db_err) = db
+                                    .record_restore_failure(
+                                        &owner,
+                                        &namespace,
+                                        &blob_id,
+                                        "decrypt_permanent",
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        "restore: failed to record decrypt-permanent negative cache for {}: {}",
+                                        blob_id,
+                                        db_err
+                                    );
+                                }
+                                RestoreDecrypt::PermanentFail
                             }
-                            RestoreDecrypt::PermanentFail
-                        } else {
-                            RestoreDecrypt::TransientFail
+                            RestoreFailClass::Transient => RestoreDecrypt::TransientFail,
                         }
                     }
                 }
@@ -917,6 +994,10 @@ async fn restore_unbounded(
     let newly_failed = decrypt_results
         .iter()
         .filter(|r| matches!(r, RestoreDecrypt::PermanentFail))
+        .count();
+    transient_unresolved += decrypt_results
+        .iter()
+        .filter(|r| matches!(r, RestoreDecrypt::TransientFail))
         .count();
     let failed = failed + newly_failed;
     let decrypted_texts: Vec<(String, String)> = decrypt_results
@@ -944,6 +1025,7 @@ async fn restore_unbounded(
                     Ok(vector) => Some((blob_id, vector)),
                     Err(e) => {
                         tracing::warn!("restore: embedding failed for {}: {}", blob_id, e);
+                        // Embed failures are transient: do not negative-cache.
                         None
                     }
                 }
@@ -960,7 +1042,10 @@ async fn restore_unbounded(
         .collect();
 
     // Step 6: Insert only new entries (no delete!)
+    transient_unresolved += decrypted_texts.len().saturating_sub(results.len());
     let restored = results.len();
+    let truncated =
+        restore_truncated_after_page(truncated, restored, newly_failed, transient_unresolved);
     for (blob_id, vector) in &results {
         let id = uuid::Uuid::new_v4().to_string();
         let blob_size = blob_sizes.get(blob_id).copied().unwrap_or_else(|| {
@@ -1231,13 +1316,10 @@ mod tests {
         let failed = vec!["c".to_string()];
 
         let (skipped, failed_count) =
-            super::restore_skip_fail_counts(&on_chain, &existing, &failed, 1);
+            super::restore_skip_fail_counts(&on_chain, &existing, &failed);
 
         assert_eq!(skipped, 2, "skipped is on-chain success index only");
-        assert_eq!(
-            failed_count, 2,
-            "failed is negative-cache len plus new permanent failures"
-        );
+        assert_eq!(failed_count, 1, "failed is page ∩ negative cache");
     }
 
     #[test]
@@ -1246,25 +1328,94 @@ mod tests {
         let existing = vec!["a".to_string(), "ghost".to_string()];
         let none: Vec<String> = vec![];
 
-        let (skipped, failed_count) =
-            super::restore_skip_fail_counts(&on_chain, &existing, &none, 0);
+        let (skipped, failed_count) = super::restore_skip_fail_counts(&on_chain, &existing, &none);
 
         assert_eq!(skipped, 1);
         assert_eq!(failed_count, 0);
     }
 
     #[test]
-    fn restore_skip_fail_counts_uses_full_negative_cache_len() {
-        let on_chain = vec!["a".to_string()];
+    fn restore_skip_fail_counts_intersects_failed_with_page() {
+        let on_chain = vec!["a".to_string(), "b".to_string()];
         let none: Vec<String> = vec![];
-        let failed = vec!["old-fail".to_string()];
+        let failed = vec![
+            "old-fail".to_string(),
+            "a".to_string(),
+            "also-old".to_string(),
+        ];
 
-        let (skipped, failed_count) = super::restore_skip_fail_counts(&on_chain, &none, &failed, 0);
+        let (skipped, failed_count) = super::restore_skip_fail_counts(&on_chain, &none, &failed);
 
         assert_eq!(skipped, 0);
         assert_eq!(
             failed_count, 1,
-            "negative-cache entries count even when not in this on-chain page"
+            "historical cache still skips re-download, but failed counts only this page"
+        );
+        assert!(failed_count <= on_chain.len());
+    }
+
+    #[test]
+    fn restore_truncated_true_when_page_is_only_transients() {
+        // Embedder down / download blip: inspected page yielded neither a
+        // restore nor a permanent failure. source_capped=false would otherwise
+        // leave truncated=false and the caller would not retry (WALM-480).
+        assert!(super::restore_truncated_after_page(false, 0, 0, 10));
+        assert!(super::restore_truncated_after_page(false, 0, 0, 1));
+    }
+
+    #[test]
+    fn restore_truncated_false_when_page_has_success_or_permanent_fail() {
+        assert!(!super::restore_truncated_after_page(false, 1, 0, 9));
+        assert!(!super::restore_truncated_after_page(false, 0, 10, 0));
+        assert!(!super::restore_truncated_after_page(false, 0, 1, 9));
+        assert!(!super::restore_truncated_after_page(false, 0, 0, 0));
+    }
+
+    #[test]
+    fn restore_truncated_after_page_preserves_existing_true() {
+        assert!(super::restore_truncated_after_page(true, 5, 0, 0));
+    }
+
+    #[test]
+    fn restore_fail_class_pins_permanent_vs_transient() {
+        use super::{restore_fail_class, RestoreFailClass, RestoreFailStage};
+
+        assert_eq!(
+            restore_fail_class(RestoreFailStage::InvalidUtf8, None),
+            RestoreFailClass::Permanent,
+            "invalid UTF-8 is deterministic for the blob"
+        );
+        assert_eq!(
+            restore_fail_class(RestoreFailStage::Decrypt, Some("InvalidCiphertext")),
+            RestoreFailClass::Permanent
+        );
+        assert_eq!(
+            restore_fail_class(
+                RestoreFailStage::Decrypt,
+                Some(
+                    "seal decrypt failed: seal/decrypt failed during fetch_keys: \
+                     NoAccessError: user does not have access to one or more of \
+                     the requested keys (traceId=abc123, timeoutMs=10000)"
+                )
+            ),
+            RestoreFailClass::Permanent
+        );
+        assert_eq!(
+            restore_fail_class(
+                RestoreFailStage::Decrypt,
+                Some("TimeoutError: The operation was aborted due to timeout")
+            ),
+            RestoreFailClass::Transient,
+            "SEAL infra blips must not be negative-cached"
+        );
+        assert_eq!(
+            restore_fail_class(RestoreFailStage::Download, None),
+            RestoreFailClass::Transient
+        );
+        assert_eq!(
+            restore_fail_class(RestoreFailStage::Embed, None),
+            RestoreFailClass::Transient,
+            "embedder-down is transient; do not negative-cache"
         );
     }
 

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -546,6 +546,37 @@ fn clamp_restore_limit(limit: usize) -> usize {
     limit.clamp(1, 100)
 }
 
+/// Count restore `skipped` / `failed`.
+///
+/// `skipped` is on-chain blobs already in the local **success** index
+/// (`existing_blob_ids`). Negative-cached blob IDs are not skipped.
+///
+/// `failed` is `failed_blob_ids.len()` (the owner+namespace negative cache)
+/// plus `newly_failed` permanent failures from this call. Callers must not
+/// include blobs already in `failed_blob_ids` in `newly_failed`.
+fn restore_skip_fail_counts(
+    on_chain_blob_ids: &[String],
+    existing_blob_ids: &[String],
+    failed_blob_ids: &[String],
+    newly_failed: usize,
+) -> (usize, usize) {
+    let existing_set: std::collections::HashSet<&str> =
+        existing_blob_ids.iter().map(|s| s.as_str()).collect();
+    let skipped = on_chain_blob_ids
+        .iter()
+        .filter(|id| existing_set.contains(id.as_str()))
+        .count();
+    (skipped, failed_blob_ids.len() + newly_failed)
+}
+
+/// One restore decrypt attempt. Permanent failures are negative-cached and
+/// counted in `RestoreResponse.failed`; transients are retried next call.
+enum RestoreDecrypt {
+    Ok(String, String),
+    PermanentFail,
+    TransientFail,
+}
+
 /// POST /api/restore
 ///
 /// Restore a namespace from Walrus:
@@ -649,6 +680,7 @@ async fn restore_unbounded(
         return Ok(Json(RestoreResponse {
             restored: 0,
             skipped: 0,
+            failed: 0,
             total: 0,
             namespace: namespace.clone(),
             owner: owner.clone(),
@@ -661,18 +693,18 @@ async fn restore_unbounded(
     // (GH #501 / WALM-299 negative cache — see `db.record_restore_failure`).
     // A foreign/attacker blob that already failed SEAL decrypt or UTF-8
     // validation for this owner+namespace is never re-downloaded and
-    // re-decrypt-attempted on a later call; it's already correctly reported
-    // as "skipped", same as any other missing-but-excluded blob.
+    // re-decrypt-attempted on a later call; it counts as `failed`, not
+    // `skipped` (COMG-719 / GH #399).
     let existing_blob_ids = state.db.get_blobs_by_namespace(owner, namespace).await?;
     let failed_blob_ids = state.db.get_failed_blob_ids(owner, namespace).await?;
-    let existing_set: std::collections::HashSet<&str> = existing_blob_ids
+    let exclude_set: std::collections::HashSet<&str> = existing_blob_ids
         .iter()
         .map(|s| s.as_str())
         .chain(failed_blob_ids.iter().map(|s| s.as_str()))
         .collect();
     let all_missing: Vec<String> = all_blob_ids
         .iter()
-        .filter(|id| !existing_set.contains(id.as_str()))
+        .filter(|id| !exclude_set.contains(id.as_str()))
         .cloned()
         .collect();
     // Apply limit — query-blobs' on-chain ordering is unspecified (the
@@ -693,12 +725,15 @@ async fn restore_unbounded(
         missing_blob_ids.len(),
         limit,
     );
-    let skipped = total - missing_blob_ids.len();
+    let (skipped, failed) =
+        restore_skip_fail_counts(&all_blob_ids, &existing_blob_ids, &failed_blob_ids, 0);
     tracing::info!(
-        "restore: total={} on-chain, existing={}, negative-cached={}, missing={} (limited to {}, truncated={}, source_capped={}) for ns={}",
+        "restore: total={} on-chain, existing={}, negative-cached={}, skipped={}, failed={}, missing={} (limited to {}, truncated={}, source_capped={}) for ns={}",
         total,
         existing_blob_ids.len(),
         failed_blob_ids.len(),
+        skipped,
+        failed,
         missing_blob_ids.len(),
         limit,
         truncated,
@@ -710,6 +745,7 @@ async fn restore_unbounded(
         return Ok(Json(RestoreResponse {
             restored: 0,
             skipped,
+            failed,
             total,
             namespace: namespace.clone(),
             owner: owner.clone(),
@@ -781,6 +817,7 @@ async fn restore_unbounded(
         return Ok(Json(RestoreResponse {
             restored: 0,
             skipped,
+            failed,
             total,
             namespace: namespace.clone(),
             owner: owner.clone(),
@@ -795,7 +832,7 @@ async fn restore_unbounded(
     );
 
     // Step 4: SEAL decrypt with bounded concurrency (3 at a time).
-    let decrypt_results: Vec<Option<(String, String)>> = stream::iter(downloaded)
+    let decrypt_results: Vec<RestoreDecrypt> = stream::iter(downloaded)
         .map(|(blob_id, encrypted_data)| {
             let http_client = &state.http_client;
             let sidecar_url = state.config.sidecar_url.clone();
@@ -822,7 +859,7 @@ async fn restore_unbounded(
                 .await
                 {
                     Ok(plaintext) => match String::from_utf8(plaintext) {
-                        Ok(text) => Some((blob_id, text)),
+                        Ok(text) => RestoreDecrypt::Ok(blob_id, text),
                         Err(e) => {
                             tracing::warn!("restore: invalid UTF-8 for {}: {}", blob_id, e);
                             // Decrypt already succeeded here, so invalid UTF-8
@@ -838,7 +875,7 @@ async fn restore_unbounded(
                                     db_err
                                 );
                             }
-                            None
+                            RestoreDecrypt::PermanentFail
                         }
                     },
                     Err(e) => {
@@ -865,8 +902,10 @@ async fn restore_unbounded(
                                     db_err
                                 );
                             }
+                            RestoreDecrypt::PermanentFail
+                        } else {
+                            RestoreDecrypt::TransientFail
                         }
-                        None
                     }
                 }
             }
@@ -875,7 +914,18 @@ async fn restore_unbounded(
         .collect()
         .await;
 
-    let decrypted_texts: Vec<(String, String)> = decrypt_results.into_iter().flatten().collect();
+    let newly_failed = decrypt_results
+        .iter()
+        .filter(|r| matches!(r, RestoreDecrypt::PermanentFail))
+        .count();
+    let failed = failed + newly_failed;
+    let decrypted_texts: Vec<(String, String)> = decrypt_results
+        .into_iter()
+        .filter_map(|r| match r {
+            RestoreDecrypt::Ok(blob_id, text) => Some((blob_id, text)),
+            RestoreDecrypt::PermanentFail | RestoreDecrypt::TransientFail => None,
+        })
+        .collect();
     tracing::info!(
         "restore: decrypted {}/{} blobs",
         decrypted_texts.len(),
@@ -957,9 +1007,10 @@ async fn restore_unbounded(
     }
 
     tracing::info!(
-        "restore complete: restored={} skipped={} total={} owner={} ns={}",
+        "restore complete: restored={} skipped={} failed={} total={} owner={} ns={}",
         restored,
         skipped,
+        failed,
         total,
         owner,
         namespace
@@ -968,6 +1019,7 @@ async fn restore_unbounded(
     Ok(Json(RestoreResponse {
         restored,
         skipped,
+        failed,
         total,
         namespace: namespace.clone(),
         owner: owner.clone(),
@@ -1140,12 +1192,80 @@ mod tests {
         let resp = RestoreResponse {
             restored: 5,
             skipped: 2,
+            failed: 0,
             total: 20,
             namespace: "ns".to_string(),
             owner: "0xabc".to_string(),
             truncated: true,
         };
         assert!(resp.truncated);
+    }
+
+    #[test]
+    fn restore_response_serializes_failed_field() {
+        let resp = RestoreResponse {
+            restored: 5,
+            skipped: 2,
+            failed: 3,
+            total: 20,
+            namespace: "ns".to_string(),
+            owner: "0xabc".to_string(),
+            truncated: false,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["failed"], 3);
+        assert_eq!(json["skipped"], 2);
+        assert!(json.get("failed").is_some());
+    }
+
+    #[test]
+    fn restore_skip_fail_counts_excludes_negative_cache_from_skipped() {
+        let on_chain = vec!["a", "b", "c", "d"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        let existing = vec!["a", "b"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        let failed = vec!["c".to_string()];
+
+        let (skipped, failed_count) =
+            super::restore_skip_fail_counts(&on_chain, &existing, &failed, 1);
+
+        assert_eq!(skipped, 2, "skipped is on-chain success index only");
+        assert_eq!(
+            failed_count, 2,
+            "failed is negative-cache len plus new permanent failures"
+        );
+    }
+
+    #[test]
+    fn restore_skip_fail_counts_does_not_count_off_chain_existing() {
+        let on_chain = vec!["a".to_string()];
+        let existing = vec!["a".to_string(), "ghost".to_string()];
+        let none: Vec<String> = vec![];
+
+        let (skipped, failed_count) =
+            super::restore_skip_fail_counts(&on_chain, &existing, &none, 0);
+
+        assert_eq!(skipped, 1);
+        assert_eq!(failed_count, 0);
+    }
+
+    #[test]
+    fn restore_skip_fail_counts_uses_full_negative_cache_len() {
+        let on_chain = vec!["a".to_string()];
+        let none: Vec<String> = vec![];
+        let failed = vec!["old-fail".to_string()];
+
+        let (skipped, failed_count) = super::restore_skip_fail_counts(&on_chain, &none, &failed, 0);
+
+        assert_eq!(skipped, 0);
+        assert_eq!(
+            failed_count, 1,
+            "negative-cache entries count even when not in this on-chain page"
+        );
     }
 
     // ── /api/forget + /api/stats empty-namespace validation ─────────────

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1826,9 +1826,10 @@ pub struct RestoreRequest {
 pub struct RestoreResponse {
     pub restored: usize,
     pub skipped: usize,
-    /// Permanent decrypt/UTF-8 failures for this owner+namespace: the
-    /// `restore_failed_blobs` negative cache plus any new permanent
-    /// failures recorded in this call. Additive JSON field (COMG-719).
+    /// Permanent decrypt/UTF-8 failures on this on-chain page: negative-cache
+    /// hits plus any new permanent failures this call. Transient download,
+    /// decrypt, or embed errors are not counted here. Additive JSON field
+    /// (COMG-719 / WALM-480).
     pub failed: usize,
     pub total: usize,
     pub namespace: String,
@@ -1841,7 +1842,8 @@ pub struct RestoreResponse {
     /// namespaces can starve this one. Once the sidecar cap is saturated
     /// (`limit >= 20`), truncation follows this call's missing-blob page,
     /// not on-chain `total`, so a fully restored namespace does not loop
-    /// (WALM-431 / GH #762).
+    /// (WALM-431 / GH #762). Also true when an inspected page produced only
+    /// transients (download/decrypt/embed) so the caller retries (WALM-480).
     pub truncated: bool,
 }
 

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1826,6 +1826,10 @@ pub struct RestoreRequest {
 pub struct RestoreResponse {
     pub restored: usize,
     pub skipped: usize,
+    /// Permanent decrypt/UTF-8 failures for this owner+namespace: the
+    /// `restore_failed_blobs` negative cache plus any new permanent
+    /// failures recorded in this call. Additive JSON field (COMG-719).
+    pub failed: usize,
     pub total: usize,
     pub namespace: String,
     pub owner: String,


### PR DESCRIPTION
## Summary

`POST /api/restore` no longer folds permanent decrypt/UTF-8 failures into `skipped`. Those blobs stay in the `restore_failed_blobs` negative cache, but the response now reports them as `failed`.

- `skipped` is on-chain blobs already in the local **success** index only
- `failed` is the owner+namespace negative-cache size plus new permanent failures this call (no double-count)
- Additive JSON field on `RestoreResponse`; TypeScript `failed?: number` (SDK defaults omitted to `0`); Python `failed: int = 0`

Fixes #399
COMG-719

## Test plan

- [x] `cargo test --bin memwal-server restore_`
- [x] `node --test packages/sdk/test/restore-truncated.test.mjs`
- [x] `pytest packages/python-sdk-memwal/tests/test_client.py::TestRestore`
- [x] `node scripts/verify-manual-sdk-release.mjs`