### PR TITLE
fix(sdk): triage empty 401s as SDK credentials, not memwal_login (WALM-469)

### DIFF
--- a/.changeset/walm-469-empty-401-sdk-auth.md
+++ b/.changeset/walm-469-empty-401-sdk-auth.md
@@ -1,0 +1,5 @@
+---
+"@mysten-incubation/memwal": patch
+---
+
+Empty-body 401s now triage SDK/headless credentials (delegate key, account ID, network) instead of telling every caller to run MCP `memwal_login` (WALM-469).

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -307,12 +307,21 @@ export function sanitizeServerError(
 ): { message: string; raw: string; serverCode?: string } {
     // Number() so a string "401" (some MCP / HTTP paths) still hits this branch.
     if (Number(status) === 401) {
-        // Empty body = no-session / bare relayer 401. Non-empty keeps
-        // the AUTH_REJECTED triage (wrong key / account / network).
+        // Empty body = bare relayer 401 (no JSON). That is not "unsigned MCP
+        // session": headless SDK clients already send a key and still hit it
+        // when the delegate/account/network is wrong (WALM-469 / GH #829).
+        // memwal_login stays in the MCP package (`auth-required.ts`).
         const empty = !String(rawBody ?? "").trim();
         return {
             message: empty
-                ? "Walrus Memory isn't signed in. Call the memwal_login tool, then retry."
+                ? "401 from relayer: the request was not authorized. " +
+                  "If you authenticate with MemWal.create({ key, accountId }) " +
+                  "(or MEMWAL_PRIVATE_KEY), check that the key is a registered " +
+                  "delegate on this account, the account ID is correct, and " +
+                  "serverUrl matches mainnet vs staging. memwal_login is only " +
+                  "the MCP browser sign-in; it cannot authorize a headless SDK " +
+                  "client. Full troubleshooting: " +
+                  "https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors"
                 : "401 from relayer: typically wrong private key, key not registered on this account, " +
                   "account ID mismatch, or staging/mainnet mismatch. Check .env.local and dashboard credentials. " +
                   "Full troubleshooting: https://docs.wal.app/walrus-memory/troubleshooting/overview#401-auth_rejected-errors",

--- a/packages/sdk/test/sanitize-server-error.test.mjs
+++ b/packages/sdk/test/sanitize-server-error.test.mjs
@@ -3,21 +3,26 @@ import test from "node:test";
 
 import { sanitizeServerError } from "../dist/utils.js";
 
-const LOGIN =
-    "Walrus Memory isn't signed in. Call the memwal_login tool, then retry.";
-
-test("empty-body 401 points at memwal_login instead of <no message>", () => {
+test("empty-body 401 triages SDK/headless auth instead of memwal_login", () => {
     const { message, serverCode } = sanitizeServerError(401, "");
     assert.equal(serverCode, "AUTH_REJECTED");
-    assert.equal(message, LOGIN);
     assert.doesNotMatch(message, /<no message>/);
+    assert.doesNotMatch(message, /Call the memwal_login tool, then retry/);
+    assert.match(message, /MemWal\.create\(\{ key, accountId \}\)/);
+    assert.match(message, /MEMWAL_PRIVATE_KEY/);
+    assert.match(message, /registered delegate/);
+    assert.match(message, /memwal_login is only the MCP browser sign-in/);
+    assert.match(
+        message,
+        /docs\.wal\.app\/walrus-memory\/troubleshooting\/overview/,
+    );
 });
 
-test("string status \"401\" with an empty body uses the login hint", () => {
+test("string status \"401\" with an empty body uses the same SDK triage", () => {
     const { message, serverCode } = sanitizeServerError("401", "   ");
     assert.equal(serverCode, "AUTH_REJECTED");
-    assert.equal(message, LOGIN);
-    assert.doesNotMatch(message, /<no message>/);
+    assert.doesNotMatch(message, /Call the memwal_login tool, then retry/);
+    assert.match(message, /MemWal\.create\(\{ key, accountId \}\)/);
 });
 
 test("non-empty 401 keeps the AUTH_REJECTED troubleshooting URL", () => {


### PR DESCRIPTION
## Ticket

WALM-469 — https://linear.app/mysten-labs/issue/WALM-469/clarify-authentication-for-headless-sdk-usage
GH #829

## What changed?

- Empty-body HTTP 401s from `sanitizeServerError` no longer tell the caller to run `memwal_login`.
- The message now triages `MemWal.create({ key, accountId })` / `MEMWAL_PRIVATE_KEY`: registered delegate, account ID, and mainnet vs staging `serverUrl`.
- It states that `memwal_login` is only the MCP browser sign-in and cannot authorize a headless SDK client.

## Why is this needed?

SDK 0.1.4 mapped every empty-body 401 to "Call the memwal_login tool". Headless backends already send a private key; that copy sent them to an MCP flow they do not have. A 401 here is almost always a wrong or unregistered delegate, account ID, or network.

## Scope

TypeScript SDK `sanitizeServerError` (empty-body 401 branch) and its unit tests. Patch changeset for `@mysten-incubation/memwal`.

### Out of scope

- MCP signed-out copy in `auth-required.ts` (`memwal_login` stays there)
- Relayer 401 status or body
- Python SDK

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `pnpm --filter @mysten-incubation/memwal test` (97 passed).

## How can the reviewer verify it?

1. `sanitizeServerError(401, "")` does not contain `Call the memwal_login tool, then retry`.
2. It mentions `MemWal.create({ key, accountId })`, `MEMWAL_PRIVATE_KEY`, registered delegate, and the AUTH_REJECTED troubleshooting URL.
3. Non-empty 401 still uses the existing AUTH_REJECTED copy and still does not mention `memwal_login`.
4. Control: 0.1.4 printed `Walrus Memory isn't signed in. Call the memwal_login tool, then retry.` for the same empty body.

## Risks and dependencies

MCP agents that are already signed in and then hit an empty-body 401 through the SDK now see the credential triage instead of `memwal_login`. First-time MCP (no `~/.memwal/credentials.json`) still uses the auth-required server, which still advertises `memwal_login`.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.

Fixes #829