### PR TITLE
fix(openclaw): clamp memory_search relevance to [0, 1] (WALM-464)

### DIFF
--- a/packages/openclaw-memory-memwal/src/cli/search.ts
+++ b/packages/openclaw-memory-memwal/src/cli/search.ts
@@ -6,6 +6,7 @@
 
 import type { MemWal } from "@mysten-incubation/memwal";
 import { resolveAgent } from "../config.js";
+import { cosineRelevance } from "../format.js";
 import type { PluginConfig } from "../types.js";
 
 /** Register the `openclaw memwal search` command. */
@@ -25,7 +26,7 @@ export function registerSearchCommand(cmd: any, client: MemWal, config: PluginCo
         const output = result.results.map((r: any) => ({
           text: r.text,
           blob_id: r.blob_id,
-          relevance: Math.round((1 - r.distance) * 100) / 100,
+          relevance: Math.round(cosineRelevance(r.distance) * 100) / 100,
         }));
         console.log(JSON.stringify(output, null, 2));
       } catch (err) {

--- a/packages/openclaw-memory-memwal/src/format.ts
+++ b/packages/openclaw-memory-memwal/src/format.ts
@@ -42,6 +42,19 @@ export function escapeForPrompt(text: string): string {
 }
 
 /**
+ * Convert pgvector cosine distance to a [0, 1] similarity for display.
+ *
+ * MemWal recall returns cosine distance (`<=>`), not L2: 0 = identical
+ * direction, 1 = orthogonal, 2 = opposite. `1 - distance` is cosine
+ * similarity and goes negative when distance > 1; clamp so OpenClaw
+ * prompts never show "(-30% relevance)".
+ */
+export function cosineRelevance(distance: number): number {
+  if (!Number.isFinite(distance)) return 0;
+  return Math.min(1, Math.max(0, 1 - distance));
+}
+
+/**
  * Format recalled memories for prompt injection with security warning.
  *
  * Wraps memories in `<memwal-memories>` tags with an instruction header

--- a/packages/openclaw-memory-memwal/src/tools/search.ts
+++ b/packages/openclaw-memory-memwal/src/tools/search.ts
@@ -10,7 +10,7 @@
 import type { MemWal } from "@mysten-incubation/memwal";
 import { Type } from "@sinclair/typebox";
 import { looksLikeInjection } from "../capture.js";
-import { escapeForPrompt, toolError, withTimeout } from "../format.js";
+import { cosineRelevance, escapeForPrompt, toolError, withTimeout } from "../format.js";
 import type { PluginConfig } from "../types.js";
 import { DEFAULT_SEARCH_LIMIT } from "../constants.js";
 
@@ -71,10 +71,10 @@ export function registerSearchTool(api: any, client: MemWal, config: PluginConfi
             };
           }
 
-          // Walrus Memory returns L2 distance — convert to similarity % for readability
+          // Cosine distance [0, 2] → clamped similarity % so d > 1 is 0%, not negative.
           const formatted = safe
             .map((r: any, i: number) => {
-              const relevance = Math.round((1 - r.distance) * 100);
+              const relevance = Math.round(cosineRelevance(r.distance) * 100);
               return `${i + 1}. ${escapeForPrompt(r.text)} (${relevance}% relevance)`;
             })
             .join("\n");
@@ -92,7 +92,7 @@ export function registerSearchTool(api: any, client: MemWal, config: PluginConfi
               memories: safe.map((r: any) => ({
                 text: r.text,
                 blob_id: r.blob_id,
-                relevance: Math.round((1 - r.distance) * 100) / 100,
+                relevance: Math.round(cosineRelevance(r.distance) * 100) / 100,
               })),
             },
           };

--- a/packages/openclaw-memory-memwal/test/plugin.test.mjs
+++ b/packages/openclaw-memory-memwal/test/plugin.test.mjs
@@ -10,7 +10,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import { parseConfig, resolveAgent, keyPreview } from "../dist/config.js";
-import { withTimeout, withRetry, escapeForPrompt, formatMemoriesForPrompt, stripMemoryTags } from "../dist/format.js";
+import { withTimeout, withRetry, cosineRelevance, escapeForPrompt, formatMemoriesForPrompt, stripMemoryTags } from "../dist/format.js";
+import { registerSearchTool } from "../dist/tools/search.js";
 import { looksLikeInjection, shouldCapture } from "../dist/capture.js";
 import { registerHooks } from "../dist/hooks/index.js";
 
@@ -206,6 +207,55 @@ test("recalled memories are escaped and framed as untrusted", () => {
 
 test("escapeForPrompt escapes every injection-relevant character", () => {
   assert.equal(escapeForPrompt(`<a href="x">&'`), "&lt;a href=&quot;x&quot;&gt;&amp;&#39;");
+});
+
+test("cosineRelevance clamps pgvector cosine distance to [0, 1]", () => {
+  assert.equal(cosineRelevance(0), 1);
+  assert.equal(cosineRelevance(0.13), 0.87);
+  assert.equal(cosineRelevance(1), 0);
+  assert.equal(cosineRelevance(1.3), 0);
+  assert.equal(cosineRelevance(2), 0);
+  assert.equal(cosineRelevance(-0.01), 1);
+  assert.equal(cosineRelevance(Number.NaN), 0);
+  assert.equal(cosineRelevance(Number.POSITIVE_INFINITY), 0);
+});
+
+test("memory_search never prints a negative relevance percent", async () => {
+  let execute;
+  const mockApi = {
+    registerTool: (def) => {
+      execute = def.execute;
+    },
+  };
+  const mockClient = {
+    recall: async () => ({
+      results: [
+        { text: "close match", distance: 0.13, blob_id: "a" },
+        { text: "orthogonal", distance: 1, blob_id: "b" },
+        { text: "dissimilar", distance: 1.3, blob_id: "c" },
+        { text: "opposite", distance: 2, blob_id: "d" },
+      ],
+    }),
+  };
+
+  registerSearchTool(mockApi, mockClient, {
+    defaultNamespace: "default",
+    requestTimeoutMs: 5_000,
+  });
+
+  const result = await execute("call-1", { query: "anything" });
+  const text = result.content[0].text;
+
+  assert.match(text, /1\. close match \(87% relevance\)/);
+  assert.match(text, /2\. orthogonal \(0% relevance\)/);
+  assert.match(text, /3\. dissimilar \(0% relevance\)/);
+  assert.match(text, /4\. opposite \(0% relevance\)/);
+  assert.doesNotMatch(text, /\(-\d+% relevance\)/);
+
+  assert.deepEqual(
+    result.details.memories.map((m) => m.relevance),
+    [0.87, 0, 0, 0],
+  );
 });
 
 test("stripMemoryTags removes injected blocks to prevent a capture feedback loop", () => {


### PR DESCRIPTION
## Ticket

WALM-464 — https://linear.app/mysten-labs/issue/WALM-464/bug-memory-search-tool-calculates-negative-relevance-percentage-when
GH #798 — https://github.com/MystenLabs/MemWal/issues/798

## What changed?

- `cosineRelevance` converts pgvector cosine distance to a similarity in `[0, 1]` (`min(1, max(0, 1 - distance))`).
- `memory_search` uses it for the LLM prompt percent and `details.memories[].relevance`.
- CLI `openclaw memwal search` uses the same helper for JSON `relevance`.

## Why is this needed?

MemWal recall returns cosine distance in `[0, 2]`, not L2. `1 - distance` is cosine similarity and goes negative when `distance > 1`, so the tool printed `(-30% relevance)` into the agent prompt.

## Scope

OpenClaw plugin display path (`format.ts`, `tools/search.ts`, `cli/search.ts`).

### Out of scope

- Auto-recall hook `minRelevance` filter (does not print `%`)
- MCP / SDK `1 - distance` formatting
- Remapping `[0, 2]` onto `[0, 1]` (orthogonal would look like 50%)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `pnpm --filter @mysten-incubation/oc-memwal test` (32 passed).

## How can the reviewer verify it?

1. `cosineRelevance(1.3)` and `cosineRelevance(2)` are `0`; `cosineRelevance(0.13)` is `0.87`.
2. Mocked `memory_search` with distances `0.13 / 1 / 1.3 / 2` prints `87%` then `0%`, never `(-N% relevance)`, and `details.relevance` is `[0.87, 0, 0, 0]`.
3. Control: unclamped `1 - 1.3` is `-0.3` and would format as `-30%`.

## Risks and dependencies

Hits with `distance >= 1` still return in top-K; they now show `0%` instead of a negative percent. Ranking is unchanged.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.

Fixes #798