### PR TITLE
feat(mcp): expose maxDistance on memwal_recall (WALM-457)

### DIFF
--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -38,6 +38,7 @@ This release forwards the MCP client's identity to the relayer so sidecar logs c
 ### Added
 
 - Forward the MCP client's `initialize.clientInfo` to the relayer as `x-memwal-client` / `x-memwal-client-version` so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, …) on each session and tool call.
+- Optional `maxDistance` on `memwal_recall`: cosine-distance cutoff (low = similar). Hits with `distance >= maxDistance` are dropped. Result lines now include both `score` (`1 − cosine distance`) and `distance`. (#373)
 
 ### Fixed
 

--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -38,11 +38,12 @@ This release forwards the MCP client's identity to the relayer so sidecar logs c
 ### Added
 
 - Forward the MCP client's `initialize.clientInfo` to the relayer as `x-memwal-client` / `x-memwal-client-version` so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, …) on each session and tool call.
-- Optional `maxDistance` on `memwal_recall`: cosine-distance cutoff (low = similar). Hits with `distance >= maxDistance` are dropped. Result lines now include both `score` (`1 − cosine distance`) and `distance`. (#373)
+- Optional `maxDistance` on `memwal_recall`: cosine-distance cutoff (low = similar, must be >= 0). Hits with `distance >= maxDistance` are dropped. Result lines now include both `score` (`1 − cosine distance`) and `distance`. (#373)
 
 ### Fixed
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
+- When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 
 ## 0.0.11

--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -106,7 +106,7 @@ Connectors UI exposes only a single bearer field and cannot supply the required
 | `memwal_login` | Connect this client to your account through browser wallet sign-in. |
 | `memwal_logout` | Remove the saved credentials from this machine. |
 
-`memwal_recall` prints `score = 1 - cosine distance` (higher = more similar); the wire and SDK field is `distance`.
+`memwal_recall` prints both `score = 1 - cosine distance` (higher = more similar) and the raw `distance` (lower = more similar), which is the wire and SDK field. Its optional `maxDistance` cutoff is expressed in `distance`, not `score`.
 
 See [Reference](/mcp/reference) for full parameters, CLI flags, and transports.
 

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -75,12 +75,14 @@ Search the user's Walrus Memory for facts relevant to a query. The agent calls t
 
 Each result line includes `score` and `distance`. `distance` is cosine distance (low = similar). Displayed `score` is `1 − cosine distance` (high = similar). Optional `maxDistance` is a cosine-distance cutoff: hits with `distance >= maxDistance` are dropped. Omit `maxDistance` to apply no cutoff.
 
+The cutoff is applied to the `limit` nearest matches, not before them, so a tight `maxDistance` returns fewer than `limit` results — that is the cutoff biting, not an empty namespace. Raise `limit` to widen the candidate pool the cutoff sees.
+
 | **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `query` | string | yes | Natural-language query to match against stored memories. |
 | `limit` | integer (1–100) | no | Max memories to return. Default `10`. |
 | `namespace` | string | no | Namespace bucket to search. |
-| `maxDistance` | number | no | Cosine-distance cutoff (low = similar). Hits with `distance >= maxDistance` are dropped. Omit for no cutoff. |
+| `maxDistance` | number (>= 0) | no | Cosine-distance cutoff (low = similar). Hits with `distance >= maxDistance` are dropped. Omit for no cutoff. |
 
 ### memwal_analyze
 

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -73,11 +73,14 @@ Save several durable facts in one batched call. Prefer this over repeated `memwa
 
 Search the user's Walrus Memory for facts relevant to a query. The agent calls this **proactively** at the start of a task or when the user references past work, decisions, or preferences. Returns matches ranked by relevance.
 
+Each result line includes `score` and `distance`. `distance` is cosine distance (low = similar). Displayed `score` is `1 − cosine distance` (high = similar). Optional `maxDistance` is a cosine-distance cutoff: hits with `distance >= maxDistance` are dropped. Omit `maxDistance` to apply no cutoff.
+
 | **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `query` | string | yes | Natural-language query to match against stored memories. |
 | `limit` | integer (1–100) | no | Max memories to return. Default `10`. |
 | `namespace` | string | no | Namespace bucket to search. |
+| `maxDistance` | number | no | Cosine-distance cutoff (low = similar). Hits with `distance >= maxDistance` are dropped. Omit for no cutoff. |
 
 ### memwal_analyze
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Forward the MCP client's `initialize.clientInfo` to the relayer as `x-memwal-client` / `x-memwal-client-version` so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, …) on each session and tool call.
+- Optional `maxDistance` on `memwal_recall`: cosine-distance cutoff (low = similar). Hits with `distance >= maxDistance` are dropped. Result lines now include both `score` (`1 − cosine distance`) and `distance`. (#373)
 
 ### Fixed
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -5,11 +5,12 @@
 ### Added
 
 - Forward the MCP client's `initialize.clientInfo` to the relayer as `x-memwal-client` / `x-memwal-client-version` so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, …) on each session and tool call.
-- Optional `maxDistance` on `memwal_recall`: cosine-distance cutoff (low = similar). Hits with `distance >= maxDistance` are dropped. Result lines now include both `score` (`1 − cosine distance`) and `distance`. (#373)
+- Optional `maxDistance` on `memwal_recall`: cosine-distance cutoff (low = similar, must be >= 0). Hits with `distance >= maxDistance` are dropped. Result lines now include both `score` (`1 − cosine distance`) and `distance`. (#373)
 
 ### Fixed
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
+- When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 
 ## 0.0.11

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -98,6 +98,11 @@ function buildToolDefinitions(proactive: boolean) {
                 query: { type: "string", minLength: 1 },
                 limit: { type: "integer", minimum: 1, maximum: 100, default: 10 },
                 namespace: { type: "string" },
+                maxDistance: {
+                    type: "number",
+                    description:
+                        "Optional cosine-distance cutoff (low = similar; 0 = identical). Hits with distance >= maxDistance are dropped. Omit to apply no cutoff. Displayed score is 1 - distance (high = similar); do not treat score as the cutoff.",
+                },
             },
             required: ["query"],
             additionalProperties: false,

--- a/packages/mcp/src/auth-required.ts
+++ b/packages/mcp/src/auth-required.ts
@@ -100,6 +100,7 @@ function buildToolDefinitions(proactive: boolean) {
                 namespace: { type: "string" },
                 maxDistance: {
                     type: "number",
+                    minimum: 0,
                     description:
                         "Optional cosine-distance cutoff (low = similar; 0 = identical). Hits with distance >= maxDistance are dropped. Omit to apply no cutoff. Displayed score is 1 - distance (high = similar); do not treat score as the cutoff.",
                 },

--- a/packages/mcp/test/tool-definitions.test.mjs
+++ b/packages/mcp/test/tool-definitions.test.mjs
@@ -38,6 +38,20 @@ test("signed-out tools/list keeps conservative remember wording", () => {
     assert.doesNotMatch(recall, /PROACTIVELY/);
 });
 
+test("cold-start memwal_recall schema exposes maxDistance as cosine distance", () => {
+    const signedIn = TOOL_DEFINITIONS.find((t) => t.name === "memwal_recall");
+    const signedOut = SIGNED_OUT_TOOL_DEFINITIONS.find((t) => t.name === "memwal_recall");
+    assert.ok(signedIn);
+    assert.ok(signedOut);
+    for (const tool of [signedIn, signedOut]) {
+        const maxDistance = tool.inputSchema.properties.maxDistance;
+        assert.equal(maxDistance.type, "number");
+        assert.match(maxDistance.description, /cosine-distance/i);
+        assert.match(maxDistance.description, /distance >= maxDistance/);
+        assert.ok(!(tool.inputSchema.required ?? []).includes("maxDistance"));
+    }
+});
+
 test("memwal_recall is advertised as a read-only search", () => {
     assert.deepEqual(annotations(TOOL_DEFINITIONS, "memwal_recall"), {
         readOnlyHint: true,

--- a/packages/mcp/test/tool-definitions.test.mjs
+++ b/packages/mcp/test/tool-definitions.test.mjs
@@ -46,6 +46,9 @@ test("cold-start memwal_recall schema exposes maxDistance as cosine distance", (
     for (const tool of [signedIn, signedOut]) {
         const maxDistance = tool.inputSchema.properties.maxDistance;
         assert.equal(maxDistance.type, "number");
+        // A negative cutoff drops every hit and reads as an empty namespace,
+        // so the schema rejects it rather than returning a plausible nothing.
+        assert.equal(maxDistance.minimum, 0);
         assert.match(maxDistance.description, /cosine-distance/i);
         assert.match(maxDistance.description, /distance >= maxDistance/);
         assert.ok(!(tool.inputSchema.required ?? []).includes("maxDistance"));

--- a/services/server/scripts/mcp/__tests__/recall-created-at.test.ts
+++ b/services/server/scripts/mcp/__tests__/recall-created-at.test.ts
@@ -54,7 +54,7 @@ test("keeps the existing numbering and score format", () => {
     const line = formatRecallLine(row({ created_at: "2026-07-06T12:00:00Z" }), 2);
 
     assert.ok(line.startsWith("3. "), `expected 1-based numbering, got: ${line}`);
-    assert.match(line, /\[score=0\.750\]/);
+    assert.match(line, /\[score=0\.750 distance=0\.250\]/);
 });
 
 test("a malformed created_at is dropped, not rendered raw", () => {

--- a/services/server/scripts/mcp/__tests__/recall-max-distance.test.ts
+++ b/services/server/scripts/mcp/__tests__/recall-max-distance.test.ts
@@ -8,7 +8,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { filterByMaxDistance, formatRecallLine } from "../tools/recall.js";
+import { emptyRecallText, filterByMaxDistance, formatRecallLine } from "../tools/recall.js";
 
 const row = (text: string, distance: number) => ({ text, distance });
 
@@ -45,6 +45,16 @@ test("keeps hits whose distance is below maxDistance", () => {
             { text: "ok", distance: 0.499 },
         ],
     );
+});
+
+test("all hits outside maxDistance does not use decrypt-failure wording", () => {
+    const results = [row("far", 0.9), row("farther", 1.1)];
+    const filtered = filterByMaxDistance(results, 0.5);
+    assert.equal(filtered.length, 0);
+    const text = emptyRecallText(results.length, 3);
+    assert.match(text, /outside maxDistance/);
+    assert.doesNotMatch(text, /decrypt/);
+    assert.doesNotMatch(text, /download/);
 });
 
 test("displayed score is 1 minus cosine distance", () => {

--- a/services/server/scripts/mcp/__tests__/recall-max-distance.test.ts
+++ b/services/server/scripts/mcp/__tests__/recall-max-distance.test.ts
@@ -21,40 +21,38 @@ test("omitting maxDistance leaves every hit in place", () => {
     assert.deepEqual(filterByMaxDistance(results, undefined), results);
 });
 
-test("drops hits whose distance is at or above maxDistance", () => {
+test("the cutoff is exclusive: keeps below maxDistance, drops at or above", () => {
     const kept = filterByMaxDistance(
-        [row("kept", 0.49), row("equal", 0.5), row("worse", 0.9)],
+        [row("best", 0.1), row("ok", 0.499), row("boundary", 0.5), row("worse", 0.9)],
         0.5,
     );
     assert.deepEqual(
         kept.map((m) => m.text),
-        ["kept"],
+        ["best", "ok"],
     );
 });
 
-test("keeps hits whose distance is below maxDistance", () => {
-    const kept = filterByMaxDistance([
-        row("best", 0.1),
-        row("ok", 0.499),
-        row("boundary", 0.5),
-    ], 0.5);
-    assert.deepEqual(
-        kept.map((m) => ({ text: m.text, distance: m.distance })),
-        [
-            { text: "best", distance: 0.1 },
-            { text: "ok", distance: 0.499 },
-        ],
-    );
-});
-
-test("all hits outside maxDistance does not use decrypt-failure wording", () => {
+test("all hits outside maxDistance is not reported as a decrypt failure", () => {
     const results = [row("far", 0.9), row("farther", 1.1)];
     const filtered = filterByMaxDistance(results, 0.5);
     assert.equal(filtered.length, 0);
-    const text = emptyRecallText(results.length, 3);
+    const text = emptyRecallText(results.length, 0);
     assert.match(text, /outside maxDistance/);
     assert.doesNotMatch(text, /decrypt/);
     assert.doesNotMatch(text, /download/);
+});
+
+test("undecrypted matches are reported alongside the cutoff, not hidden by it", () => {
+    // Their distance was never computed, so "all outside maxDistance" would
+    // claim more than we know: they may well have been inside the cutoff.
+    const text = emptyRecallText(2, 3);
+    assert.match(text, /outside maxDistance/);
+    assert.match(text, /3 further matches/);
+    assert.match(text, /decrypt/);
+});
+
+test("a single undecrypted match reads as singular", () => {
+    assert.match(emptyRecallText(2, 1), /1 further match was/);
 });
 
 test("displayed score is 1 minus cosine distance", () => {
@@ -63,5 +61,4 @@ test("displayed score is 1 minus cosine distance", () => {
         0,
     );
     assert.match(line, /\[score=0\.750 distance=0\.250\]/);
-    assert.equal((1 - 0.25).toFixed(3), "0.750");
 });

--- a/services/server/scripts/mcp/__tests__/recall-max-distance.test.ts
+++ b/services/server/scripts/mcp/__tests__/recall-max-distance.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `memwal_recall` can cut weakly related top-K hits with `maxDistance`.
+ *
+ * The sidecar is pinned to an SDK that may not accept object-form
+ * `recall({ maxDistance })`, so the cutoff is applied here on `result.results`
+ * — same polarity as the SDK: cosine distance, keep `distance < maxDistance`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { filterByMaxDistance, formatRecallLine } from "../tools/recall.js";
+
+const row = (text: string, distance: number) => ({ text, distance });
+
+test("omitting maxDistance leaves every hit in place", () => {
+    const results = [
+        row("close", 0.1),
+        row("far", 0.9),
+    ];
+    assert.deepEqual(filterByMaxDistance(results), results);
+    assert.deepEqual(filterByMaxDistance(results, undefined), results);
+});
+
+test("drops hits whose distance is at or above maxDistance", () => {
+    const kept = filterByMaxDistance(
+        [row("kept", 0.49), row("equal", 0.5), row("worse", 0.9)],
+        0.5,
+    );
+    assert.deepEqual(
+        kept.map((m) => m.text),
+        ["kept"],
+    );
+});
+
+test("keeps hits whose distance is below maxDistance", () => {
+    const kept = filterByMaxDistance([
+        row("best", 0.1),
+        row("ok", 0.499),
+        row("boundary", 0.5),
+    ], 0.5);
+    assert.deepEqual(
+        kept.map((m) => ({ text: m.text, distance: m.distance })),
+        [
+            { text: "best", distance: 0.1 },
+            { text: "ok", distance: 0.499 },
+        ],
+    );
+});
+
+test("displayed score is 1 minus cosine distance", () => {
+    const line = formatRecallLine(
+        { text: "shipped the composite ranker", distance: 0.25 },
+        0,
+    );
+    assert.match(line, /\[score=0\.750 distance=0\.250\]/);
+    assert.equal((1 - 0.25).toFixed(3), "0.750");
+});

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -82,6 +82,22 @@ export function filterByMaxDistance<T extends { distance: number }>(
 }
 
 /**
+ * Empty-result copy after the maxDistance filter.
+ *
+ * Decrypted hits that all missed the cutoff are not a download/decrypt
+ * failure, even when `dropped_count` is also > 0.
+ */
+export function emptyRecallText(resultCount: number, dropped: number): string {
+    if (resultCount > 0) {
+        return "All matching memories were outside maxDistance.";
+    }
+    if (dropped > 0) {
+        return `No matching memories could be returned (${dropped} matched but failed to download or decrypt). This is not an empty namespace.`;
+    }
+    return "No matching memories found.";
+}
+
+/**
  * Render one recall hit as the line the model sees.
  *
  * `created_at` is the memory's write-time, shown so a model implementing
@@ -146,15 +162,11 @@ export function registerRecallTool(
             const dropped = typeof droppedRaw === "number" ? droppedRaw : 0;
             const filtered = filterByMaxDistance(result.results, maxDistance);
             if (filtered.length === 0) {
-                const empty =
-                    dropped > 0
-                        ? `No matching memories could be returned (${dropped} matched but failed to download or decrypt). This is not an empty namespace.`
-                        : "No matching memories found.";
                 return {
                     content: [
                         {
                             type: "text",
-                            text: empty,
+                            text: emptyRecallText(result.results.length, dropped),
                         },
                     ],
                 };

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -23,6 +23,12 @@ const RECALL_INPUT = {
         .describe(
             "Optional namespace bucket to search within. Defaults to the session's namespace."
         ),
+    maxDistance: z
+        .number()
+        .optional()
+        .describe(
+            "Optional cosine-distance cutoff (low = similar; 0 = identical). Hits with distance >= maxDistance are dropped. Omit to apply no cutoff. Displayed score is 1 - distance (high = similar); do not treat score as the cutoff."
+        ),
 } as const;
 
 /** Key deciding whether two results say the same thing: trimmed, internal
@@ -61,6 +67,21 @@ export function collapseDuplicates<T extends { text: string }>(
 }
 
 /**
+ * Drop hits whose cosine distance is at or above `maxDistance`.
+ *
+ * Same polarity as the SDK: cosine distance is low-is-similar, keep
+ * `distance < maxDistance`. Omit `maxDistance` (or pass a non-number) to
+ * leave the list unchanged.
+ */
+export function filterByMaxDistance<T extends { distance: number }>(
+    results: T[],
+    maxDistance?: number,
+): T[] {
+    if (typeof maxDistance !== "number") return results;
+    return results.filter((memory) => memory.distance < maxDistance);
+}
+
+/**
  * Render one recall hit as the line the model sees.
  *
  * `created_at` is the memory's write-time, shown so a model implementing
@@ -83,9 +104,10 @@ export function formatRecallLine(
     index: number,
 ): string {
     const score = (1 - memory.distance).toFixed(3);
+    const distance = memory.distance.toFixed(3);
     const written = isoDateOrNull(memory.created_at);
     const stamp = written ? ` [written=${written}]` : "";
-    return `${index + 1}. [score=${score}]${stamp} ${memory.text}`;
+    return `${index + 1}. [score=${score} distance=${distance}]${stamp} ${memory.text}`;
 }
 
 /** `YYYY-MM-DD` for a parseable timestamp, else null. */
@@ -118,11 +140,12 @@ export function registerRecallTool(
                 "Search the user's Walrus Memory for relevant facts before responding. Call this PROACTIVELY at the start of a task, or whenever the user references past work, prior decisions, their preferences, or anything you may have stored earlier — don't wait to be asked. A single focused query is usually enough — recall is a real retrieval over encrypted storage, so do NOT fire multiple redundant searches for the same question. Returns matching memories ranked by semantic relevance, NOT by date: the most recent memory can fall outside `limit` when an older one happens to match your wording more literally, so do not treat the results as a complete or current view of a namespace. Each result carries `written=YYYY-MM-DD`, the date the memory was saved (not any date its text mentions) — check it rather than assuming the top result is the latest.",
             inputSchema: RECALL_INPUT,
         },
-        wrapTool<{ query: string; limit: number; namespace?: string }>(session, "memwal_recall", async ({ query, limit, namespace }) => {
+        wrapTool<{ query: string; limit: number; namespace?: string; maxDistance?: number }>(session, "memwal_recall", async ({ query, limit, namespace, maxDistance }) => {
             const result = await session.memwal.recall(query, limit, namespace);
             const droppedRaw = (result as { dropped_count?: unknown }).dropped_count;
             const dropped = typeof droppedRaw === "number" ? droppedRaw : 0;
-            if (result.results.length === 0) {
+            const filtered = filterByMaxDistance(result.results, maxDistance);
+            if (filtered.length === 0) {
                 const empty =
                     dropped > 0
                         ? `No matching memories could be returned (${dropped} matched but failed to download or decrypt). This is not an empty namespace.`
@@ -136,7 +159,7 @@ export function registerRecallTool(
                     ],
                 };
             }
-            const { unique, collapsed } = collapseDuplicates(result.results);
+            const { unique, collapsed } = collapseDuplicates(filtered);
             const lines = unique.map((m, i) => formatRecallLine(m, i));
             // Say what was folded away rather than quietly returning fewer rows
             // than the caller asked for. It also surfaces that the same fact was

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -25,6 +25,7 @@ const RECALL_INPUT = {
         ),
     maxDistance: z
         .number()
+        .nonnegative()
         .optional()
         .describe(
             "Optional cosine-distance cutoff (low = similar; 0 = identical). Hits with distance >= maxDistance are dropped. Omit to apply no cutoff. Displayed score is 1 - distance (high = similar); do not treat score as the cutoff."
@@ -72,6 +73,9 @@ export function collapseDuplicates<T extends { text: string }>(
  * Same polarity as the SDK: cosine distance is low-is-similar, keep
  * `distance < maxDistance`. Omit `maxDistance` (or pass a non-number) to
  * leave the list unchanged.
+ *
+ * TODO(WALM-428): drop this once the sidecar SDK pin moves off 0.0.3 — 0.1.x
+ * applies the identical filter inside `recall({ maxDistance })`.
  */
 export function filterByMaxDistance<T extends { distance: number }>(
     results: T[],
@@ -85,11 +89,18 @@ export function filterByMaxDistance<T extends { distance: number }>(
  * Empty-result copy after the maxDistance filter.
  *
  * Decrypted hits that all missed the cutoff are not a download/decrypt
- * failure, even when `dropped_count` is also > 0.
+ * failure, so the decrypt copy must not claim the whole result. But an
+ * undecrypted match never had a distance computed, so the cutoff copy cannot
+ * speak for it either: when both counts are non-zero, say both rather than
+ * letting "outside maxDistance" imply the namespace held nothing relevant.
  */
 export function emptyRecallText(resultCount: number, dropped: number): string {
     if (resultCount > 0) {
-        return "All matching memories were outside maxDistance.";
+        const unchecked =
+            dropped > 0
+                ? ` (${dropped} further ${dropped === 1 ? "match was" : "matches were"} never checked against the cutoff: they failed to download or decrypt.)`
+                : "";
+        return `All matching memories were outside maxDistance.${unchecked}`;
     }
     if (dropped > 0) {
         return `No matching memories could be returned (${dropped} matched but failed to download or decrypt). This is not an empty namespace.`;


### PR DESCRIPTION
## Ticket

WALM-457 — https://linear.app/mysten-labs/issue/WALM-457/mcp-expose-maxdistance-on-memwal-recall
GH #373 — https://github.com/MystenLabs/MemWal/issues/373

## What changed?

- Optional `maxDistance` on MCP `memwal_recall` (sidecar + cold-start schema).
- Client-side cosine-distance filter (`distance < maxDistance`) after positional `recall(query, limit, namespace)`, before duplicate collapse. Does **not** bump the sidecar SDK pin (`0.0.3`).
- Result lines include both `score` (`1 − distance`) and `distance`.
- Empty copy distinguishes “all hits outside maxDistance” from decrypt failures.
- Docs + changelog under MCP `0.0.12` (no version bump; `dev` already ahead of `main`).

## Why is this needed?

Recall returned top-K with no relevance cutoff, so agents ingested weak matches. SDK already had `maxDistance`; MCP did not (GH #373).

## Scope

MCP `memwal_recall` cutoff + polarity in the tool output/docs.

### Out of scope

- Bumping `@mysten-incubation/memwal` in `services/server/scripts` (WALM-428)
- Server-side `/api/recall` filter
- OpenClaw relevance % (WALM-441)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands:

```bash
cd services/server/scripts && node --test --import tsx './mcp/__tests__/recall-*.test.ts'
pnpm --filter @mysten-incubation/memwal-mcp test
node scripts/verify-manual-sdk-release.mjs
```

## How can the reviewer verify it?

1. Sidecar `RECALL_INPUT` and `packages/mcp/src/auth-required.ts` both expose optional `maxDistance`.
2. Filter keeps `distance < maxDistance`; omit = no filter.
3. Result line looks like `[score=0.750 distance=0.250]`.
4. All hits outside cutoff → `All matching memories were outside maxDistance.` (not decrypt-failure copy).
5. `packages/mcp` version still `0.0.12`.

## Risks and dependencies

None. Sidecar stays on SDK `0.0.3`; filter is local.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
