### PR TITLE
fix(sdk): use typed tx.pure helpers for Move call arguments (WALM-465)

### DIFF
--- a/packages/sdk/src/account.ts
+++ b/packages/sdk/src/account.ts
@@ -287,8 +287,8 @@ export async function addDelegateKey(
         arguments: [
             tx.object(opts.accountId),
             tx.object(opts.registryId),
-            tx.pure("vector<u8>", Array.from(pkBytes)),
-            tx.pure("string", opts.label),
+            tx.pure.vector("u8", Array.from(pkBytes)),
+            tx.pure.string(opts.label),
             tx.object(SUI_CLOCK),
         ],
     });
@@ -338,7 +338,7 @@ export async function removeDelegateKey(
         arguments: [
             tx.object(opts.accountId),
             tx.object(opts.registryId),
-            tx.pure("vector<u8>", Array.from(pkBytes)),
+            tx.pure.vector("u8", Array.from(pkBytes)),
         ],
     });
 

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -505,7 +505,7 @@ export class MemWalManual {
                 tx.moveCall({
                     target: `${this.config.sealPolicyPackageId ?? this.config.packageId}::account::seal_approve`,
                     arguments: [
-                        tx.pure("vector<u8>", idBytes),
+                        tx.pure.vector("u8", idBytes),
                         tx.object(this.config.registryId),
                         tx.object(this.config.accountId),
                     ],

--- a/packages/sdk/test/pure-argument-syntax.test.mjs
+++ b/packages/sdk/test/pure-argument-syntax.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { Transaction } from "@mysten/sui/transactions";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "../src");
+
+// WALM-465 / GH #799: @mysten/sui >= 2.5 treats tx.pure("vector<u8>", value)
+// as a Pure argument whose *value* is the type string, not a typed vector.
+function source(name) {
+    return readFileSync(join(srcDir, name), "utf8");
+}
+
+test("account.ts and manual.ts do not use the two-argument tx.pure(type, value) form", () => {
+    for (const file of ["account.ts", "manual.ts"]) {
+        const text = source(file);
+        assert.equal(
+            text.includes('tx.pure("vector<u8>"'),
+            false,
+            `${file} still passes "vector<u8>" as a tx.pure type string`
+        );
+        assert.equal(
+            text.includes('tx.pure("string"'),
+            false,
+            `${file} still passes "string" as a tx.pure type string`
+        );
+    }
+    const account = source("account.ts");
+    assert.match(account, /tx\.pure\.vector\(\s*"u8"/);
+    assert.match(account, /tx\.pure\.string\(/);
+    assert.match(source("manual.ts"), /tx\.pure\.vector\(\s*"u8"/);
+});
+
+test("typed pure helpers construct a PTB without treating the Move type as the value", () => {
+    const tx = new Transaction();
+    tx.moveCall({
+        target: "0x1::account::add_delegate_key",
+        arguments: [
+            tx.object("0x2"),
+            tx.object("0x3"),
+            tx.pure.vector("u8", Array.from(new Uint8Array(32))),
+            tx.pure.string("My Laptop"),
+            tx.object("0x6"),
+        ],
+    });
+    const inputs = tx.getData().inputs;
+    // Two-arg tx.pure("vector<u8>", bytes) used to serialize the type name as
+    // the pure value. Typed helpers must produce Pure inputs, not a string
+    // argument equal to "vector<u8>".
+    for (const input of inputs) {
+        const pure = input.Pure?.bytes ?? input.Pure;
+        const decoded = typeof pure === "string" ? pure : undefined;
+        assert.notEqual(decoded, "vector<u8>");
+        assert.notEqual(decoded, "string");
+    }
+    assert.ok(inputs.length >= 2);
+});


### PR DESCRIPTION
## Ticket

WALM-465 — https://linear.app/mysten-labs/issue/WALM-465/bug-legacy-txpure-movecall-argument-syntax-in-accountts-and-manualts
GH #799

## What changed?

- `addDelegateKey` and `removeDelegateKey` now pass `tx.pure.vector("u8", …)` and `tx.pure.string(label)` instead of `tx.pure("vector<u8>", …)` / `tx.pure("string", …)`.
- `recallManual` `seal_approve` uses `tx.pure.vector("u8", idBytes)`.
- Unit tests reject the two-argument type-string form in those SDK files and build a PTB with the typed helpers.

## Why is this needed?

`@mysten/sui` >= 2.5 treats `tx.pure("vector<u8>", value)` as a Pure whose *value* is the type string `"vector<u8>"`, not a typed vector. Delegate-key and manual-recall Move calls then fail to serialize or abort on-chain.

## Scope

TypeScript SDK Move wrappers in `packages/sdk/src/account.ts` and `packages/sdk/src/manual.ts`.

### Out of scope

- Sidecar scripts that still call `tx.pure("vector<u8>", …)` (`services/server/scripts/sidecar/seal-ptb.ts`, `blob-metadata.ts`, `seal-decrypt.ts`)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `pnpm --filter @mysten-incubation/memwal test` (99 passed, including 2 new tests). No on-chain e2e.

## How can the reviewer verify it?

1. `packages/sdk/src/account.ts` and `packages/sdk/src/manual.ts` have no `tx.pure("vector<u8>"` / `tx.pure("string"` call sites.
2. `packages/sdk/test/pure-argument-syntax.test.mjs` fails if those strings return, and builds a PTB whose Pure inputs are not the type names.
3. Control: with `@mysten/sui` >= 2.5, `tx.pure("vector<u8>", bytes)` serializes the type string as the value; the typed helpers must not.

## Risks and dependencies

Sidecar scripts still use the legacy form; they are not on this SDK path. Callers that already used typed helpers are unchanged.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.

Fixes #799