### PR TITLE
fix(chatbot): treat a malformed Bearer header as no session (WALM-416)

### DIFF
--- a/apps/chatbot/app/(auth)/api/auth/guest/route.ts
+++ b/apps/chatbot/app/(auth)/api/auth/guest/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { getToken } from "next-auth/jwt";
 import { signIn } from "@/app/(auth)/auth";
-import { isDevelopmentEnvironment } from "@/lib/constants";
+import { getSessionToken } from "@/lib/session-token";
 
 /**
  * Validate a redirect target before forwarding to auth.
@@ -35,11 +34,7 @@ export async function GET(request: Request) {
     ? rawRedirectUrl
     : "/";
 
-  const token = await getToken({
-    req: request,
-    secret: process.env.AUTH_SECRET,
-    secureCookie: !isDevelopmentEnvironment,
-  });
+  const token = await getSessionToken(request);
 
   if (token) {
     return NextResponse.redirect(new URL("/", request.url));

--- a/apps/chatbot/lib/session-token.ts
+++ b/apps/chatbot/lib/session-token.ts
@@ -1,0 +1,23 @@
+import { getToken } from "next-auth/jwt";
+import { isDevelopmentEnvironment } from "@/lib/constants";
+
+/**
+ * Read the Auth.js session JWT. A malformed `Authorization: Bearer` value
+ * (`%%`, lone `%`, …) makes `getToken` throw `URIError` from
+ * `decodeURIComponent` *before* its inner decode try/catch — that was HTTP 500
+ * on proxy and `/api/auth/guest`. Treat it as no session.
+ */
+export async function getSessionToken(request: Request) {
+  try {
+    return await getToken({
+      req: request,
+      secret: process.env.AUTH_SECRET,
+      secureCookie: !isDevelopmentEnvironment,
+    });
+  } catch (error) {
+    if (error instanceof URIError) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/apps/chatbot/lib/session-token.ts
+++ b/apps/chatbot/lib/session-token.ts
@@ -1,12 +1,6 @@
 import { getToken } from "next-auth/jwt";
 import { isDevelopmentEnvironment } from "@/lib/constants";
 
-/**
- * Read the Auth.js session JWT. A malformed `Authorization: Bearer` value
- * (`%%`, lone `%`, …) makes `getToken` throw `URIError` from
- * `decodeURIComponent` *before* its inner decode try/catch — that was HTTP 500
- * on proxy and `/api/auth/guest`. Treat it as no session.
- */
 export async function getSessionToken(request: Request) {
   try {
     return await getToken({
@@ -15,6 +9,7 @@ export async function getSessionToken(request: Request) {
       secureCookie: !isDevelopmentEnvironment,
     });
   } catch (error) {
+    // Auth.js URL-decodes Bearer outside its JWT try/catch; malformed % sequences are not a session.
     if (error instanceof URIError) {
       return null;
     }

--- a/apps/chatbot/lib/session-token.unit.test.ts
+++ b/apps/chatbot/lib/session-token.unit.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getToken } from "next-auth/jwt";
+import { describe, expect, it } from "vitest";
+import { getSessionToken } from "@/lib/session-token";
+
+function requestWithBearer(value: string): Request {
+  return new Request("http://127.0.0.1:3001/api/chat", {
+    headers: { Authorization: `Bearer ${value}` },
+  });
+}
+
+describe("getSessionToken", () => {
+  it("returns null for a malformed Bearer value instead of throwing", async () => {
+    const request = requestWithBearer("%%");
+
+    await expect(
+      getToken({ req: request, secret: "unit-test-secret-not-for-production" })
+    ).rejects.toBeInstanceOf(URIError);
+
+    await expect(getSessionToken(request)).resolves.toBeNull();
+  });
+
+  it("returns null when there is no session cookie or Bearer header", async () => {
+    await expect(
+      getSessionToken(new Request("http://127.0.0.1:3001/api/chat"))
+    ).resolves.toBeNull();
+  });
+});
+
+describe("malformed Bearer call sites", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  it("proxy and guest route read the session through the wrapper", () => {
+    const proxy = readFileSync(join(here, "../proxy.ts"), "utf8");
+    const guest = readFileSync(
+      join(here, "../app/(auth)/api/auth/guest/route.ts"),
+      "utf8"
+    );
+
+    expect(proxy).toContain("getSessionToken");
+    expect(proxy).not.toContain("getToken(");
+    expect(guest).toContain("getSessionToken");
+    expect(guest).not.toContain("getToken(");
+  });
+});

--- a/apps/chatbot/proxy.ts
+++ b/apps/chatbot/proxy.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { getToken } from "next-auth/jwt";
-import { guestRegex, isDevelopmentEnvironment } from "./lib/constants";
+import { guestRegex } from "./lib/constants";
+import { getSessionToken } from "./lib/session-token";
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -17,11 +17,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const token = await getToken({
-    req: request,
-    secret: process.env.AUTH_SECRET,
-    secureCookie: !isDevelopmentEnvironment,
-  });
+  const token = await getSessionToken(request);
 
   if (!token) {
     const redirectUrl = encodeURIComponent(request.url);


### PR DESCRIPTION
## Ticket

WALM-416 — https://linear.app/mysten-labs/issue/WALM-416/bug-malformed-bearer-header-crashes-the-chatbot-proxy-and
GH #776 — https://github.com/MystenLabs/MemWal/issues/776

## What changed?

- `getSessionToken()` wraps Auth.js `getToken()` and returns `null` on `URIError` from a malformed `Authorization: Bearer` value.
- `proxy.ts` and `GET /api/auth/guest` use the wrapper, so a bad Bearer is treated as no session (guest redirect), not HTTP 500.
- Unit test: `Bearer %%` makes raw `getToken` throw; the wrapper returns `null`. Call sites are pinned to the wrapper.

## Why is this needed?

`getToken()` URL-decodes the Bearer token *before* its inner JWT decode try/catch. `Authorization: Bearer %%` throws `URIError: URI malformed` and both the chatbot proxy and guest route returned 500 instead of an auth miss.

## Scope

Chatbot session read path only.

### Out of scope

- Chatbot `AUTH_SECRET` length (PR #644)
- Researcher session `AUTH_SECRET` (PR #834 / WALM-417)
- Changing Auth.js itself

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `pnpm exec vitest run lib/session-token.unit.test.ts` in `apps/chatbot` (3 passed).

## How can the reviewer verify it?

1. `getToken()` in `@auth/core/jwt` calls `decodeURIComponent` on the Bearer value outside its decode try/catch.
2. `curl -i -H 'Authorization: Bearer %%' http://127.0.0.1:3001/api/chat` → 307 to guest, not 500.
3. Same header on `/api/auth/guest` → 307 from `signIn("guest")`, not 500.
4. Valid sessions are unchanged.

## Risks and dependencies

None. Other `getToken` errors (for example a missing `AUTH_SECRET`) still throw.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.

Fixes #776