### PR TITLE
fix(noter): require a server-issued single-use challenge for connectWallet (WALM-414)

### DIFF
--- a/apps/noter/doc/zklogin-integration.md
+++ b/apps/noter/doc/zklogin-integration.md
@@ -6,8 +6,10 @@ auth tRPC router (`package/feature/auth/api/route.ts`) and consumed by the `useA
 1. **Enoki zkLogin** (`connectEnoki`) — the primary sign-in. The Enoki flow runs client-side
    (`app/components/enoki-login-card.tsx` / `sui-providers.tsx`); on completion the app registers or
    looks up the user by Sui address and creates a session. This is the login the UI drives.
-2. **Sui wallet** (`connectWallet`) — sign-in with a Sui wallet (e.g. Slush). The server verifies the
-   personal-message signature before creating a session.
+2. **Sui wallet** (`connectWallet`) — sign-in with a Sui wallet (e.g. Slush). Two-step, like the Enoki
+   flow: the client calls `issueWalletChallenge` for a server-issued single-use message, signs it with
+   the wallet, and returns `{ challengeId, signature }`. The server verifies the signature against the
+   challenge and consumes it before creating a session, so a captured signature cannot be replayed.
 3. **Delegate key** (`connectDelegateKey`) — manual login with a delegate private key + account id.
 
 Sessions are stored in the `wallet_sessions` table (Enoki reuses it with `walletType = "enoki"`).

--- a/apps/noter/package/feature/auth/api/connect-wallet-replay.unit.test.ts
+++ b/apps/noter/package/feature/auth/api/connect-wallet-replay.unit.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Replay-protection tests for the Sui-wallet sign-in path. These exercise the
+// REAL authRouter procedures via createCaller, asserting the route:
+//   - accepts only a server-issued challenge, so the caller can no longer pick
+//     the message it signs;
+//   - consumes that challenge, so replaying the same {challengeId, signature}
+//     is UNAUTHORIZED and mints exactly one 24-hour wallet_sessions row;
+//   - fails closed (SERVICE_UNAVAILABLE) when the challenge store is down.
+// The service + challenge layers are mocked so no DB/Redis/crypto is needed; the
+// single-use semantics of the store itself are covered by
+// ../lib/enoki-challenge.unit.test.ts.
+
+vi.mock("server-only", () => ({}));
+
+const ADDR = `0x${"a".repeat(64)}`;
+const CHALLENGE_ID = "challenge-1";
+const SIGNATURE = "wallet-signature";
+
+// Service mock: the wallet upsert resolves to a stub user.
+const upsertWalletUser = vi.fn(async () => ({ id: "user-1", suiAddress: ADDR }));
+
+vi.mock("../domain/service", () => ({
+  upsertWalletUser,
+  toSafeUser: (u: unknown) => u,
+  DelegateCredentialConflictError: class extends Error {},
+}));
+
+// Challenge mock mirroring the real GETDEL contract: a challenge verifies at
+// most once, for the purpose and address it was issued under.
+const issuedChallenges = new Set<string>();
+const verifyAndConsumeEnokiChallenge = vi.fn(
+  async ({
+    challengeId,
+    purpose,
+  }: {
+    rawAddress: string;
+    challengeId: string;
+    signature: string;
+    purpose: string;
+  }) => {
+    if (purpose !== "signin") return false;
+    if (!issuedChallenges.has(challengeId)) return false;
+    issuedChallenges.delete(challengeId); // atomic consume
+    return true;
+  }
+);
+const issueEnokiChallenge = vi.fn(async () => ({
+  challengeId: CHALLENGE_ID,
+  message: "Sign in to Walrus Memory Noter",
+}));
+
+vi.mock("../lib/enoki-challenge", () => ({
+  issueEnokiChallenge,
+  verifyAndConsumeEnokiChallenge,
+}));
+
+const SharedRedisUnavailableError = class extends Error {};
+vi.mock("@/shared/lib/shared-redis", () => ({ SharedRedisUnavailableError }));
+
+// Session inserts go through ctx.db.insert(...).values(...); capture each row so
+// the number of sessions created — and what was written — can be asserted.
+type SessionRow = { walletAddress: string; signedMessage: string };
+const insertedRows: SessionRow[] = [];
+const insertValues = vi.fn(async (row: SessionRow) => {
+  insertedRows.push(row);
+});
+const db = { insert: vi.fn(() => ({ values: insertValues })) };
+
+async function caller() {
+  const { authRouter } = await import("./route");
+  // Minimal ctx matching the tRPC Context shape used by these procedures.
+  const ctx = {
+    db,
+    request: new Request("http://localhost/api/trpc/auth"),
+    userId: null,
+  };
+  return authRouter.createCaller(ctx as never);
+}
+
+const connectInput = {
+  walletType: "slush" as const,
+  address: ADDR,
+  challengeId: CHALLENGE_ID,
+  signature: SIGNATURE,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertedRows.length = 0;
+  issuedChallenges.clear();
+  issuedChallenges.add(CHALLENGE_ID);
+});
+
+describe("connectWallet — challenge replay protection", () => {
+  it("rejects a replayed {challengeId, signature} and creates only one session", async () => {
+    const c = await caller();
+
+    const first = await c.connectWallet(connectInput);
+    expect(first.sessionId).toBeTruthy();
+    expect(insertValues).toHaveBeenCalledTimes(1);
+
+    // Same triple again: the challenge is spent, so this must not mint a
+    // second 24-hour session.
+    await expect(c.connectWallet(connectInput)).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(insertValues).toHaveBeenCalledTimes(1);
+  });
+
+  it("verifies the challenge under the signin purpose and the normalized address", async () => {
+    const c = await caller();
+    await c.connectWallet(connectInput);
+
+    expect(verifyAndConsumeEnokiChallenge).toHaveBeenCalledWith({
+      rawAddress: ADDR,
+      challengeId: CHALLENGE_ID,
+      signature: SIGNATURE,
+      purpose: "signin",
+    });
+  });
+
+  it("rejects an unknown challengeId with UNAUTHORIZED and creates no session", async () => {
+    const c = await caller();
+    await expect(
+      c.connectWallet({ ...connectInput, challengeId: "never-issued" })
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(upsertWalletUser).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with SERVICE_UNAVAILABLE when the challenge store is down", async () => {
+    verifyAndConsumeEnokiChallenge.mockRejectedValueOnce(
+      new SharedRedisUnavailableError()
+    );
+    const c = await caller();
+    await expect(c.connectWallet(connectInput)).rejects.toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("does not persist a caller-chosen message as the signed credential", async () => {
+    const c = await caller();
+    await c.connectWallet(connectInput);
+
+    // The consumed challenge id, never a caller-supplied string.
+    expect(insertedRows[0].signedMessage).toBe(
+      `wallet-challenge:${CHALLENGE_ID}`
+    );
+    expect(insertedRows[0].walletAddress).toBe(ADDR);
+  });
+});
+
+describe("connectWallet — input contract", () => {
+  it("rejects the legacy {message, signature} shape that carries no challengeId", async () => {
+    const c = await caller();
+    await expect(
+      c.connectWallet({
+        walletType: "slush",
+        address: ADDR,
+        signature: SIGNATURE,
+        message: "Sign this message to authenticate with Noter",
+      } as never)
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(verifyAndConsumeEnokiChallenge).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed address before doing any challenge work", async () => {
+    const c = await caller();
+    await expect(
+      c.connectWallet({ ...connectInput, address: "0xdeadbeef" })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(verifyAndConsumeEnokiChallenge).not.toHaveBeenCalled();
+  });
+});
+
+describe("issueWalletChallenge", () => {
+  it("issues a signin-purpose challenge for the requested address", async () => {
+    const c = await caller();
+    const result = await c.issueWalletChallenge({ address: ADDR });
+
+    expect(result).toEqual({
+      challengeId: CHALLENGE_ID,
+      message: "Sign in to Walrus Memory Noter",
+    });
+    expect(issueEnokiChallenge).toHaveBeenCalledWith(ADDR, "signin");
+  });
+
+  it("fails closed with SERVICE_UNAVAILABLE when the challenge store is down", async () => {
+    issueEnokiChallenge.mockRejectedValueOnce(
+      new SharedRedisUnavailableError()
+    );
+    const c = await caller();
+    await expect(
+      c.issueWalletChallenge({ address: ADDR })
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+  });
+});

--- a/apps/noter/package/feature/auth/api/input.ts
+++ b/apps/noter/package/feature/auth/api/input.ts
@@ -14,19 +14,36 @@ import { walletSessionInsertSchema } from "@/shared/db/type";
 // x-session-id header via the tRPC context, so it can never be supplied as input.
 
 // ═══════════════════════════════════════════════════════════════
+// Shared Field Schemas
+// ═══════════════════════════════════════════════════════════════
+
+// Canonical Sui address: 0x + 64 hex. Reject malformed input at the boundary so
+// it never reaches normalizeSuiAddress (which would silently left-pad garbage
+// into a valid-looking-but-wrong address) or a DB lookup.
+export const suiAddressSchema = z
+  .string()
+  .regex(/^0x[0-9a-f]{64}$/i, "Invalid Sui address");
+
+// ═══════════════════════════════════════════════════════════════
 // Wallet Auth Inputs
 // ═══════════════════════════════════════════════════════════════
 
 /**
  * Input for wallet authentication
  * Derives field types from walletSessionInsertSchema
- * Uses client-friendly names (address/message instead of walletAddress/signedMessage)
+ * Uses client-friendly names (address instead of walletAddress)
+ *
+ * The caller does NOT supply the message that was signed: it proves ownership of
+ * `address` by signing a server-issued single-use challenge (issueWalletChallenge)
+ * and returning that challenge's id. Accepting a caller-chosen message would let
+ * anyone replay one captured {message, signature, address} triple into an
+ * unlimited number of 24-hour sessions.
  */
 export const connectWalletInput = z.object({
   walletType: walletSessionInsertSchema.shape.walletType.pipe(z.enum(["slush"])), // Subset validation
-  address: walletSessionInsertSchema.shape.walletAddress, // Maps to walletAddress in DB
-  signature: walletSessionInsertSchema.shape.signature,
-  message: walletSessionInsertSchema.shape.signedMessage, // Maps to signedMessage in DB
+  address: suiAddressSchema, // Maps to walletAddress in DB
+  challengeId: z.string().min(1),
+  signature: z.string().min(1),
 });
 
 export type ConnectWalletInput = z.infer<typeof connectWalletInput>;

--- a/apps/noter/package/feature/auth/api/route.ts
+++ b/apps/noter/package/feature/auth/api/route.ts
@@ -6,10 +6,9 @@
 import { router, procedure, protectedProcedure } from "@/shared/lib/trpc/init";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { verifyPersonalMessageSignature } from "@mysten/sui/verify";
 import { normalizeSuiAddress } from "@mysten/sui/utils";
 import { uuidv7 } from "uuidv7";
-import { connectWalletInput } from "./input";
+import { connectWalletInput, suiAddressSchema } from "./input";
 import { AUTH_ERRORS } from "../constant";
 import { walletSessions } from "@/shared/db/schema";
 import * as authService from "../domain/service";
@@ -28,13 +27,6 @@ import {
   AuthRateLimitError,
   checkPublicAuthRateLimit,
 } from "../lib/auth-rate-limit";
-
-// Canonical Sui address: 0x + 64 hex. Reject malformed input at the boundary so
-// it never reaches normalizeSuiAddress (which would silently left-pad garbage
-// into a valid-looking-but-wrong address) or a DB lookup.
-const suiAddressSchema = z
-  .string()
-  .regex(/^0x[0-9a-f]{64}$/i, "Invalid Sui address");
 
 export const authRouter = router({
   /**
@@ -63,25 +55,75 @@ export const authRouter = router({
   }),
 
   /**
+   * Issue a single-use SIGN-IN challenge for the Sui-wallet flow. The client
+   * signs the returned `message` with its wallet and returns
+   * `{ challengeId, signature }` to connectWallet. Shares the challenge store
+   * with the Enoki flow and is likewise scoped to sign-in only — it cannot be
+   * used to authorize a delegate-key export.
+   */
+  issueWalletChallenge: procedure
+    .input(z.object({ address: suiAddressSchema }))
+    .mutation(async ({ input }) => {
+      try {
+        const { challengeId, message } = await issueEnokiChallengeToken(
+          input.address,
+          "signin"
+        );
+        return { challengeId, message };
+      } catch (error) {
+        if (error instanceof SharedRedisUnavailableError) {
+          throw new TRPCError({
+            code: "SERVICE_UNAVAILABLE",
+            message: "Authentication service temporarily unavailable",
+          });
+        }
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: error instanceof Error ? error.message : AUTH_ERRORS.NETWORK_ERROR,
+        });
+      }
+    }),
+
+  /**
    * Connect wallet - authenticate with Sui wallet (Slush, Sui Wallet)
-   * Verifies signature and creates session
+   * Every call must prove address ownership with a server-issued single-use
+   * challenge (issueWalletChallenge). The caller never chooses the signed
+   * message, and the challenge is consumed atomically, so a captured
+   * {challengeId, signature} pair cannot be replayed into a second session.
    */
   connectWallet: procedure
     .input(connectWalletInput)
     .mutation(async ({ ctx, input }) => {
-      const { walletType, address, signature, message } = input;
+      const { walletType, challengeId, signature } = input;
+      // Normalize once so the challenge check and every DB op key on the same
+      // canonical address (a non-canonical variant would otherwise verify but
+      // miss the stored row).
+      const address = normalizeSuiAddress(input.address);
 
       try {
-        // Verify the wallet signature before creating a session
-        const signerAddress = await verifyPersonalMessageSignature(
-          new TextEncoder().encode(message),
-          signature,
-        ).catch(() => {
-          throw new TRPCError({ code: "UNAUTHORIZED", message: "Invalid signature" });
-        });
-
-        if (signerAddress.toSuiAddress() !== address) {
-          throw new TRPCError({ code: "UNAUTHORIZED", message: "Signature does not match address" });
+        // Ownership gate — must pass BEFORE the user upsert or session insert.
+        let ownershipVerified: boolean;
+        try {
+          ownershipVerified = await verifyAndConsumeEnokiChallenge({
+            rawAddress: address,
+            challengeId,
+            signature,
+            purpose: "signin",
+          });
+        } catch (error) {
+          if (error instanceof SharedRedisUnavailableError) {
+            throw new TRPCError({
+              code: "SERVICE_UNAVAILABLE",
+              message: "Authentication service temporarily unavailable",
+            });
+          }
+          throw error;
+        }
+        if (!ownershipVerified) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Wallet ownership verification failed",
+          });
         }
 
         // Create or update user via service
@@ -100,7 +142,9 @@ export const authRouter = router({
           userId: user.id,
           walletAddress: address,
           walletType,
-          signedMessage: message,
+          // The consumed challenge is the credential of record. Record its id
+          // for audit rather than a message a caller could choose and replay.
+          signedMessage: `wallet-challenge:${challengeId}`,
           signature,
           signedAt: new Date(),
           expiresAt,

--- a/apps/noter/package/feature/auth/lib/wallet-client.ts
+++ b/apps/noter/package/feature/auth/lib/wallet-client.ts
@@ -179,18 +179,3 @@ export async function disconnectWallet(type: WalletType): Promise<void> {
     console.error(`[Wallet Disconnect] Error:`, error);
   }
 }
-
-/**
- * Generate authentication message
- */
-export function generateAuthMessage(): string {
-  const timestamp = Date.now();
-  const nonce = Math.random().toString(36).substring(7);
-
-  return `Sign this message to authenticate with Noter
-
-Timestamp: ${timestamp}
-Nonce: ${nonce}
-
-This will not trigger any blockchain transaction or cost any gas fees.`;
-}


### PR DESCRIPTION
## Problem

`auth.connectWallet` verified a wallet signature over a message the **caller** supplied, and consumed nothing:

```ts
const { walletType, address, signature, message } = input;
const signerAddress = await verifyPersonalMessageSignature(
  new TextEncoder().encode(message),
  signature,
);
if (signerAddress.toSuiAddress() !== address) { /* 401 */ }
```

That proves only that the address holder signed *some* string at *some* point — no freshness, no server intent, no single-use property. The same `{message, signature, address}` triple verified an unbounded number of times, and every replay inserted a new `wallet_sessions` row with a fresh 24-hour expiry. `connectWallet` is a bare (unauthenticated) `procedure` on the publicly mounted auth router, so this was remotely reachable. Both the signature and the exact signed message were persisted in plaintext, so one DB read, log line, or network capture yielded a permanently reusable credential.

## Fix

`connectWallet` now uses the same ownership gate `connectEnoki` and `exportDelegateKey` already use:

- **`issueWalletChallenge`** issues a server-built, single-use `"signin"` challenge through the existing `enoki-challenge` module (Redis `SET NX EX` at issue, atomic `GETDEL` at verify).
- **`connectWallet`** calls `verifyAndConsumeEnokiChallenge` *before* any user upsert or session insert; a failed verify maps to `UNAUTHORIZED`, an unreachable challenge store to `SERVICE_UNAVAILABLE` (fail-closed, matching `connectEnoki`).
- **`connectWalletInput`** drops `message` and requires `challengeId`. Leaving the caller-chosen message accepted would have kept the vulnerable path alive. The address is tightened from a bare string to the canonical `0x` + 64-hex schema, promoted to a shared `suiAddressSchema` export, and normalized once so the challenge check and every DB op key on the same value.
- **`wallet_sessions.signedMessage`** records the consumed challenge id instead of a caller-supplied string.
- Removes the uncalled `generateAuthMessage()` (`Date.now() + Math.random()`) from `wallet-client.ts`.

Because the consume is an atomic `GETDEL` that runs *before* signature verification, there is no TOCTOU window: of any set of parallel replays, at most one caller can obtain the challenge. The address is bound three independent ways (`issued.address` equality, the `{ address }` option inside `verifyPersonalMessageSignature`, and `publicKey.toSuiAddress()` equality). Reusing the `"signin"` purpose preserves the existing guarantee that a sign-in signature can never authorize a delegate-key export.

## Testing

`apps/noter/package/feature/auth/api/connect-wallet-replay.unit.test.ts` drives the **real** router via `createCaller`, with the challenge layer mocked by a stub that reproduces the `GETDEL` single-use contract. It pins the reported symptom (a replayed call is `UNAUTHORIZED` and exactly one session row is written) plus the unknown-challenge, fail-closed, legacy-input, and malformed-address paths. The real store's single-use semantics remain covered by `lib/enoki-challenge.unit.test.ts`.

All three `noter-checks` gates pass:

```
Test Files  10 passed (10)
     Tests  54 passed (54)
tsc --noEmit  → exit 0, no output
next build    → Compiled successfully
```

Non-vacuity was verified by mutation: deleting the `if (!ownershipVerified) throw` gate fails exactly two tests (the replay assertion and the unknown-challenge assertion), then the suite returns green once restored.

## Reviewer notes

- **Breaking wire change.** Dropping `message` and requiring `challengeId` changes the contract of a public unauthenticated tRPC endpoint. `auth.connectWallet` has no caller anywhere in the repo and `generateAuthMessage` was never imported, so nothing in this monorepo breaks — an external consumer of the old shape would now get a 400.
- **Redis is now a fail-closed dependency for wallet sign-in.** A deployment without `REDIS_URL` returns `SERVICE_UNAVAILABLE`. This already applies to `connectEnoki`, so it is consistent rather than new.
- **Shared verifier and plain wallets.** `verifyAndConsumeEnokiChallenge` passes `{ address, client }` to `verifyPersonalMessageSignature`, which was written for zkLogin. That is safe for an ed25519 wallet signature: in `@mysten/sui` the `client` option is read only by `ZkLoginPublicIdentifier.fromBytes`, so the `ED25519` branch (`new Ed25519PublicKey(bytes)`) ignores it, while `address` is applied generically and supplies exactly the binding this path needs.
- **Follow-up worth filing:** `lib/wallet-verify.ts` still exports a dead `verifyWalletSignature(message, signature, address)` that accepts `address` and never uses it, returning `true` for any valid signature by any key. It has zero callers today, but it is the same vulnerability class and should be deleted.

---
Linear: WALM-414
