### PR TITLE
fix(server): report why restore skipped blobs instead of a bare count (WALM-385)

### DIFF
--- a/services/server/scripts/mcp/__tests__/restore.test.ts
+++ b/services/server/scripts/mcp/__tests__/restore.test.ts
@@ -68,3 +68,179 @@ test("memwal_restore treats an omitted legacy truncated field as false", () => {
     assert.match(text, /truncated=false/);
     assert.match(text, /not proof the sidecar saw every blob/);
 });
+
+// ── skipped_reasons breakdown (WALM-385) ───────────────────────────────
+//
+// A namespace whose ciphertexts predate a SEAL package change fails decrypt
+// deterministically, lands in the relayer's permanent-failure cache, and
+// from then on returns restored=0 skipped=N total=N on every call — the
+// same counts a fully-restored namespace returns — while recall stays
+// empty. These pin that the two stop rendering identically.
+
+test("memwal_restore does not call a wholly permanently-failed namespace finished", () => {
+    const text = formatRestoreResult(
+        {
+            namespace: "pre-migration",
+            total: 19,
+            restored: 0,
+            skipped: 19,
+            truncated: true,
+            skipped_reasons: {
+                already_indexed: 0,
+                permanently_failed: 19,
+                over_limit: 0,
+                by_reason: { decrypt_permanent: 19 },
+            },
+        },
+        10,
+    );
+
+    assert.match(text, /^Restore blocked/);
+    assert.doesNotMatch(text, /Restore page finished/);
+    assert.doesNotMatch(text, /Restore partially complete/);
+    assert.match(text, /19 blob\(s\) permanently failed to restore/);
+    assert.match(text, /decrypt_permanent=19/);
+    assert.match(text, /will NOT recover them/);
+    assert.match(text, /do not loop/);
+});
+
+test("memwal_restore lists every permanent-failure reason in a stable order", () => {
+    const text = formatRestoreResult({
+        namespace: "mixed",
+        total: 4,
+        restored: 1,
+        skipped: 3,
+        truncated: false,
+        skipped_reasons: {
+            already_indexed: 1,
+            permanently_failed: 2,
+            over_limit: 0,
+            by_reason: { invalid_utf8: 1, decrypt_permanent: 1 },
+        },
+    });
+
+    assert.match(text, /^Restore blocked/);
+    assert.match(text, /\(decrypt_permanent=1, invalid_utf8=1\)/);
+    assert.match(text, /already_indexed=1 {2}permanently_failed=2 {2}over_limit=0/);
+});
+
+test("memwal_restore keeps the benign wording when nothing permanently failed", () => {
+    // Same restored=0 / skipped=19 counts as the blocked case above; the
+    // only difference is why, so the warning must not fire here.
+    const text = formatRestoreResult({
+        namespace: "already-restored",
+        total: 19,
+        restored: 0,
+        skipped: 19,
+        truncated: false,
+        skipped_reasons: {
+            already_indexed: 19,
+            permanently_failed: 0,
+            over_limit: 0,
+            by_reason: {},
+        },
+    });
+
+    assert.match(text, /^Restore page finished/);
+    assert.match(text, /already_indexed=19/);
+    assert.doesNotMatch(text, /permanently failed to restore/);
+    assert.doesNotMatch(text, /will NOT recover them/);
+});
+
+test("memwal_restore still tells agents to raise limit when blobs are only over_limit", () => {
+    const text = formatRestoreResult(
+        {
+            namespace: "big",
+            total: 30,
+            restored: 10,
+            skipped: 20,
+            truncated: true,
+            skipped_reasons: {
+                already_indexed: 0,
+                permanently_failed: 0,
+                over_limit: 20,
+                by_reason: {},
+            },
+        },
+        10,
+    );
+
+    assert.match(text, /^Restore partially complete/);
+    assert.match(text, /over_limit=20/);
+    assert.match(text, /increase limit and call again/);
+    assert.doesNotMatch(text, /will NOT recover them/);
+});
+
+test("memwal_restore renders a pre-WALM-385 relayer's response unchanged", () => {
+    // Older relayers omit skipped_reasons entirely. The breakdown line must
+    // not appear, and the existing wording must survive byte-for-byte.
+    const legacy = formatRestoreResult(
+        { namespace: "legacy", total: 19, restored: 0, skipped: 19, truncated: true },
+        10,
+    );
+
+    assert.match(legacy, /^Restore partially complete/);
+    assert.doesNotMatch(legacy, /skipped breakdown/);
+    assert.doesNotMatch(legacy, /permanently failed to restore/);
+    assert.equal(
+        legacy,
+        'Restore partially complete for namespace "legacy":\n' +
+            "  total=19  restored=0  skipped=19  truncated=true\n" +
+            "  ⚠️ More blobs remain to restore — increase limit and call again.",
+    );
+});
+
+test("memwal_restore omits the breakdown line when nothing was skipped", () => {
+    const text = formatRestoreResult({
+        namespace: "clean",
+        total: 3,
+        restored: 3,
+        skipped: 0,
+        truncated: false,
+        skipped_reasons: {
+            already_indexed: 0,
+            permanently_failed: 0,
+            over_limit: 0,
+            by_reason: {},
+        },
+    });
+
+    assert.match(text, /^Restore page finished/);
+    assert.doesNotMatch(text, /skipped breakdown/);
+});
+
+test("memwal_restore keeps paging when a poison blob sits beside restorable ones", () => {
+    // GH #501: anyone can transfer a foreign Walrus blob carrying memwal_*
+    // metadata into the owner's address. It fails SEAL decrypt once and is
+    // negative-cached forever, so permanently_failed >= 1 is a permanent,
+    // attacker-reachable state for an otherwise healthy namespace. Gating
+    // the "stop retrying" wording on that alone would abandon a restore
+    // that is 189/190 recoverable.
+    const text = formatRestoreResult(
+        {
+            namespace: "work",
+            total: 200,
+            restored: 10,
+            skipped: 190,
+            truncated: true,
+            skipped_reasons: {
+                already_indexed: 0,
+                permanently_failed: 1,
+                over_limit: 189,
+                by_reason: { decrypt_permanent: 1 },
+            },
+        },
+        10,
+    );
+
+    assert.match(text, /^Restore partially complete/);
+    assert.doesNotMatch(text, /Restore blocked/);
+    // The permanent failure is still reported — it is real and the caller
+    // should know one blob will never come back.
+    assert.match(text, /1 blob\(s\) permanently failed to restore/);
+    // ...but not with the instruction that contradicts the retry hint on
+    // the very next line.
+    assert.doesNotMatch(text, /do not loop/);
+    assert.match(text, /189 skipped blob\(s\) are only over_limit/);
+    assert.match(text, /increase limit and call again/);
+});

--- a/services/server/scripts/mcp/tools/restore.ts
+++ b/services/server/scripts/mcp/tools/restore.ts
@@ -37,6 +37,22 @@ export function formatRestoreResult(
         restored: number;
         skipped: number;
         truncated?: boolean;
+        /**
+         * Relayer breakdown of `skipped` (WALM-385). Reaches us because
+         * `MemWal.restore` spreads the whole response body, so unknown fields
+         * survive even though the SDK's `RestoreResult` does not declare this
+         * one yet — surfacing it in the SDK/Python types is a tracked
+         * follow-up. Do not "tidy" that spread into a field pick.
+         *
+         * Optional on purpose: relayers older than WALM-385 omit it, and the
+         * wording below must be unchanged for them.
+         */
+        skipped_reasons?: {
+            already_indexed: number;
+            permanently_failed: number;
+            over_limit: number;
+            by_reason?: Record<string, number>;
+        };
     },
     limit = 10,
 ): string {
@@ -46,9 +62,60 @@ export function formatRestoreResult(
         : limit < SIDECAR_CAP_SATURATES_AT_LIMIT
           ? "\n  ⚠️ More blobs remain to restore — increase limit and call again."
           : "\n  ⚠️ Sidecar cap is saturated — truncation follows this call's missing-blob page; truncated is not completeness (WALM-451 sourceCapped).";
+
+    // A namespace whose blobs all sit in the relayer's permanent-failure
+    // cache reports restored=0 skipped=N total=N — the same counts as a
+    // namespace that is already fully restored — while recall stays empty.
+    // Without this the agent reads "Restore page finished", retries, and
+    // gets the identical answer forever (WALM-385).
+    const breakdown = result.skipped_reasons;
+    const permanentlyFailed = breakdown?.permanently_failed ?? 0;
+    const overLimit = breakdown?.over_limit ?? 0;
+    // Only call the restore blocked when no skipped blob is merely deferred
+    // past `limit`. `over_limit > 0` means the next call provably makes
+    // progress, and a single permanently-failed blob must not suppress that
+    // retry signal: under the GH #501 threat model anyone can transfer one
+    // foreign blob into the owner's address, it fails SEAL decrypt once and
+    // stays negative-cached forever, so `permanently_failed >= 1` is a
+    // permanent, attacker-reachable state for an otherwise healthy
+    // namespace. Gating on it alone would tell agents to stop paging a
+    // namespace that is 99% restorable — the mirror image of the WALM-431 /
+    // GH #762 retry loop.
+    const blocked = permanentlyFailed > 0 && overLimit === 0;
+    const headline = blocked
+        ? "Restore blocked"
+        : truncated
+          ? "Restore partially complete"
+          : "Restore page finished";
+
+    let detail = "";
+    if (breakdown && result.skipped > 0) {
+        detail +=
+            `\n  skipped breakdown: already_indexed=${breakdown.already_indexed}` +
+            `  permanently_failed=${permanentlyFailed}  over_limit=${breakdown.over_limit}`;
+    }
+    if (permanentlyFailed > 0) {
+        // Sorted so the line is deterministic regardless of JSON key order.
+        const reasons = Object.entries(breakdown?.by_reason ?? {})
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([reason, count]) => `${reason}=${count}`)
+            .join(", ");
+        detail +=
+            `\n  ⚠️ ${permanentlyFailed} blob(s) permanently failed to restore` +
+            (reasons ? ` (${reasons})` : "") +
+            " — retrying or raising limit will NOT recover them; the relayer never re-attempts a" +
+            " blob it has recorded as permanently failed." +
+            (blocked
+                ? " If recall is empty for this namespace, do not loop: report it, as the blobs" +
+                  " exist on chain but the relayer cannot decrypt them (WALM-385)."
+                : ` The other ${overLimit} skipped blob(s) are only over_limit and DO come back —` +
+                  " keep calling with a higher limit until over_limit reaches 0 (WALM-385).");
+    }
+
     return (
-        `${truncated ? "Restore partially complete" : "Restore page finished"} for namespace "${result.namespace}":\n` +
+        `${headline} for namespace "${result.namespace}":\n` +
         `  total=${result.total}  restored=${result.restored}  skipped=${result.skipped}  truncated=${truncated}` +
+        detail +
         hint
     );
 }
@@ -62,7 +129,7 @@ export function registerRestoreTool(
         {
             ...TOOL_METADATA.memwal_restore,
             description:
-                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. truncated=true is known-retryable-incomplete: raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. Call memwal_recall afterwards to query the rebuilt index.",
+                "Recovery tool. Re-index a namespace from Walrus blobs back into the relayer's search index — use when memwal_recall unexpectedly returns nothing even though facts were saved before (e.g. on a new machine, a fresh relayer, or after switching servers). Returns counts plus truncated status — does not return memory texts. truncated=true is known-retryable-incomplete: raising limit expands the sidecar cap only while limit < 20; after the cap saturates, truncation follows this call's missing-blob page. truncated=false is not completeness; WALM-451 will add sourceCapped. skipped_reasons explains the skipped count: permanently_failed blobs can never be restored, but keep paging while over_limit is non-zero; stop retrying and report it only once over_limit is 0 and permanently_failed is not. Call memwal_recall afterwards to query the rebuilt index.",
             inputSchema: RESTORE_INPUT,
         },
         wrapTool<{ namespace: string; limit: number }>(session, "memwal_restore", async ({ namespace, limit }) => {

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -546,6 +546,65 @@ fn clamp_restore_limit(limit: usize) -> usize {
     limit.clamp(1, 100)
 }
 
+/// Explain restore's `skipped` count instead of returning a bare integer
+/// (WALM-385).
+///
+/// `skipped` collapses three unrelated outcomes into one number: blobs
+/// already in the index (benign), blobs the `restore_failed_blobs` negative
+/// cache excludes (a permanent dead end — nothing in the relayer clears that
+/// cache), and blobs deferred past `limit` (returns next call). A namespace
+/// whose ciphertexts were all written under a superseded SEAL package lands
+/// entirely in the middle bucket and reports `restored: 0, skipped: N,
+/// total: N` — byte-identical to a fully-restored namespace — while `recall`
+/// returns nothing.
+///
+/// `indexed` and `failed` are passed separately, *not* pre-unioned as
+/// `restore_unbounded` does for its missing-blob filter: a blob can be in
+/// both, and the union would make the two buckets double-count it. Counting
+/// intersects with `all_blob_ids` so only blobs discovered by this call are
+/// classified — a stale negative-cache row for a blob the owner no longer
+/// holds must not inflate the total.
+///
+/// `restorable_this_page` is `missing_blob_ids.len()` after pagination.
+/// Deriving `over_limit` from it (rather than counting it) is what keeps
+/// `already_indexed + permanently_failed + over_limit == skipped` true by
+/// construction.
+///
+/// Kept a free function over plain data so it is unit-testable without an
+/// `AppState` or a database, like the other restore helpers above.
+fn classify_skipped(
+    all_blob_ids: &[String],
+    indexed: &std::collections::HashSet<&str>,
+    failed: &std::collections::HashMap<&str, &str>,
+    restorable_this_page: usize,
+) -> SkipBreakdown {
+    let mut breakdown = SkipBreakdown::default();
+
+    for blob_id in all_blob_ids {
+        let blob_id = blob_id.as_str();
+        if indexed.contains(blob_id) {
+            // Checked first so a blob that is both indexed and negative-cached
+            // is counted exactly once, matching the union used to build
+            // `all_missing`.
+            breakdown.already_indexed += 1;
+        } else if let Some(reason) = failed.get(blob_id) {
+            breakdown.permanently_failed += 1;
+            *breakdown
+                .by_reason
+                .entry((*reason).to_string())
+                .or_insert(0) += 1;
+        }
+    }
+
+    let missing = all_blob_ids
+        .len()
+        .saturating_sub(breakdown.already_indexed)
+        .saturating_sub(breakdown.permanently_failed);
+    breakdown.over_limit = missing.saturating_sub(restorable_this_page);
+
+    breakdown
+}
+
 /// POST /api/restore
 ///
 /// Restore a namespace from Walrus:
@@ -652,6 +711,8 @@ async fn restore_unbounded(
             total: 0,
             namespace: namespace.clone(),
             owner: owner.clone(),
+            // Nothing was discovered, so nothing was skipped for any reason.
+            skipped_reasons: SkipBreakdown::default(),
             truncated: restore_is_truncated(false, source_capped, 0, limit),
         }));
     }
@@ -664,11 +725,20 @@ async fn restore_unbounded(
     // re-decrypt-attempted on a later call; it's already correctly reported
     // as "skipped", same as any other missing-but-excluded blob.
     let existing_blob_ids = state.db.get_blobs_by_namespace(owner, namespace).await?;
-    let failed_blob_ids = state.db.get_failed_blob_ids(owner, namespace).await?;
-    let existing_set: std::collections::HashSet<&str> = existing_blob_ids
+    let failed_blob_reasons = state.db.get_failed_blob_reasons(owner, namespace).await?;
+    // Kept as two lookups rather than one merged set: the union below decides
+    // what to restore, while `classify_skipped` needs to tell the two causes
+    // apart to explain `skipped` (WALM-385).
+    let indexed_set: std::collections::HashSet<&str> =
+        existing_blob_ids.iter().map(|s| s.as_str()).collect();
+    let failed_map: std::collections::HashMap<&str, &str> = failed_blob_reasons
         .iter()
-        .map(|s| s.as_str())
-        .chain(failed_blob_ids.iter().map(|s| s.as_str()))
+        .map(|(blob_id, reason)| (blob_id.as_str(), reason.as_str()))
+        .collect();
+    let existing_set: std::collections::HashSet<&str> = indexed_set
+        .iter()
+        .copied()
+        .chain(failed_map.keys().copied())
         .collect();
     let all_missing: Vec<String> = all_blob_ids
         .iter()
@@ -694,15 +764,28 @@ async fn restore_unbounded(
         limit,
     );
     let skipped = total - missing_blob_ids.len();
+    // Explain that `skipped` rather than shipping a bare count: an all-
+    // permanently-failed namespace is otherwise indistinguishable from a
+    // fully-restored one (WALM-385).
+    let skipped_reasons = classify_skipped(
+        &all_blob_ids,
+        &indexed_set,
+        &failed_map,
+        missing_blob_ids.len(),
+    );
     tracing::info!(
-        "restore: total={} on-chain, existing={}, negative-cached={}, missing={} (limited to {}, truncated={}, source_capped={}) for ns={}",
+        "restore: total={} on-chain, existing={}, negative-cached={}, missing={} (limited to {}, truncated={}, source_capped={}) skipped={} (already_indexed={}, permanently_failed={}, over_limit={}) for ns={}",
         total,
         existing_blob_ids.len(),
-        failed_blob_ids.len(),
+        failed_map.len(),
         missing_blob_ids.len(),
         limit,
         truncated,
         source_capped,
+        skipped,
+        skipped_reasons.already_indexed,
+        skipped_reasons.permanently_failed,
+        skipped_reasons.over_limit,
         namespace
     );
 
@@ -713,6 +796,7 @@ async fn restore_unbounded(
             total,
             namespace: namespace.clone(),
             owner: owner.clone(),
+            skipped_reasons,
             truncated,
         }));
     }
@@ -784,6 +868,7 @@ async fn restore_unbounded(
             total,
             namespace: namespace.clone(),
             owner: owner.clone(),
+            skipped_reasons,
             truncated,
         }));
     }
@@ -971,6 +1056,7 @@ async fn restore_unbounded(
         total,
         namespace: namespace.clone(),
         owner: owner.clone(),
+        skipped_reasons,
         truncated,
     }))
 }
@@ -978,7 +1064,14 @@ async fn restore_unbounded(
 #[cfg(test)]
 mod tests {
     use super::encode_untrusted_memory_context;
-    use crate::types::{RecallResult, RestoreResponse};
+    use crate::types::{RecallResult, RestoreResponse, SkipBreakdown};
+    use std::collections::{HashMap, HashSet};
+
+    /// Build the `(all_blob_ids, indexed, failed)` trio `classify_skipped`
+    /// takes, from plain `&str` fixtures.
+    fn blob_ids(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
 
     // ── Memory context stays structured, untrusted JSON ──────────
 
@@ -1143,9 +1236,188 @@ mod tests {
             total: 20,
             namespace: "ns".to_string(),
             owner: "0xabc".to_string(),
+            skipped_reasons: SkipBreakdown::default(),
             truncated: true,
         };
         assert!(resp.truncated);
+    }
+
+    // ── restore() skip classification (WALM-385) ───────────────────────
+    //
+    // A namespace whose ciphertexts were written under a superseded SEAL
+    // package fails decrypt deterministically, lands in the
+    // `restore_failed_blobs` negative cache, and from then on reports
+    // `restored: 0, skipped: N, total: N` on every call — byte-identical to
+    // a namespace that is already fully restored — while `recall` returns
+    // nothing. Nothing in the relayer clears that cache, so the state is
+    // permanent as well as silent. These pin the breakdown that tells the
+    // two apart, exercising the real `super::classify_skipped` so a wiring
+    // bug fails here rather than a re-derived copy of the same arithmetic.
+
+    #[test]
+    fn classify_skipped_reports_a_wholly_negative_cached_namespace_as_permanent() {
+        // The reported repro: every discovered blob is negative-cached, so
+        // restore can never make progress no matter how often it is called.
+        let all = blob_ids(&["b1", "b2", "b3"]);
+        let indexed = HashSet::new();
+        let failed: HashMap<&str, &str> = all
+            .iter()
+            .map(|id| (id.as_str(), "decrypt_permanent"))
+            .collect();
+
+        let breakdown = super::classify_skipped(&all, &indexed, &failed, 0);
+
+        assert_eq!(breakdown.permanently_failed, 3);
+        assert_eq!(breakdown.already_indexed, 0);
+        assert_eq!(breakdown.over_limit, 0);
+        assert_eq!(breakdown.by_reason.get("decrypt_permanent"), Some(&3));
+    }
+
+    #[test]
+    fn classify_skipped_reports_a_fully_indexed_namespace_as_benign() {
+        // Same `skipped` total as the case above and the one the caller must
+        // NOT be warned about — nothing is wrong here.
+        let all = blob_ids(&["b1", "b2", "b3"]);
+        let indexed: HashSet<&str> = all.iter().map(|id| id.as_str()).collect();
+        let failed = HashMap::new();
+
+        let breakdown = super::classify_skipped(&all, &indexed, &failed, 0);
+
+        assert_eq!(breakdown.already_indexed, 3);
+        assert_eq!(breakdown.permanently_failed, 0);
+        assert_eq!(breakdown.over_limit, 0);
+        assert!(breakdown.by_reason.is_empty());
+    }
+
+    #[test]
+    fn classify_skipped_splits_mixed_causes_and_both_failure_reasons() {
+        let all = blob_ids(&["indexed", "utf8", "decrypt", "restorable"]);
+        let indexed: HashSet<&str> = ["indexed"].into_iter().collect();
+        let failed: HashMap<&str, &str> =
+            [("utf8", "invalid_utf8"), ("decrypt", "decrypt_permanent")]
+                .into_iter()
+                .collect();
+
+        // One blob ("restorable") is actually being restored this call.
+        let breakdown = super::classify_skipped(&all, &indexed, &failed, 1);
+
+        assert_eq!(breakdown.already_indexed, 1);
+        assert_eq!(breakdown.permanently_failed, 2);
+        assert_eq!(breakdown.over_limit, 0);
+        assert_eq!(breakdown.by_reason.get("invalid_utf8"), Some(&1));
+        assert_eq!(breakdown.by_reason.get("decrypt_permanent"), Some(&1));
+    }
+
+    #[test]
+    fn classify_skipped_counts_a_blob_in_both_sets_exactly_once() {
+        // `restore_unbounded` unions the two lookups to build `all_missing`,
+        // so a blob that is indexed *and* negative-cached is excluded once.
+        // Counting it in both buckets would push the breakdown above
+        // `skipped`.
+        let all = blob_ids(&["both"]);
+        let indexed: HashSet<&str> = ["both"].into_iter().collect();
+        let failed: HashMap<&str, &str> = [("both", "decrypt_permanent")].into_iter().collect();
+
+        let breakdown = super::classify_skipped(&all, &indexed, &failed, 0);
+
+        assert_eq!(breakdown.already_indexed, 1);
+        assert_eq!(breakdown.permanently_failed, 0);
+        assert!(breakdown.by_reason.is_empty());
+    }
+
+    #[test]
+    fn classify_skipped_ignores_negative_cache_rows_not_discovered_this_call() {
+        // The negative cache is keyed by owner+namespace and never pruned, so
+        // it can hold blobs the owner no longer holds on chain. Those must
+        // not inflate the breakdown past this call's discovered set.
+        let all = blob_ids(&["discovered"]);
+        let indexed = HashSet::new();
+        let failed: HashMap<&str, &str> = [
+            ("discovered", "decrypt_permanent"),
+            ("long-gone", "decrypt_permanent"),
+        ]
+        .into_iter()
+        .collect();
+
+        let breakdown = super::classify_skipped(&all, &indexed, &failed, 0);
+
+        assert_eq!(breakdown.permanently_failed, 1);
+        assert_eq!(breakdown.by_reason.get("decrypt_permanent"), Some(&1));
+    }
+
+    #[test]
+    fn classify_skipped_attributes_paginated_out_blobs_to_over_limit() {
+        // Restorable blobs deferred past `limit` are skipped too, but they
+        // come back next call — the one bucket a retry actually helps.
+        let all = blob_ids(&["b1", "b2", "b3", "b4", "b5"]);
+        let indexed = HashSet::new();
+        let failed = HashMap::new();
+
+        let breakdown = super::classify_skipped(&all, &indexed, &failed, 2);
+
+        assert_eq!(breakdown.over_limit, 3);
+        assert_eq!(breakdown.already_indexed, 0);
+        assert_eq!(breakdown.permanently_failed, 0);
+    }
+
+    #[test]
+    fn classify_skipped_partitions_skipped_exactly() {
+        // The invariant `restore_unbounded` relies on: the three buckets must
+        // sum to `total - missing_blob_ids.len()` — the `skipped` the caller
+        // is shown — for every mix, or the breakdown contradicts the number
+        // it claims to explain.
+        let all = blob_ids(&["indexed", "failed", "page", "deferred"]);
+        let indexed: HashSet<&str> = ["indexed"].into_iter().collect();
+        let failed: HashMap<&str, &str> = [("failed", "decrypt_permanent")].into_iter().collect();
+
+        for restorable_this_page in 0..=2 {
+            let breakdown = super::classify_skipped(&all, &indexed, &failed, restorable_this_page);
+            assert_eq!(
+                breakdown.already_indexed + breakdown.permanently_failed + breakdown.over_limit,
+                all.len() - restorable_this_page,
+                "breakdown must sum to skipped for page={}",
+                restorable_this_page
+            );
+        }
+    }
+
+    #[test]
+    fn classify_skipped_on_an_empty_namespace_is_all_zeroes() {
+        let breakdown = super::classify_skipped(&[], &HashSet::new(), &HashMap::new(), 0);
+
+        assert_eq!(breakdown.already_indexed, 0);
+        assert_eq!(breakdown.permanently_failed, 0);
+        assert_eq!(breakdown.over_limit, 0);
+        assert!(breakdown.by_reason.is_empty());
+    }
+
+    #[test]
+    fn restore_response_carries_skip_breakdown() {
+        let resp = RestoreResponse {
+            restored: 0,
+            skipped: 3,
+            total: 3,
+            namespace: "ns".to_string(),
+            owner: "0xabc".to_string(),
+            skipped_reasons: super::classify_skipped(
+                &blob_ids(&["b1", "b2", "b3"]),
+                &HashSet::new(),
+                &[
+                    ("b1", "decrypt_permanent"),
+                    ("b2", "decrypt_permanent"),
+                    ("b3", "decrypt_permanent"),
+                ]
+                .into_iter()
+                .collect(),
+                0,
+            ),
+            truncated: true,
+        };
+
+        assert_eq!(resp.skipped_reasons.permanently_failed, resp.skipped);
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["skipped_reasons"]["permanently_failed"], 3);
+        assert_eq!(json["skipped_reasons"]["by_reason"]["decrypt_permanent"], 3);
     }
 
     // ── /api/forget + /api/stats empty-namespace validation ─────────────

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -2974,18 +2974,24 @@ impl VectorDb {
         Ok(rows)
     }
 
-    /// Return blob_ids that have permanently failed to restore for `owner` +
-    /// `namespace` (GH #501 / WALM-299). Used by restore() to exclude blobs
-    /// that already failed decrypt/validation once and should never be
-    /// re-downloaded and re-decrypt-attempted on every subsequent restore() call.
-    pub async fn get_failed_blob_ids(
+    /// Return `(blob_id, reason)` for every blob that has permanently failed
+    /// to restore for `owner` + `namespace` (GH #501 / WALM-299). Used by
+    /// restore() to exclude blobs that already failed decrypt/validation once
+    /// and should never be re-downloaded and re-decrypt-attempted on every
+    /// subsequent restore() call.
+    ///
+    /// The `reason` column rides along because restore() reports *why* each
+    /// blob was skipped rather than a bare count (WALM-385): a blob excluded
+    /// by this negative cache is a permanent dead end, which is a materially
+    /// different outcome from one skipped because it is already indexed.
+    pub async fn get_failed_blob_reasons(
         &self,
         owner: &str,
         namespace: &str,
-    ) -> Result<Vec<String>, AppError> {
+    ) -> Result<Vec<(String, String)>, AppError> {
         let started = std::time::Instant::now();
-        let result: Result<Vec<(String,)>, AppError> = sqlx::query_as(
-            "SELECT blob_id FROM restore_failed_blobs
+        let result: Result<Vec<(String, String)>, AppError> = sqlx::query_as(
+            "SELECT blob_id, reason FROM restore_failed_blobs
              WHERE owner = $1 AND namespace = $2",
         )
         .bind(owner)
@@ -2994,13 +3000,12 @@ impl VectorDb {
         .await
         .map_err(|e| AppError::Internal(format!("Failed to get failed blobs: {}", e)));
         crate::observability::observe_db(
-            "vector.get_failed_blob_ids",
+            "vector.get_failed_blob_reasons",
             db_status(&result),
             started.elapsed(),
         );
-        let rows = result?;
 
-        Ok(rows.into_iter().map(|(blob_id,)| blob_id).collect())
+        result
     }
 
     /// Record that `blob_id` permanently failed to restore for `owner` +

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -1,5 +1,6 @@
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
@@ -1822,6 +1823,40 @@ pub struct RestoreRequest {
     pub limit: usize,
 }
 
+/// Why the blobs counted by `RestoreResponse.skipped` were skipped
+/// (WALM-385).
+///
+/// `skipped` on its own cannot distinguish "already indexed, nothing to do"
+/// — entirely benign — from "in the permanent-failure negative cache, no
+/// future call can ever restore this" — a silent dead end. A namespace whose
+/// blobs were all encrypted under a superseded SEAL package reports
+/// `restored: 0, skipped: N, total: N`, identical to a fully-restored
+/// namespace, while `recall` returns nothing.
+///
+/// The three buckets partition `skipped` exactly:
+/// `already_indexed + permanently_failed + over_limit == skipped`.
+/// They describe the blobs this call declined to restore *before* any
+/// download; blobs that were attempted and failed mid-flight reduce
+/// `restored` instead, so `restored + skipped` can still be below `total`.
+#[derive(Debug, Default, Serialize)]
+pub struct SkipBreakdown {
+    /// Already present in the local vector index — the benign case.
+    pub already_indexed: usize,
+    /// Excluded by the `restore_failed_blobs` negative cache (GH #501 /
+    /// WALM-299). Permanent by construction: only deterministic decrypt
+    /// rejections and invalid UTF-8 are recorded there, and nothing in the
+    /// relayer clears the cache, so retrying or raising `limit` cannot
+    /// recover these.
+    pub permanently_failed: usize,
+    /// Missing locally and restorable, but beyond this call's `limit`.
+    /// Unlike the other two, these come back on a later call.
+    pub over_limit: usize,
+    /// `permanently_failed` split by the `reason` recorded at failure time —
+    /// `"decrypt_permanent"` (SEAL rejected it deterministically) or
+    /// `"invalid_utf8"`. Sums to `permanently_failed`.
+    pub by_reason: BTreeMap<String, usize>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct RestoreResponse {
     pub restored: usize,
@@ -1829,6 +1864,9 @@ pub struct RestoreResponse {
     pub total: usize,
     pub namespace: String,
     pub owner: String,
+    /// Breakdown of `skipped` by cause, so a permanent dead end stops
+    /// looking identical to a no-op (WALM-385). See [`SkipBreakdown`].
+    pub skipped_reasons: SkipBreakdown,
     /// True when this restore is known-incomplete: more on-chain blobs were
     /// missing locally than `limit` allowed this call to restore, or the
     /// sidecar's owner-wide candidate fetch hit its cap *and* raising


### PR DESCRIPTION
## What

`POST /api/restore` collapsed three unrelated outcomes into one `skipped` integer, so a namespace that can **never** be restored returned the same counts as one that was already fully restored.

When a blob fails SEAL decrypt deterministically it is written to the `restore_failed_blobs` negative cache (GH #501 / WALM-299). Every later call folds that cache into the same `existing_set` as genuinely-indexed blobs, so `all_missing` is empty and `skipped == total`. Nothing in the relayer deletes from that table — not even `forget`, whose `delete_by_namespace` only touches `vector_entries`, `memory_tombstones` and `remember_jobs` — so the state is permanent as well as silent. A namespace whose ciphertexts were written under a superseded SEAL package lands entirely in that bucket and returns `restored: 0, skipped: N, total: N` forever while `recall` returns nothing, byte-identical to the benign "already restored" response.

## Changes

- `RestoreResponse` gains `skipped_reasons`, partitioning `skipped` into `already_indexed`, `permanently_failed` and `over_limit`, plus a `by_reason` split over the two reasons the relayer actually records (`decrypt_permanent`, `invalid_utf8`). `over_limit` is *derived* from the paginated page length rather than counted, which makes `already_indexed + permanently_failed + over_limit == skipped` true by construction — including when `all_blob_ids` contains duplicates.
- Classification intersects with the blobs discovered by *this* call, so a stale cache row for a blob the owner no longer holds cannot inflate the count; `indexed` is checked before `failed` so a blob in both sets is counted once.
- `Db::get_failed_blob_ids` → `get_failed_blob_reasons`, carrying the `reason` column along. Exactly one caller.
- The MCP formatter renders the permanent case as **"Restore blocked"** and states that retrying or raising `limit` will not recover those blobs, instead of the "Restore page finished" wording that made agents loop.

## Scope

This is the diagnosability half only. Deliberately **not** in this PR, each needing its own decision:

- rebuilding the memory index across the package boundary (the ticket's headline ask);
- a reset path for the negative cache, which re-opens the WALM-299 unbounded-retry vector and needs its own security note;
- a package-mismatch-specific 401 — `auth.rs` collapses account-resolution failures to a uniform 401 on purpose (`constant_time_reject`) to avoid an account-enumeration oracle, so the safe version is client-side;
- surfacing `skipped_reasons` in the TS/Python SDK types and `docs/relayer/api-reference.md`, following the same pattern the `truncated` field used (WALM-319 / WALM-431).

**Known limitation, stated plainly:** this makes the dead end legible but ships no remedy. A user who sees `permanently_failed > 0` still has nothing to do except escalate.

## Compatibility

Additive: the response gains a field, no existing field changes meaning. `pnpm check:compatibility` passes without a version bump, matching the `truncated` addition in WALM-317. Relayers older than this change omit the field and the MCP output renders byte-for-byte as before (pinned by a test). The published SDK returns the response body unmodified, so the field reaches the MCP tool without an SDK release; the Python SDK picks fields explicitly and is unaffected.

## Review note

Review caught and fixed a behavioural regression in the formatter before this was opened: the "Restore blocked" headline and the "do not loop" instruction were gated on `permanently_failed > 0` alone. Under GH #501 anyone can transfer a foreign blob into the owner's address, where it fails decrypt once and stays negative-cached forever — so a single attacker-supplied blob made a 189/190-recoverable page render "Restore blocked … do not loop" directly above the existing "increase limit and call again" hint. Both are now gated on `over_limit == 0`; permanent failures are still reported in every case, only the stop-retrying imperative is conditional. Regression test added.

## Testing

- `cd services/server && cargo test --offline` — 699 + 454 passed, 0 failed. 8 new `classify_skipped` cases: the all-permanent repro, the benign all-indexed case, mixed causes, double-membership, stale cache rows, pagination, the partition invariant, and the empty namespace.
- `cd services/server/scripts && npm ci && npm test` — 255 passed, 0 failed. 7 formatter cases pinning the blocked wording, reason ordering, the benign case, the poison-blob-beside-restorable-blobs case, and byte-for-byte legacy rendering.
- `npm run typecheck` — clean. `node scripts/check-compatibility-contract.mjs` — OK.

No handler-level test: the repo has no axum-handler harness (see `routes/accounts.rs:84`), so `restore_unbounded`'s wiring of the two lookups into `classify_skipped` is not covered — same shape as every existing restore test.

Fixes WALM-385 (diagnosability half).

---
Linear: WALM-385 · Refs #623 (diagnosability half only — does NOT close the issue)
