### PR TITLE
fix(chatbot): reject cross-user getSuggestions server actions (WALM-461)

### DIFF
--- a/apps/chatbot/app/(chat)/api/suggestions/route.ts
+++ b/apps/chatbot/app/(chat)/api/suggestions/route.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/app/(auth)/auth";
-import { getSuggestionsByDocumentId } from "@/lib/db/queries";
 import { ChatbotError } from "@/lib/errors";
+import { getSuggestionsForUser } from "@/lib/suggestions-access";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -15,23 +15,20 @@ export async function GET(request: Request) {
 
   const session = await auth();
 
-  if (!session?.user) {
+  if (!session?.user?.id) {
     return new ChatbotError("unauthorized:suggestions").toResponse();
   }
 
-  const suggestions = await getSuggestionsByDocumentId({
-    documentId,
-  });
-
-  const [suggestion] = suggestions;
-
-  if (!suggestion) {
-    return Response.json([], { status: 200 });
+  try {
+    const suggestions = await getSuggestionsForUser({
+      documentId,
+      userId: session.user.id,
+    });
+    return Response.json(suggestions, { status: 200 });
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+    throw error;
   }
-
-  if (suggestion.userId !== session.user.id) {
-    return new ChatbotError("forbidden:api").toResponse();
-  }
-
-  return Response.json(suggestions, { status: 200 });
 }

--- a/apps/chatbot/artifacts/actions.ts
+++ b/apps/chatbot/artifacts/actions.ts
@@ -1,8 +1,18 @@
 "use server";
 
-import { getSuggestionsByDocumentId } from "@/lib/db/queries";
+import { auth } from "@/app/(auth)/auth";
+import { ChatbotError } from "@/lib/errors";
+import { getSuggestionsForUser } from "@/lib/suggestions-access";
 
 export async function getSuggestions({ documentId }: { documentId: string }) {
-  const suggestions = await getSuggestionsByDocumentId({ documentId });
-  return suggestions ?? [];
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    throw new ChatbotError("unauthorized:suggestions");
+  }
+
+  return getSuggestionsForUser({
+    documentId,
+    userId: session.user.id,
+  });
 }

--- a/apps/chatbot/artifacts/get-suggestions.unit.test.ts
+++ b/apps/chatbot/artifacts/get-suggestions.unit.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatbotError } from "@/lib/errors";
+
+// Regression for WALM-461: the getSuggestions server action used to return
+// another user's suggestion rows (originalText / suggestedText) as long as
+// the caller knew the document UUID. GET /api/suggestions already rejected
+// that with auth() + suggestion.userId === session.user.id.
+
+const OWNER_ID = "a80ba4b1-829e-4651-8fe6-da7b428192a3";
+const ATTACKER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const DOC_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const ownerRow = {
+  documentId: DOC_ID,
+  originalText: "secret draft paragraph",
+  suggestedText: "rewritten secret draft",
+  userId: OWNER_ID,
+};
+
+const auth = vi.fn();
+const getSuggestionsByDocumentId = vi.fn(async ({ documentId }: { documentId: string }) =>
+  documentId === DOC_ID ? [ownerRow] : []
+);
+
+vi.mock("@/app/(auth)/auth", () => ({ auth }));
+vi.mock("@/lib/db/queries", () => ({ getSuggestionsByDocumentId }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSuggestionsByDocumentId.mockImplementation(
+    async ({ documentId }: { documentId: string }) =>
+      documentId === DOC_ID ? [ownerRow] : []
+  );
+});
+
+describe("getSuggestions server action", () => {
+  it("rejects an unauthenticated caller without querying", async () => {
+    auth.mockResolvedValue(null);
+    const { getSuggestions } = await import("./actions");
+
+    await expect(getSuggestions({ documentId: DOC_ID })).rejects.toMatchObject({
+      type: "unauthorized",
+      surface: "suggestions",
+    } satisfies Partial<ChatbotError>);
+    expect(getSuggestionsByDocumentId).not.toHaveBeenCalled();
+  });
+
+  it("rejects a signed-in caller for another user's document", async () => {
+    auth.mockResolvedValue({ user: { id: ATTACKER_ID } });
+    const { getSuggestions } = await import("./actions");
+
+    await expect(getSuggestions({ documentId: DOC_ID })).rejects.toMatchObject({
+      type: "forbidden",
+      surface: "api",
+    } satisfies Partial<ChatbotError>);
+    expect(getSuggestionsByDocumentId).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+    });
+  });
+
+  it("returns the owner's rows to the owner", async () => {
+    auth.mockResolvedValue({ user: { id: OWNER_ID } });
+    const { getSuggestions } = await import("./actions");
+
+    await expect(getSuggestions({ documentId: DOC_ID })).resolves.toEqual([
+      ownerRow,
+    ]);
+  });
+
+  it("returns an empty list when the document has no suggestions", async () => {
+    auth.mockResolvedValue({ user: { id: OWNER_ID } });
+    getSuggestionsByDocumentId.mockResolvedValue([]);
+    const { getSuggestions } = await import("./actions");
+
+    await expect(
+      getSuggestions({ documentId: "dddddddd-dddd-dddd-dddd-dddddddddddd" })
+    ).resolves.toEqual([]);
+  });
+});

--- a/apps/chatbot/lib/suggestions-access.ts
+++ b/apps/chatbot/lib/suggestions-access.ts
@@ -1,0 +1,32 @@
+import { ChatbotError } from "@/lib/errors";
+import { getSuggestionsByDocumentId } from "@/lib/db/queries";
+import type { Suggestion } from "@/lib/db/schema";
+
+/**
+ * Load suggestions for a document only if they belong to `userId`.
+ *
+ * The HTTP GET /api/suggestions route already did this (auth +
+ * `suggestion.userId === session.user.id`). The `getSuggestions` server
+ * action did not — it returned any document's rows to whoever posted the
+ * action id (WALM-461). Shared here so the two surfaces cannot drift.
+ */
+export async function getSuggestionsForUser({
+  documentId,
+  userId,
+}: {
+  documentId: string;
+  userId: string;
+}): Promise<Suggestion[]> {
+  const suggestions = await getSuggestionsByDocumentId({ documentId });
+  const [suggestion] = suggestions;
+
+  if (!suggestion) {
+    return [];
+  }
+
+  if (suggestion.userId !== userId) {
+    throw new ChatbotError("forbidden:api");
+  }
+
+  return suggestions;
+}


### PR DESCRIPTION
## Ticket

WALM-461 — https://linear.app/mysten-labs/issue/WALM-461/bug-getsuggestions-server-action-returns-another-users-suggestion-text
GH #786 — https://github.com/MystenLabs/MemWal/issues/786

## What changed?

- `getSuggestions` server action now requires `auth()` and loads rows through `getSuggestionsForUser`, which rejects when `suggestion.userId` is not the session user.
- `GET /api/suggestions` uses the same helper so the HTTP route and the server action cannot drift.
- Unit tests: unauthenticated caller does not query; signed-in caller for another user's document is forbidden; owner still gets their rows.

## Why is this needed?

`GET /api/suggestions` already checked session ownership. The `getSuggestions` server action queried by `documentId` only, so a signed-in guest who knew another user's document UUID received that user's `originalText` / `suggestedText` as HTTP 200.

## Scope

Chatbot suggestion read path (`artifacts/actions.ts`, `GET /api/suggestions`).

### Out of scope

- Adding a `userId` filter to `getSuggestionsByDocumentId` SQL (same as the previous HTTP check: fetch by document, then reject)
- Noter / researcher suggestion surfaces

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `pnpm --filter @memwal/chatbot exec vitest run artifacts/get-suggestions.unit.test.ts` (4 passed).

## How can the reviewer verify it?

1. `apps/chatbot/artifacts/actions.ts` calls `auth()` and `getSuggestionsForUser`; it no longer calls `getSuggestionsByDocumentId` directly.
2. Unit test: attacker session + owner's document id → `forbidden:api`; owner session → the owner's rows.
3. Control: `GET /api/suggestions?documentId=<A's UUID>` with B's cookie still 403.
4. Same cookie and document on the `getSuggestions` server action must reject, not return A's `originalText` / `suggestedText`.

## Risks and dependencies

Empty suggestion lists still return `[]` for a signed-in caller (same as the HTTP route when no rows exist). The query still selects by `documentId` only; ownership is enforced after fetch, matching the previous route.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.

Fixes #786