### PR TITLE
fix(app): complete WALM-199 prompt template routes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,29 @@ jobs:
       - name: MCP integration tests
         run: pnpm --filter @mysten-incubation/memwal-mcp test
 
+  app-checks:
+    name: App / Unit, lint and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
+
+      - name: Build SDK
+        run: pnpm build:sdk
+
+      - name: App unit tests
+        run: pnpm --filter @memwal/app test
+
+      - name: App lint
+        run: pnpm --filter @memwal/app lint
+
+      - name: App build
+        run: pnpm --filter @memwal/app build
+
   sdk-checks:
     name: SDK / Unit (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -33,6 +33,7 @@ import SetupWizard from './pages/SetupWizard'
 import Playground from './pages/Playground'
 import ConnectMcp from './pages/ConnectMcp'
 import ConnectClaude from './pages/ConnectClaude'
+import PromptTemplatesRedirect from './pages/PromptTemplatesRedirect'
 import { useRouteAnalytics } from './hooks/useRouteAnalytics'
 
 
@@ -305,6 +306,7 @@ function AppContent() {
       )} />
       <Route path="/connect/mcp" element={<ConnectMcp />} />
       <Route path="/connect/claude" element={<ConnectClaude />} />
+      <Route path="/prompt-templates" element={<PromptTemplatesRedirect />} />
       <Route path="/admin" element={<AdminDashboard />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/apps/app/src/pages/ConnectMcp.test.tsx
+++ b/apps/app/src/pages/ConnectMcp.test.tsx
@@ -7,9 +7,6 @@ const mocks = vi.hoisted(() => ({
     address: '0xowner',
     accountId: '0xaccount',
     signAndExecute: vi.fn(),
-}))
-
-vi.mock('../config', () => ({
     config: {
         memwalServerUrl: 'https://relayer.test',
         memwalPackageId: '0xpkg',
@@ -17,6 +14,10 @@ vi.mock('../config', () => ({
         suiNetwork: 'testnet',
         docsUrl: 'https://docs.test',
     },
+}))
+
+vi.mock('../config', () => ({
+    config: mocks.config,
 }))
 vi.mock('@mysten/dapp-kit', () => ({
     ConnectModal: () => null,
@@ -73,6 +74,7 @@ async function signIn() {
 
 beforeEach(() => {
     vi.clearAllMocks()
+    mocks.config.docsUrl = 'https://docs.test'
     mocks.signAndExecute.mockResolvedValue({ digest: '0xdigest' })
 })
 
@@ -93,6 +95,22 @@ describe('MCP sign-in hand-off', () => {
         expect(screen.getByText(/most agents only write when told to/i)).toBeInTheDocument()
         expect(screen.getByText(/call memwal_remember in that same turn/i)).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /copy prompt/i })).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /more templates/i })).toHaveAttribute(
+            'href',
+            'https://docs.test/guides/system-prompt-templates',
+        )
+    })
+
+    it('keeps the template library link when no docs URL is configured', async () => {
+        mocks.config.docsUrl = ''
+        stubListener(async () => new Response('{}', { status: 200 }))
+        await signIn()
+
+        expect(await screen.findByText(/MCP client connected/i)).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /more templates/i })).toHaveAttribute(
+            'href',
+            'https://docs.wal.app/walrus-memory/guides/system-prompt-templates',
+        )
     })
 
     it('withholds the starter prompt when the hand-off never landed', async () => {

--- a/apps/app/src/pages/ConnectMcp.tsx
+++ b/apps/app/src/pages/ConnectMcp.tsx
@@ -40,6 +40,7 @@ import { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
 import { Link, useSearchParams } from 'react-router-dom'
 import { useSponsoredTransaction } from '../hooks/useSponsoredTransaction'
 import { config } from '../config'
+import { docsUrl } from '../utils/docsUrl'
 import { getAnalyticsErrorType, trackEvent } from '../utils/analytics'
 import { fetchAccountIdForOwner } from '../utils/suiClientCompat'
 
@@ -626,7 +627,7 @@ function SuccessCard({
                         Remove it from the dashboard if you are not using it.{' '}
                         {config.docsUrl && (
                             <a
-                                href={`${config.docsUrl}/troubleshooting/overview#sign-in-succeeds-but-credentials-are-not-saved`}
+                                href={docsUrl('troubleshooting/overview#sign-in-succeeds-but-credentials-are-not-saved')}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 onClick={() =>
@@ -705,22 +706,20 @@ function StarterPromptCard() {
                 <button type="button" onClick={handleCopy} style={copyButtonStyle}>
                     {copied ? 'Copied' : 'Copy prompt'}
                 </button>
-                {config.docsUrl && (
-                    <a
-                        href={`${config.docsUrl}/guides/system-prompt-templates`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={promptLinkStyle}
-                        onClick={() =>
-                            trackEvent('outbound_link_click', {
-                                link: 'docs',
-                                location: 'connect_mcp_prompt_templates',
-                            })
-                        }
-                    >
-                        More templates (coding, research, support)
-                    </a>
-                )}
+                <a
+                    href={docsUrl('guides/system-prompt-templates')}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={promptLinkStyle}
+                    onClick={() =>
+                        trackEvent('outbound_link_click', {
+                            link: 'docs',
+                            location: 'connect_mcp_prompt_templates',
+                        })
+                    }
+                >
+                    More templates (coding, research, support)
+                </a>
             </div>
         </div>
     )

--- a/apps/app/src/pages/PromptTemplatesRedirect.tsx
+++ b/apps/app/src/pages/PromptTemplatesRedirect.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { docsUrl } from '../utils/docsUrl'
+
+/**
+ * Compatibility landing page for the short URL named in WALM-199.
+ *
+ * The canonical copy lives in the docs site. Keeping this route in the app
+ * means old bookmarks and the public memory.walrus.xyz origin do not fall
+ * through to the dashboard sign-in page.
+ */
+export default function PromptTemplatesRedirect() {
+    const destination = docsUrl('guides/system-prompt-templates')
+
+    useEffect(() => {
+        window.location.replace(destination)
+    }, [destination])
+
+    return (
+        <main style={{ maxWidth: 640, margin: '96px auto', padding: '0 24px', fontFamily: 'system-ui, sans-serif' }}>
+            <h1>System Prompt Templates</h1>
+            <p>The template library is opening in the Walrus Memory documentation.</p>
+            <p>
+                <a href={destination}>Open the template library</a>
+            </p>
+            <p>
+                <Link to="/">Return to Walrus Memory</Link>
+            </p>
+        </main>
+    )
+}

--- a/apps/app/src/utils/docsUrl.test.ts
+++ b/apps/app/src/utils/docsUrl.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    config: { docsUrl: '' },
+}))
+
+vi.mock('../config', () => ({ config: mocks.config }))
+
+import { docsUrl } from './docsUrl'
+
+describe('docsUrl', () => {
+    beforeEach(() => {
+        mocks.config.docsUrl = ''
+    })
+
+    it('falls back to the published Walrus Memory docs root', () => {
+        expect(docsUrl('/guides/system-prompt-templates')).toBe(
+            'https://docs.wal.app/walrus-memory/guides/system-prompt-templates',
+        )
+    })
+
+    it('joins a configured root without duplicating boundary slashes', () => {
+        mocks.config.docsUrl = 'https://docs.example/walrus-memory///'
+
+        expect(docsUrl('///guides/system-prompt-templates')).toBe(
+            'https://docs.example/walrus-memory/guides/system-prompt-templates',
+        )
+    })
+})

--- a/apps/app/src/utils/docsUrl.ts
+++ b/apps/app/src/utils/docsUrl.ts
@@ -1,0 +1,9 @@
+import { config } from '../config'
+
+const DEFAULT_DOCS_ROOT = 'https://docs.wal.app/walrus-memory'
+
+/** Build a stable link into the published Walrus Memory documentation. */
+export function docsUrl(path: string): string {
+    const root = (config.docsUrl || DEFAULT_DOCS_ROOT).replace(/\/+$/, '')
+    return `${root}/${path.replace(/^\/+/, '')}`
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -33,6 +33,13 @@
       "github": "https://github.com/MystenLabs/MemWal"
     }
   },
+  "redirects": [
+    {
+      "source": "/prompt-templates",
+      "destination": "/guides/system-prompt-templates",
+      "permanent": true
+    }
+  ],
   "navigation": {
     "tabs": [
       {

--- a/docs/prompt-templates.md
+++ b/docs/prompt-templates.md
@@ -1,0 +1,8 @@
+---
+title: System Prompt Templates
+description: Compatibility entry point for the system prompt template library.
+---
+
+The system prompt template library has moved to the Guides section.
+
+[Open the System Prompt Templates guide](/guides/system-prompt-templates).


### PR DESCRIPTION
Follow-up for WALM-199 and PR #808.

## Context

PR #808 merged the system prompt template library, but the short URL from the issue still returned 404, the app link disappeared when `VITE_DOCS_URL` was unset, and `apps/app` had no CI gate. This follow-up closes those delivery gaps while keeping the canonical page at `https://docs.wal.app/walrus-memory/guides/system-prompt-templates`.

## What changed

- Add a public app compatibility route at `/prompt-templates` that redirects to the canonical guide and provides a fallback link.
- Add Mintlify redirect metadata and a compatibility entry page for the short docs route.
- Centralize docs URL construction with a production fallback and normalized boundary slashes.
- Keep the MCP success-screen template link visible even when `VITE_DOCS_URL` is empty.
- Add app unit, lint, and production-build coverage to the main CI workflow.

## Production readiness

- Compatibility: both short app and docs paths resolve toward the canonical guide; no existing route is removed.
- Config and security: no new config, secret, storage, or authorization surface.
- Rollout: merging into `dev` does not update the production `memory.walrus.xyz` bundle. A normal promotion to `main` is still required.
- Rollback: revert this commit; there is no migration or persisted state.

## Verification

- `pnpm install --frozen-lockfile` — passed
- `pnpm build:sdk` — passed
- `pnpm --filter @memwal/app test` — 13 files, 94 tests passed
- `pnpm --filter @memwal/app lint` — passed
- `pnpm --filter @memwal/app build` — passed
- `pnpm --filter @memwal/app verify:static-server` — passed
- `node scripts/check-docs-code-sync.mjs` — passed
- `node scripts/check-docs-freshness.mjs` — passed
- `pnpm --filter memwal-docs exec mintlify validate` — passed
- `pnpm --filter memwal-docs exec mintlify broken-links` — passed
- Built-app browser check: `/prompt-templates` landed on the canonical docs URL.
- Live pre-merge baseline: canonical docs URL returns 200; short docs URL returns 404 until this change is deployed.

Review depth: full pre-ship review across correctness, WALM-199 intent, code quality, cross-surface consistency, edge cases, security, and production readiness. No unresolved findings.