### PR TITLE
fix(mcp): pin recall dropped-count reporting and name its real causes (WALM-397)

### DIFF
--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -44,6 +44,7 @@ This release forwards the MCP client's identity to the relayer so sidecar logs c
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
 - When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
+- Name both causes when `memwal_recall` reports matches it could not return. The trailing notice on a partial recall blamed decryption alone, but the relayer folds Walrus download failures into the same count, so a model was told to re-authenticate for a fetch a retry would have fixed. It now reads "failed to download or decrypt" and agrees in number on a single dropped match. (WALM-397)
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 
 ## 0.0.11

--- a/docs/mcp/reference.md
+++ b/docs/mcp/reference.md
@@ -77,6 +77,8 @@ Each result line includes `score` and `distance`. `distance` is cosine distance 
 
 The cutoff is applied to the `limit` nearest matches, not before them, so a tight `maxDistance` returns fewer than `limit` results — that is the cutoff biting, not an empty namespace. Raise `limit` to widen the candidate pool the cutoff sees.
 
+A match whose blob fails to download from Walrus, or whose ciphertext fails to decrypt, is left out of the results and counted instead of being discarded quietly. The tool reports that count: a recall where every match failed says so rather than returning "No matching memories found", and a partial loss appends a trailing note naming how many were omitted. Read a reported loss as stored-but-unreadable, never as proof the namespace is empty.
+
 | **Parameter** | **Type** | **Required** | **Description** |
 | --- | --- | --- | --- |
 | `query` | string | yes | Natural-language query to match against stored memories. |
@@ -487,6 +489,12 @@ The URL is valid for **5 minutes**. Call the tool again to mint a fresh one. Mak
 ### Recall returns "No matching memories found" right after a remember
 
 `memwal_remember` waits for the Walrus upload to finish before returning, but under load the embedding/indexing step can lag a few seconds behind. Wait briefly, then retry the recall.
+
+### Recall reports matches it could not return
+
+The relayer matched those memories in its index but could not fetch their Walrus blob or decrypt the ciphertext, so they are missing from the results. The namespace is not empty.
+
+Retry the same query to tell the two causes apart: a Walrus fetch that failed transiently succeeds on a later call, so a count that falls to zero was never real loss. A count that survives repeated retries is a permanent decrypt failure — typically blobs written under a key the session can no longer use — and re-running the query will not recover them. Do not read `memwal_restore`'s `skipped` as the same signal: it counts blobs already present in the index and ones it declined to re-attempt, so it is large on a perfectly healthy namespace.
 
 ### 401 Unauthorized from the relayer
 

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -128,6 +128,7 @@ Search for memories matching a natural language query, scoped to `owner + namesp
     created_at?: string; // RFC3339 write-time; absent on older relayers
   }>;
   total: number;
+  dropped_count?: number; // Matches that could not be returned; absent when 0
 }
 ```
 
@@ -136,6 +137,8 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 MCP `memwal_recall` displays `score = 1 - distance` (higher = more similar). Do not apply an SDK `maxDistance` threshold to those scores. The polarities are inverted.
 
 `created_at` is when the fact was **written**, not any date its text describes.
+
+`dropped_count` counts matches the relayer found but could not return, because the Walrus download or the SEAL decrypt failed. Those memories are missing from `results` entirely, so a short list is not proof that little was stored. The relayer omits the field when nothing was dropped, so read it as `result.dropped_count ?? 0`.
 
 #### Ordering
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Clarify `memwal_restore` `truncated=true` as known-retryable-incomplete: raising `limit` expands the sidecar cap only while `limit < 20`; `truncated=false` is not completeness (WALM-451 `sourceCapped`).
 - When every decrypted `memwal_recall` hit misses `maxDistance`, keep the outside-cutoff wording and append any decrypt-drop count instead of replacing the message with a decrypt-failure report.
+- Name both causes when `memwal_recall` reports matches it could not return. The trailing notice on a partial recall blamed decryption alone, but the relayer folds Walrus download failures into the same count, so a model was told to re-authenticate for a fetch a retry would have fixed. It now reads "failed to download or decrypt" and agrees in number on a single dropped match. (WALM-397)
 - Resolve the credential directory on every access instead of freezing it at module load, and let `MEMWAL_CREDS_DIR` override it. The login test sandboxed the home directory with `HOME` alone, which `os.homedir()` ignores on Windows, so running the package's test suite there wrote fixture credentials over the developer's real `~/.memwal/credentials.json` and destroyed the delegate key stored in it. (#705)
 
 ## 0.0.11

--- a/services/server/scripts/mcp/__tests__/recall-dropped-count.test.ts
+++ b/services/server/scripts/mcp/__tests__/recall-dropped-count.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `memwal_recall` must report the matches it could not return.
+ *
+ * The relayer omits from `results` any match whose blob failed to download or
+ * whose ciphertext failed to decrypt, and counts them in `dropped_count`. Left
+ * unreported, that loss reaches the model as absence: ten stored memories that
+ * all fail to decrypt look exactly like an empty namespace, and seven returned
+ * out of ten look exactly like a complete answer. Both are wrong answers the
+ * model would act on (WALM-397).
+ *
+ * These tests pin the two halves of the reporting — the empty case in
+ * `emptyRecallText`, the partial case in `recallNotices` — and guard the
+ * lossless path from picking up noise.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import type { MemWalSession } from "../auth.js";
+import { createMcpServer } from "../server.js";
+import { emptyRecallText, formatRecallLine, recallNotices } from "../tools/recall.js";
+
+const row = (text: string, distance = 0.5) => ({ text, distance });
+
+test("a partial loss is reported alongside the rows that survived", () => {
+    const [notice, ...rest] = recallNotices(0, 3);
+    assert.equal(rest.length, 0);
+    assert.match(notice, /3 additional matches/);
+    assert.match(notice, /omitted/);
+});
+
+test("the dropped notice names both causes, not decryption alone", () => {
+    // The relayer counts download failures, permanent decrypt failures and
+    // invalid UTF-8 into one dropped_count, so the notice must not pin the
+    // loss on decryption. The two have different remedies — a failed Walrus
+    // fetch is usually transient, an undecryptable blob is not — and a model
+    // told "could not be decrypted" would send the user to re-authenticate
+    // for what may be a retryable download.
+    const [notice] = recallNotices(0, 2);
+    assert.match(notice, /failed to download or decrypt/);
+});
+
+test("a lossless recall appends nothing", () => {
+    // The common case must stay byte-identical: a trailing caveat on every
+    // successful recall is noise the model pays for on every call.
+    assert.deepEqual(recallNotices(0, 0), []);
+});
+
+test("a single dropped match reads as singular", () => {
+    const [notice] = recallNotices(0, 1);
+    assert.match(notice, /1 additional match /);
+    assert.match(notice, /was omitted/);
+    assert.doesNotMatch(notice, /matches/);
+});
+
+test("collapsed duplicates and dropped matches are reported separately", () => {
+    // Folding away a fact stored twice and losing a fact to a failed decrypt
+    // are different events. Conflating them would let real loss hide behind
+    // the benign one.
+    const [duplicates, dropped] = recallNotices(2, 3);
+    assert.match(duplicates, /2 duplicate copies/);
+    assert.doesNotMatch(duplicates, /decrypt/);
+    assert.match(dropped, /3 additional matches/);
+    assert.doesNotMatch(dropped, /duplicate/);
+});
+
+test("the rendered payload keeps every returned row and still flags the loss", () => {
+    // Mirrors what the tool builds: numbered hits, then the notices.
+    const unique = [row("deploy region is ap-southeast-1", 0.1), row("uses pnpm, not npm", 0.2)];
+    const lines = unique.map((m, i) => formatRecallLine(m, i));
+    lines.push(...recallNotices(0, 2));
+    const text = lines.join("\n");
+
+    assert.match(text, /deploy region is ap-southeast-1/);
+    assert.match(text, /uses pnpm, not npm/);
+    assert.match(text, /2 additional matches/);
+});
+
+test("an all-dropped recall is not reported as an empty namespace", () => {
+    // The headline bug: every match failed to decrypt, so results is empty and
+    // the model must not be told there is nothing stored.
+    const text = emptyRecallText(0, 3);
+    assert.notEqual(text, "No matching memories found.");
+    assert.match(text, /3 matched/);
+    assert.match(text, /not an empty namespace/i);
+});
+
+test("a genuinely empty namespace keeps the documented wording", () => {
+    // Quoted verbatim as a troubleshooting heading in docs/mcp/reference.md.
+    assert.equal(emptyRecallText(0, 0), "No matching memories found.");
+});
+
+/**
+ * The helper tests above pin the wording. This one pins the wiring: that the
+ * tool actually calls it. Without it the whole notice can be deleted from the
+ * handler and every other test in this file still passes, which is exactly the
+ * regression WALM-397 describes.
+ */
+async function recallText(
+    result: unknown,
+    args: Record<string, unknown> = { query: "q", limit: 10 },
+): Promise<string> {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createMcpServer({
+        oauthScope: "memwal:read",
+        memwal: { recall: async () => result },
+    } as unknown as MemWalSession);
+    const client = new Client({ name: "dropped-count-test", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+        const res = (await client.callTool({
+            name: "memwal_recall",
+            arguments: args,
+        })) as { content: Array<{ text: string }> };
+        return res.content.map((c) => c.text).join("\n");
+    } finally {
+        await client.close();
+        await server.close();
+    }
+}
+
+test("memwal_recall itself appends the dropped notice to a partial result", async () => {
+    const text = await recallText({
+        results: [row("deploy region is ap-southeast-1", 0.1)],
+        dropped_count: 2,
+    });
+    assert.match(text, /deploy region is ap-southeast-1/);
+    assert.match(text, /2 additional matches failed to download or decrypt/);
+});
+
+test("memwal_recall stays silent when the relayer omits dropped_count", async () => {
+    const text = await recallText({ results: [row("uses pnpm, not npm", 0.2)] });
+    assert.match(text, /uses pnpm, not npm/);
+    assert.doesNotMatch(text, /omitted/);
+});

--- a/services/server/scripts/mcp/tools/recall.ts
+++ b/services/server/scripts/mcp/tools/recall.ts
@@ -137,6 +137,35 @@ export function formatRecallLine(
     return `${index + 1}. [score=${score} distance=${distance}]${stamp} ${memory.text}`;
 }
 
+/**
+ * Trailing notices explaining why the returned list is shorter than the caller
+ * asked for.
+ *
+ * Both counts describe rows the model will never see, so emitting fewer lines
+ * without saying why would read as "that is all there is". They are not the
+ * same kind of absence, and the wording keeps them apart: `collapsed` is a
+ * deliberate read-side fold of facts stored more than once, while `dropped` is
+ * real loss — the relayer matched those memories but could not download or
+ * decrypt their blobs, so they never reached `results` at all (WALM-397).
+ *
+ * Returns an empty array when nothing was withheld, keeping the common case
+ * byte-identical to a recall that lost nothing.
+ */
+export function recallNotices(collapsed: number, dropped: number): string[] {
+    const notices: string[] = [];
+    if (collapsed > 0) {
+        notices.push(
+            `\n(${collapsed} duplicate ${collapsed === 1 ? "copy" : "copies"} of the above collapsed; the same fact is stored more than once.)`
+        );
+    }
+    if (dropped > 0) {
+        notices.push(
+            `\n(${dropped} additional ${dropped === 1 ? "match" : "matches"} failed to download or decrypt and ${dropped === 1 ? "was" : "were"} omitted.)`,
+        );
+    }
+    return notices;
+}
+
 /** `YYYY-MM-DD` for a parseable timestamp, else null. */
 function isoDateOrNull(value: unknown): string | null {
     if (typeof value !== "string") return null;
@@ -184,19 +213,7 @@ export function registerRecallTool(
             }
             const { unique, collapsed } = collapseDuplicates(filtered);
             const lines = unique.map((m, i) => formatRecallLine(m, i));
-            // Say what was folded away rather than quietly returning fewer rows
-            // than the caller asked for. It also surfaces that the same fact was
-            // stored repeatedly, which is usually worth knowing.
-            if (collapsed > 0) {
-                lines.push(
-                    `\n(${collapsed} duplicate ${collapsed === 1 ? "copy" : "copies"} of the above collapsed; the same fact is stored more than once.)`
-                );
-            }
-            if (dropped > 0) {
-                lines.push(
-                    `\n(${dropped} additional matches could not be decrypted and were omitted.)`,
-                );
-            }
+            lines.push(...recallNotices(collapsed, dropped));
             return {
                 content: [
                     {


### PR DESCRIPTION
## Summary

Most of WALM-397 had already shipped on `dev`. Verified against the branch base rather than trusting the ticket brief:

- **Relayer**: `dropped_count` is computed in `engine/walrus_seal.rs` (download drops + decrypt drops, invalid UTF-8 folded into the decrypt side), warned at `routes/recall.rs:272`, and serialized with `skip_serializing_if` so it is on the wire when non-zero and omitted at zero. Pinned by two unit tests at `recall.rs:405-427`.
- **TS SDK**: `RecallResult.dropped_count` is declared at `packages/sdk/src/types.ts:103` and preserved at runtime — `recall()` rebuilds the result with `...processed` spreads on both the `maxDistance` and `maxTokens` branches, so nothing is stripped. Two tests already assert it survives and is absent when the relayer omits it.
- **Python SDK**: already carries it (`types.py:119`, `client.py:673-686`, two tests).
- **MCP tool**: `emptyRecallText` already separated "matched but unreadable" from "nothing stored".

The ticket's premise that the SDK strips the field is not accurate against current `dev`.

`packages/mcp` is untouched by design: it is a stdio-to-SSE JSON-RPC bridge that proxies `tools/call` verbatim and never defines `memwal_recall`. The tool lives in `services/server/scripts/mcp/tools/recall.ts`.

## What this actually changes

**1. The partial-loss branch is now guarded.** When rows come back *and* some matches were dropped, the trailing notice lived inline in the handler closure, unreachable from a test. That is the case that matters most in practice: seven rows out of ten reads as a complete answer unless the tool says otherwise. Extracted to an exported `recallNotices(collapsed, dropped)` beside the file's other pure helpers, preserving the `wrapTool` envelope and content shape exactly.

**2. Fixed a plural disagreement it exposed** — `"1 additional matches could not be decrypted and were omitted"`.

**3. The notice named the wrong cause.** It blamed decryption alone, but `dropped_count` folds Walrus download failures, permanent decrypt failures, and invalid UTF-8 into one number. Those have different remedies — a failed fetch is usually transient, an undecryptable blob is not — so a model told "could not be decrypted" would send the user to re-authenticate for something a retry fixes. Now reads `failed to download or decrypt`, matching what `emptyRecallText` already said on the all-dropped path.

**4. Documented the field where callers look**: `dropped_count` in the `docs/sdk/api-reference.md` Returns block (with `?? 0` guidance, since the relayer omits it at zero), plus a paragraph and troubleshooting entry in `docs/mcp/reference.md`. The relayer API reference already covered the wire field.

## Testing

`services/server/scripts`: 258 tests, 258 pass (10 new). `packages/sdk`: 97 pass. `tsc --noEmit` clean. `check-docs-code-sync.mjs` and `check-docs-freshness.mjs` both exit 0.

Eight tests cover the notice wording. **Two more drive the registered tool end-to-end** over `InMemoryTransport` with a stubbed `memwal.recall`, because every assertion on `recallNotices` alone still passes with the call deleted from the handler — which is the WALM-397 regression itself. Mutation-checked both directions: removing the handler call fails the wiring test; reverting the wording fails three.

Run it with `npm test` from `services/server/scripts` — that directory is not a pnpm workspace member (the globs are `services/*`, not `services/*/scripts`) and has its own `node_modules`, which is how CI invokes it too.

## Scope

This makes the loss **visible**. It does not make recall resilient to blobs it cannot read, and the notice is advisory text a model may or may not act on. Do not read it as solving data loss.

Deliberately out of scope, flagged rather than silently skipped:

- `recallWithDiagnostics()` — the ticket floats it as "e.g.", but the data is already typed on `RecallResult` and returned at runtime, so a parallel method would only re-wrap what callers can already read. API-surface design, not a bug fix.
- Client-side `filterByMaxDistance` discards hits without reporting how many the *client* dropped, separately from the relayer's `dropped_count`. Same defect class, different cause — and arguably requested behavior, since the caller supplied the cutoff. Worth a follow-up.
- `restore()` accounting (`restored + skipped` as a lower bound) — different code path.
- GitHub #626 (no operation to list stored blobs) — needs a new endpoint.

No changeset: `.changeset/` holds only `README.md` and `config.json`, and the only changed package (`memwal-server-scripts`) is private and unpublished. The user-visible wording change is recorded in `packages/mcp/CHANGELOG.md` and `docs/mcp/changelog.mdx` under 0.0.12 instead, matching how the preceding change to this same file was logged.

Related: #622, #626.

---
Linear: WALM-397 · Refs #636 (already resolved by #747 / WALM-407; this is follow-on hardening)
