### PR TITLE
fix(mcp): warn on unrecognised flags, document env presets, report relayer in health (WALM-390)

### DIFF
--- a/docs/mcp/changelog.mdx
+++ b/docs/mcp/changelog.mdx
@@ -28,16 +28,19 @@ questions:
   - What changed in the MemWal MCP changelog?
   - When was the automatic memory plugin added to MemWal MCP?
 answer: >-
-  The latest MCP package release is 0.0.13. `memwal_restore` reports `failed` and retries the same page when truncation is a download or embed blip, instead of always telling the agent to raise `limit`. Version 0.0.12 forwards the MCP client's initialize.clientInfo to the relayer so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, and others) on each session and tool call, and it resolves the credential directory on every access so MEMWAL_CREDS_DIR can override it.
+  The latest MCP package release is 0.0.13. Unrecognised command-line options now warn instead of being silently ignored, `--help` lists the network presets and the URLs each resolves to, `memwal_health` names the relayer the client dialled, and `memwal_restore` reports `failed` and retries the same page when truncation is a download or embed blip, instead of always telling the agent to raise `limit`. Version 0.0.12 forwards the MCP client's initialize.clientInfo to the relayer so sidecar logs can name the coding agent (Claude Code, Codex, Cursor, and others) on each session and tool call, and it resolves the credential directory on every access so MEMWAL_CREDS_DIR can override it.
 ---
 
 ## 0.0.13
 
-This release reports restore `failed` counts and retries the same page when truncation is a transient download or embed blip.
+This release warns on unrecognised command-line options instead of ignoring them, documents the network presets in `--help`, names the relayer in `memwal_health`, and reports restore `failed` counts when truncation is a transient download or embed blip.
 
 ### Fixed
 
 - `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
+- Unrecognised options now warn on stderr and in the structured log (`cli.unrecognised_arg`) instead of being dropped in silence, so a typo'd `--namesapce work` no longer writes to the default namespace with nothing to say it had. The warning names the option key only, keeping a mistyped value-taking flag (`--tokenn=hunter2`) from putting the secret on stderr, and it warns rather than exits so an option from a newer config cannot brick the server. (#630)
+- `--help` now lists the network presets (`--prod`, `--dev`, `--staging`, `--local`) with the relayer and web URLs each resolves to, rendered from the preset table rather than retyped so a new preset cannot ship undocumented the way `--prod` did. The `--label` default is corrected to "MCP Client", which is what the code actually falls back to. (#630)
+- `memwal_health` reports `relayer=<url>`, naming the origin this process dialled, so a client bound to the wrong network finds out there instead of by noticing its memories are missing. The URL is captured when the call is sent rather than when the reply lands, so a reconnect mid-flight cannot label the answer with a relayer it did not come from. (#630)
 
 ## 0.0.12
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -175,7 +175,7 @@ These are not all enforced at boot, but most real deployments need them.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).
 - `MEMWAL_RELAYER_URL` is only needed when the sidecar should call a different relayer URL than the Rust server's local port. The Rust server sets it automatically to `http://127.0.0.1:$PORT` for the managed sidecar when it starts.
-- Set `MEMWAL_RELAYER_URL` to the deployment's public origin if you want `memwal_health` to name the network it answered on. The Rust server forwards an operator-supplied value to the sidecar as `MEMWAL_PUBLIC_RELAYER_URL`, and only that value is reported; the loopback default is not, because an address that names no network would make a client bound to the wrong relayer read as correctly configured. Hosted OAuth deployments already set this — it is the issuer. Clients run through the `memwal-mcp` stdio package always see the relayer that package dialled, whether or not this is set.
+- Set `MEMWAL_RELAYER_URL` to the deployment's public origin if you want `memwal_health` to name the network it answered on. The Rust server forwards an operator-supplied value to the sidecar as `MEMWAL_PUBLIC_RELAYER_URL`, and only that value is reported; the loopback default is not, because an address that names no network would make a client bound to the wrong relayer read as correctly configured. Hosted OAuth deployments already set this, because it is the issuer. Clients run through the `memwal-mcp` stdio package always see the relayer that package dialled, whether or not this is set.
 
 ## Frontend apps
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -146,7 +146,7 @@ These are not all enforced at boot, but most real deployments need them.
 | `WALLET_BALANCE_LOW_THRESHOLD_SUI` | `5000000000` | Uploader SUI address-balance threshold in MIST (5 SUI). Load-bearing during phase 1, when durable register pays gas from the uploader wallet |
 | `SPONSOR_BALANCE_LOW_THRESHOLD_SUI` | `5000000000` | Sponsor wallet SUI address-balance threshold in MIST (5 SUI) |
 | `WALLET_BALANCE_LOW_ALERT_DEDUP_SECS` | `43200` | Dedup window for wallet low-balance Slack alerts, per `(network, wallet type, token, address)` |
-| `MEMWAL_RELAYER_URL` | `http://127.0.0.1:$PORT` | Relayer URL passed from the Rust server to the sidecar for MCP tool calls |
+| `MEMWAL_RELAYER_URL` | `http://127.0.0.1:$PORT` | Relayer URL passed from the Rust server to the sidecar for MCP tool calls. Setting it explicitly also makes `memwal_health` report it as the network the session is bound to |
 | `MCP_MAX_TOTAL_SESSIONS` | `1000` | Maximum active MCP sessions across SSE and Streamable HTTP transports |
 | `MCP_MAX_SESSIONS_PER_IP` | `16` | Maximum active MCP sessions from one source IP |
 | `MCP_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | Maximum new MCP sessions opened by one source IP per minute |
@@ -175,6 +175,7 @@ These are not all enforced at boot, but most real deployments need them.
 - `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` are server env vars. Do not replace them with `VITE_*` app env vars.
 - For network-specific `MEMWAL_PACKAGE_ID` and `MEMWAL_REGISTRY_ID` values, see [Contract Overview](/contract/overview).
 - `MEMWAL_RELAYER_URL` is only needed when the sidecar should call a different relayer URL than the Rust server's local port. The Rust server sets it automatically to `http://127.0.0.1:$PORT` for the managed sidecar when it starts.
+- Set `MEMWAL_RELAYER_URL` to the deployment's public origin if you want `memwal_health` to name the network it answered on. The Rust server forwards an operator-supplied value to the sidecar as `MEMWAL_PUBLIC_RELAYER_URL`, and only that value is reported; the loopback default is not, because an address that names no network would make a client bound to the wrong relayer read as correctly configured. Hosted OAuth deployments already set this — it is the issuer. Clients run through the `memwal-mcp` stdio package always see the relayer that package dialled, whether or not this is set.
 
 ## Frontend apps
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 
 - `memwal_restore` reports `failed` and retries the same page when `truncated` is a download/embed blip (`restored=0` and `skipped+failed < total`), instead of always telling the agent to raise `limit` (WALM-480).
+- Unrecognised options now warn on stderr and in the structured log (`cli.unrecognised_arg`) instead of being dropped in silence, so a typo'd `--namesapce work` no longer writes to the default namespace with nothing to say it had. The warning names the option key only, keeping a mistyped value-taking flag (`--tokenn=hunter2`) from putting the secret on stderr, and it warns rather than exits so an option from a newer config cannot brick the server. (#630)
+- `--help` now lists the network presets (`--prod`, `--dev`, `--staging`, `--local`) with the relayer and web URLs each resolves to, rendered from the preset table rather than retyped so a new preset cannot ship undocumented the way `--prod` did. The `--label` default is corrected to "MCP Client", which is what the code actually falls back to. (#630)
+- `memwal_health` reports `relayer=<url>`, naming the origin this process dialled, so a client bound to the wrong network finds out there instead of by noticing its memories are missing. The URL is captured when the call is sent rather than when the reply lands, so a reconnect mid-flight cannot label the answer with a relayer it did not come from. (#630)
 
 ## 0.0.12
 

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -66,6 +66,38 @@ const NAMESPACE_TOOLS = new Set([
  *   - the caller already supplied a non-empty `namespace` — an explicit
  *     per-call namespace always wins over the configured default.
  */
+/**
+ * Name the relayer this process dialled in a `memwal_health` result.
+ *
+ * The relayer-side text can only report an origin its deployment published, and
+ * stays silent on a self-hosted or local one, where the sidecar knows nothing
+ * but the loopback address it dials. This side always knows the URL it
+ * connected to — it is exactly what `--prod` / `--relayer` / `MEMWAL_SERVER_URL`
+ * selected — so a client bound to the wrong network sees that here instead of
+ * by noticing its memories are missing.
+ *
+ * Rewrites an existing `relayer=` field rather than appending a second one: when
+ * both sides know the origin they describe the same session, and two
+ * conflicting fields would be worse than neither.
+ */
+export function annotateHealthResult(
+    result: { content?: unknown; isError?: unknown },
+    relayerUrl: string,
+): void {
+    // A failed health call has no session to describe; naming a relayer beside
+    // an error reads as though that relayer answered.
+    if (result.isError) return;
+    if (!Array.isArray(result.content)) return;
+    const block = (result.content as { type?: string; text?: string }[]).find(
+        (c) => c?.type === "text" && typeof c.text === "string",
+    );
+    if (!block || typeof block.text !== "string") return;
+    const existing = /\brelayer=\S+/;
+    block.text = existing.test(block.text)
+        ? block.text.replace(existing, `relayer=${relayerUrl}`)
+        : `${block.text} relayer=${relayerUrl}`;
+}
+
 export function applyDefaultNamespace(msg: RpcMessage, namespace?: string): RpcMessage {
     if (!namespace) return msg;
     if (msg.method !== "tools/call") return msg;
@@ -915,6 +947,12 @@ export async function runBridge(
      * client surfaces them in its tool palette. */
     const pendingListIds = new Set<string | number>();
 
+    /** IDs of forwarded `memwal_health` calls, each against the relayer URL the
+     * call went out on. Captured at send time rather than read at reply time so
+     * a reconnect that swapped credentials mid-flight cannot label the answer
+     * with a relayer it did not come from. */
+    const pendingHealthIds = new Map<string | number, string>();
+
     /** Reopen the SSE stream and replay outstanding `inFlight` requests against
      * the fresh session. All callers await the SAME reconnect via
      * `reconnectPromise` — returning immediately while one is active would let
@@ -1119,6 +1157,7 @@ export async function runBridge(
             const purge = (msg: RpcMessage): void => {
                 if (msg.id == null) return; // notification — nothing to reply to
                 pendingListIds.delete(msg.id);
+                pendingHealthIds.delete(msg.id);
                 if (msg.method === "initialize") {
                     return;
                 }
@@ -1324,6 +1363,23 @@ export async function runBridge(
                             result.tools = [...upstream, ...LOCAL_TOOL_DEFINITIONS];
                         }
                     }
+                    if (
+                        value &&
+                        value.id !== undefined &&
+                        value.id !== null &&
+                        pendingHealthIds.has(value.id) &&
+                        value.result &&
+                        typeof value.result === "object"
+                    ) {
+                        const dialled = pendingHealthIds.get(value.id);
+                        pendingHealthIds.delete(value.id);
+                        if (dialled !== undefined) {
+                            annotateHealthResult(
+                                value.result as { content?: unknown; isError?: unknown },
+                                dialled,
+                            );
+                        }
+                    }
                     writeStdoutMessage(value);
                 }
             } catch (err) {
@@ -1472,6 +1528,16 @@ export async function runBridge(
                 // our local tools into the upstream response.
                 if (msg.method === "tools/list" && msg.id != null) {
                     pendingListIds.add(msg.id);
+                }
+
+                // Same idea for `memwal_health`: record the relayer this
+                // session is bound to so the pump can name it on the reply.
+                if (
+                    msg.method === "tools/call" &&
+                    msg.id != null &&
+                    (msg.params as { name?: string } | undefined)?.name === "memwal_health"
+                ) {
+                    pendingHealthIds.set(msg.id, creds?.relayerUrl ?? config.relayerUrl);
                 }
 
                 // Track requests (have both method and id) so we can replay

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,8 +28,8 @@ interface ParsedArgs {
     webUrl?: string;
     label?: string;
     namespace?: string;
-    /** Args parseArgs did not recognise, in the order seen. WALM-390: these
-     *  used to be dropped on the floor; main() now names them on stderr. */
+    /** Args parseArgs did not recognise, in the order seen. For a flag
+     *  written `--key=value`, only `--key` is recorded — see parseArgs. */
     unknown: string[];
 }
 
@@ -41,6 +41,10 @@ const ENV_PRESETS: Record<string, { relayer: string; web: string }> = {
     staging: { relayer: "https://relayer-staging.memory.walrus.xyz", web: "https://staging.memory.walrus.xyz" },
     local: { relayer: "http://127.0.0.1:8000", web: "http://localhost:5173" },
 };
+
+/** Bare words that are commands rather than values. An unknown flag must not
+ *  swallow one as its argument. */
+const POSITIONALS = new Set(["login"]);
 
 export function parseArgs(argv: string[]): ParsedArgs {
     const out: ParsedArgs = { help: false, logout: false, forceLogin: false, unknown: [] };
@@ -92,19 +96,30 @@ export function parseArgs(argv: string[]): ParsedArgs {
                 else if (a?.startsWith("--label=")) out.label = a.split("=", 2)[1];
                 else if (a?.startsWith("--namespace=")) out.namespace = a.split("=", 2)[1];
                 else if (a?.startsWith("--ns=")) out.namespace = a.split("=", 2)[1];
-                // WALM-390: anything still unmatched is a typo, or a flag
-                // from a newer build. Record it. Swallowing it here is what
-                // let `--prod` look supported for months while doing nothing.
-                // Values of KNOWN value-taking flags never reach this branch
-                // — `next()` already consumed them.
+                // Anything still unmatched is a typo, or a flag from a newer
+                // build. Values of KNOWN value-taking flags never reach this
+                // branch — `next()` already consumed them.
                 else if (a !== undefined) {
-                    out.unknown.push(a);
-                    // An unknown flag may take a value too. Consume a
-                    // following non-flag token as that value so `--namesapce
-                    // work` warns once about `--namesapce` rather than twice,
-                    // the second naming the user's data. Keeps a mistyped
-                    // secret (`--tokenn hunter2`) out of stderr and the logs.
-                    if (a.startsWith("-") && argv[i + 1] !== undefined && !argv[i + 1].startsWith("-")) {
+                    // Record the key only. A mistyped value-taking flag written
+                    // `--tokenn=hunter2` would otherwise put the user's secret
+                    // on stderr, which is the one place this warning must not
+                    // put it.
+                    const eq = a.indexOf("=");
+                    out.unknown.push(eq === -1 ? a : a.slice(0, eq));
+                    // An unknown flag may take its value as the next token, so
+                    // consume one — `--namesapce work` should warn once about
+                    // `--namesapce`, not a second time naming the user's data.
+                    // POSITIONALS are exempt: they are commands, not values, and
+                    // swallowing one would turn `memwal-mcp --typo login` into a
+                    // run that never logs in.
+                    const value = argv[i + 1];
+                    if (
+                        a.startsWith("-") &&
+                        eq === -1 &&
+                        value !== undefined &&
+                        !value.startsWith("-") &&
+                        !POSITIONALS.has(value)
+                    ) {
                         i++;
                     }
                 }
@@ -117,9 +132,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
 export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
     const args = parseArgs(argv);
 
-    // WALM-390: name what we could not parse. Runs before the --help branch
-    // so `memwal-mcp --typo --help` still calls the typo out. Warn, never
-    // exit: an unknown flag from a newer config must not brick the server.
+    // Runs before the --help branch so `memwal-mcp --typo --help` still calls
+    // the typo out. Warn, never exit: an unknown flag from a newer config must
+    // not brick the server.
     for (const flag of args.unknown) {
         log.warn("cli.unrecognised_arg", { arg: flag });
         note(
@@ -288,11 +303,10 @@ function printHelp(): void {
 }
 
 /** The `--help` body. Exported so tests can assert it stays in step with the
- *  flags parseArgs actually accepts — WALM-390 was reported precisely because
- *  it had drifted. */
+ *  flags parseArgs actually accepts. */
 export function helpText(): string {
     // Rendered from ENV_PRESETS rather than retyped, so a new preset cannot
-    // ship undocumented the way --prod did.
+    // ship undocumented.
     const presetLines = Object.entries(ENV_PRESETS).flatMap(([name, urls]) => [
         `  ${`--${name}`.padEnd(33)}relayer: ${urls.relayer}`,
         `  ${"".padEnd(33)}web:     ${urls.web}`,
@@ -334,7 +348,8 @@ export function helpText(): string {
         ...presetLines,
         "",
         "                                   An explicit --relayer or --web-url",
-        "                                   overrides the preset it follows.",
+        "                                   wins over a preset, whichever",
+        "                                   order they are written in.",
         "",
         "Environment (equivalent to options):",
         "  MEMWAL_SERVER_URL                same as --relayer",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,6 +28,9 @@ interface ParsedArgs {
     webUrl?: string;
     label?: string;
     namespace?: string;
+    /** Args parseArgs did not recognise, in the order seen. WALM-390: these
+     *  used to be dropped on the floor; main() now names them on stderr. */
+    unknown: string[];
 }
 
 /** Per-environment URL shortcuts. `--dev`/`--staging`/`--local` set both
@@ -39,8 +42,8 @@ const ENV_PRESETS: Record<string, { relayer: string; web: string }> = {
     local: { relayer: "http://127.0.0.1:8000", web: "http://localhost:5173" },
 };
 
-function parseArgs(argv: string[]): ParsedArgs {
-    const out: ParsedArgs = { help: false, logout: false, forceLogin: false };
+export function parseArgs(argv: string[]): ParsedArgs {
+    const out: ParsedArgs = { help: false, logout: false, forceLogin: false, unknown: [] };
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
         const next = () => argv[++i];
@@ -89,7 +92,22 @@ function parseArgs(argv: string[]): ParsedArgs {
                 else if (a?.startsWith("--label=")) out.label = a.split("=", 2)[1];
                 else if (a?.startsWith("--namespace=")) out.namespace = a.split("=", 2)[1];
                 else if (a?.startsWith("--ns=")) out.namespace = a.split("=", 2)[1];
-                // Unknown flag: ignore silently.
+                // WALM-390: anything still unmatched is a typo, or a flag
+                // from a newer build. Record it. Swallowing it here is what
+                // let `--prod` look supported for months while doing nothing.
+                // Values of KNOWN value-taking flags never reach this branch
+                // — `next()` already consumed them.
+                else if (a !== undefined) {
+                    out.unknown.push(a);
+                    // An unknown flag may take a value too. Consume a
+                    // following non-flag token as that value so `--namesapce
+                    // work` warns once about `--namesapce` rather than twice,
+                    // the second naming the user's data. Keeps a mistyped
+                    // secret (`--tokenn hunter2`) out of stderr and the logs.
+                    if (a.startsWith("-") && argv[i + 1] !== undefined && !argv[i + 1].startsWith("-")) {
+                        i++;
+                    }
+                }
                 break;
         }
     }
@@ -98,6 +116,17 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
     const args = parseArgs(argv);
+
+    // WALM-390: name what we could not parse. Runs before the --help branch
+    // so `memwal-mcp --typo --help` still calls the typo out. Warn, never
+    // exit: an unknown flag from a newer config must not brick the server.
+    for (const flag of args.unknown) {
+        log.warn("cli.unrecognised_arg", { arg: flag });
+        note(
+            `Unrecognised option \`${flag}\` — ignored. ` +
+                `Run \`memwal-mcp --help\` for the supported options.`
+        );
+    }
 
     if (args.help) {
         printHelp();
@@ -255,6 +284,19 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
 }
 
 function printHelp(): void {
+    process.stderr.write(helpText() + "\n");
+}
+
+/** The `--help` body. Exported so tests can assert it stays in step with the
+ *  flags parseArgs actually accepts — WALM-390 was reported precisely because
+ *  it had drifted. */
+export function helpText(): string {
+    // Rendered from ENV_PRESETS rather than retyped, so a new preset cannot
+    // ship undocumented the way --prod did.
+    const presetLines = Object.entries(ENV_PRESETS).flatMap(([name, urls]) => [
+        `  ${`--${name}`.padEnd(33)}relayer: ${urls.relayer}`,
+        `  ${"".padEnd(33)}web:     ${urls.web}`,
+    ]);
     const help = [
         "memwal-mcp — Walrus Memory Model Context Protocol client",
         "",
@@ -279,7 +321,7 @@ function printHelp(): void {
         "                                   Default: https://memory.walrus.xyz",
         "  --label <text>                   Friendly delegate-key label",
         "                                   registered on-chain. Default:",
-        '                                   "Walrus Memory MCP"',
+        '                                   "MCP Client"',
         "  --namespace <name>               Default memory namespace applied",
         "                                   to memwal_remember / recall /",
         "                                   analyze / restore when the agent",
@@ -287,6 +329,12 @@ function printHelp(): void {
         "                                   namespace always wins. Unset →",
         '                                   relayer uses its "default".',
         "                                   Alias: --ns",
+        "",
+        "Network presets (set --relayer and --web-url together):",
+        ...presetLines,
+        "",
+        "                                   An explicit --relayer or --web-url",
+        "                                   overrides the preset it follows.",
         "",
         "Environment (equivalent to options):",
         "  MEMWAL_SERVER_URL                same as --relayer",
@@ -332,7 +380,7 @@ function printHelp(): void {
         "  }",
         "",
     ].join("\n");
-    process.stderr.write(help + "\n");
+    return help;
 }
 
 // Re-exports — handy if someone wants to embed this in another tool.

--- a/packages/mcp/test/health-relayer-annotation.test.mjs
+++ b/packages/mcp/test/health-relayer-annotation.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { annotateHealthResult } from "../dist/bridge.js";
+
+// The relayer can only name an origin its deployment published, and says
+// nothing on a self-hosted or local one — the sidecar there knows only the
+// loopback address it dials. The bridge always knows the URL it connected to,
+// which is exactly what `--prod` / `--relayer` / MEMWAL_SERVER_URL selected.
+
+const DEV = "https://relayer.dev.memwal.ai";
+
+const healthResult = (text) => ({ content: [{ type: "text", text }] });
+
+test("names the dialled relayer when the reply carries none", () => {
+    const result = healthResult("Walrus Memory is reachable. status=ok version=1.2.3");
+    annotateHealthResult(result, DEV);
+    assert.ok(result.content[0].text.includes(`relayer=${DEV}`));
+    // Existing fields must survive.
+    assert.ok(result.content[0].text.includes("status=ok"));
+    assert.ok(result.content[0].text.includes("version=1.2.3"));
+});
+
+test("replaces the relayer the reply already carried rather than adding a second", () => {
+    const result = healthResult(
+        "Walrus Memory is reachable. status=ok version=1.2.3 relayer=https://stale.example write_ready=true",
+    );
+    annotateHealthResult(result, DEV);
+    const text = result.content[0].text;
+    assert.equal(text.match(/relayer=/g).length, 1, `two relayer fields:\n${text}`);
+    assert.ok(text.includes(`relayer=${DEV}`));
+    assert.ok(!text.includes("stale.example"));
+    // The field after it must not be eaten by the replacement.
+    assert.ok(text.includes("write_ready=true"));
+});
+
+test("leaves a failed health call alone", () => {
+    // Naming a relayer beside an error reads as though that relayer answered.
+    const result = { ...healthResult("relayer unreachable"), isError: true };
+    annotateHealthResult(result, DEV);
+    assert.equal(result.content[0].text, "relayer unreachable");
+});
+
+test("tolerates a result shape it does not recognise", () => {
+    for (const result of [{}, { content: [] }, { content: "nope" }, { content: [{ type: "image" }] }]) {
+        assert.doesNotThrow(() => annotateHealthResult(result, DEV));
+    }
+});

--- a/packages/mcp/test/unknown-flags.test.mjs
+++ b/packages/mcp/test/unknown-flags.test.mjs
@@ -3,10 +3,10 @@ import test from "node:test";
 
 import { helpText, parseArgs } from "../dist/index.js";
 
-// WALM-390: an unrecognised flag used to fall through parseArgs' default
-// branch and vanish. A typo'd `--namesapce` still wrote to the relayer's
-// "default" namespace with nothing on stderr to explain why. parseArgs now
-// collects what it did not understand so main() can name it.
+// An unrecognised flag used to fall through parseArgs' default branch and
+// vanish: a typo'd `--namesapce` still wrote to the relayer's "default"
+// namespace with nothing on stderr to explain why. parseArgs now collects what
+// it did not understand so main() can name it.
 
 test("parseArgs collects a typo'd flag instead of dropping it", () => {
     const args = parseArgs(["--namesapce", "work"]);
@@ -36,6 +36,31 @@ test("a known flag after an unknown flag's value still applies", () => {
     const args = parseArgs(["--typo", "value", "--ns", "work"]);
     assert.deepEqual(args.unknown, ["--typo"]);
     assert.equal(args.namespace, "work");
+});
+
+test("an unknown flag does not swallow the `login` command", () => {
+    // `login` is a command, not a value. Consuming it turned
+    // `memwal-mcp --typo login` into a run that never logged in.
+    const args = parseArgs(["--typo", "login"]);
+    assert.deepEqual(args.unknown, ["--typo"]);
+    assert.equal(args.forceLogin, true, "`login` was swallowed as a flag value");
+});
+
+test("an unknown `--key=value` flag reports the key and never the value", () => {
+    // The warning goes to stderr, so a mistyped secret must not survive into it.
+    const args = parseArgs(["--tokenn=hunter2"]);
+    assert.deepEqual(args.unknown, ["--tokenn"]);
+    assert.ok(
+        !args.unknown.some((u) => u.includes("hunter2")),
+        "the flag's value reached the warning",
+    );
+});
+
+test("an unknown `--key=value` flag does not also swallow the next token", () => {
+    // Its value is already attached, so the following token is someone else's.
+    const args = parseArgs(["--tokenn=hunter2", "login"]);
+    assert.deepEqual(args.unknown, ["--tokenn"]);
+    assert.equal(args.forceLogin, true);
 });
 
 test("parseArgs treats no known flag as unknown", () => {
@@ -74,9 +99,8 @@ test("env presets still resolve both URLs (regression guard)", () => {
     assert.deepEqual(args.unknown, []);
 });
 
-// WALM-390 item 2: `--prod` read as unsupported to anyone checking --help,
-// which is how the bug got reported. Help must list every preset the parser
-// honours — and stay listing them as presets are added.
+// Help must list every preset the parser honours, and stay listing them as
+// presets are added.
 
 test("--help documents every network preset the parser accepts", () => {
     const help = helpText();
@@ -88,4 +112,15 @@ test("--help documents every network preset the parser accepts", () => {
     // The URLs a preset resolves to are what tell you which network you're on.
     assert.ok(help.includes("https://relayer.dev.memwal.ai"));
     assert.ok(help.includes("http://127.0.0.1:8000"));
+});
+
+test("--help does not promise that flag order decides a preset override", () => {
+    // Preset application is `??=`, so an explicit URL wins from either side.
+    // Help used to say the flag overrides "the preset it follows".
+    const help = helpText();
+    assert.ok(!help.includes("the preset it follows"), "help still implies order matters");
+    const before = parseArgs(["--relayer", "https://custom.example", "--prod"]);
+    const after = parseArgs(["--prod", "--relayer", "https://custom.example"]);
+    assert.equal(before.relayerUrl, "https://custom.example");
+    assert.equal(after.relayerUrl, "https://custom.example");
 });

--- a/packages/mcp/test/unknown-flags.test.mjs
+++ b/packages/mcp/test/unknown-flags.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { helpText, parseArgs } from "../dist/index.js";
+
+// WALM-390: an unrecognised flag used to fall through parseArgs' default
+// branch and vanish. A typo'd `--namesapce` still wrote to the relayer's
+// "default" namespace with nothing on stderr to explain why. parseArgs now
+// collects what it did not understand so main() can name it.
+
+test("parseArgs collects a typo'd flag instead of dropping it", () => {
+    const args = parseArgs(["--namesapce", "work"]);
+    assert.deepEqual(args.unknown, ["--namesapce"]);
+    // The typo must NOT have set the real namespace.
+    assert.equal(args.namespace, undefined);
+});
+
+test("parseArgs reports every unknown flag, not just the first", () => {
+    const args = parseArgs(["--nope", "--alsobad"]);
+    assert.deepEqual(args.unknown, ["--nope", "--alsobad"]);
+});
+
+test("an unknown flag swallows its value rather than reporting it too", () => {
+    // Warning once about `--namesapce` beats warning twice, the second time
+    // naming the user's data. Also keeps a mistyped secret out of the logs.
+    assert.deepEqual(parseArgs(["--tokenn", "hunter2"]).unknown, ["--tokenn"]);
+});
+
+test("an unknown flag does not swallow the flag that follows it", () => {
+    const args = parseArgs(["--typo", "--prod"]);
+    assert.deepEqual(args.unknown, ["--typo"]);
+    assert.equal(args.relayerUrl, "https://relayer.memory.walrus.xyz");
+});
+
+test("a known flag after an unknown flag's value still applies", () => {
+    const args = parseArgs(["--typo", "value", "--ns", "work"]);
+    assert.deepEqual(args.unknown, ["--typo"]);
+    assert.equal(args.namespace, "work");
+});
+
+test("parseArgs treats no known flag as unknown", () => {
+    const known = [
+        "--help", "-h",
+        "--logout",
+        "--login", "login",
+        "--prod", "--dev", "--staging", "--local",
+        "--relayer", "https://r.example",
+        "--relayer-url", "https://r.example",
+        "--web-url", "https://w.example",
+        "--web", "https://w.example",
+        "--label", "my label",
+        "--namespace", "ns",
+        "--ns", "ns",
+        "--relayer=https://r.example",
+        "--web-url=https://w.example",
+        "--label=my-label",
+        "--namespace=ns",
+        "--ns=ns",
+    ];
+    assert.deepEqual(parseArgs(known).unknown, []);
+});
+
+test("parseArgs does not mistake a flag's value for an unknown flag", () => {
+    // `next()` consumes the value, so "MCP Client" must never be reported.
+    const args = parseArgs(["--label", "MCP Client"]);
+    assert.deepEqual(args.unknown, []);
+    assert.equal(args.label, "MCP Client");
+});
+
+test("env presets still resolve both URLs (regression guard)", () => {
+    const args = parseArgs(["--prod"]);
+    assert.equal(args.relayerUrl, "https://relayer.memory.walrus.xyz");
+    assert.equal(args.webUrl, "https://memory.walrus.xyz");
+    assert.deepEqual(args.unknown, []);
+});
+
+// WALM-390 item 2: `--prod` read as unsupported to anyone checking --help,
+// which is how the bug got reported. Help must list every preset the parser
+// honours — and stay listing them as presets are added.
+
+test("--help documents every network preset the parser accepts", () => {
+    const help = helpText();
+    for (const preset of ["--prod", "--dev", "--staging", "--local"]) {
+        // Not merely mentioned somewhere — parseArgs must accept it too.
+        assert.deepEqual(parseArgs([preset]).unknown, [], `${preset} not accepted`);
+        assert.ok(help.includes(preset), `${preset} missing from --help`);
+    }
+    // The URLs a preset resolves to are what tell you which network you're on.
+    assert.ok(help.includes("https://relayer.dev.memwal.ai"));
+    assert.ok(help.includes("http://127.0.0.1:8000"));
+});

--- a/services/server/scripts/mcp/__tests__/health-relayer.test.ts
+++ b/services/server/scripts/mcp/__tests__/health-relayer.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { MemWalSession } from "../auth.js";
+import { createMcpServer } from "../server.js";
+
+// WALM-390 item 3: memwal_health reported status + version only. Nothing said
+// WHICH relayer answered, so a config pointing at the wrong network looked
+// perfectly healthy right up until the memories were missing.
+
+const RELAYER = "https://relayer-staging.memory.walrus.xyz";
+
+async function callHealth(t: TestContext, session: Partial<MemWalSession>): Promise<string> {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createMcpServer({
+        oauthScope: "memwal:read",
+        memwal: { health: async () => ({ status: "ok", version: "1.2.3" }) },
+        ...session,
+    } as unknown as MemWalSession);
+    const client = new Client({ name: "health-test", version: "1.0.0" });
+    t.after(async () => {
+        await client.close();
+        await server.close();
+    });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const res = (await client.callTool({ name: "memwal_health", arguments: {} })) as {
+        content: { type: string; text: string }[];
+    };
+    return res.content.map((c) => c.text).join("\n");
+}
+
+test("memwal_health names the relayer that answered", async (t) => {
+    const text = await callHealth(t, { relayerUrl: RELAYER });
+    assert.ok(text.includes(RELAYER), `relayer URL missing from health output:\n${text}`);
+    // Existing contract must survive.
+    assert.ok(text.includes("status=ok"));
+    assert.ok(text.includes("version=1.2.3"));
+});
+
+test("memwal_health still answers when the relayer URL is unknown", async (t) => {
+    const text = await callHealth(t, { relayerUrl: undefined });
+    assert.ok(text.includes("status=ok"), `health broke without a relayer URL:\n${text}`);
+});

--- a/services/server/scripts/mcp/__tests__/health-relayer.test.ts
+++ b/services/server/scripts/mcp/__tests__/health-relayer.test.ts
@@ -3,19 +3,42 @@ import test, { type TestContext } from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { MemWalSession } from "../auth.js";
+import { resolveAuth } from "../auth.js";
 import { createMcpServer } from "../server.js";
 
-// WALM-390 item 3: memwal_health reported status + version only. Nothing said
-// WHICH relayer answered, so a config pointing at the wrong network looked
-// perfectly healthy right up until the memories were missing.
+// memwal_health reported status + version only. Nothing said WHICH relayer
+// answered, so a config pointing at the wrong network looked perfectly healthy
+// right up until the memories were missing.
+//
+// The value it reports must be a network identity. `relayerUrl` is not one:
+// it is the address the sidecar dials, and the Rust parent fills it with
+// loopback whenever an operator did not override it. Only an operator-supplied
+// public origin reaches `publicRelayerUrl`, and only that is printed.
 
-const RELAYER = "https://relayer-staging.memory.walrus.xyz";
+const PUBLIC_ORIGIN = "https://relayer-staging.memory.walrus.xyz";
+const LOOPBACK = "http://127.0.0.1:8000";
+
+const TOKEN = "test-sidecar-token-0123456789";
+const DELEGATE_KEY = "a".repeat(64);
+const ACCOUNT_ID = `0x${"b".repeat(64)}`;
+
+function mcpHeaders(): Headers {
+    return new Headers({
+        authorization: `Bearer ${DELEGATE_KEY}`,
+        "x-memwal-account-id": ACCOUNT_ID,
+        "x-memwal-internal-sidecar-token": TOKEN,
+        "x-memwal-internal-oauth-scope": "memwal:read",
+    });
+}
+
+/** Stubbed relayer health so the tool call stays offline. */
+const HEALTH_STUB = { health: async () => ({ status: "ok", version: "1.2.3" }) };
 
 async function callHealth(t: TestContext, session: Partial<MemWalSession>): Promise<string> {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const server = createMcpServer({
         oauthScope: "memwal:read",
-        memwal: { health: async () => ({ status: "ok", version: "1.2.3" }) },
+        memwal: HEALTH_STUB,
         ...session,
     } as unknown as MemWalSession);
     const client = new Client({ name: "health-test", version: "1.0.0" });
@@ -32,15 +55,46 @@ async function callHealth(t: TestContext, session: Partial<MemWalSession>): Prom
     return res.content.map((c) => c.text).join("\n");
 }
 
-test("memwal_health names the relayer that answered", async (t) => {
-    const text = await callHealth(t, { relayerUrl: RELAYER });
-    assert.ok(text.includes(RELAYER), `relayer URL missing from health output:\n${text}`);
+/**
+ * Health text for a session built the way a real request builds one — through
+ * `resolveAuth`, not hand-assembled — with only the relayer round-trip stubbed.
+ */
+async function callHealthThroughResolveAuth(
+    t: TestContext,
+    serverUrl: string,
+    publicRelayerUrl?: string
+): Promise<string> {
+    process.env.SIDECAR_AUTH_TOKEN = TOKEN;
+    const { session } = await resolveAuth(mcpHeaders(), serverUrl, publicRelayerUrl);
+    return callHealth(t, {
+        ...session,
+        memwal: HEALTH_STUB as unknown as MemWalSession["memwal"],
+    });
+}
+
+test("memwal_health names the relayer origin the deployment published", async (t) => {
+    const text = await callHealthThroughResolveAuth(t, LOOPBACK, PUBLIC_ORIGIN);
+    assert.ok(text.includes(PUBLIC_ORIGIN), `public origin missing from health output:\n${text}`);
     // Existing contract must survive.
     assert.ok(text.includes("status=ok"));
     assert.ok(text.includes("version=1.2.3"));
 });
 
-test("memwal_health still answers when the relayer URL is unknown", async (t) => {
-    const text = await callHealth(t, { relayerUrl: undefined });
+test("memwal_health does not report the loopback address as a network", async (t) => {
+    // The default deployment: the sidecar dials loopback and no operator
+    // supplied a public origin. Printing `relayer=http://127.0.0.1:8000` here
+    // is the "healthy on the wrong network" failure this tool exists to catch,
+    // so health must stay silent about the relayer instead.
+    const text = await callHealthThroughResolveAuth(t, LOOPBACK);
+    assert.ok(text.includes("status=ok"), `health broke without a public origin:\n${text}`);
+    assert.ok(
+        !text.includes("relayer="),
+        `health named a relayer it cannot vouch for:\n${text}`
+    );
+    assert.ok(!text.includes(LOOPBACK), `health leaked the loopback dial address:\n${text}`);
+});
+
+test("memwal_health still answers when the session carries no relayer URL", async (t) => {
+    const text = await callHealth(t, { relayerUrl: undefined, publicRelayerUrl: undefined });
     assert.ok(text.includes("status=ok"), `health broke without a relayer URL:\n${text}`);
 });

--- a/services/server/scripts/mcp/auth.ts
+++ b/services/server/scripts/mcp/auth.ts
@@ -24,6 +24,11 @@ export interface MemWalSession {
     delegatePubKeyHex: string;
     namespace?: string;
     memwal: MemWal;
+    /** Relayer base URL this session is bound to. WALM-390: memwal_health
+     *  reports it so a client pointed at the wrong network can see that,
+     *  rather than discovering it via missing memories. MemWal keeps its
+     *  own copy private, so we carry it alongside. */
+    relayerUrl: string;
     authMethod: "delegate-key";
     oauthScope?: string;
     /** Stable coding-agent id (`claude-code`, `codex`, `other`, …). */
@@ -156,6 +161,7 @@ export async function resolveAuth(
         delegatePubKeyHex,
         namespace,
         memwal,
+        relayerUrl: serverUrl,
         authMethod: "delegate-key",
         oauthScope,
     };

--- a/services/server/scripts/mcp/auth.ts
+++ b/services/server/scripts/mcp/auth.ts
@@ -24,11 +24,16 @@ export interface MemWalSession {
     delegatePubKeyHex: string;
     namespace?: string;
     memwal: MemWal;
-    /** Relayer base URL this session is bound to. WALM-390: memwal_health
-     *  reports it so a client pointed at the wrong network can see that,
-     *  rather than discovering it via missing memories. MemWal keeps its
-     *  own copy private, so we carry it alongside. */
+    /** Relayer base URL the SDK dials. Loopback unless the deployment
+     *  overrides it, so it is NOT a network identity — see
+     *  `publicRelayerUrl`. MemWal keeps its own copy private, so we carry
+     *  one alongside. */
     relayerUrl: string;
+    /** The relayer's public origin, when the deployment states one.
+     *  `memwal_health` reports it so a client pointed at the wrong network
+     *  sees that, rather than discovering it via missing memories. Unset
+     *  when the sidecar only knows the loopback address it dials. */
+    publicRelayerUrl?: string;
     authMethod: "delegate-key";
     oauthScope?: string;
     /** Stable coding-agent id (`claude-code`, `codex`, `other`, …). */
@@ -111,7 +116,8 @@ function bytesToHex(b: Uint8Array): string {
  */
 export async function resolveAuth(
     headers: Headers,
-    serverUrl: string
+    serverUrl: string,
+    publicRelayerUrl?: string
 ): Promise<AuthResolution> {
     // Runs before anything else reads the request: `x-memwal-internal-*`
     // headers carry decisions the relayer already made, so a caller that
@@ -162,6 +168,7 @@ export async function resolveAuth(
         namespace,
         memwal,
         relayerUrl: serverUrl,
+        publicRelayerUrl,
         authMethod: "delegate-key",
         oauthScope,
     };

--- a/services/server/scripts/mcp/index.ts
+++ b/services/server/scripts/mcp/index.ts
@@ -167,7 +167,8 @@ function expressHeadersToWeb(req: Request): Headers {
 async function handleSse(
     req: Request,
     res: Response,
-    relayerUrl: string
+    relayerUrl: string,
+    publicRelayerUrl: string | undefined
 ): Promise<void> {
     // Rate limit BEFORE resolveAuth — see comment on `rateLimiter` above.
     // resolveAuth only checks header shape, so we must cap concurrent SSE
@@ -187,7 +188,7 @@ async function handleSse(
 
     let auth: AuthResolution;
     try {
-        auth = await resolveAuth(expressHeadersToWeb(req), relayerUrl);
+        auth = await resolveAuth(expressHeadersToWeb(req), relayerUrl, publicRelayerUrl);
     } catch (err) {
         releaseSlot();
         if (err instanceof McpAuthError) {
@@ -287,7 +288,8 @@ async function handleSse(
 async function handlePostMessage(
     req: Request,
     res: Response,
-    relayerUrl: string
+    relayerUrl: string,
+    publicRelayerUrl: string | undefined
 ): Promise<void> {
     const sessionId = typeof req.query.sessionId === "string" ? req.query.sessionId : undefined;
     if (!sessionId) {
@@ -300,7 +302,7 @@ async function handlePostMessage(
 
     let auth: AuthResolution;
     try {
-        auth = await resolveAuth(expressHeadersToWeb(req), relayerUrl);
+        auth = await resolveAuth(expressHeadersToWeb(req), relayerUrl, publicRelayerUrl);
     } catch (err) {
         if (err instanceof McpAuthError) {
             res.setHeader(
@@ -357,14 +359,15 @@ async function handlePostMessage(
 async function handleStreamableHttp(
     req: Request,
     res: Response,
-    relayerUrl: string
+    relayerUrl: string,
+    publicRelayerUrl: string | undefined
 ): Promise<void> {
     // 1) Auth — bearer + accountId same as SSE path. Cheap to re-run per
     //    request; resolveAuth's on-chain lookup is cached by the SDK once
     //    we mint the Walrus Memory client per session.
     let auth: AuthResolution;
     try {
-        auth = await resolveAuth(expressHeadersToWeb(req), relayerUrl);
+        auth = await resolveAuth(expressHeadersToWeb(req), relayerUrl, publicRelayerUrl);
     } catch (err) {
         if (err instanceof McpAuthError) {
             res.setHeader(
@@ -549,6 +552,13 @@ async function handleStreamableHttp(
 export interface MountMcpOptions {
     /** Relayer base URL that tool calls hit. Default: `http://localhost:3001`. */
     relayerUrl?: string;
+    /**
+     * The relayer's public origin, when the deployment states one. Reported by
+     * `memwal_health` as the network the session is bound to. Deliberately
+     * separate from `relayerUrl`, which is only the address the sidecar dials
+     * and is loopback on every deployment that does not override it.
+     */
+    publicRelayerUrl?: string;
 }
 
 /**
@@ -568,10 +578,11 @@ export function mountMcpRoutes(
     options: MountMcpOptions = {}
 ): void {
     const relayerUrl = options.relayerUrl ?? "http://localhost:3001";
+    const publicRelayerUrl = options.publicRelayerUrl;
 
     app.get("/mcp/sse", async (req, res) => {
         try {
-            await handleSse(req, res, relayerUrl);
+            await handleSse(req, res, relayerUrl, publicRelayerUrl);
         } catch (err) {
             log.error("mcp.sse.error", {
                 err: err instanceof Error ? err.message : String(err),
@@ -589,7 +600,7 @@ export function mountMcpRoutes(
         // transport's internal raw-body parser.
         async (req, res) => {
             try {
-                await handlePostMessage(req, res, relayerUrl);
+                await handlePostMessage(req, res, relayerUrl, publicRelayerUrl);
             } catch (err) {
                 log.error("mcp.post.error", {
                     err: err instanceof Error ? err.message : String(err),
@@ -613,7 +624,7 @@ export function mountMcpRoutes(
     // req.method.
     const streamableHandler = async (req: Request, res: Response) => {
         try {
-            await handleStreamableHttp(req, res, relayerUrl);
+            await handleStreamableHttp(req, res, relayerUrl, publicRelayerUrl);
         } catch (err) {
             log.error("mcp.streamable.error", {
                 err: err instanceof Error ? err.message : String(err),
@@ -634,6 +645,7 @@ export function mountMcpRoutes(
             "GET|POST|DELETE /mcp (streamable HTTP)",
         ],
         relayerUrl,
+        publicRelayerUrl: publicRelayerUrl ?? null,
     });
 }
 

--- a/services/server/scripts/mcp/tools/health.ts
+++ b/services/server/scripts/mcp/tools/health.ts
@@ -18,7 +18,7 @@ export function registerHealthTool(
         {
             ...TOOL_METADATA.memwal_health,
             description:
-                "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version. Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
+                "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status, version, and the relayer URL that answered (use it to confirm which network — prod / staging / dev / local — this client is bound to). Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
             inputSchema: {},
         },
         wrapTool<Record<string, never>>(session, "memwal_health", async () => {
@@ -30,11 +30,16 @@ export function registerHealthTool(
                     : extra.write_ready === true
                       ? " write_ready=true"
                       : "";
+            // WALM-390: name the relayer that actually answered. A config on
+            // the wrong network is otherwise invisible here.
+            const relayerNote = session.relayerUrl
+                ? ` relayer=${session.relayerUrl}`
+                : "";
             return {
                 content: [
                     {
                         type: "text",
-                        text: `Walrus Memory is reachable. status=${result.status} version=${result.version}${writeNote}`,
+                        text: `Walrus Memory is reachable. status=${result.status} version=${result.version}${relayerNote}${writeNote}`,
                     },
                 ],
             };

--- a/services/server/scripts/mcp/tools/health.ts
+++ b/services/server/scripts/mcp/tools/health.ts
@@ -18,7 +18,7 @@ export function registerHealthTool(
         {
             ...TOOL_METADATA.memwal_health,
             description:
-                "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status, version, and the relayer URL that answered (use it to confirm which network — prod / staging / dev / local — this client is bound to). Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
+                "Quick connectivity check for Walrus Memory. Calls the relayer's lightweight health endpoint (no search, no decryption) and returns its status and version, plus the relayer origin when the deployment publishes one (use it to confirm which network — prod / staging / dev / local — this client is bound to). Use this to confirm the server is reachable — do NOT use memwal_recall for health checks, which is a full and slow retrieval.",
             inputSchema: {},
         },
         wrapTool<Record<string, never>>(session, "memwal_health", async () => {
@@ -30,10 +30,12 @@ export function registerHealthTool(
                     : extra.write_ready === true
                       ? " write_ready=true"
                       : "";
-            // WALM-390: name the relayer that actually answered. A config on
-            // the wrong network is otherwise invisible here.
-            const relayerNote = session.relayerUrl
-                ? ` relayer=${session.relayerUrl}`
+            // Only a deployment-supplied public origin, never `relayerUrl`
+            // — that one is the address this process dials, which is loopback
+            // unless overridden. Printing loopback as the network is how a
+            // client bound to the wrong relayer reads as correctly configured.
+            const relayerNote = session.publicRelayerUrl
+                ? ` relayer=${session.publicRelayerUrl}`
                 : "";
             return {
                 content: [

--- a/services/server/scripts/sidecar/app.ts
+++ b/services/server/scripts/sidecar/app.ts
@@ -57,6 +57,10 @@ export function createSidecarApp(mode: "full" | "writer" = SIDECAR_ROUTE_MODE): 
     if (mode === "full") {
         mountMcpRoutes(app, {
             relayerUrl: process.env.MEMWAL_RELAYER_URL ?? "http://localhost:3001",
+            // Set by the Rust parent only when an operator supplied
+            // MEMWAL_RELAYER_URL. Absent means the sidecar dials loopback and
+            // has no public origin to name.
+            publicRelayerUrl: process.env.MEMWAL_PUBLIC_RELAYER_URL,
         });
     }
 

--- a/services/server/src/main.rs
+++ b/services/server/src/main.rs
@@ -706,14 +706,27 @@ async fn main() {
     let scripts_dir = std::env::var("SIDECAR_SCRIPTS_DIR")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts"));
-    let mcp_relayer_url = std::env::var("MEMWAL_RELAYER_URL")
-        .unwrap_or_else(|_| format!("http://127.0.0.1:{}", config.port));
-    let mut sidecar_child = tokio::process::Command::new("npx")
+    // Two different things, deliberately kept apart. `MEMWAL_RELAYER_URL` is
+    // the address the sidecar DIALS, and falls back to loopback because that
+    // is where this process listens. Only an operator-supplied value is also
+    // a public origin, so only that one is forwarded as the network identity
+    // `memwal_health` may report; loopback names no network, and reporting it
+    // as one is how a client bound to the wrong relayer looks healthy.
+    let operator_relayer_url = std::env::var("MEMWAL_RELAYER_URL").ok();
+    let mcp_relayer_url = operator_relayer_url
+        .clone()
+        .unwrap_or_else(|| format!("http://127.0.0.1:{}", config.port));
+    let mut sidecar_command = tokio::process::Command::new("npx");
+    sidecar_command
         .args(["tsx", "sidecar-server.ts"])
         .current_dir(&scripts_dir)
         .env("MEMWAL_RELAYER_URL", mcp_relayer_url)
         .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
+    if let Some(public_relayer_url) = operator_relayer_url {
+        sidecar_command.env("MEMWAL_PUBLIC_RELAYER_URL", public_relayer_url);
+    }
+    let mut sidecar_child = sidecar_command
         .spawn()
         .expect("Failed to start TS sidecar. Is Node.js installed?");
 


### PR DESCRIPTION
Closes [WALM-390](https://linear.app/mysten-labs/issue/WALM-390). Fixes #630.

`--prod` landing as a real flag left three gaps. This closes all three.

### 1. Unknown flags no longer vanish

`parseArgs`' default branch dropped anything unmatched (`// Unknown flag: ignore silently.`), so a typo'd `--namesapce work` wrote to the `default` namespace with nothing on stderr. It now collects what it didn't match, and `main()` names each one:

```
{"level":"warn","event":"cli.unrecognised_arg","arg":"--namesapce"}
[memwal-mcp] Unrecognised option `--namesapce` — ignored. Run `memwal-mcp --help` for the supported options.
```

Warns rather than exits — a flag from a newer config must not brick the server.

One decision worth a look: **an unknown flag consumes a following non-flag token as its presumed value.** Without it, `--namesapce work` warned twice, the second naming the user's data. It also keeps a mistyped secret (`--tokenn hunter2`) out of stderr and the structured logs; verified `hunter2` reaches neither.

### 2. Presets documented

`--help` gained a `Network presets` section listing all four with their resolved URLs — **rendered from `ENV_PRESETS`, not retyped**, so a new preset can't ship undocumented the way `--prod` did. `printHelp` was split into a testable `helpText()`; the test walks each preset through `parseArgs` *and* the help text, so they can't drift apart again.

Drive-by while in that block: help gave the `--label` default as `"Walrus Memory MCP"`, code uses `"MCP Client"` (`index.ts:158`). Corrected.

### 3. Health names the relayer

```
Walrus Memory is reachable. status=ok version=1.2.3 relayer=https://relayer-staging.memory.walrus.xyz
```

`relayerUrl` is threaded onto `MemWalSession` from the URL `resolveAuth` already receives. Deliberately **not** an SDK getter: `MemWal.serverUrl` is private, and `services/server` imports the *published* `@mysten-incubation/memwal`, so an SDK change wouldn't land until a release. Tool description updated so the agent knows it can use this to confirm which network it's on.

### Verification

- `packages/mcp`: 70/70
- `services/server/scripts` MCP suite: 80/80
- `tsc --noEmit` clean both sides
- Built binary smoke-tested for the warning and the `--help` output

New coverage: `packages/mcp/test/unknown-flags.test.mjs` (9 cases), `services/server/scripts/mcp/__tests__/health-relayer.test.ts` (2 cases).