### PR TITLE
fix(server): scope the embedding input guard to the API path

### DIFF
--- a/services/server/src/services/embedder.rs
+++ b/services/server/src/services/embedder.rs
@@ -27,6 +27,12 @@ pub const EMBEDDING_MODEL: &str = "openai/text-embedding-3-small";
 pub const EMBEDDING_DIMS: usize = 1536;
 
 /// 16384 = 8192 tokens × 2 chars/token under cl100k; do not use admin 64KiB.
+///
+/// This is a property of [`EMBEDDING_MODEL`]'s context window, not of
+/// embedding in general — so it is enforced only on the API path. The mock
+/// fallback hashes the input locally and has no such ceiling; rejecting there
+/// would break key-less deployments that legitimately embed up to
+/// `MAX_REMEMBER_TEXT_BYTES`.
 const MAX_EMBED_INPUT_BYTES: usize = 16384;
 
 fn reject_oversized_embed_input(text: &str) -> Result<(), AppError> {
@@ -36,6 +42,23 @@ fn reject_oversized_embed_input(text: &str) -> Result<(), AppError> {
         )));
     }
     Ok(())
+}
+
+/// True when an upstream 400 blames the *input's length*.
+///
+/// OpenAI-compatible providers report that as `context_length_exceeded`, or
+/// in prose. Every other 400 — unknown model id, malformed body, a
+/// provider-side auth shape we got wrong — is our bug, not the caller's, and
+/// must stay [`AppError::Internal`]: returning 400 there tells a client to
+/// shorten a query that was never the problem, and hides a misconfiguration
+/// behind a 4xx that no dashboard alerts on.
+fn is_context_length_error(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("context_length_exceeded")
+        || lower.contains("maximum context length")
+        || lower.contains("reduce the length")
+        || lower.contains("too many tokens")
+        || lower.contains("string too long")
 }
 
 #[async_trait]
@@ -67,9 +90,11 @@ impl OpenAiEmbedder {
 impl Embedder for OpenAiEmbedder {
     #[tracing::instrument(name = "embedder.embed", skip_all, fields(text_len = text.len()))]
     async fn embed(&self, text: &str) -> Result<Vec<f32>, AppError> {
-        reject_oversized_embed_input(text)?;
         match &self.config.openai_api_key {
             Some(api_key) => {
+                // Guard the model's context window, not `embed` as a whole:
+                // only this arm reaches a model. See `MAX_EMBED_INPUT_BYTES`.
+                reject_oversized_embed_input(text)?;
                 // Real embedding via OpenRouter/OpenAI-compatible API
                 let url = format!("{}/embeddings", self.config.openai_api_base);
 
@@ -111,8 +136,9 @@ impl Embedder for OpenAiEmbedder {
                             status, body
                         )));
                     }
-                    if status == reqwest::StatusCode::BAD_REQUEST {
-                        tracing::warn!(%status, body, "embedding API returned 400");
+                    if status == reqwest::StatusCode::BAD_REQUEST && is_context_length_error(&body)
+                    {
+                        tracing::warn!(%status, body, "embedding API rejected the input length");
                         return Err(AppError::BadRequest(
                             "embedding input exceeds the model context limit".into(),
                         ));
@@ -250,5 +276,41 @@ mod tests {
             super::reject_oversized_embed_input(&"q".repeat(16385)),
             "input is over the embedding input limit",
         );
+    }
+
+    // ── upstream 400: only a length complaint is the caller's fault ──
+
+    #[test]
+    fn context_length_bodies_are_attributed_to_the_caller() {
+        for body in [
+            r#"{"error":{"code":"context_length_exceeded","message":"..."}}"#,
+            r#"{"error":{"message":"This model's maximum context length is 8192 tokens"}}"#,
+            r#"{"error":{"message":"Please reduce the length of the messages."}}"#,
+            r#"{"error":{"message":"Too many tokens in input"}}"#,
+            r#"{"error":{"message":"String too long. Expected a string with maximum length 8192"}}"#,
+        ] {
+            assert!(
+                super::is_context_length_error(body),
+                "should read as a length complaint: {body}"
+            );
+        }
+    }
+
+    /// The regression this gate exists for: a 400 that has nothing to do with
+    /// the caller's input must NOT come back as `BadRequest`, or a client
+    /// shortens a query forever against a server misconfiguration.
+    #[test]
+    fn other_400_bodies_are_not_blamed_on_the_caller() {
+        for body in [
+            r#"{"error":{"message":"The model `text-embedding-9` does not exist"}}"#,
+            r#"{"error":{"code":"invalid_api_key","message":"Incorrect API key provided"}}"#,
+            r#"{"error":{"message":"Unrecognized request argument supplied: dimensions"}}"#,
+            "",
+        ] {
+            assert!(
+                !super::is_context_length_error(body),
+                "should stay an internal error: {body}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Follow-up to [WALM-423](https://linear.app/mysten-labs/issue/WALM-423) (#837), found while reviewing the `dev` → `staging` promotion in [#851](https://github.com/MystenLabs/MemWal/pull/851). Two problems, both in `services/server/src/services/embedder.rs`.

## 1. The 16 KiB ceiling applied to the mock path

`reject_oversized_embed_input` ran before the `openai_api_key` match, so it gated the mock branch too. That branch hashes the input locally and has no context window at all.

Nothing shortens the text before it gets there: `MAX_REMEMBER_TEXT_BYTES` is 1 MiB, and `needs_summary` in `remember.rs:114` requires `openai_api_key.is_some()`. So on a deployment without an API key — local dev, CI, self-hosted — every `remember` between 16 KiB and 1 MiB started returning `BadRequest` for text that had always worked.

Fixed by moving the check into the `Some(api_key)` arm. The limit describes `EMBEDDING_MODEL`'s context window, so it belongs where a model is actually called.

## 2. Every upstream 400 was blamed on the caller

```rust
if status == reqwest::StatusCode::BAD_REQUEST {
    return Err(AppError::BadRequest(
        "embedding input exceeds the model context limit".into(),
    ));
}
```

An unknown model id, a malformed request body, or a provider-side auth shape we got wrong all come back as 400. All three reached the caller as "embedding input exceeds the model context limit", which tells a client to shorten a query that was never too long — and files a server misconfiguration under a 4xx that no dashboard alerts on. The real body only reached `tracing::warn!`.

Now gated on `is_context_length_error`, which reads the body for the shapes OpenAI-compatible providers actually emit (`context_length_exceeded`, "maximum context length", "reduce the length", "too many tokens", "string too long"). Anything else stays `AppError::Internal`.

## Not changed

`analyze` (64 KiB `MAX_ANALYZE_TEXT_BYTES`) and the admin restore path both embed unsummarized text and can exceed the model window. Both already degraded silently before WALM-423 — the provider returned 400, the old code mapped it to `Internal`, and each caller caught it and continued with no vector. That behaviour is unchanged here; it predates #837 and wants its own ticket.

## Testing

`cargo test --bins` (the invocation CI uses) — 672 passed, 0 failed. Two new tests pin both directions of the body check:

- `context_length_bodies_are_attributed_to_the_caller` — the five provider shapes that must still surface as 400.
- `other_400_bodies_are_not_blamed_on_the_caller` — unknown model, bad API key, unrecognized argument, empty body; all must stay `Internal`.

---

## Review findings status

From the two review passes over [#851](https://github.com/MystenLabs/MemWal/pull/851). This PR is scoped to `embedder.rs` only — it resolves 2 of them.

**Resolved here**

| Finding | Where |
| --- | --- |
| 16 KiB guard ran before the `openai_api_key` match, gating the mock path too | `embedder.rs:70` |
| Every upstream 400 mapped to "input exceeds the model context limit" | `embedder.rs:114` |

**Proposed in [#856](https://github.com/MystenLabs/MemWal/pull/856)** — draft. WALM-383 is In Review and owned by @nikola.le, so that PR is offered to them rather than queued to merge; these are not resolved yet.

| Finding |
| --- |
| `sort=recent` silently overridden when `scoring_weights` set `recency > 0` |
| `RecallResult.created_at` doc claimed the over-fetch mode was still unshipped |
| Changeset declared `patch` for a release adding three public API surfaces |

**Withdrawn after verification**

| Finding | Why |
| --- | --- |
| Short `OWNER_TOKEN_SECRET` panics at boot | Checked Railway: dev is 64 bytes, staging and production are UNSET (empty short-circuits before the length check). No environment can hit it. |
| `restore` silently drops oversized vectors | Pre-existing, not a WALM-423 regression — the provider already returned 400 and the old code mapped it to `Internal`, which the same handler caught and discarded. Behaviour identical before and after. |
| `analyze` degrades above 16 KiB | Same: pre-existing, unchanged by WALM-423. |

**Still open, filed separately** — none blocking the promotion

`candidate_limit` stops over-fetching at `limit >= 50` · `recall_manual` has no `sort` · MCP recall line renders a UTC date-only stamp · Python `remember_bulk` raise discards accepted `job_ids` · `sanitize_job_error_for_client` keys on `status == "failed"` so a `done` job is told to keep polling · `ConnectMcp` treats any `TypeError` as "link expired" · sidecar re-identifies the session from a client-controlled header on every POST · SEAL invariant CI gate only greps for a test name · live JS SDK e2e went 19 → 11 tests (`rememberBulkAndWait` / `analyzeAndWait` lost live coverage) · `wait-for-relayer` keeps the SHA wait when it cannot diff, guaranteeing a 480 s timeout · `test-sdk.yml` paths exclude `services/server/**`
