### PR TITLE
fix(server,sdk): an explicit recall sort suppresses scoring_weights (WALM-383)

### DIFF
--- a/.changeset/recall-write-time-and-recency-weights.md
+++ b/.changeset/recall-write-time-and-recency-weights.md
@@ -1,5 +1,5 @@
 ---
-"@mysten-incubation/memwal": patch
+"@mysten-incubation/memwal": minor
 ---
 
 Expose each memory's write-time on `recall()`, and let callers ask for a newest-first ordering (#621).
@@ -9,5 +9,7 @@ Expose each memory's write-time on `recall()`, and let callers ask for a newest-
 `created_at` is the piece a "newest wins" protocol was missing: previously the only date available was whatever the memory text happened to mention, so callers could neither order nor verify by write-time.
 
 `sort: "recent"` is the newest-wins mode: the relayer over-fetches semantic candidates (5x `limit`, capped at 50), orders them by write-time descending, then truncates to `limit`. `scoringWeights` does something narrower — it re-ranks the candidates the vector search already returned and does not widen the search, so a record that fell outside the cosine top-`limit` cannot be recovered by any weighting.
+
+An explicit `sort` suppresses `scoringWeights` for that request: the two are alternatives, not layers. Weights apply only when `sort` is omitted.
 
 Fully backward-compatible: omitting `sort` and `scoringWeights` leaves the request byte-identical to a plain cosine sort, and `created_at` is optional so relayers that don't send it behave exactly as before.

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -165,6 +165,11 @@ export interface RecallOptions {
      *
      * For newest-wins, use `sort: "recent"` instead. It over-fetches
      * candidates server-side before ordering them by write-time.
+     *
+     * IGNORED when `sort` is set. An explicit `sort` — either value — decides
+     * the order outright; weights apply only when `sort` is omitted. Otherwise
+     * `sort: "recent"` would stop meaning newest-first as soon as the same
+     * request carried `recency > 0`.
      */
     scoringWeights?: ScoringWeights;
     /**
@@ -179,6 +184,8 @@ export interface RecallOptions {
      * widens the candidate set; weights only re-rank the set that was already
      * returned, so weights alone cannot surface a record that fell outside
      * the window.
+     *
+     * Setting `sort` at all suppresses `scoringWeights` for that request.
      */
     sort?: "relevance" | "recent";
 }

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -236,6 +236,29 @@ pub(super) fn select_hits_for_sort(
     hits
 }
 
+/// Which scoring weights actually reach the ranker (WALM-383 precedence).
+///
+/// An explicit `sort` **is** the order: it suppresses the caller's weights
+/// entirely. Only an omitted `sort` lets them re-rank.
+///
+/// Without this, `sort=recent` stops meaning newest-first the moment the same
+/// request carries `recency > 0`: `select_hits_for_sort` orders by write-time
+/// and truncates, and then `CompositeRanker::rank` reorders the survivors by
+/// composite score — leaving an order that is neither mode. Suppressing the
+/// weights (rather than skipping the ranker call) keeps one code path: at
+/// `ScoringWeights::default()` the ranker short-circuits and returns its input
+/// order with `score: None`, which is exactly "no ranker ran".
+pub(super) fn effective_scoring_weights(
+    sort: Option<crate::types::RecallSort>,
+    requested: crate::types::ScoringWeights,
+) -> crate::types::ScoringWeights {
+    if sort.is_some() {
+        crate::types::ScoringWeights::default()
+    } else {
+        requested
+    }
+}
+
 /// Project the ranker's output onto the `/api/recall` and `/api/ask` wire
 /// shape, preserving ranked order.
 ///
@@ -445,6 +468,61 @@ mod recall_sort_tests {
         let kept = super::select_hits_for_sort(hits, RecallSort::Recent, 10);
 
         assert_eq!(kept.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod recall_sort_precedence_tests {
+    use crate::types::{RecallSort, ScoringWeights};
+
+    /// Non-default weights: `recency` high enough that the ranker would
+    /// reorder if it ever saw them.
+    fn recency_heavy() -> ScoringWeights {
+        ScoringWeights {
+            semantic: 1.0,
+            recency: 0.8,
+            recency_half_life_days: 30.0,
+            importance: 0.0,
+        }
+    }
+
+    #[test]
+    fn omitted_sort_lets_the_caller_weights_through() {
+        let out = super::effective_scoring_weights(None, recency_heavy());
+        assert!(
+            out.is_ranker_active(),
+            "with no sort, weights must still re-rank"
+        );
+        assert_eq!(out.recency, 0.8);
+    }
+
+    /// The WALM-383 bug: `sort=recent` ordered by write-time, then the ranker
+    /// reordered the survivors by composite score and the newest row stopped
+    /// being first. An explicit sort must suppress the weights outright.
+    #[test]
+    fn explicit_recent_suppresses_the_weights() {
+        let out = super::effective_scoring_weights(Some(RecallSort::Recent), recency_heavy());
+        assert!(
+            !out.is_ranker_active(),
+            "sort=recent must not be reordered by scoring_weights"
+        );
+    }
+
+    /// Henry's contract is "any explicit sort", not "recent only" — an
+    /// explicit `relevance` is just as much a request for that exact order.
+    #[test]
+    fn explicit_relevance_also_suppresses_the_weights() {
+        let out = super::effective_scoring_weights(Some(RecallSort::Relevance), recency_heavy());
+        assert!(
+            !out.is_ranker_active(),
+            "an explicit sort=relevance must not be reordered either"
+        );
+    }
+
+    #[test]
+    fn omitted_sort_with_default_weights_is_still_the_plain_cosine_path() {
+        let out = super::effective_scoring_weights(None, ScoringWeights::default());
+        assert!(!out.is_ranker_active());
     }
 }
 

--- a/services/server/src/routes/mod.rs
+++ b/services/server/src/routes/mod.rs
@@ -527,6 +527,135 @@ mod recall_sort_precedence_tests {
 }
 
 #[cfg(test)]
+mod recall_sort_precedence_regression_tests {
+    //! Proof that the defect is real, not just that the fix compiles.
+    //!
+    //! These replay the recall handler's actual ordering pipeline —
+    //! `select_hits_for_sort` → `CompositeRanker::rank` — over the two rows
+    //! from the WALM-383 report. `apply_precedence: false` is `dev` today.
+
+    use crate::engine::HydratedMemory;
+    use crate::services::ranker::{CompositeRanker, Ranker};
+    use crate::types::{RecallSort, ScoringWeights, SearchHit};
+
+    /// Fixed "now" so the decay term is deterministic.
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        ts("2026-07-06T00:00:00Z")
+    }
+
+    fn ts(rfc3339: &str) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339(rfc3339)
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    }
+
+    fn hit(blob_id: &str, distance: f64, created_at: &str) -> SearchHit {
+        SearchHit {
+            blob_id: blob_id.to_string(),
+            distance,
+            created_at: ts(created_at),
+            importance: 0.5,
+        }
+    }
+
+    /// The reported shape: the newest checkpoint is worded naturally so it
+    /// matches poorly, while a month-old row echoes the query literally.
+    fn reported_hits() -> Vec<SearchHit> {
+        vec![
+            hit("old-but-close", 0.10, "2026-06-06T00:00:00Z"),
+            hit("newest-but-far", 0.90, "2026-07-06T00:00:00Z"),
+        ]
+    }
+
+    /// Non-default weights a caller might reasonably pair with `sort=recent`,
+    /// thinking the two reinforce each other.
+    fn recency_weights() -> ScoringWeights {
+        ScoringWeights {
+            semantic: 1.0,
+            recency: 0.3,
+            recency_half_life_days: 30.0,
+            importance: 0.0,
+        }
+    }
+
+    /// Replay `recall`'s ordering. With `apply_precedence == false` the
+    /// caller's weights reach the ranker, which is what `dev` does today.
+    fn ordering(
+        sort: Option<RecallSort>,
+        requested: ScoringWeights,
+        apply_precedence: bool,
+    ) -> Vec<String> {
+        let weights = if apply_precedence {
+            super::effective_scoring_weights(sort, requested)
+        } else {
+            requested
+        };
+        let selected = super::select_hits_for_sort(reported_hits(), sort.unwrap_or_default(), 2);
+        let hydrated: Vec<HydratedMemory> = selected
+            .into_iter()
+            .map(|h| HydratedMemory {
+                blob_id: h.blob_id,
+                text: String::new(),
+                distance: h.distance,
+                created_at: Some(h.created_at),
+                importance: Some(h.importance),
+            })
+            .collect();
+        CompositeRanker
+            .rank(hydrated, &weights, now())
+            .into_iter()
+            .map(|r| r.memory.blob_id)
+            .collect()
+    }
+
+    /// `select_hits_for_sort` does its job: newest first, before the ranker.
+    #[test]
+    fn selection_alone_puts_the_newest_row_first() {
+        let selected = super::select_hits_for_sort(reported_hits(), RecallSort::Recent, 2);
+        assert_eq!(selected[0].blob_id, "newest-but-far");
+    }
+
+    /// THE BUG. Composite score with these weights:
+    ///   old-but-close = 1.0*(1-0.10) + 0.3*2^(-30/30) = 0.90 + 0.15 = 1.05
+    ///   newest-but-far = 1.0*(1-0.90) + 0.3*2^(0/30)  = 0.10 + 0.30 = 0.40
+    /// so the ranker undoes the write-time order that `sort=recent` just
+    /// established, and the caller gets the stale row first — the exact
+    /// failure WALM-383 was filed for.
+    #[test]
+    fn dev_today_lets_scoring_weights_undo_sort_recent() {
+        let order = ordering(Some(RecallSort::Recent), recency_weights(), false);
+        assert_eq!(
+            order[0], "old-but-close",
+            "reproduces the defect: sort=recent ordered newest-first, then the \
+             ranker reordered by composite score and the stale row won"
+        );
+    }
+
+    /// With precedence applied the weights are suppressed, the ranker
+    /// short-circuits at default weights, and selection order survives.
+    #[test]
+    fn precedence_keeps_the_newest_row_first() {
+        let order = ordering(Some(RecallSort::Recent), recency_weights(), true);
+        assert_eq!(
+            order[0], "newest-but-far",
+            "sort=recent must mean newest-first regardless of scoring_weights"
+        );
+    }
+
+    /// The fix must not touch the omitted-sort path: weights still re-rank.
+    #[test]
+    fn omitted_sort_still_lets_weights_reorder() {
+        let with_fix = ordering(None, recency_weights(), true);
+        let without_fix = ordering(None, recency_weights(), false);
+        assert_eq!(
+            with_fix, without_fix,
+            "no sort means no precedence rule; behaviour must be unchanged"
+        );
+        assert_eq!(with_fix[0], "old-but-close");
+    }
+}
+
+#[cfg(test)]
 mod recall_result_mapping_tests {
     use crate::engine::HydratedMemory;
     use crate::services::ranker::RankedHit;

--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -161,8 +161,15 @@ pub async fn recall(
     // Validate scoring_weights up front — fail fast on malformed input
     // (NaN, out-of-range, sub-floor half-life) BEFORE we spend an embed +
     // vector search + Walrus + SEAL round-trip just to 400 at the end.
-    let weights = body.scoring_weights.clone().unwrap_or_default();
-    weights.validate()?;
+    // Validate what the caller SENT, even when an explicit `sort` will
+    // suppress it: a malformed weight vector is a 400 either way, not
+    // something `sort` quietly excuses.
+    let requested_weights = body.scoring_weights.clone().unwrap_or_default();
+    requested_weights.validate()?;
+    // WALM-383 precedence: an explicit `sort` decides the order; weights only
+    // re-rank when `sort` is omitted. See `super::effective_scoring_weights`.
+    let sort = body.sort.unwrap_or_default();
+    let weights = super::effective_scoring_weights(body.sort, requested_weights);
 
     // Owner is derived from delegate key via onchain verification (auth middleware)
     let owner = &auth.owner;
@@ -186,7 +193,7 @@ pub async fn recall(
     // row is frequently a mediocre semantic match and would otherwise fall
     // outside the cosine top-`limit` entirely. `Relevance` fetches exactly
     // `limit`, so the default path issues the identical query it always has.
-    let candidate_limit = body.sort.candidate_limit(limit);
+    let candidate_limit = sort.candidate_limit(limit);
     let t1 = std::time::Instant::now();
     let hits = state
         .db
@@ -198,7 +205,7 @@ pub async fn recall(
     // only distance + created_at, both already on the row, so the over-fetch
     // costs one wider SQL query instead of 5x the Walrus downloads and SEAL
     // decrypts.
-    let hits = super::select_hits_for_sort(hits, body.sort, limit);
+    let hits = super::select_hits_for_sort(hits, sort, limit);
     let hit_count = hits.len();
 
     if hits.is_empty() {

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1353,10 +1353,17 @@ pub struct RecallRequest {
     /// [`ScoringWeights`].
     #[serde(default)]
     pub scoring_weights: Option<ScoringWeights>,
-    /// How to order results. Omitted → [`RecallSort::Relevance`], today's
-    /// behaviour. See [`RecallSort`].
+    /// How to order results. `None` (omitted) → [`RecallSort::Relevance`],
+    /// today's behaviour. See [`RecallSort`].
+    ///
+    /// Deliberately `Option`, not a bare [`RecallSort`] with a default: the
+    /// WALM-383 precedence contract distinguishes *omitted* from *explicit*.
+    /// An explicit `sort` — including `sort=relevance` — decides the order
+    /// outright and suppresses `scoring_weights`; only an omitted `sort`
+    /// lets the weights re-rank. A `#[serde(default)]` bare enum collapses
+    /// both cases to `Relevance` and makes that rule unexpressable.
     #[serde(default)]
-    pub sort: RecallSort,
+    pub sort: Option<RecallSort>,
 }
 
 /// Result ordering mode for `/api/recall`.
@@ -1439,10 +1446,11 @@ pub struct RecallResult {
     /// of the memory text (WALM-383). Note this is the *write* time, not any
     /// event time the text itself may describe.
     ///
-    /// This alone does not make "newest wins" correct: the candidate set is
-    /// the cosine top-`limit` from `search_similar`, so the newest row can be
-    /// missing from `results` entirely and no client-side sort recovers it.
-    /// The server-side recency mode that over-fetches is still open.
+    /// This alone does not make "newest wins" correct: a client-side sort over
+    /// `results` still only sees the cosine top-`limit` from `search_similar`,
+    /// so the newest row can be missing entirely. Ask for
+    /// [`RecallSort::Recent`] instead — it over-fetches candidates server-side
+    /// before ordering them by write-time.
     ///
     /// `None` only when the hydrated record had no matching `SearchHit`,
     /// which shouldn't happen on the recall path. `skip_serializing_if`


### PR DESCRIPTION
> **Draft — needs @nikola.le's call before it merges.**
> [WALM-383](https://linear.app/mysten-labs/issue/WALM-383/memwal-recall-has-no-date-aware-ordering-or-write-time-field-newest) is In Review and owned by Nikola. This PR is offered as one way to close a gap found in it, not a claim on the ticket. Fold it into `nikolale/walm-383-recall-date-aware`, take the diff, or tell me to close it — all fine.

Found while reviewing the `dev` → `staging` promotion in [#851](https://github.com/MystenLabs/MemWal/pull/851). Not a promotion blocker.

## The gap

[#810](https://github.com/MystenLabs/MemWal/pull/810) is merged, and the design it implements is exactly what Henry approved on 2026-08-27. The gap is one level below that design.

In the WALM-383 thread Henry ruled out option **C** — *"both, with `scoring_weights` overriding `sort`"* — with *"Not B, not C. C adds a precedence rule the model will get wrong."* But at the server layer the merged code behaves like C anyway, because nothing enforces the choice:

1. `select_hits_for_sort` (`recall.rs:201`) orders candidates by write-time descending and truncates to `limit`.
2. `CompositeRanker::rank` (`recall.rs:262`) then reorders the survivors by composite score.

So `{sort: "recent", scoring_weights: {recency: 0.3}}` returns neither ordering — the newest row is no longer first. Henry restated the same precedence on [WALM-460](https://linear.app/mysten-labs/issue/WALM-460/promote-dev-to-staging-sep-2026#comment-4db9eaf8) yesterday:

> **`sort` wins.** If the caller sets `sort=recent` (or any explicit `sort`), that mode is the order. `scoring_weights` must not override it. Weights only apply when `sort` is omitted.

The SDK exposes both on `RecallOptions`, so the combination is one object literal away. No test covered it.

## What this does

`RecallRequest.sort` becomes `Option<RecallSort>`.

The rule distinguishes *omitted* from *explicit*, which a `#[serde(default)]` bare enum cannot express — `{}` and `{"sort":"relevance"}` both deserialize to `Relevance`. With `Option`, `effective_scoring_weights(sort, requested)` collapses the caller's weights to the default whenever `sort` is present.

Suppressing the weights rather than skipping the ranker keeps one code path: at `ScoringWeights::default()` the ranker short-circuits and returns its input order with `score: None`, which is exactly "no ranker ran".

Validation still runs on what the caller **sent**, so a malformed weight vector is a 400 whether or not `sort` would have discarded it.

## Two extras, same feature

- **`RecallResult.created_at` doc was stale.** It said the server-side over-fetching recency mode "is still open" — it shipped in #810 forty lines above. The field's own docs were pointing integrators at the client-side sort WALM-383 exists to replace.
- **Changeset was `patch`.** #810 adds three public API surfaces (`created_at`, `sort`, `scoringWeights`); bumped to `minor` so a consumer can depend on `sort`.

## Not changed

`recall_manual` — `RecallManualRequest` has no `sort`, so there is no precedence to resolve. Whether the manual path should get `sort` is a separate question, as is [WALM-428](https://linear.app/mysten-labs/issue/WALM-428/memwal-recall-expose-sortrecent-on-the-mcp-tool) (MCP knob).

## Proof the defect is real

`recall_sort_precedence_regression_tests` replays the handler's actual ordering pipeline — `select_hits_for_sort` → `CompositeRanker::rank` — over the two rows from the WALM-383 report, with a switch for whether precedence is applied. `apply_precedence: false` **is `dev` today**.

Inputs: `old-but-close` (distance 0.10, written 2026-06-06) and `newest-but-far` (distance 0.90, written 2026-07-06), `now = 2026-07-06`, weights `semantic 1.0 / recency 0.3 / half-life 30d`.

```
old-but-close    1.0*(1-0.10) + 0.3*2^(-30/30) = 0.90 + 0.15 = 1.05
newest-but-far   1.0*(1-0.90) + 0.3*2^(0/30)   = 0.10 + 0.30 = 0.40
```

| Test | Asserts |
| --- | --- |
| `selection_alone_puts_the_newest_row_first` | `select_hits_for_sort` does its job — newest first, before the ranker |
| `dev_today_lets_scoring_weights_undo_sort_recent` | **the defect**: the ranker reorders and `old-but-close` is returned first |
| `precedence_keeps_the_newest_row_first` | with the fix, `newest-but-far` is first |
| `omitted_sort_still_lets_weights_reorder` | with no `sort`, both paths produce identical output — weighted recall is not regressed |

Worth noting the weights above *favour* recency. The defect is not an artefact of hostile inputs: it survives weights a caller would pick specifically to reinforce `sort=recent`, because at a 30-day half-life the semantic gap (0.80) dwarfs the recency gap (0.15).

## Testing

`cargo test --bins` (CI's invocation): **678 passed, 0 failed**. Clippy: 0 errors. The SDK change is JSDoc only.

Four further unit tests pin the rule on `effective_scoring_weights` itself:

- `omitted_sort_lets_the_caller_weights_through`
- `explicit_recent_suppresses_the_weights`
- `explicit_relevance_also_suppresses_the_weights` — "any explicit sort", per the decision
- `omitted_sort_with_default_weights_is_still_the_plain_cosine_path`
