### PR TITLE
fix(sdk): throw when positional recall gets a namespace string (WALM-161)

### DIFF
--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -112,7 +112,7 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 
 - Preferred form: `recall({ query, limit?, topK?, namespace?, maxDistance?, sort?, scoringWeights? })`
 - `limit` defaults to `10`; `topK` is an alias and wins when both are set
-- Legacy positional forms still work: `recall(query)`, `recall(query, limit)`, `recall(query, limit, namespace)`, and `recall(query, options)`
+- Legacy positional forms still work: `recall(query)`, `recall(query, limit)`, `recall(query, limit, namespace)`, and `recall(query, options)`. `recall(query, namespace)` throws `TypeError` — namespace is not a valid second argument.
 - `maxDistance` filters weak matches client-side by dropping results where `distance >= maxDistance`
 - `sort` picks the ordering: `"relevance"` (default) or `"recent"` for newest-among-matches
 - `scoringWeights` blends recency and importance into the ranking (see [Ordering](#ordering) below)

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -112,7 +112,7 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 
 - Preferred form: `recall({ query, limit?, topK?, namespace?, maxDistance?, sort?, scoringWeights? })`
 - `limit` defaults to `10`; `topK` is an alias and wins when both are set
-- Legacy positional forms still work: `recall(query)`, `recall(query, limit)`, `recall(query, limit, namespace)`, and `recall(query, options)`. `recall(query, namespace)` throws `TypeError` — namespace is not a valid second argument.
+- Legacy positional forms still work: `recall(query)`, `recall(query, limit)`, `recall(query, limit, namespace)`, and `recall(query, options)`. `recall(query, namespace)` throws `TypeError`; namespace is not a valid second argument.
 - `maxDistance` filters weak matches client-side by dropping results where `distance >= maxDistance`
 - `sort` picks the ordering: `"relevance"` (default) or `"recent"` for newest-among-matches
 - `scoringWeights` blends recency and importance into the ranking (see [Ordering](#ordering) below)
@@ -347,6 +347,9 @@ Embed locally, SEAL encrypt locally, send encrypted payload + vector to relayer 
 ### `recallManual(query, limit?, namespace?): Promise<RecallManualResult>`
 
 Embed locally, search via relayer, download from Walrus, SEAL decrypt locally. Returns decrypted text results.
+
+- `recallManual(query, { limit?, namespace?, scoringWeights? })` is valid
+- `recallManual(query, namespace)` throws `TypeError`; namespace is not a valid second argument
 
 ### `restore(namespace, limit?): Promise<RestoreResult>`
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -43,6 +43,7 @@ This release adds write-time on recall results, lets callers sort by recency or 
 ### Fixed
 
 - HTTP 503 from the relayer is reported as a retryable upstream outage, not a sign-in failure. Empty-body 401s still point at `memwal_login`.
+- Positional `recall(query, namespace)` now throws `TypeError` instead of silently ignoring the namespace.
 
 ## 0.1.5
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - HTTP 503 with `x-auth-error: AUTH_UPSTREAM_UNAVAILABLE` is reported as a retryable credential-verification outage, not a sign-in failure. Other 503s keep the generic sanitized body. Empty-body 401s still point at `memwal_login`.
+- Positional `recall(query, namespace)` now throws `TypeError` instead of silently ignoring the namespace.
 
 ## 0.1.5
 

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -379,6 +379,9 @@ export class MemWalManual {
      * 2. Search server for matching vectors
      * 3. Download blobs from Walrus
      * 4. SEAL decrypt each blob
+     *
+     * `recallManual(query, { limit?, namespace? })` is valid.
+     * `recallManual(query, namespace)` throws `TypeError`.
      */
     async recallManual(query: string, options: MemWalManualRecallOptions): Promise<RecallManualResult>;
     async recallManual(query: string, limit?: number, namespace?: string): Promise<RecallManualResult>;

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -51,6 +51,7 @@ import {
     scoringWeightsToWire,
 } from "./utils.js";
 import { assertCompatibleRelayer, compatibilityErrorFromStatus } from "./compatibility.js";
+import { resolveLimitOrOptions } from "./recall-args.js";
 
 // ============================================================
 // Constants
@@ -379,8 +380,8 @@ export class MemWalManual {
      * 3. Download blobs from Walrus
      * 4. SEAL decrypt each blob
      */
+    async recallManual(query: string, options: MemWalManualRecallOptions): Promise<RecallManualResult>;
     async recallManual(query: string, limit?: number, namespace?: string): Promise<RecallManualResult>;
-    async recallManual(query: string, options?: MemWalManualRecallOptions): Promise<RecallManualResult>;
     async recallManual(
         query: string,
         limitOrOptions: number | MemWalManualRecallOptions = 10,
@@ -388,7 +389,11 @@ export class MemWalManual {
     ): Promise<RecallManualResult> {
         if (!query.trim()) throw new Error("Query cannot be empty");
 
-        const options = typeof limitOrOptions === "number" ? { limit: limitOrOptions, namespace } : limitOrOptions;
+        const options = resolveLimitOrOptions(
+            "recallManual",
+            limitOrOptions,
+            namespace,
+        );
         const limit = options.limit ?? 10;
         const ns = options.namespace ?? this.namespace;
 

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -74,6 +74,7 @@ import {
     compatibilityErrorFromStatus,
 } from "./compatibility.js";
 import { applyTokenBudget, estimateTokens } from "./tokens.js";
+import { resolveRecallCall } from "./recall-args.js";
 
 // ============================================================
 // Ed25519 Signing (lazy-loaded)
@@ -591,6 +592,8 @@ export class MemWal {
      * - `recall(query, limit, namespace)`
      * - `recall(query, { limit, namespace, maxDistance, topK })`
      *
+     * `recall(query, namespace)` is invalid and throws `TypeError`.
+     *
      * `topK` and `limit` are aliases; if both are set, `topK` wins.
      *
      * @returns RecallResult with decrypted text results
@@ -637,9 +640,16 @@ export class MemWal {
      * `recall({ query, limit, namespace })`. Positional will be removed in a
      * future major version of the SDK.
      */
+    async recall(query: string, options: RecallOptions): Promise<RecallResult>;
+    /**
+     * @deprecated Positional `recall(query, limit, namespace)` is easy to
+     * misread as `recall(query, namespace)`. Prefer the object form
+     * `recall({ query, limit, namespace })`. Positional will be removed in a
+     * future major version of the SDK.
+     */
     async recall(
         query: string,
-        limitOrOptions?: number | RecallOptions,
+        limit?: number,
         namespace?: string,
     ): Promise<RecallResult>;
     async recall(
@@ -647,22 +657,11 @@ export class MemWal {
         limitOrOptions: number | RecallOptions | undefined = 10,
         namespace?: string,
     ): Promise<RecallResult> {
-        let query: string;
-        let options: RecallOptions;
-        if (typeof queryOrParams === "object") {
-            const { query: q, ...rest } = queryOrParams;
-            query = q;
-            options = rest;
-        } else {
-            query = queryOrParams;
-            if (limitOrOptions == null) {
-                options = { limit: 10, namespace };
-            } else if (typeof limitOrOptions === "number") {
-                options = { limit: limitOrOptions, namespace };
-            } else {
-                options = limitOrOptions;
-            }
-        }
+        const { query, options } = resolveRecallCall(
+            queryOrParams,
+            limitOrOptions,
+            namespace,
+        );
         const limit = options.topK ?? options.limit ?? 10;
         const resolvedNamespace = options.namespace ?? this.namespace;
 

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -577,6 +577,25 @@ export class MemWal {
     }
 
     /**
+     * Estimate the token cost of a string using the SDK's default
+     * character-based approximation (~chars/4, code-point aware). Useful to weigh
+     * a recall payload before injecting it into a model context:
+     *
+     * ```ts
+     * const hits = await memwal.recall({ query, limit: 8 });
+     * const joined = hits.results.map((h) => h.text).join("\n---\n");
+     * if (memwal.countTokens(joined) > 2048) { /* re-query with maxTokens *\/ }
+     * ```
+     *
+     * This is an estimate, not an exact tokenizer count — see `estimateTokens`
+     * for accuracy caveats. For exact counts, pass your own counter to
+     * `recall({ maxTokens, countTokens })`.
+     */
+    countTokens(text: string): number {
+        return estimateTokens(text);
+    }
+
+    /**
      * Recall memories similar to a query — server handles:
      * verify → embed query → search → Walrus download → decrypt → return plaintext.
      *
@@ -614,36 +633,17 @@ export class MemWal {
      * const result2 = await memwal.recall("food allergies", 5, "profile");
      * ```
      */
-    /**
-     * Estimate the token cost of a string using the SDK's default
-     * character-based approximation (~chars/4, code-point aware). Useful to weigh
-     * a recall payload before injecting it into a model context:
-     *
-     * ```ts
-     * const hits = await memwal.recall({ query, limit: 8 });
-     * const joined = hits.results.map((h) => h.text).join("\n---\n");
-     * if (memwal.countTokens(joined) > 2048) { /* re-query with maxTokens *\/ }
-     * ```
-     *
-     * This is an estimate, not an exact tokenizer count — see `estimateTokens`
-     * for accuracy caveats. For exact counts, pass your own counter to
-     * `recall({ maxTokens, countTokens })`.
-     */
-    countTokens(text: string): number {
-        return estimateTokens(text);
-    }
-
     async recall(params: RecallParams): Promise<RecallResult>;
     /**
      * @deprecated Positional `recall(query, limit, namespace)` is easy to
-     * misread as `recall(query, namespace)`. Prefer the object form
+     * misread as `recall(query, namespace)`, which throws `TypeError`. Prefer
      * `recall({ query, limit, namespace })`. Positional will be removed in a
      * future major version of the SDK.
      */
     async recall(query: string, options: RecallOptions): Promise<RecallResult>;
     /**
      * @deprecated Positional `recall(query, limit, namespace)` is easy to
-     * misread as `recall(query, namespace)`. Prefer the object form
+     * misread as `recall(query, namespace)`, which throws `TypeError`. Prefer
      * `recall({ query, limit, namespace })`. Positional will be removed in a
      * future major version of the SDK.
      */

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -22,6 +22,7 @@ import type {
     ListNamespacesOptions,
 } from "./types.js";
 import { applyTokenBudget, estimateTokens } from "./tokens.js";
+import { resolveRecallCall } from "./recall-args.js";
 
 export interface MemWalMockSeed {
     text: string;
@@ -245,9 +246,16 @@ export class MemWalMock {
     }
 
     async recall(params: RecallParams): Promise<RecallResult>;
+    /**
+     * @deprecated Prefer `recall({ query, limit, namespace })`.
+     */
+    async recall(query: string, options: RecallOptions): Promise<RecallResult>;
+    /**
+     * @deprecated Prefer `recall({ query, limit, namespace })`.
+     */
     async recall(
         query: string,
-        limitOrOptions?: number | RecallOptions,
+        limit?: number,
         namespace?: string
     ): Promise<RecallResult>;
     async recall(
@@ -255,22 +263,11 @@ export class MemWalMock {
         limitOrOptions: number | RecallOptions | undefined = 10,
         namespace?: string
     ): Promise<RecallResult> {
-        let query: string;
-        let options: RecallOptions;
-        if (typeof queryOrParams === "object") {
-            const { query: objectQuery, ...rest } = queryOrParams;
-            query = objectQuery;
-            options = rest;
-        } else {
-            query = queryOrParams;
-            if (limitOrOptions == null) {
-                options = { limit: 10, namespace };
-            } else if (typeof limitOrOptions === "number") {
-                options = { limit: limitOrOptions, namespace };
-            } else {
-                options = limitOrOptions;
-            }
-        }
+        const { query, options } = resolveRecallCall(
+            queryOrParams,
+            limitOrOptions,
+            namespace
+        );
         validateText(query, "query");
         const resolvedNamespace = options.namespace ?? this.namespace;
         const resolvedLimit = options.topK ?? options.limit ?? 10;

--- a/packages/sdk/src/recall-args.ts
+++ b/packages/sdk/src/recall-args.ts
@@ -1,0 +1,52 @@
+import type { RecallOptions, RecallParams } from "./types.js";
+
+/**
+ * Parse `limit` / options for deprecated positional recall-style calls.
+ * A string second argument is the `recall(query, namespace)` footgun (#293).
+ */
+export function resolveLimitOrOptions<T extends { limit?: number; namespace?: string }>(
+    method: string,
+    limitOrOptions: number | T | undefined | null,
+    namespace?: string,
+    defaultLimit = 10,
+): T {
+    if (limitOrOptions == null) {
+        return { limit: defaultLimit, namespace } as T;
+    }
+    if (typeof limitOrOptions === "number") {
+        return { limit: limitOrOptions, namespace } as T;
+    }
+    if (typeof limitOrOptions === "object" && !Array.isArray(limitOrOptions)) {
+        return limitOrOptions;
+    }
+    throw new TypeError(
+        `${method}() second argument must be a number (limit) or an options object, not a string. ` +
+            `Namespace goes in ${method}({ query, namespace }) or as the third argument: ` +
+            `${method}(query, limit, namespace).`,
+    );
+}
+
+/** Normalize object-style and positional `recall()` arguments. */
+export function resolveRecallCall(
+    queryOrParams: string | RecallParams,
+    limitOrOptions?: number | RecallOptions | null,
+    namespace?: string,
+): { query: string; options: RecallOptions } {
+    if (
+        queryOrParams !== null &&
+        typeof queryOrParams === "object" &&
+        !Array.isArray(queryOrParams)
+    ) {
+        const { query, ...rest } = queryOrParams;
+        return { query, options: rest };
+    }
+    if (typeof queryOrParams !== "string") {
+        throw new TypeError(
+            "recall() first argument must be a query string or a RecallParams object.",
+        );
+    }
+    return {
+        query: queryOrParams,
+        options: resolveLimitOrOptions("recall", limitOrOptions, namespace),
+    };
+}

--- a/packages/sdk/src/recall-args.ts
+++ b/packages/sdk/src/recall-args.ts
@@ -1,9 +1,6 @@
 import type { RecallOptions, RecallParams } from "./types.js";
 
-/**
- * Parse `limit` / options for deprecated positional recall-style calls.
- * A string second argument is the `recall(query, namespace)` footgun (#293).
- */
+/** String second argument is a namespace, not options. */
 export function resolveLimitOrOptions<T extends { limit?: number; namespace?: string }>(
     method: string,
     limitOrOptions: number | T | undefined | null,
@@ -19,11 +16,17 @@ export function resolveLimitOrOptions<T extends { limit?: number; namespace?: st
     if (typeof limitOrOptions === "object" && !Array.isArray(limitOrOptions)) {
         return limitOrOptions;
     }
-    throw new TypeError(
+    throw new TypeError(invalidSecondArgMessage(method));
+}
+
+function invalidSecondArgMessage(method: string): string {
+    const shared =
         `${method}() second argument must be a number (limit) or an options object, not a string. ` +
-            `Namespace goes in ${method}({ query, namespace }) or as the third argument: ` +
-            `${method}(query, limit, namespace).`,
-    );
+        `Namespace belongs in an options object (${method}(query, { namespace })) or as the third argument (${method}(query, limit, namespace)).`;
+    if (method === "recall") {
+        return `${shared} Preferred form: recall({ query, namespace }).`;
+    }
+    return shared;
 }
 
 /** Normalize object-style and positional `recall()` arguments. */

--- a/packages/sdk/test/manual-seal-identity.test.mjs
+++ b/packages/sdk/test/manual-seal-identity.test.mjs
@@ -236,6 +236,8 @@ test("manual recall rejects a string second argument", async () => {
     const { manual } = manualWithAccountResponse({});
     await assert.rejects(() => manual.recallManual("query", "profile"), {
         name: "TypeError",
-        message: /recallManual/,
+        message:
+            "recallManual() second argument must be a number (limit) or an options object, not a string. " +
+            "Namespace belongs in an options object (recallManual(query, { namespace })) or as the third argument (recallManual(query, limit, namespace)).",
     });
 });

--- a/packages/sdk/test/manual-seal-identity.test.mjs
+++ b/packages/sdk/test/manual-seal-identity.test.mjs
@@ -231,3 +231,11 @@ test("manual recall returns valid memories when another ciphertext package is fo
     assert.equal(errors.length, 1);
     assert.match(errors[0], /Skipping ciphertext foreign: packageId does not match/);
 });
+
+test("manual recall rejects a string second argument", async () => {
+    const { manual } = manualWithAccountResponse({});
+    await assert.rejects(() => manual.recallManual("query", "profile"), {
+        name: "TypeError",
+        message: /recallManual/,
+    });
+});

--- a/packages/sdk/test/mock.test.mjs
+++ b/packages/sdk/test/mock.test.mjs
@@ -85,6 +85,34 @@ test("MemWalMock matches production recall overloads and topK precedence", async
     assert.equal(objectStyle.results.length, 2);
 });
 
+test("MemWalMock throws when positional recall gets a namespace string as the second arg", async () => {
+    const mock = MemWalMock.create();
+    await mock.rememberAndWait("food allergies", "profile");
+
+    await assert.rejects(() => mock.recall("food allergies", "profile"), {
+        name: "TypeError",
+        message: /not a string/,
+    });
+
+    const positional = await mock.recall("food allergies", 5, "profile");
+    const optionsStyle = await mock.recall("food allergies", {
+        namespace: "profile",
+    });
+    const objectStyle = await mock.recall({
+        query: "food allergies",
+        namespace: "profile",
+    });
+    const defaultNs = await mock.recall({ query: "food allergies" });
+
+    assert.deepEqual(
+        positional.results.map((memory) => memory.text),
+        ["food allergies"]
+    );
+    assert.equal(optionsStyle.total, 1);
+    assert.equal(objectStyle.total, 1);
+    assert.equal(defaultNs.total, 0);
+});
+
 test("MemWalMock matches production token-budget behavior", async () => {
     const mock = MemWalMock.create({
         initialMemories: [

--- a/packages/sdk/test/recall-args.test.mjs
+++ b/packages/sdk/test/recall-args.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveLimitOrOptions, resolveRecallCall } from "../dist/recall-args.js";
+
+test("resolveRecallCall maps object and positional forms", () => {
+    assert.deepEqual(resolveRecallCall({ query: "food", namespace: "profile", limit: 3 }), {
+        query: "food",
+        options: { namespace: "profile", limit: 3 },
+    });
+    assert.deepEqual(resolveRecallCall("food", 5, "profile"), {
+        query: "food",
+        options: { limit: 5, namespace: "profile" },
+    });
+    assert.deepEqual(resolveRecallCall("food", { namespace: "profile" }), {
+        query: "food",
+        options: { namespace: "profile" },
+    });
+});
+
+test("resolveRecallCall rejects a namespace string as the second argument", () => {
+    assert.throws(() => resolveRecallCall("food allergies", "profile"), {
+        name: "TypeError",
+        message: /recall\(\{ query, namespace \}\)/,
+    });
+    assert.throws(() => resolveLimitOrOptions("recallManual", "profile"), {
+        name: "TypeError",
+        message: /recallManual/,
+    });
+    assert.throws(() => resolveRecallCall("food", ["profile"]), TypeError);
+});

--- a/packages/sdk/test/recall-args.test.mjs
+++ b/packages/sdk/test/recall-args.test.mjs
@@ -21,11 +21,16 @@ test("resolveRecallCall maps object and positional forms", () => {
 test("resolveRecallCall rejects a namespace string as the second argument", () => {
     assert.throws(() => resolveRecallCall("food allergies", "profile"), {
         name: "TypeError",
-        message: /recall\(\{ query, namespace \}\)/,
+        message:
+            "recall() second argument must be a number (limit) or an options object, not a string. " +
+            "Namespace belongs in an options object (recall(query, { namespace })) or as the third argument (recall(query, limit, namespace)). " +
+            "Preferred form: recall({ query, namespace }).",
     });
     assert.throws(() => resolveLimitOrOptions("recallManual", "profile"), {
         name: "TypeError",
-        message: /recallManual/,
+        message:
+            "recallManual() second argument must be a number (limit) or an options object, not a string. " +
+            "Namespace belongs in an options object (recallManual(query, { namespace })) or as the third argument (recallManual(query, limit, namespace)).",
     });
     assert.throws(() => resolveRecallCall("food", ["profile"]), TypeError);
 });


### PR DESCRIPTION
## Ticket

WALM-161 — https://linear.app/mysten-labs/issue/WALM-161
GH #293 — https://github.com/MystenLabs/MemWal/issues/293

## What changed?

- Positional `recall(query, "namespace")` now throws `TypeError` instead of treating the string as `RecallOptions` and silently querying the default namespace.
- Shared `resolveRecallCall` / `resolveLimitOrOptions` used by `MemWal`, `MemWalMock`, and `MemWalManual.recallManual`.
- Deprecated overloads split into `recall(query, options)` and `recall(query, limit?, namespace?)` so a string second argument does not type-check.
- Valid calls unchanged: `recall({ query, namespace })`, `recall(query, limit, namespace)`, `recall(query, { namespace })`.

## Why is this needed?

`recall("food allergies", "profile")` compiled and ran against the default namespace with no error, so namespace isolation failed silently.

## Scope

TypeScript SDK `recall()` and `MemWalManual.recallManual()` argument parsing.

### Out of scope

- Removing positional `recall` (already deprecated; future major)
- Python SDK positional `recall(query, limit, namespace)`
- MCP / `withMemWal` (already pass a numeric limit)

## Test plan

- [x] `pnpm test` in `packages/sdk` (115 pass)
- [x] `recall("q", "profile")` throws `TypeError`
- [x] `recall("q", 5, "profile")`, `recall("q", { namespace })`, and object form still isolate namespaces

Fixes #293

Made with [Cursor](https://cursor.com)