### PR TITLE
docs: clarify MCP score vs SDK distance polarity (WALM-458)

### DIFF
--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -63,6 +63,8 @@ The proactive behavior comes from the tool layer, so it works on both installati
 | `memwal_login` | Connect this client to your account through browser wallet sign-in. |
 | `memwal_logout` | Remove the saved credentials from this machine. |
 
+`memwal_recall` prints `score = 1 - cosine distance` (higher = more similar); the wire and SDK field is `distance`.
+
 See [Reference](/mcp/reference) for full parameters, CLI flags, and transports.
 
 ## How it works

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -133,6 +133,8 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 
 `distance` is cosine distance — lower is more similar.
 
+MCP `memwal_recall` displays `score = 1 - distance` (higher = more similar). Do not apply an SDK `maxDistance` threshold to those scores — the polarities are inverted.
+
 `created_at` is when the fact was **written**, not any date its text describes.
 
 #### Ordering

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -160,6 +160,10 @@ Probably not. The relayer processes saves as background jobs and keeps working a
 
 Recall is one search request. A save embeds, encrypts, uploads to Walrus, and indexes the result, and `memwal_analyze` does that for every fact it extracts. Saves are expected to take longer, and they run in the background.
 
+### Score vs distance
+
+SDK `recall` returns cosine **distance** (lower = more similar), and `maxDistance` drops hits where `distance >= maxDistance`. MCP `memwal_recall` prints **score** as `1 - distance` (higher = more similar). Do not apply an SDK `maxDistance` to MCP scores — that inverts the filter.
+
 ### How do I check whether the service is reachable?
 
 Run `memwal_health`. It does not require authentication, so it separates the question of whether the relayer is reachable from whether your credentials are valid.


### PR DESCRIPTION
## Ticket

WALM-458 — https://linear.app/mysten-labs/issue/WALM-458/dx-document-mcp-score-vs-sdk-distance-polarity

## What changed?

- SDK API reference: MCP `memwal_recall` prints `score = 1 − distance`; do not apply SDK `maxDistance` to those scores.
- MCP overview: same polarity in one sentence.
- Troubleshooting FAQ: score vs distance.

## Why is this needed?

Community builders treated MCP `score` (high = similar) as SDK `distance` (low = similar) and inverted relevance filters.

## Scope

Document the two polarities. No wire-format or ranking change.

### Out of scope

- MCP `maxDistance` param (WALM-457 / GH #373)
- OpenClaw negative % (WALM-441)

## How was this tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not applicable

Commands: docs-only review of the three files vs `origin/dev`.

## How can the reviewer verify it?

1. `docs/sdk/api-reference.md` — `recall` says MCP score polarity is inverted vs `maxDistance`.
2. `docs/mcp/overview.md` — one sentence that MCP score is `1 − cosine distance`.
3. `docs/troubleshooting/overview.md` — "Score vs distance" FAQ.

## Risks and dependencies

None

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
