### PR TITLE
ci: add production-safe SEAL cross-account synthetic (COMG-715)

### DIFF
--- a/.github/workflows/synthetic-seal-cross-account.yml
+++ b/.github/workflows/synthetic-seal-cross-account.yml
@@ -1,0 +1,59 @@
+name: Synthetic SEAL cross-account
+
+# Production-safe negative synthetic (COMG-715).
+# workflow_dispatch only — never on pull_request. Missing secrets skip (exit 0).
+# A live cross-account SEAL authorization fails the job with
+# SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL and should page on-call.
+#
+# Schedule from ops (not enabled here on purpose):
+#   gh workflow run synthetic-seal-cross-account.yml --ref <protected-branch>
+# or add `on.schedule` after the two-account secrets exist.
+
+on:
+  workflow_dispatch:
+    inputs:
+      relayer_url:
+        description: Relayer base URL for GET /config when SUI_RPC_URL / MEMWAL_PACKAGE_ID are unset
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  synthetic:
+    name: Cross-account SEAL deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SEAL_CROSS_ACCOUNT_A_ID: ${{ secrets.SEAL_CROSS_ACCOUNT_A_ID }}
+      SEAL_CROSS_ACCOUNT_B_ID: ${{ secrets.SEAL_CROSS_ACCOUNT_B_ID }}
+      SEAL_CROSS_ACCOUNT_A_KEY: ${{ secrets.SEAL_CROSS_ACCOUNT_A_KEY }}
+      SEAL_CROSS_ACCOUNT_B_KEY: ${{ secrets.SEAL_CROSS_ACCOUNT_B_KEY }}
+      SUI_RPC_URL: ${{ vars.SUI_RPC_URL }}
+      SUI_NETWORK: ${{ vars.SUI_NETWORK }}
+      MEMWAL_PACKAGE_ID: ${{ vars.MEMWAL_PACKAGE_ID }}
+      MEMWAL_REGISTRY_ID: ${{ vars.MEMWAL_REGISTRY_ID }}
+      MEMWAL_SEAL_POLICY_PACKAGE_ID: ${{ vars.MEMWAL_SEAL_POLICY_PACKAGE_ID }}
+      MEMWAL_SERVER_URL: ${{ inputs.relayer_url || vars.MEMWAL_SERVER_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect secrets
+        id: cfg
+        shell: bash
+        run: |
+          if [ -z "${SEAL_CROSS_ACCOUNT_A_ID:-}" ] || [ -z "${SEAL_CROSS_ACCOUNT_B_ID:-}" ] || \
+             [ -z "${SEAL_CROSS_ACCOUNT_A_KEY:-}" ] || [ -z "${SEAL_CROSS_ACCOUNT_B_KEY:-}" ]; then
+            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup JS
+        if: steps.cfg.outputs.has_secrets == 'true'
+        uses: ./.github/actions/setup-js
+
+      - name: Run cross-account SEAL synthetic
+        run: node scripts/synthetic-seal-cross-account.mjs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
             script: scripts/check-docs-code-sync.mjs
           - name: Docs / Freshness
             script: scripts/check-docs-freshness.mjs
+          - name: SEAL cross-account synthetic parser
+            script: scripts/synthetic-seal-cross-account.test.mjs
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -175,6 +175,7 @@
               "relayer/self-hosting",
               "relayer/nautilus-tee",
               "relayer/observability",
+              "relayer/synthetic-seal-cross-account",
               "relayer/versioning-and-compatibility",
               "relayer/api-reference"
             ]

--- a/docs/relayer/synthetic-seal-cross-account.md
+++ b/docs/relayer/synthetic-seal-cross-account.md
@@ -37,7 +37,7 @@ answer: >-
   Schedule it with `gh workflow run` or an ops cron that dispatches that workflow.
 ---
 
-# SEAL Cross-Account Synthetic
+## SEAL Cross-Account Synthetic
 
 COMG-715 adds a production-safe **negative** synthetic on top of the Move unit
 test `test_seal_approve_delegate_requires_matching_owner`. The unit test covers

--- a/docs/relayer/synthetic-seal-cross-account.md
+++ b/docs/relayer/synthetic-seal-cross-account.md
@@ -1,0 +1,99 @@
+---
+title: "SEAL Cross-Account Synthetic"
+description: >-
+  How operators schedule the production-safe negative synthetic that pages if
+  an identity from MemWal account A can authorize account B's SEAL key.
+keywords:
+  - Walrus Memory
+  - MemWal
+  - SEAL
+  - synthetic
+  - cross-account
+  - CI
+goal:
+  description: Configure two isolated test accounts and run the read-only SEAL cross-account synthetic on a schedule.
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 150
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - "How do I run the SEAL cross-account synthetic?"
+  - "What secrets does the SEAL cross-account synthetic need?"
+  - "How do I schedule the SEAL cross-account check in production?"
+answer: >-
+  Run `scripts/synthetic-seal-cross-account.mjs` or dispatch
+  `.github/workflows/synthetic-seal-cross-account.yml`. The check is read-only:
+  it dry-runs `seal_approve` and never writes memories or mutates chain. Unset
+  secrets skip the job (exit 0). If identity A can authorize account B, the job
+  exits 1 with `SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL` and should page on-call.
+  Schedule it with `gh workflow run` or an ops cron that dispatches that workflow.
+---
+
+# SEAL Cross-Account Synthetic
+
+COMG-715 adds a production-safe **negative** synthetic on top of the Move unit
+test `test_seal_approve_delegate_requires_matching_owner`. The unit test covers
+the contract in isolation. This check would **alert** if a live identity from
+account A can authorize account B's SEAL key.
+
+The script is **read-only**. It never calls remember, never fetches SEAL
+decryption keys, and never executes a transaction. It `devInspect`s
+`account::seal_approve` only.
+
+## When it runs
+
+`.github/workflows/synthetic-seal-cross-account.yml` is `workflow_dispatch`
+only. It does **not** run on pull requests, so a PR without production secrets
+cannot page and cannot touch chain.
+
+If the two account ids and two delegate keys are unset, the script prints
+`skip` and exits 0.
+
+## Secrets and variables
+
+Use two **isolated** MemWal accounts (different owners). Each key must be a
+delegate or owner of its own account and must **not** be registered on the other.
+
+| Name | Where | Purpose |
+| --- | --- | --- |
+| `SEAL_CROSS_ACCOUNT_A_ID` / `SEAL_CROSS_ACCOUNT_B_ID` | GitHub secret | Account object ids |
+| `SEAL_CROSS_ACCOUNT_A_KEY` / `SEAL_CROSS_ACCOUNT_B_KEY` | GitHub secret | Delegate private keys (hex or `suiprivkey1…`) |
+| `SUI_RPC_URL` | GitHub variable | JSON-RPC fullnode |
+| `MEMWAL_PACKAGE_ID` | GitHub variable | Policy package id |
+| `MEMWAL_REGISTRY_ID` | GitHub variable | `AccountRegistry` object id |
+| `MEMWAL_SERVER_URL` | GitHub variable or workflow input | Optional; `GET /config` fills package id and RPC URL |
+| `SUI_NETWORK` | GitHub variable | `mainnet` or `testnet` when the RPC URL does not say |
+
+Do not commit private keys. Do not reuse the shared benchmark account as both A and B.
+
+## Schedule (ops)
+
+Dispatch from a protected ref after the secrets exist:
+
+```bash
+gh workflow run synthetic-seal-cross-account.yml --ref main
+```
+
+Or Actions → **Synthetic SEAL cross-account** → **Run workflow**.
+
+To cron it, add `on.schedule` to that workflow once the two-account secrets
+are in place (left off by default so an empty repo cannot false-green or page):
+
+```yaml
+on:
+  schedule:
+    - cron: "17 6 * * *"   # daily 06:17 UTC
+  workflow_dispatch:
+```
+
+Point the workflow failure at on-call. A red job whose log contains
+`SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL` means live `seal_approve` allowed a
+cross-account identity. That is a SEAL policy regression, not a flake.

--- a/scripts/synthetic-seal-cross-account.mjs
+++ b/scripts/synthetic-seal-cross-account.mjs
@@ -1,0 +1,586 @@
+#!/usr/bin/env node
+/**
+ * Production-safe negative synthetic for COMG-715.
+ *
+ * Asserts that an identity from MemWal account A cannot authorize account B's
+ * SEAL key (and the reverse). Read-only: `sui_devInspectTransactionBlock` of
+ * `account::seal_approve` only. Does not remember, decrypt, fetch SEAL keys,
+ * or execute a transaction.
+ *
+ * Exit 0  — required secrets unset (skip) or deny as expected.
+ * Exit 1  — SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL (page: A authorized B).
+ * Exit 2  — misconfiguration or RPC failure (check is not valid).
+ *
+ *   node scripts/synthetic-seal-cross-account.mjs
+ *   node scripts/synthetic-seal-cross-account.mjs --help
+ */
+
+const E_NO_ACCESS = 100;
+const FAIL_TOKEN = "SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL";
+const OBJECT_ID_RE = /^0x[0-9a-fA-F]{64}$/;
+const HEX_32_RE = /^(0x)?[0-9a-fA-F]{64}$/;
+
+const REQUIRED_SECRETS = [
+    ["SEAL_CROSS_ACCOUNT_A_ID", ["SEAL_CROSS_ACCOUNT_A_ID", "MEMWAL_ACCOUNT_A_ID"]],
+    ["SEAL_CROSS_ACCOUNT_B_ID", ["SEAL_CROSS_ACCOUNT_B_ID", "MEMWAL_ACCOUNT_B_ID"]],
+    ["SEAL_CROSS_ACCOUNT_A_KEY", ["SEAL_CROSS_ACCOUNT_A_KEY", "MEMWAL_DELEGATE_KEY_A"]],
+    ["SEAL_CROSS_ACCOUNT_B_KEY", ["SEAL_CROSS_ACCOUNT_B_KEY", "MEMWAL_DELEGATE_KEY_B"]],
+];
+
+function env(name) {
+    const v = process.env[name];
+    return typeof v === "string" && v.trim() ? v.trim() : "";
+}
+
+function firstEnv(names) {
+    for (const name of names) {
+        const v = env(name);
+        if (v) return v;
+    }
+    return "";
+}
+
+function usage() {
+    process.stdout.write(`Production-safe SEAL cross-account synthetic (COMG-715).
+
+Read-only dry-run of account::seal_approve. Never writes memories or mutates chain.
+
+Skip (exit 0) when the two account ids and two delegate keys are unset.
+
+Required to run:
+  SEAL_CROSS_ACCOUNT_A_ID / SEAL_CROSS_ACCOUNT_B_ID
+  SEAL_CROSS_ACCOUNT_A_KEY / SEAL_CROSS_ACCOUNT_B_KEY
+  SUI_RPC_URL and MEMWAL_PACKAGE_ID
+    (or MEMWAL_SERVER_URL / MEMWAL_RELAYER_URL — GET /config fills both)
+
+Also used when set:
+  MEMWAL_REGISTRY_ID          AccountRegistry object id
+  MEMWAL_SEAL_POLICY_PACKAGE_ID   seal_approve package (defaults to MEMWAL_PACKAGE_ID)
+  SUI_NETWORK                 mainnet|testnet (inferred from the RPC URL when omitted)
+
+Expected: ENoAccess / deny. If A can authorize B: exit 1 ${FAIL_TOKEN}.
+`);
+}
+
+function normalizeHexAddress(value) {
+    const hex = String(value).replace(/^0x/i, "").toLowerCase();
+    if (!/^[0-9a-f]{1,64}$/.test(hex)) {
+        throw new Error(`not a Sui address: ${value}`);
+    }
+    return `0x${hex.padStart(64, "0")}`;
+}
+
+function u64ToLeBytes(value) {
+    const n = BigInt(value);
+    if (n < 0n || n > 0xffff_ffff_ffff_ffffn) {
+        throw new Error(`u64 out of range: ${value}`);
+    }
+    const out = new Uint8Array(8);
+    for (let i = 0; i < 8; i++) out[i] = Number((n >> (8n * BigInt(i))) & 0xffn);
+    return out;
+}
+
+function sealKeyIdBytes(ownerHex, counter) {
+    const owner = Uint8Array.from(
+        normalizeHexAddress(ownerHex)
+            .slice(2)
+            .match(/.{2}/g)
+            .map((b) => parseInt(b, 16)),
+    );
+    const id = new Uint8Array(40);
+    id.set(owner, 0);
+    id.set(u64ToLeBytes(counter), 32);
+    return id;
+}
+
+function shortId(id) {
+    const n = normalizeHexAddress(id);
+    return `${n.slice(0, 10)}…${n.slice(-6)}`;
+}
+
+function secretPresence() {
+    return REQUIRED_SECRETS.map(([label, names]) => ({
+        label,
+        value: firstEnv(names),
+    }));
+}
+
+function shouldSkip(presence) {
+    return presence.every((p) => !p.value);
+}
+
+function missingSecrets(presence) {
+    return presence.filter((p) => !p.value).map((p) => p.label);
+}
+
+async function rpc(url, method, params, timeoutMs = 30_000) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const res = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+            signal: controller.signal,
+        });
+        const json = await res.json();
+        if (json.error) {
+            throw new Error(`${method}: ${json.error.message || JSON.stringify(json.error)}`);
+        }
+        return json.result;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+async function getRelayerConfig(serverUrl) {
+    const url = `${serverUrl.replace(/\/$/, "")}/config`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 15_000);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) throw new Error(`GET ${url} → ${res.status}`);
+        return await res.json();
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+function inferNetwork(rpcUrl, explicit) {
+    if (explicit === "mainnet" || explicit === "testnet") return explicit;
+    const u = (rpcUrl || "").toLowerCase();
+    if (u.includes("testnet")) return "testnet";
+    if (u.includes("devnet")) return "devnet";
+    if (u.includes("mainnet")) return "mainnet";
+    return "mainnet";
+}
+
+function keypairFromDelegateKey(Ed25519Keypair, decodeSuiPrivateKey, raw) {
+    try {
+        if (raw.toLowerCase().startsWith("suiprivkey")) {
+            const { scheme, secretKey } = decodeSuiPrivateKey(raw);
+            if (scheme !== "ED25519") {
+                throw new Error(`delegate key must be Ed25519, got ${scheme}`);
+            }
+            return Ed25519Keypair.fromSecretKey(secretKey);
+        }
+        if (!HEX_32_RE.test(raw)) {
+            throw new Error("not hex");
+        }
+        const hex = raw.startsWith("0x") || raw.startsWith("0X") ? raw.slice(2) : raw;
+        return Ed25519Keypair.fromSecretKey(Uint8Array.from(Buffer.from(hex, "hex")));
+    } catch {
+        throw new Error("invalid delegate key (need 32-byte hex seed or suiprivkey1…)");
+    }
+}
+
+function parseAccountObject(objectId, result, packageId) {
+    const data = result?.data ?? result?.object ?? result;
+    const content = data?.content ?? {};
+    const fields = data?.json ?? content?.fields ?? data?.fields;
+    const objectType =
+        data?.type ?? content?.type ?? result?.data?.type ?? result?.data?.content?.type;
+    if (!fields || typeof objectType !== "string") {
+        throw new Error(`account ${shortId(objectId)}: missing Move content`);
+    }
+    const typeParts = objectType.split("::");
+    if (typeParts[1] !== "account" || typeParts[2] !== "MemWalAccount") {
+        throw new Error(`account ${shortId(objectId)} is ${objectType}, expected MemWalAccount`);
+    }
+    const typePkg = normalizeHexAddress(typeParts[0]);
+    const configuredPkg = normalizeHexAddress(packageId);
+    // Types keep the first-published package id across upgrades; PACKAGE_ID is
+    // the current policy package. Equality holds only until the first upgrade.
+    if (typePkg !== configuredPkg) {
+        console.log(
+            `note: ${shortId(objectId)} type package ${shortId(typePkg)} ≠ MEMWAL_PACKAGE_ID ${shortId(configuredPkg)} (expected after an upgrade)`,
+        );
+    }
+    if (fields.active !== true) {
+        throw new Error(`account ${shortId(objectId)} is not active`);
+    }
+    if (typeof fields.owner !== "string") {
+        throw new Error(`account ${shortId(objectId)} has no owner`);
+    }
+    const rawCounter = fields.access_counter_version;
+    if (rawCounter === undefined || rawCounter === null) {
+        throw new Error(`account ${shortId(objectId)} has no access_counter_version`);
+    }
+    const delegates = [];
+    const rawKeys = fields.delegate_keys ?? [];
+    for (const entry of rawKeys) {
+        const d = entry?.fields ?? entry;
+        if (typeof d?.sui_address === "string") {
+            delegates.push(normalizeHexAddress(d.sui_address));
+        }
+    }
+    return {
+        id: normalizeHexAddress(objectId),
+        owner: normalizeHexAddress(fields.owner),
+        counter: BigInt(rawCounter),
+        delegates,
+        typePackageId: typePkg,
+        objectType,
+    };
+}
+
+function roleOnAccount(address, account) {
+    const addr = normalizeHexAddress(address);
+    if (addr === account.owner) return "owner";
+    if (account.delegates.includes(addr)) return "delegate";
+    return null;
+}
+
+function extractAbortCode(inspect) {
+    const effects = inspect?.effects ?? inspect?.transactionEffects ?? inspect;
+    const status = effects?.status ?? inspect?.status;
+    if (!status) return { outcome: "unknown", detail: JSON.stringify(inspect).slice(0, 500) };
+
+    const kind = status.status ?? status;
+    if (kind === "success" || status.success === true) {
+        return { outcome: "success", detail: "success" };
+    }
+
+    const error = status.error ?? inspect?.error ?? effects?.error;
+    const text = typeof error === "string" ? error : JSON.stringify(error ?? status);
+
+    const moveAbort = text.match(/MoveAbort\([^,]+,\s*(\d+)\)/);
+    if (moveAbort) {
+        return { outcome: "abort", code: Number(moveAbort[1]), detail: text };
+    }
+    if (error && typeof error === "object") {
+        const abort = error.MoveAbort ?? error.moveAbort;
+        if (Array.isArray(abort) && abort.length >= 2) {
+            return { outcome: "abort", code: Number(abort[1]), detail: text };
+        }
+        if (abort && typeof abort === "object" && abort.abortCode !== undefined) {
+            return { outcome: "abort", code: Number(abort.abortCode), detail: text };
+        }
+    }
+    const abortCode = text.match(/"abortCode"\s*:\s*"?(\d+)/);
+    if (abortCode) {
+        return { outcome: "abort", code: Number(abortCode[1]), detail: text };
+    }
+    return { outcome: "failure", detail: text };
+}
+
+function pureU8Vector(tx, bytes) {
+    const arr = Array.from(bytes);
+    if (tx.pure && typeof tx.pure.vector === "function") {
+        return tx.pure.vector("u8", arr);
+    }
+    return tx.pure("vector<u8>", arr);
+}
+
+async function discoverRegistry(network, typePackageId) {
+    const endpoints = {
+        mainnet: "https://graphql.mainnet.sui.io/graphql",
+        testnet: "https://graphql.testnet.sui.io/graphql",
+    };
+    const url = endpoints[network];
+    if (!url) return "";
+    const type = `${typePackageId}::account::AccountRegistry`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 15_000);
+    try {
+        const res = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                query: "query ($type: String!) { objects(first: 5, filter: { type: $type }) { nodes { address } } }",
+                variables: { type },
+            }),
+            signal: controller.signal,
+        });
+        if (!res.ok) return "";
+        const json = await res.json();
+        const nodes = json?.data?.objects?.nodes;
+        if (!Array.isArray(nodes) || nodes.length === 0) return "";
+        if (nodes.length > 1) {
+            throw new Error(
+                `GraphQL found ${nodes.length} AccountRegistry objects; set MEMWAL_REGISTRY_ID`,
+            );
+        }
+        return typeof nodes[0]?.address === "string" ? nodes[0].address : "";
+    } catch (err) {
+        if (err instanceof Error && err.message.includes("AccountRegistry")) throw err;
+        return "";
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+async function inspectSealApprove({
+    client,
+    Transaction,
+    sender,
+    policyPackageId,
+    registryId,
+    accountId,
+    idBytes,
+}) {
+    const tx = new Transaction();
+    tx.setSenderIfNotSet?.(sender);
+    tx.moveCall({
+        target: `${policyPackageId}::account::seal_approve`,
+        arguments: [
+            pureU8Vector(tx, idBytes),
+            tx.object(registryId),
+            tx.object(accountId),
+        ],
+    });
+
+    if (typeof client.devInspectTransactionBlock === "function") {
+        return client.devInspectTransactionBlock({
+            sender,
+            transactionBlock: tx,
+        });
+    }
+    if (typeof client.core?.simulateTransaction === "function") {
+        return client.core.simulateTransaction({ sender, transaction: tx });
+    }
+
+    const bytes = await tx.build({ client, onlyTransactionKind: true });
+    const b64 = Buffer.from(bytes).toString("base64");
+    const url = client.transport?.url ?? client.url;
+    if (!url) {
+        throw new Error("Sui client has no JSON-RPC URL for sui_devInspectTransactionBlock");
+    }
+    return rpc(url, "sui_devInspectTransactionBlock", [sender, b64, null, null]);
+}
+
+function failSecurity(message) {
+    const line = `${FAIL_TOKEN}: ${message}`;
+    console.error(`::error::${line}`);
+    console.error(line);
+    console.error("Page on-call. Identity from one MemWal account authorized another account's SEAL key.");
+    process.exit(1);
+}
+
+function failMisconfig(message) {
+    console.error(`synthetic-seal-cross-account: misconfig: ${message}`);
+    process.exit(2);
+}
+
+async function run() {
+    const presence = secretPresence();
+    if (shouldSkip(presence)) {
+        console.log(
+            "synthetic-seal-cross-account: skip (required env vars unset; safe in CI without secrets)",
+        );
+        return;
+    }
+    const missing = missingSecrets(presence);
+    if (missing.length) {
+        failMisconfig(`partial secrets; missing ${missing.join(", ")}`);
+    }
+
+    const accountAId = firstEnv(["SEAL_CROSS_ACCOUNT_A_ID", "MEMWAL_ACCOUNT_A_ID"]);
+    const accountBId = firstEnv(["SEAL_CROSS_ACCOUNT_B_ID", "MEMWAL_ACCOUNT_B_ID"]);
+    const keyA = firstEnv(["SEAL_CROSS_ACCOUNT_A_KEY", "MEMWAL_DELEGATE_KEY_A"]);
+    const keyB = firstEnv(["SEAL_CROSS_ACCOUNT_B_KEY", "MEMWAL_DELEGATE_KEY_B"]);
+
+    if (!OBJECT_ID_RE.test(accountAId) || !OBJECT_ID_RE.test(accountBId)) {
+        failMisconfig("account ids must be 0x-prefixed 32-byte object ids");
+    }
+    if (normalizeHexAddress(accountAId) === normalizeHexAddress(accountBId)) {
+        failMisconfig("account A and account B must be different objects");
+    }
+
+    let packageId = firstEnv(["MEMWAL_PACKAGE_ID", "PACKAGE_ID"]);
+    let rpcUrl = firstEnv(["SUI_RPC_URL"]);
+    let network = env("SUI_NETWORK");
+    const serverUrl = firstEnv(["MEMWAL_SERVER_URL", "MEMWAL_RELAYER_URL"]);
+
+    if ((!packageId || !rpcUrl) && serverUrl) {
+        const cfg = await getRelayerConfig(serverUrl);
+        packageId = packageId || cfg.packageId || "";
+        rpcUrl = rpcUrl || cfg.suiRpcUrl || "";
+        network = network || cfg.network || "";
+        console.log(`loaded GET ${serverUrl.replace(/\/$/, "")}/config`);
+    }
+    if (!packageId) failMisconfig("MEMWAL_PACKAGE_ID unset (or GET /config)");
+    if (!rpcUrl) failMisconfig("SUI_RPC_URL unset (or GET /config)");
+    network = inferNetwork(rpcUrl, network);
+
+    let suiMod;
+    try {
+        const [jsonRpc, txMod, keysMod, cryptoMod] = await Promise.all([
+            import("@mysten/sui/jsonRpc"),
+            import("@mysten/sui/transactions"),
+            import("@mysten/sui/keypairs/ed25519"),
+            import("@mysten/sui/cryptography"),
+        ]);
+        suiMod = { jsonRpc, txMod, keysMod, cryptoMod };
+    } catch (err) {
+        failMisconfig(
+            `cannot import @mysten/sui (${err instanceof Error ? err.message : err}). From repo root: pnpm install --frozen-lockfile`,
+        );
+    }
+
+    const { SuiJsonRpcClient } = suiMod.jsonRpc;
+    const { Transaction } = suiMod.txMod;
+    const { Ed25519Keypair } = suiMod.keysMod;
+    const { decodeSuiPrivateKey } = suiMod.cryptoMod;
+    if (typeof SuiJsonRpcClient !== "function" || typeof Transaction !== "function") {
+        failMisconfig("@mysten/sui JSON-RPC client or Transaction missing");
+    }
+
+    const client = new SuiJsonRpcClient({ url: rpcUrl, network });
+    const keypairA = keypairFromDelegateKey(Ed25519Keypair, decodeSuiPrivateKey, keyA);
+    const keypairB = keypairFromDelegateKey(Ed25519Keypair, decodeSuiPrivateKey, keyB);
+    const addrA = normalizeHexAddress(keypairA.getPublicKey().toSuiAddress());
+    const addrB = normalizeHexAddress(keypairB.getPublicKey().toSuiAddress());
+    if (addrA === addrB) {
+        failMisconfig("delegate keys A and B derive the same Sui address");
+    }
+
+    const readAccount = async (id) => {
+        let result;
+        if (typeof client.getObject === "function") {
+            result = await client.getObject({
+                objectId: id,
+                id,
+                include: { json: true, type: true },
+                options: { showContent: true, showType: true },
+            });
+        } else {
+            result = await rpc(rpcUrl, "sui_getObject", [id, { showContent: true, showType: true }]);
+        }
+        return parseAccountObject(id, result, packageId);
+    };
+
+    const accountA = await readAccount(accountAId);
+    const accountB = await readAccount(accountBId);
+    if (accountA.owner === accountB.owner) {
+        failMisconfig("account A and B share an owner; pick two isolated accounts");
+    }
+
+    const roleAonA = roleOnAccount(addrA, accountA);
+    const roleBonB = roleOnAccount(addrB, accountB);
+    const roleAonB = roleOnAccount(addrA, accountB);
+    const roleBonA = roleOnAccount(addrB, accountA);
+    if (!roleAonA) {
+        failMisconfig(`key A (${shortId(addrA)}) is not owner/delegate of account A`);
+    }
+    if (!roleBonB) {
+        failMisconfig(`key B (${shortId(addrB)}) is not owner/delegate of account B`);
+    }
+    if (roleAonB) {
+        failMisconfig(`key A is also ${roleAonB} on account B; accounts are not isolated`);
+    }
+    if (roleBonA) {
+        failMisconfig(`key B is also ${roleBonA} on account A; accounts are not isolated`);
+    }
+
+    const policyPackageId =
+        firstEnv(["MEMWAL_SEAL_POLICY_PACKAGE_ID", "SEAL_POLICY_PACKAGE_ID"]) || packageId;
+    let registryId = firstEnv(["MEMWAL_REGISTRY_ID", "REGISTRY_ID"]);
+    if (!registryId) {
+        registryId = await discoverRegistry(network, accountA.typePackageId);
+    }
+    if (!registryId || !OBJECT_ID_RE.test(normalizeHexAddress(registryId))) {
+        failMisconfig("MEMWAL_REGISTRY_ID unset and AccountRegistry discovery failed");
+    }
+    registryId = normalizeHexAddress(registryId);
+
+    console.log(
+        `synthetic-seal-cross-account: ${network} policy=${shortId(policyPackageId)} registry=${shortId(registryId)}`,
+    );
+    console.log(
+        `  A ${shortId(accountA.id)} owner=${shortId(accountA.owner)} caller=${shortId(addrA)} (${roleAonA}) counter=${accountA.counter}`,
+    );
+    console.log(
+        `  B ${shortId(accountB.id)} owner=${shortId(accountB.owner)} caller=${shortId(addrB)} (${roleBonB}) counter=${accountB.counter}`,
+    );
+
+    const inspect = (sender, accountId, ownerHex, counter) =>
+        inspectSealApprove({
+            client,
+            Transaction,
+            sender,
+            policyPackageId,
+            registryId,
+            accountId,
+            idBytes: sealKeyIdBytes(ownerHex, counter),
+        });
+
+    const sameAccount = [
+        {
+            name: "A authorizes A (sanity)",
+            promise: inspect(addrA, accountA.id, accountA.owner, accountA.counter),
+            expect: "success",
+        },
+        {
+            name: "B authorizes B (sanity)",
+            promise: inspect(addrB, accountB.id, accountB.owner, accountB.counter),
+            expect: "success",
+        },
+    ];
+    for (const step of sameAccount) {
+        const result = extractAbortCode(await step.promise);
+        if (result.outcome !== "success") {
+            failMisconfig(
+                `${step.name} did not succeed (${result.outcome}${result.code !== undefined ? ` ${result.code}` : ""}). Check keys, package, registry.`,
+            );
+        }
+        console.log(`  ok  ${step.name}`);
+    }
+
+    const negatives = [
+        {
+            name: "A on B's account + B's SEAL id",
+            from: "A",
+            to: "B",
+            promise: inspect(addrA, accountB.id, accountB.owner, accountB.counter),
+        },
+        {
+            name: "A on A's account + B's SEAL id",
+            from: "A",
+            to: "B",
+            promise: inspect(addrA, accountA.id, accountB.owner, accountB.counter),
+        },
+        {
+            name: "B on A's account + A's SEAL id",
+            from: "B",
+            to: "A",
+            promise: inspect(addrB, accountA.id, accountA.owner, accountA.counter),
+        },
+        {
+            name: "B on B's account + A's SEAL id",
+            from: "B",
+            to: "A",
+            promise: inspect(addrB, accountB.id, accountA.owner, accountA.counter),
+        },
+    ];
+
+    for (const step of negatives) {
+        const result = extractAbortCode(await step.promise);
+        if (result.outcome === "success") {
+            failSecurity(
+                `identity ${step.from} authorized account ${step.to}'s SEAL key (${step.name}); expected ENoAccess`,
+            );
+        }
+        if (result.outcome === "abort" && result.code === E_NO_ACCESS) {
+            console.log(`  deny ${step.name} (ENoAccess)`);
+            continue;
+        }
+        failMisconfig(
+            `${step.name}: expected ENoAccess (100), got ${result.outcome}${result.code !== undefined ? ` ${result.code}` : ""}: ${result.detail.slice(0, 300)}`,
+        );
+    }
+
+    console.log("synthetic-seal-cross-account: ok (cross-account seal_approve denied as expected)");
+}
+
+const args = process.argv.slice(2);
+if (args.includes("--help") || args.includes("-h")) {
+    usage();
+    process.exit(0);
+}
+
+run().catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`synthetic-seal-cross-account: ${msg}`);
+    process.exit(2);
+});

--- a/scripts/synthetic-seal-cross-account.mjs
+++ b/scripts/synthetic-seal-cross-account.mjs
@@ -15,6 +15,9 @@
  *   node scripts/synthetic-seal-cross-account.mjs --help
  */
 
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 const E_NO_ACCESS = 100;
 const FAIL_TOKEN = "SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL";
 const OBJECT_ID_RE = /^0x[0-9a-fA-F]{64}$/;
@@ -231,7 +234,7 @@ function roleOnAccount(address, account) {
     return null;
 }
 
-function extractAbortCode(inspect) {
+export function extractAbortCode(inspect) {
     const effects = inspect?.effects ?? inspect?.transactionEffects ?? inspect;
     const status = effects?.status ?? inspect?.status;
     if (!status) return { outcome: "unknown", detail: JSON.stringify(inspect).slice(0, 500) };
@@ -244,7 +247,10 @@ function extractAbortCode(inspect) {
     const error = status.error ?? inspect?.error ?? effects?.error;
     const text = typeof error === "string" ? error : JSON.stringify(error ?? status);
 
-    const moveAbort = text.match(/MoveAbort\([^,]+,\s*(\d+)\)/);
+    // JSON-RPC Display: MoveAbort(<location>, <code>) in command N.
+    // Location is MoveLocation { module: ModuleId { ... }, function, ... } and
+    // contains commas, so the abort code is the decimal after that location.
+    const moveAbort = text.match(/MoveAbort\([\s\S]*,\s*(\d+)\)/);
     if (moveAbort) {
         return { outcome: "abort", code: Number(moveAbort[1]), detail: text };
     }
@@ -257,7 +263,7 @@ function extractAbortCode(inspect) {
             return { outcome: "abort", code: Number(abort.abortCode), detail: text };
         }
     }
-    const abortCode = text.match(/"abortCode"\s*:\s*"?(\d+)/);
+    const abortCode = text.match(/abort code:\s*(\d+)/i) ?? text.match(/"abortCode"\s*:\s*"?(\d+)/);
     if (abortCode) {
         return { outcome: "abort", code: Number(abortCode[1]), detail: text };
     }
@@ -573,14 +579,20 @@ async function run() {
     console.log("synthetic-seal-cross-account: ok (cross-account seal_approve denied as expected)");
 }
 
-const args = process.argv.slice(2);
-if (args.includes("--help") || args.includes("-h")) {
-    usage();
-    process.exit(0);
-}
+const isMain =
+    Boolean(process.argv[1]) &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
-run().catch((err) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`synthetic-seal-cross-account: ${msg}`);
-    process.exit(2);
-});
+if (isMain) {
+    const args = process.argv.slice(2);
+    if (args.includes("--help") || args.includes("-h")) {
+        usage();
+        process.exit(0);
+    }
+
+    run().catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`synthetic-seal-cross-account: ${msg}`);
+        process.exit(2);
+    });
+}

--- a/scripts/synthetic-seal-cross-account.test.mjs
+++ b/scripts/synthetic-seal-cross-account.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { extractAbortCode } from "./synthetic-seal-cross-account.mjs";
+
+const SCRIPT = fileURLToPath(new URL("./synthetic-seal-cross-account.mjs", import.meta.url));
+const E_NO_ACCESS = 100;
+
+// Verbatim JSON-RPC Display string from a sui_devInspectTransactionBlock
+// effects.status.error (a string, not a structured object). Nested commas
+// inside MoveLocation must not hide abort code 100.
+const JSON_RPC_SEAL_ENOACCESS =
+    'MoveAbort(MoveLocation { module: ModuleId { address: ..., name: Identifier("account") }, function: 25, instruction: 11, function_name: Some("seal_approve") }, 100) in command 0';
+
+const JSON_RPC_SEAL_ENOACCESS_HEX =
+    "MoveAbort(MoveLocation { module: ModuleId { address: " +
+    "0000000000000000000000000000000000000000000000000000000000000abc, " +
+    'name: Identifier("account") }, function: 25, instruction: 11, ' +
+    'function_name: Some("seal_approve") }, 100) in command 0';
+
+function inspectFailure(error) {
+    return { effects: { status: { status: "failure", error } } };
+}
+
+function classifyNegative(inspect) {
+    const result = extractAbortCode(inspect);
+    if (result.outcome === "success") return "security-fail";
+    if (result.outcome === "abort" && result.code === E_NO_ACCESS) return "deny";
+    return "misconfig";
+}
+
+const SECRET_KEYS = [
+    "SEAL_CROSS_ACCOUNT_A_ID",
+    "SEAL_CROSS_ACCOUNT_B_ID",
+    "SEAL_CROSS_ACCOUNT_A_KEY",
+    "SEAL_CROSS_ACCOUNT_B_KEY",
+    "MEMWAL_ACCOUNT_A_ID",
+    "MEMWAL_ACCOUNT_B_ID",
+    "MEMWAL_DELEGATE_KEY_A",
+    "MEMWAL_DELEGATE_KEY_B",
+];
+
+function spawnScript(envExtra = {}, args = []) {
+    const env = { ...process.env, ...envExtra };
+    for (const key of SECRET_KEYS) {
+        if (!(key in envExtra)) delete env[key];
+    }
+    return spawnSync(process.execPath, [SCRIPT, ...args], {
+        env,
+        encoding: "utf8",
+    });
+}
+
+test("JSON-RPC MoveAbort Display string with nested location commas is ENoAccess", () => {
+    const result = extractAbortCode(inspectFailure(JSON_RPC_SEAL_ENOACCESS));
+    assert.equal(result.outcome, "abort");
+    assert.equal(result.code, E_NO_ACCESS);
+    assert.equal(classifyNegative(inspectFailure(JSON_RPC_SEAL_ENOACCESS)), "deny");
+});
+
+test("production-like JSON-RPC MoveAbort with hex ModuleId address is ENoAccess", () => {
+    const result = extractAbortCode(inspectFailure(JSON_RPC_SEAL_ENOACCESS_HEX));
+    assert.equal(result.outcome, "abort");
+    assert.equal(result.code, E_NO_ACCESS);
+    assert.equal(classifyNegative(inspectFailure(JSON_RPC_SEAL_ENOACCESS_HEX)), "deny");
+});
+
+test("comma-excluding regex cannot reach abort code 100 in the JSON-RPC string", () => {
+    assert.equal(JSON_RPC_SEAL_ENOACCESS.match(/MoveAbort\([^,]+,\s*(\d+)\)/), null);
+    assert.equal(JSON_RPC_SEAL_ENOACCESS_HEX.match(/MoveAbort\([^,]+,\s*(\d+)\)/), null);
+});
+
+test("simple MoveAbort without nested location commas still parses", () => {
+    const result = extractAbortCode(
+        inspectFailure("MoveAbort(MoveLocation { module: 0x2::account }, 100) in command 0"),
+    );
+    assert.equal(result.outcome, "abort");
+    assert.equal(result.code, E_NO_ACCESS);
+});
+
+test("formatMoveAbortMessage abort code phrase is ENoAccess", () => {
+    const result = extractAbortCode(
+        inspectFailure(
+            "MoveAbort in 1st command, abort code: 100, in '0xabc::account::seal_approve' (instruction 11)",
+        ),
+    );
+    assert.equal(result.outcome, "abort");
+    assert.equal(result.code, E_NO_ACCESS);
+});
+
+test("structured MoveAbort object fallback still works", () => {
+    const result = extractAbortCode(
+        inspectFailure({ MoveAbort: [{ module: "account", function_name: "seal_approve" }, 100] }),
+    );
+    assert.equal(result.outcome, "abort");
+    assert.equal(result.code, E_NO_ACCESS);
+});
+
+test("same-account success is not classified as a deny", () => {
+    const result = extractAbortCode({ effects: { status: { status: "success" } } });
+    assert.equal(result.outcome, "success");
+    assert.equal(classifyNegative({ effects: { status: { status: "success" } } }), "security-fail");
+});
+
+test("unrelated abort is misconfiguration, not a healthy deny", () => {
+    const result = extractAbortCode(inspectFailure("MoveAbort(MoveLocation { module: foo }, 1) in command 0"));
+    assert.equal(result.outcome, "abort");
+    assert.equal(result.code, 1);
+    assert.equal(classifyNegative(inspectFailure("MoveAbort(MoveLocation { module: foo }, 1) in command 0")), "misconfig");
+});
+
+test("skips with exit 0 when required secrets are unset", () => {
+    const result = spawnScript();
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /skip \(required env vars unset/);
+});
+
+test("partial secrets exit 2 as misconfiguration", () => {
+    const result = spawnScript({
+        SEAL_CROSS_ACCOUNT_A_ID: `0x${"aa".repeat(32)}`,
+        SEAL_CROSS_ACCOUNT_B_ID: `0x${"bb".repeat(32)}`,
+        SEAL_CROSS_ACCOUNT_A_KEY: "aa".repeat(32),
+    });
+    assert.equal(result.status, 2, result.stderr);
+    assert.match(result.stderr, /partial secrets/);
+});

--- a/scripts/synthetic-seal-cross-account.test.mjs
+++ b/scripts/synthetic-seal-cross-account.test.mjs
@@ -14,21 +14,8 @@ const E_NO_ACCESS = 100;
 const JSON_RPC_SEAL_ENOACCESS =
     'MoveAbort(MoveLocation { module: ModuleId { address: ..., name: Identifier("account") }, function: 25, instruction: 11, function_name: Some("seal_approve") }, 100) in command 0';
 
-const JSON_RPC_SEAL_ENOACCESS_HEX =
-    "MoveAbort(MoveLocation { module: ModuleId { address: " +
-    "0000000000000000000000000000000000000000000000000000000000000abc, " +
-    'name: Identifier("account") }, function: 25, instruction: 11, ' +
-    'function_name: Some("seal_approve") }, 100) in command 0';
-
 function inspectFailure(error) {
     return { effects: { status: { status: "failure", error } } };
-}
-
-function classifyNegative(inspect) {
-    const result = extractAbortCode(inspect);
-    if (result.outcome === "success") return "security-fail";
-    if (result.outcome === "abort" && result.code === E_NO_ACCESS) return "deny";
-    return "misconfig";
 }
 
 const SECRET_KEYS = [
@@ -42,12 +29,12 @@ const SECRET_KEYS = [
     "MEMWAL_DELEGATE_KEY_B",
 ];
 
-function spawnScript(envExtra = {}, args = []) {
+function spawnScript(envExtra = {}) {
     const env = { ...process.env, ...envExtra };
     for (const key of SECRET_KEYS) {
         if (!(key in envExtra)) delete env[key];
     }
-    return spawnSync(process.execPath, [SCRIPT, ...args], {
+    return spawnSync(process.execPath, [SCRIPT], {
         env,
         encoding: "utf8",
     });
@@ -57,19 +44,6 @@ test("JSON-RPC MoveAbort Display string with nested location commas is ENoAccess
     const result = extractAbortCode(inspectFailure(JSON_RPC_SEAL_ENOACCESS));
     assert.equal(result.outcome, "abort");
     assert.equal(result.code, E_NO_ACCESS);
-    assert.equal(classifyNegative(inspectFailure(JSON_RPC_SEAL_ENOACCESS)), "deny");
-});
-
-test("production-like JSON-RPC MoveAbort with hex ModuleId address is ENoAccess", () => {
-    const result = extractAbortCode(inspectFailure(JSON_RPC_SEAL_ENOACCESS_HEX));
-    assert.equal(result.outcome, "abort");
-    assert.equal(result.code, E_NO_ACCESS);
-    assert.equal(classifyNegative(inspectFailure(JSON_RPC_SEAL_ENOACCESS_HEX)), "deny");
-});
-
-test("comma-excluding regex cannot reach abort code 100 in the JSON-RPC string", () => {
-    assert.equal(JSON_RPC_SEAL_ENOACCESS.match(/MoveAbort\([^,]+,\s*(\d+)\)/), null);
-    assert.equal(JSON_RPC_SEAL_ENOACCESS_HEX.match(/MoveAbort\([^,]+,\s*(\d+)\)/), null);
 });
 
 test("simple MoveAbort without nested location commas still parses", () => {
@@ -101,14 +75,12 @@ test("structured MoveAbort object fallback still works", () => {
 test("same-account success is not classified as a deny", () => {
     const result = extractAbortCode({ effects: { status: { status: "success" } } });
     assert.equal(result.outcome, "success");
-    assert.equal(classifyNegative({ effects: { status: { status: "success" } } }), "security-fail");
 });
 
 test("unrelated abort is misconfiguration, not a healthy deny", () => {
     const result = extractAbortCode(inspectFailure("MoveAbort(MoveLocation { module: foo }, 1) in command 0"));
     assert.equal(result.outcome, "abort");
     assert.equal(result.code, 1);
-    assert.equal(classifyNegative(inspectFailure("MoveAbort(MoveLocation { module: foo }, 1) in command 0")), "misconfig");
 });
 
 test("skips with exit 0 when required secrets are unset", () => {


### PR DESCRIPTION
## Summary

COMG-715 remaining gap: the Move unit test `test_seal_approve_delegate_requires_matching_owner` already denies a delegate of A requesting B's SEAL identity. There was no production-safe synthetic that would **alert** if a live identity from account A can authorize account B's SEAL key.

This adds a read-only synthetic:

- `scripts/synthetic-seal-cross-account.mjs` — `devInspect` of `account::seal_approve` only. No remember, no SEAL key fetch, no executed transaction.
- Unset secrets print `skip` and **exit 0** (safe in CI without secrets).
- Same-account sanity must succeed; A→B and B→A must abort `ENoAccess` (100).
- If A can authorize B: **exit 1** with `SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL` (page).
- `.github/workflows/synthetic-seal-cross-account.yml` is `workflow_dispatch` only (not every PR).
- Ops note: `docs/relayer/synthetic-seal-cross-account.md` (how to dispatch / cron).

Does not bump SDK versions.

## Test plan

- [x] `node scripts/synthetic-seal-cross-account.mjs` with no env → skip, exit 0
- [x] Partial secrets → exit 2 (misconfig, not a skip)
- [x] `node scripts/check-docs-code-sync.mjs` and `check-docs-freshness.mjs`
- [ ] Dispatch the workflow without secrets → skip, green
- [ ] Dispatch with two isolated accounts → deny as expected, exit 0
- [ ] On-call: treat `SYNTHETIC_SEAL_CROSS_ACCOUNT_FAIL` as a SEAL policy regression