### PR TITLE
docs(mcp): position the plugin as the automatic-memory path

### DIFF
--- a/apps/app/public/skills/setup
+++ b/apps/app/public/skills/setup
@@ -15,8 +15,11 @@ the exact config and terminal commands to run.
 ## Agent Goal
 
 Connect Walrus Memory MCP to the user's AI client, sign the user in, and verify
-that memory tools work. On Claude Code, the plugin is required: MCP-only is an
-incomplete setup and auto-remember/recall will not be reliable.
+that memory tools work. Install the plugin wherever one exists: Claude Code,
+Codex, Cursor, Antigravity, and the ChatGPT desktop app. The plugin ships
+lifecycle hooks that make save and recall automatic with no extra instructions,
+so MCP-only is an incomplete setup on those clients. On clients with no plugin,
+MCP-only is the whole setup, and proactive behavior is best-effort.
 
 Do not install the Walrus Memory SDK or edit application source code unless the
 user explicitly asks for developer integration.
@@ -26,15 +29,18 @@ user explicitly asks for developer integration.
 1. Identify the AI client first. A client that cannot run a local MCP command
    but can attach two custom connector headers uses the Remote MCP section
    below. Every other client (Claude Desktop, Claude Code, Cursor, Codex,
-   other local apps) uses the Local MCP Server section. ChatGPT is not
-   supported today: its connector UI exposes only a single bearer field and
-   cannot supply the required `x-memwal-account-id` header.
+   other local apps) uses the Local MCP Server section. ChatGPT web
+   connectors are not supported: chatgpt.com exposes only a single bearer
+   field and cannot supply the required `x-memwal-account-id` header. The
+   ChatGPT desktop app is a different product: it ships the Codex CLI and
+   reads `~/.codex`, so treat it as Codex and use the Codex section below.
 2. Decide whether you have local shell and filesystem access.
 3. If you can edit local user config files, do the setup yourself after showing
    the config you will add.
 4. If you cannot edit local files yourself, prefer giving the user ONE terminal
-   command to paste over raw JSON/TOML to hand-edit. On Claude Code that
-   command is `claude plugin install`, not `claude mcp add`. Fall back to a
+   command to paste over raw JSON/TOML to hand-edit. Every client with a
+   plugin has one: `claude plugin install` on Claude Code, `codex plugin add`
+   on Codex, and a single `npx degit` on Cursor and Antigravity. Fall back to a
    config block only when no command exists for that client; then state the
    exact file path and merge the `memwal` entry, never replace the whole file.
 5. Preserve existing MCP servers. Merge the `memwal` server; do not replace the
@@ -44,18 +50,20 @@ user explicitly asks for developer integration.
 8. Stop at the first real blocker and report the exact failure.
 9. Keep the final status short. Do not repeat full config blocks or terminal
    commands after setup succeeds unless the user must copy/paste them manually.
-10. On Claude Code, install the plugin and verify it with `claude plugin list`.
-    Do not treat MCP-only as success. If marketplace add or plugin install
-    fails, stop and report that error. Do not silently fall back to
-    `claude mcp add`.
-11. On Claude Code, show the Walrus Memory routing block and get the user's
-    go-ahead before writing `~/.claude/CLAUDE.md` (a global file outside the
-    project). Create the file if needed. Do not replace the whole file. If
-    `<!-- memwal:start -->` ... `<!-- memwal:end -->` already exists, replace
-    that span only. Claude's built-in `MEMORY.md` lives in the system prompt
-    and outranks MCP instructions; without this user-level rule the agent
-    often writes `MEMORY.md` instead of calling `memwal_*`. Tell the user to
-    turn off Claude's built-in / native memory in account settings if it is on.
+10. Prefer the plugin on every client that has one: Claude Code, Codex,
+    Cursor, Antigravity, and the ChatGPT desktop app. Verify it with
+    `claude plugin list`, `codex plugin list`, or the installed folder for
+    Cursor and Antigravity. Do not treat MCP-only as success on those clients.
+    If a marketplace add or a plugin install fails, stop and report that error
+    rather than silently falling back to a plain MCP config.
+11. Do not write `~/.claude/CLAUDE.md` during a normal plugin install. The
+    plugin's `SessionStart` hook already injects the routing text ("prefer the
+    memwal_* tools over any built-in or local memory feature") and the save
+    rules on every session, so a plugin install needs no extra instructions
+    from the user. Use the routing block under Walrus Memory only as a
+    fallback: when the user is on MCP-only, or when they report the agent
+    still writing `MEMORY.md`. If Claude's built-in memory is switched on and
+    competes, tell the user they can turn it off in account settings.
 
 ## Requirements
 
@@ -126,7 +134,26 @@ npx -y @mysten-incubation/memwal-mcp
 
 ### Cursor
 
-Edit `~/.cursor/mcp.json` and merge:
+Cursor loads plugins from `~/.cursor/plugins/local/<name>/`. Install the plugin
+there, which brings the MCP server and the lifecycle hooks together:
+
+```bash
+npx -y degit MystenLabs/MemWal/packages/mcp/plugin ~/.cursor/plugins/local/memwal --force
+```
+
+Cursor has no plugin CLI. Do not look for a `cursor plugin` command, and do not
+try to add the repo as a marketplace: importing a third-party marketplace needs
+a Cursor team admin. The copy above is the install.
+
+Fully quit and reopen Cursor. The plugin then shows under Customize in the
+sidebar, and its hooks give proactive recall and save with no further
+instructions.
+
+If the user already has a manual `memwal` entry in `~/.cursor/mcp.json`, remove
+it. The plugin ships its own server and the two entries duplicate it.
+
+MCP-only fallback, if the user does not want the hooks. Edit `~/.cursor/mcp.json`
+and merge:
 
 ```json
 {
@@ -168,7 +195,26 @@ other servers.
 
 ### Codex
 
-Edit `~/.codex/config.toml` and merge:
+This section also covers the ChatGPT desktop app, which ships the Codex CLI and
+reads the same `~/.codex`.
+
+Install the plugin, which bundles the MCP server and the lifecycle hooks:
+
+```bash
+codex plugin marketplace add MystenLabs/MemWal
+codex plugin add memwal@memwal-plugins
+codex plugin list
+```
+
+Codex loads plugin-bundled hooks but does not run them until the user trusts
+them once. Tell the user to run `/hooks` in Codex, or to follow the startup
+review prompt, and trust the MemWal hook commands.
+
+Do not also add a `[mcp_servers.memwal]` block. The plugin brings its own
+server and a manual block duplicates it.
+
+MCP-only fallback, if the Codex build has no `codex plugin` support. Edit
+`~/.codex/config.toml` and merge:
 
 ```toml
 [mcp_servers.memwal]
@@ -228,8 +274,9 @@ claude mcp add --scope user memwal -- npx -y @mysten-incubation/memwal-mcp
 
 If you use that fallback, tell the user the automatic-memory hooks are missing.
 
-Show this block, get the user's go-ahead, then merge it into
-`~/.claude/CLAUDE.md`. Create the file if it does not exist. If
+Use this block only as the fallback described in rule 11, not during a normal
+plugin install. When it applies, show it, get the user's go-ahead, then merge it
+into `~/.claude/CLAUDE.md`. Create the file if it does not exist. If
 `<!-- memwal:start -->` ... `<!-- memwal:end -->` is already there, replace
 that span only. Never overwrite the rest of the file.
 
@@ -251,6 +298,19 @@ memwal_recall first.
 Tell the user: if Claude's built-in memory is enabled in account settings,
 turn it off. That feature competes with Walrus Memory and makes it look like
 memory is unavailable or already handled.
+
+### Antigravity
+
+Antigravity loads plugins from its own plugin directory. Install with one
+command:
+
+```bash
+npx -y degit MystenLabs/MemWal/packages/mcp/plugin ~/.gemini/config/plugins/memwal --force
+```
+
+Fully quit and reopen Antigravity. The plugin brings the MCP server and the
+lifecycle hooks, so proactive recall and save work with no further
+instructions.
 
 ### Other Local MCP Clients
 
@@ -320,10 +380,12 @@ command. Use this path only when the client can attach BOTH custom request
 headers shown below. A client that exposes only a single bearer/token field
 cannot use this path.
 
-ChatGPT is not supported today. Its connector UI exposes only one bearer slot,
-so the required `x-memwal-account-id` header cannot be provided. Do not attempt
-ChatGPT setup; offer a local client (Claude Desktop, Claude Code, Cursor, or
-Codex) instead.
+ChatGPT web connectors are not supported. The chatgpt.com connector UI exposes
+only one bearer slot, so the required `x-memwal-account-id` header cannot be
+provided. Do not attempt that setup.
+
+This does not apply to the ChatGPT desktop app, which ships the Codex CLI and
+reads `~/.codex`. Set that up through the Codex section above, not here.
 
 Prerequisite: credentials must already exist. Have the user run the login once
 on their computer (see Recommended Login). The Remote MCP path needs Node.js
@@ -368,7 +430,10 @@ this skill for the same client.
 | `node: command not found` | Install Node.js 20+ from https://nodejs.org/. |
 | `npx` fails | Confirm Node/npm and internet access. If inside a Node monorepo, run from the home directory or set MCP `cwd` to the home directory. |
 | No Walrus Memory tools after restart | Check the MCP config path and fully restart the client. |
-| Claude Code saves to `MEMORY.md` instead of `memwal_remember` | Plugin missing, or Claude's built-in memory is winning. Run `claude plugin list`. Merge the Walrus Memory block into `~/.claude/CLAUDE.md`. Ask the user to disable Claude's built-in / native memory in account settings. MCP-only is not enough. |
+| Claude Code saves to `MEMORY.md` instead of `memwal_remember` | Run `claude plugin list` first: the plugin is usually missing, and its hook supplies the routing on its own. If the plugin is installed and this still happens, ask the user to disable Claude's built-in / native memory in account settings, then merge the Walrus Memory block into `~/.claude/CLAUDE.md` as a fallback. |
+| `codex plugin marketplace add` prints `already added from a different source` | A stale clone is left in `~/.codex/.tmp/marketplaces/memwal-plugins/`. Note the command still exits 0, so a scripted install does not notice. Remove that folder and the empty `~/.codex/plugins/cache/memwal-plugins/`, then add the marketplace again. |
+| Cursor shows no Walrus Memory plugin | Confirm the folder `~/.cursor/plugins/local/memwal` exists and holds `.cursor-plugin/plugin.json`, then fully quit and reopen Cursor. There is no `cursor plugin` CLI, so verify from the logs instead: the newest folder under `~/Library/Application Support/Cursor/logs/` on macOS gets an `mcp-server-plugin-memwal-memwal.log` once the plugin loads. A `mcp-server-user-memwal.log` next to it means a duplicate manual entry is still in `~/.cursor/mcp.json`. |
+| Memory tools fail with `MCP rate limit: ip_active_cap` (HTTP 429), sometimes followed by 503 | Too many concurrent memwal-mcp sessions from one machine. The usual causes are a duplicate server, where a plugin install sits next to a leftover manual `memwal` entry in the client's MCP config, and stale `memwal-mcp` processes left behind by earlier sessions. Remove the duplicate entry first. Then list the leftovers with `pgrep -fl memwal-mcp` and ask the user which clients they still want running before ending any process. Restart the client afterwards. |
 | `claude plugin` commands are not recognized | This Claude Code build has no plugin CLI. Update Claude Code, or use the MCP-only fallback and tell the user hooks are missing. |
 | Only `memwal_login` works | Credentials are missing. Run `memwal_login` or `npx -y @mysten-incubation/memwal-mcp login --prod`. |
 | Memory tools return 401 | The delegate key may be stale or revoked. Run `npx -y @mysten-incubation/memwal-mcp login --prod` again. |
@@ -389,8 +454,7 @@ Next: fully quit and reopen <AI client> now. On macOS, use Cmd+Q; closing the
 window is not enough.
 
 Login: succeeded.
-Plugin: installed (Claude Code only) or n/a.
-CLAUDE.md: routing block merged (Claude Code only) or n/a.
+Plugin: installed, or n/a for an MCP-only client.
 Config: <path changed>.
 After reopening, ask: "What MCP tools do you have available?"
 

--- a/docs/mcp/claude-desktop.md
+++ b/docs/mcp/claude-desktop.md
@@ -63,6 +63,25 @@ Newer Claude Desktop versions pre-populate `claude_desktop_config.json` with oth
 
 Quit and reopen Claude Desktop (`Cmd+Q` on macOS; closing the window is not enough), then ask the agent to run `memwal_login` on first use.
 
+## Add memory instructions
+
+Claude Desktop cannot run the lifecycle hooks that reinforce automatic memory on
+[Claude Code](/mcp/claude-code), [Codex](/mcp/codex), and [Antigravity](/mcp/antigravity).
+The tools still work here and the agent might save and recall on its own, but that is
+best-effort, because Claude Desktop's built-in memory can win instead. State the
+expectation yourself to get closer to the plugin behavior.
+
+Open **Settings → Profile → personal preferences** (applies to every conversation), or a
+single **Project's instructions** (applies only inside that project), and paste:
+
+```text
+Use Walrus Memory as my memory.
+- Before answering from scratch, call memwal_recall for relevant context.
+- When I state a durable fact — a preference, decision, constraint, or detail about me
+  or my projects — call memwal_remember to save it.
+- Prefer Walrus Memory over your built-in memory.
+```
+
 ## Available tools
 
 | Tool | Description |

--- a/docs/mcp/cursor.md
+++ b/docs/mcp/cursor.md
@@ -2,7 +2,7 @@
 title: Cursor
 description: >-
   Add portable Walrus Memory to Cursor through the MemWal MCP server.
-  Cursor supports MCP-only installation and optional lifecycle hooks via its plugin system.
+  Install as a plugin with automatic memory hooks or as MCP-only for just the memory tools.
 keywords:
   - MCP
   - Cursor
@@ -11,7 +11,7 @@ keywords:
   - plugin
   - automatic memory
 goal:
-  description: Add MemWal to Cursor's MCP configuration, optionally enable plugin lifecycle hooks for automatic memory, and verify persistent recall is working across Cursor sessions.
+  description: Add MemWal to Cursor as a plugin with lifecycle hooks or as a standalone MCP server, authenticate with your account credentials, and verify persistent recall is working across Cursor sessions.
   requires:
     - has_frontmatter:
         - title
@@ -26,13 +26,13 @@ goal:
       label: Needs answer summary for AI citation
 questions:
   - How do I add Walrus Memory to Cursor?
-  - How do I configure the MemWal MCP server for Cursor?
+  - How do I install the MemWal plugin on Cursor?
   - Does Cursor support MemWal lifecycle hooks?
 answer: >-
-  To add Walrus Memory to Cursor, configure the MemWal MCP server in ~/.cursor/mcp.json using npx -y @mysten-incubation/memwal-mcp as the command. Cursor also supports optional lifecycle hooks via its plugin system for session start, before prompt, and post-tool events. The MCP-only setup already provides proactive save and recall through tool descriptions, so the hooks are optional reinforcement.
+  To add Walrus Memory to Cursor, install the MemWal plugin by copying it into ~/.cursor/plugins/local/memwal with npx degit. That copy brings the MCP server and the lifecycle hooks together, so automatic recall and save need no extra instructions. Cursor ships no plugin CLI, so the copy is the install. You can instead configure MemWal as MCP-only by adding the server to ~/.cursor/mcp.json, which gives the memory tools without the hooks.
 ---
 
-Add MemWal to Cursor so the agent can save and recall durable facts. The **MCP server** (memory tools, below) works on every Cursor version; Cursor's plugin system can also add **lifecycle hooks** for extra reinforcement (see [Lifecycle hooks](#lifecycle-hooks-plugin)).
+Add MemWal to Cursor so the agent recalls context and saves durable facts. Install it as a **plugin** (adds automatic-memory hooks) or as **MCP-only** (just the tools).
 
 ## Prerequisites
 
@@ -41,20 +41,58 @@ Add MemWal to Cursor so the agent can save and recall durable facts. The **MCP s
 
 ## Installation
 
-Add the server to `~/.cursor/mcp.json`:
+<Tabs>
+  <Tab title="Plugin (recommended)">
+    Cursor loads plugins from `~/.cursor/plugins/local/<name>/`. Copy the plugin (MCP server + lifecycle hooks) into that directory:
+    ```bash
+    npx -y degit MystenLabs/MemWal/packages/mcp/plugin ~/.cursor/plugins/local/memwal
+    ```
+    Append `--force` when you reinstall over an existing copy.
 
-```json
-{
-  "mcpServers": {
-    "memwal": {
-      "command": "npx",
-      "args": ["-y", "@mysten-incubation/memwal-mcp"]
+    Fully quit and reopen Cursor (`Cmd+Q` on macOS; closing the window is not enough). The plugin then appears under **Customize** in the sidebar, and its hooks give proactive recall and save with no further instructions.
+
+    If you already added a manual `memwal` entry to `~/.cursor/mcp.json`, remove it. The plugin ships its own server and the two entries duplicate it.
+  </Tab>
+  <Tab title="MCP-only">
+    Add the server to `~/.cursor/mcp.json`:
+    ```json
+    {
+      "mcpServers": {
+        "memwal": {
+          "command": "npx",
+          "args": ["-y", "@mysten-incubation/memwal-mcp"]
+        }
+      }
     }
-  }
-}
-```
+    ```
+    To pin a default namespace, pass `"--namespace", "<name>"` in `args` (or set `MEMWAL_NAMESPACE` in `env`). Restart Cursor (MCP servers load at startup), then ask the agent to run `memwal_login` on first use.
 
-To pin a default namespace, pass `"--namespace", "<name>"` in `args` (or set `MEMWAL_NAMESPACE` in `env`). Restart Cursor (MCP servers load at startup), then ask the agent to run `memwal_login` on first use.
+    This path gives the memory tools without the hooks, so proactive behavior is best-effort.
+  </Tab>
+</Tabs>
+
+<Note>
+Cursor ships no plugin CLI. Do not look for a `cursor plugin` command, and do not try to add this repository as a marketplace: importing a third-party marketplace needs a Cursor team admin. The copy above is the install.
+</Note>
+
+## What the plugin includes
+
+| Component | Plugin | MCP-only |
+|---|:-:|:-:|
+| MemWal MCP (memory tools) | ✓ | ✓ |
+| Lifecycle hooks (automatic recall/save) | ✓ | ✗ |
+
+## Lifecycle hooks (plugin)
+
+The plugin runs **lifecycle hooks** on Cursor's own events:
+
+| Hook | Cursor event | What it does |
+|------|--------------|--------------|
+| Session start | `sessionStart` | Tells the agent to prefer the `memwal_*` tools over any built-in or local memory feature. |
+| Before prompt | `beforeSubmitPrompt` | Detects recall/remember intent and reminds the agent. |
+| Post-tool | `postToolUse` (Bash) | On command errors, reminds the agent to recall prior fixes. |
+
+The hook scripts ship inside the plugin bundle (`packages/mcp/plugin/`), so the copy above installs them alongside the MCP server. The MCP-only setup gives the tools without these hooks.
 
 ## Available tools
 
@@ -70,24 +108,16 @@ To pin a default namespace, pass `"--namespace", "<name>"` in `args` (or set `ME
 
 The tool descriptions tell the agent to save and recall proactively. See [Reference](/mcp/reference) for full parameters.
 
-## Lifecycle hooks (plugin)
-
-Beyond the MCP tools, Cursor's plugin system can run **lifecycle hooks** that reinforce automatic memory:
-
-| Hook | Cursor event | What it does |
-|------|--------------|--------------|
-| Session start | `sessionStart` | Reminds the agent to use the `memwal_*` tools. |
-| Before prompt | `beforeSubmitPrompt` | Detects recall/remember intent and reminds the agent. |
-| Post-tool | `postToolUse` (Bash) | On command errors, reminds the agent to recall prior fixes. |
-
-The hook scripts ship inside the plugin bundle (`packages/mcp/plugin/`); hook support depends on your Cursor version. The MCP-only setup above already gives proactive save/recall, so the hooks are an optional reinforcement.
-
 ## Verify
 
 Ask the agent what MCP tools it has available. You should see the `memwal_*` tools. State a durable fact (for example, a preferred package manager) and confirm the agent saves it with `memwal_remember`.
 
+Cursor has no plugin CLI to list what loaded, so confirm the plugin from its logs instead. The newest folder under `~/Library/Application Support/Cursor/logs/` on macOS gets an `mcp-server-plugin-memwal-memwal.log` once the plugin loads. The `plugin-` prefix is Cursor's own naming for a plugin-scoped server.
+
 ## Troubleshooting
 
 - **Tools missing**: restart Cursor; check the MCP connection status in Settings.
+- **No plugin after restart**: confirm `~/.cursor/plugins/local/memwal` exists and holds `.cursor-plugin/plugin.json`, then fully quit and reopen Cursor and check for the log file named above.
+- **`MCP rate limit: ip_active_cap` (HTTP 429), sometimes followed by 503**: too many concurrent `memwal-mcp` sessions from one machine. The usual cause is a duplicate server, where the plugin sits next to a leftover manual `memwal` entry in `~/.cursor/mcp.json`. An `mcp-server-user-memwal.log` beside the plugin log confirms it. Remove the manual entry, then list leftover processes with `pgrep -fl memwal-mcp` and close the clients still holding them before restarting Cursor.
 - **Not signed in**: ask the agent to run `memwal_login`, approve in the browser, then retry.
 - **`memwal_recall` returns nothing although you saved before**: run `memwal_restore <namespace>` to rebuild the index from Walrus.

--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -43,11 +43,54 @@ There are two ways to use MemWal. The difference is whether you also get the **l
 | MemWal MCP: memory tools (`memwal_remember`, `memwal_recall`, …) | ✓ | ✓ |
 | Lifecycle hooks: automatic recall/save reminders | ✓ | ✗ |
 
-- **MCP-only** gives the agent the memory tools. Because the tool descriptions encourage proactive use, the agent already saves and recalls on its own; you just do not get the hooks. Available on **every** MCP client.
-- **Plugin** bundles the MCP server **and** lifecycle hooks that reinforce the behavior (for example, preferring Walrus Memory over a client's built-in memory). Available on **Claude Code**, **Codex**, **Antigravity**, and **Cursor**.
+- **Plugin** bundles the MCP server **and** lifecycle hooks. The `SessionStart` hook tells the agent to prefer the `memwal_*` tools over any built-in or local memory feature, and when to save without being asked. Automatic memory works with no further instructions from you. Available on **Claude Code**, **Codex**, **Antigravity**, and **Cursor**.
+- **MCP-only** gives the agent the memory tools on **every** MCP client. The tool descriptions encourage proactive use, so agents often do save and recall on their own. Treat that as best-effort: it varies by client and model, and on a client that ships its own memory feature the built-in one commonly wins.
 
 <Note>
-The proactive behavior comes from the tool layer, so it works on both installation paths. The plugin hooks add reinforcement on the clients that support them.
+Prefer the plugin wherever you can install it. It is the tested path for reliable automatic save and recall, and it needs no extra instructions from you. On MCP-only clients, paste the client's instruction block (see [Claude Desktop](/mcp/claude-desktop#add-memory-instructions)) to get closer to the same behavior.
+</Note>
+
+## Fastest path: let your agent set it up
+
+Paste this into the AI client you want to connect:
+
+```text
+Run `curl -sL https://memory.walrus.xyz/skills/setup` and use the returned
+instructions to connect Walrus Memory to this AI client.
+```
+
+The agent identifies the client, writes the right config or runs the right install
+command, signs you in, and verifies the memory tools. Use the per-client table below
+if you would rather do it by hand.
+
+## Which install path for your client
+
+What the user actually does differs per client. Pick your row:
+
+| Client | Automatic memory (hooks) | What you do |
+|---|:-:|---|
+| [Claude Code](/mcp/claude-code) | ✓ Plugin | `/plugin marketplace add MystenLabs/MemWal`, then `/plugin install memwal@memwal-plugins` |
+| [Codex](/mcp/codex) | ✓ Plugin | `codex plugin marketplace add MystenLabs/MemWal`, then `codex plugin add memwal@memwal-plugins`, then trust the hooks through `/hooks` |
+| [Antigravity](/mcp/antigravity) | ✓ Plugin | `npx degit MystenLabs/MemWal/packages/mcp/plugin ~/.gemini/config/plugins/memwal` |
+| [Cursor](/mcp/cursor) | ✓ Plugin | `npx -y degit MystenLabs/MemWal/packages/mcp/plugin ~/.cursor/plugins/local/memwal` |
+| [Claude Desktop](/mcp/claude-desktop) | ✗ MCP-only | Edit `claude_desktop_config.json`, then [add memory instructions](/mcp/claude-desktop#add-memory-instructions) |
+| [OpenCode](/mcp/opencode) | ✗ MCP-only | Edit the OpenCode MCP config |
+| ChatGPT desktop app | ✓ Plugin | Ships Codex, so follow [Codex](/mcp/codex) |
+| ChatGPT web (Connectors) | ✗ Not supported | n/a |
+
+On the plugin rows, that command is the whole setup. The plugin's hooks carry the memory
+instructions, so you do not need to add routing text to `CLAUDE.md`, `AGENTS.md`, or a
+system prompt yourself.
+
+<Note>
+**"ChatGPT" means two different things here.** The macOS **ChatGPT desktop app** ships
+Codex (`/Applications/ChatGPT.app/Contents/Resources/codex`) and reads the same
+`~/.codex/config.toml`, so the [Codex](/mcp/codex) plugin install works there unchanged.
+
+**ChatGPT web connectors are not supported.** MemWal's remote
+[Streamable HTTP transport](/mcp/reference#transports) needs two custom headers, but the
+Connectors UI exposes only a single bearer field and cannot supply the required
+`x-memwal-account-id` header.
 </Note>
 
 ## Available tools
@@ -62,6 +105,8 @@ The proactive behavior comes from the tool layer, so it works on both installati
 | `memwal_health` | Fast connectivity check (no search or decryption). |
 | `memwal_login` | Connect this client to your account through browser wallet sign-in. |
 | `memwal_logout` | Remove the saved credentials from this machine. |
+
+`memwal_recall` prints `score = 1 - cosine distance` (higher = more similar); the wire and SDK field is `distance`.
 
 See [Reference](/mcp/reference) for full parameters, CLI flags, and transports.
 


### PR DESCRIPTION
Docs-only. Cherry-picks the four documentation files from #848 onto `main` directly.

**This is the narrow alternative to #861** (`staging → main`, the full promotion). Merge one or the other, not both — #861 already contains these same four files. If the team wants the plugin-positioning docs live without shipping this cycle's server/SDK/MCP code, merge this and close #861. Otherwise close this one.

## What changed

The docs presented the plugin and the bare MCP server as interchangeable install options. They are not.

- **Plugin** ships lifecycle hooks that carry the memory instructions, so proactive save and recall works with no further setup from the user. Available on Claude Code, Codex, Antigravity and Cursor.
- **MCP-only** gives the agent the same tools, but proactive behaviour depends on the client and the system prompt. It varies by client and model, and on a client that ships its own memory feature the built-in one commonly wins. Positioned as compatible / tool access.

Three corrections fall out of that:

- **Cursor** was documented as MCP-only. It installs a plugin from a local directory, so its page is rewritten plugin-first.
- **Claude Desktop** has no hook mechanism, so it gets an explicit instruction block to paste.
- **ChatGPT** was being read as one product. The macOS desktop app ships Codex and takes the plugin; ChatGPT web Connectors cannot use it. These are now distinguished.

The setup skill served from the product page is updated to match — it installs the plugin on every client that has one, and verifies the Cursor plugin from logs.

## Scope

| File | |
|---|---|
| `docs/mcp/overview.md` | per-client install table, plugin-vs-MCP-only framing |
| `docs/mcp/cursor.md` | rewritten plugin-first |
| `docs/mcp/claude-desktop.md` | instruction block to paste |
| `apps/app/public/skills/setup` | setup skill matched to the above |

Deliberately excludes the other 10 docs files that differ between `main` and `staging`, because they document code that is not on `main`: `docs/sdk/api-reference.md` covers `sort=recent` and `created_at`, `docs/api/owner-token-auth.md` covers the 32-byte `OWNER_TOKEN_SECRET` rule, and the two changelog pages cover unreleased versions. Those ship with #861.

Verified before opening:

- No reference to anything unreleased on `main` — no `sort=recent`, no `created_at`, no `OWNER_TOKEN_SECRET` length rule, no version numbers.
- All seven internal doc links (`/mcp/antigravity`, `/mcp/claude-code`, `/mcp/claude-desktop`, `/mcp/codex`, `/mcp/cursor`, `/mcp/opencode`, `/mcp/reference`) resolve against `main`.
- No new pages, so `docs/docs.json` needs no nav entry.

## Note for the merger

`apps/app/public/skills/setup` sits under `apps/app/**`, the path filter on `deploy-app-walrus.yml`. Merging triggers a mainnet Walrus Site deploy. Intended — the setup skill is served from the product page — but worth knowing.

Unlike #861, this PR does **not** carry `.changeset/recall-write-time-and-recency-weights.md`, so it cannot trip the `release-sdk.yml` version-drift bug described there.