### PR TITLE
fix(app): retry missing account object instead of fatal 404 (WALM-596)

### DIFF
--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -28,7 +28,7 @@ import { SecretValueInput } from '../components/SecretValueInput'
 import { config } from '../config'
 import { getAnalyticsErrorType, trackEvent } from '../utils/analytics'
 import { apiGet } from '../utils/api'
-import { fetchAccountIdForOwner, fetchObjectJson, publicKeyToHex } from '../utils/suiClientCompat'
+import { fetchAccountIdForOwner, fetchObjectJson, isMissingObjectError, pollAccountIdForOwner, publicKeyToHex } from '../utils/suiClientCompat'
 
 function DelegateKeyCtaIcon(props: SVGProps<SVGSVGElement>) {
     return (
@@ -346,12 +346,16 @@ export default function Dashboard({
         setAccountLookupComplete(false)
         setLoadingAccount(true)
         try {
-            const accountId = await fetchAccountIdForOwner(suiClient, config.memwalRegistryId, address)
+            const accountId = await pollAccountIdForOwner(suiClient, config.memwalRegistryId, address, { attempts: 4 })
             if (accountId) {
                 setResolvedAccountObjectId(accountId)
             }
         } catch (err) {
-            console.error('Failed to fetch account object ID:', err)
+            if (isMissingObjectError(err)) {
+                console.warn('Account object not readable yet:', err)
+            } else {
+                console.error('Failed to fetch account object ID:', err)
+            }
             setResolvedAccountObjectId(null)
         } finally {
             setAccountLookupAddress(address)

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -28,7 +28,7 @@ import { SecretValueInput } from '../components/SecretValueInput'
 import { config } from '../config'
 import { getAnalyticsErrorType, trackEvent } from '../utils/analytics'
 import { apiGet } from '../utils/api'
-import { fetchAccountIdForOwner, fetchObjectJson, isMissingObjectError, pollAccountIdForOwner, publicKeyToHex } from '../utils/suiClientCompat'
+import { fetchAccountIdForOwner, fetchObjectJson, pollAccountIdForOwner, publicKeyToHex } from '../utils/suiClientCompat'
 
 function DelegateKeyCtaIcon(props: SVGProps<SVGSVGElement>) {
     return (
@@ -351,11 +351,7 @@ export default function Dashboard({
                 setResolvedAccountObjectId(accountId)
             }
         } catch (err) {
-            if (isMissingObjectError(err)) {
-                console.warn('Account object not readable yet:', err)
-            } else {
-                console.error('Failed to fetch account object ID:', err)
-            }
+            console.error('Failed to fetch account object ID:', err)
             setResolvedAccountObjectId(null)
         } finally {
             setAccountLookupAddress(address)

--- a/apps/app/src/pages/SetupWizard.tsx
+++ b/apps/app/src/pages/SetupWizard.tsx
@@ -92,12 +92,10 @@ async function accountIdAfterCreate(
     try {
         const waited = await suiClient.waitForTransaction({
             digest,
+            include: { events: true, effects: true, objectTypes: true },
             options: { showEvents: true, showObjectChanges: true },
-        })
-        const fromTx = findCreatedAccountId(waited as {
-            objectChanges?: Array<Record<string, unknown>> | null
-            events?: Array<Record<string, unknown>> | null
-        })
+        } as Parameters<typeof suiClient.waitForTransaction>[0])
+        const fromTx = findCreatedAccountId(waited)
         if (fromTx) return fromTx
     } catch {
         await suiClient.waitForTransaction({ digest })

--- a/apps/app/src/pages/SetupWizard.tsx
+++ b/apps/app/src/pages/SetupWizard.tsx
@@ -22,7 +22,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { LogOut, Copy, TriangleAlert } from 'lucide-react'
 import { config } from '../config'
 import { getAnalyticsErrorType, trackEvent } from '../utils/analytics'
-import { fetchAccountIdForOwner, fetchObjectJson, publicKeyToHex } from '../utils/suiClientCompat'
+import { fetchObjectJson, findCreatedAccountId, pollAccountIdForOwner, publicKeyToHex } from '../utils/suiClientCompat'
 
 type Step = 'intro' | 'import-key' | 'generating' | 'show-key' | 'onchain' | 'done' | 'error'
 
@@ -77,11 +77,32 @@ function hexToBytes(hex: string): Uint8Array {
 
 async function getAccountObjectId(suiClient: ReturnType<typeof useSuiClient>, ownerAddress: string): Promise<string | null> {
     try {
-        return await fetchAccountIdForOwner(suiClient, config.memwalRegistryId, ownerAddress)
+        return await pollAccountIdForOwner(suiClient, config.memwalRegistryId, ownerAddress, { attempts: 3 })
     } catch (err) {
         console.warn('[getAccountObjectId] lookup failed, treating as no-account', err)
         return null
     }
+}
+
+async function accountIdAfterCreate(
+    suiClient: ReturnType<typeof useSuiClient>,
+    ownerAddress: string,
+    digest: string,
+): Promise<string | null> {
+    try {
+        const waited = await suiClient.waitForTransaction({
+            digest,
+            options: { showEvents: true, showObjectChanges: true },
+        })
+        const fromTx = findCreatedAccountId(waited as {
+            objectChanges?: Array<Record<string, unknown>> | null
+            events?: Array<Record<string, unknown>> | null
+        })
+        if (fromTx) return fromTx
+    } catch {
+        await suiClient.waitForTransaction({ digest })
+    }
+    return pollAccountIdForOwner(suiClient, config.memwalRegistryId, ownerAddress)
 }
 
 type AccountJson = { delegate_keys?: { public_key?: unknown }[] }
@@ -191,15 +212,10 @@ export default function SetupWizard() {
                 ],
             })
             const createResult = await signAndExecute({ transaction: tx })
-            await suiClient.waitForTransaction({ digest: createResult.digest })
-
-            // Resolve through AccountRegistry after finality. This works for
-            // both the app-wide gRPC client and the local JSON-RPC E2E client;
-            // getTransactionBlock() is JSON-RPC-only.
-            knownAccountId = await getAccountObjectId(suiClient, ownerAddress)
+            knownAccountId = await accountIdAfterCreate(suiClient, ownerAddress, createResult.digest)
 
             if (!knownAccountId) {
-                throw new Error('Account created but object ID was not found in the registry. Please try again.')
+                throw new Error('Account created but the object is not readable yet. Please try again.')
             }
 
             setTxStatus('adding delegate key...')

--- a/apps/app/src/utils/suiClientCompat.test.ts
+++ b/apps/app/src/utils/suiClientCompat.test.ts
@@ -45,6 +45,37 @@ describe('gRPC Sui client compatibility', () => {
         expect(request.name.type).toBe('address')
         expect(request.name.bcs).toEqual(new Uint8Array(32).fill(0).map((_, i) => i === 31 ? 1 : 0))
     })
+
+    it('returns null when gRPC getObject throws Object {id} not found', async () => {
+        const objectId = `0x${'ab'.repeat(32)}`
+        const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'https://provider.example/grpc' })
+        vi.spyOn(client, 'getObject').mockRejectedValue(new Error(`Object ${objectId} not found`))
+
+        await expect(fetchObjectJson(client, objectId)).resolves.toBeNull()
+    })
+
+    it('retries when gRPC getDynamicField throws Object {id} not found', async () => {
+        const fieldId = `0x${'cd'.repeat(32)}`
+        const accountBytes = new Uint8Array(32).fill(0x11)
+        const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'https://provider.example/grpc' })
+        vi.spyOn(client, 'getObject').mockResolvedValue({
+            object: { json: { accounts: { id: '0xtable-grpc-miss' } } },
+        } as never)
+        let lookups = 0
+        vi.spyOn(client, 'getDynamicField').mockImplementation(async () => {
+            lookups += 1
+            if (lookups < 3) throw new Error(`Object ${fieldId} not found`)
+            return { dynamicField: { value: { bcs: accountBytes } } } as never
+        })
+
+        await expect(
+            pollAccountIdForOwner(client, '0xregistry-grpc-df', '0x1', {
+                attempts: 4,
+                sleep: async () => undefined,
+            }),
+        ).resolves.toBe(`0x${'11'.repeat(32)}`)
+        expect(lookups).toBe(3)
+    })
 })
 
 describe('JSON-RPC registry lookup', () => {
@@ -127,6 +158,77 @@ describe('JSON-RPC registry lookup', () => {
         ).resolves.toBe('0xaccount-ready')
         expect(lookups).toBe(3)
     })
+
+    it('returns null on a gRPC Object {id} not found miss', async () => {
+        const client = {
+            async getObject() {
+                throw new Error('Object 0xabc not found')
+            },
+        }
+
+        await expect(fetchObjectJson(client, '0xabc')).resolves.toBeNull()
+    })
+
+    it('retries a gRPC Object {id} not found miss then returns the account id', async () => {
+        let lookups = 0
+        const client = {
+            async getObject() {
+                return { data: { content: { fields: { accounts: { fields: { id: { id: '0xtable5' } } } } } } }
+            },
+            async getDynamicFieldObject() {
+                lookups += 1
+                if (lookups < 3) {
+                    throw new Error('Object 0xtable5 not found')
+                }
+                return { data: { content: { fields: { value: '0xaccount-grpc-ready' } } } }
+            },
+        }
+
+        await expect(
+            pollAccountIdForOwner(client, '0xregistry-grpc-retry', '0xowner', {
+                attempts: 4,
+                sleep: async () => undefined,
+            }),
+        ).resolves.toBe('0xaccount-grpc-ready')
+        expect(lookups).toBe(3)
+    })
+
+    it('retries an unrecognized lookup throw instead of aborting on the first attempt', async () => {
+        let lookups = 0
+        const client = {
+            async getObject() {
+                return { data: { content: { fields: { accounts: { fields: { id: { id: '0xtable6' } } } } } } }
+            },
+            async getDynamicFieldObject() {
+                lookups += 1
+                if (lookups < 3) throw new Error('Could not load object')
+                return { data: { content: { fields: { value: '0xaccount-unrecognized' } } } }
+            },
+        }
+
+        await expect(
+            pollAccountIdForOwner(client, '0xregistry-unrecognized', '0xowner', {
+                attempts: 4,
+                sleep: async () => undefined,
+            }),
+        ).resolves.toBe('0xaccount-unrecognized')
+        expect(lookups).toBe(3)
+    })
+
+    it('rethrows a non-miss after the attempt budget is spent', async () => {
+        const client = {
+            async getObject() {
+                throw new Error('ECONNRESET')
+            },
+        }
+
+        await expect(
+            pollAccountIdForOwner(client, '0xregistry-fatal', '0xowner', {
+                attempts: 2,
+                sleep: async () => undefined,
+            }),
+        ).rejects.toThrow('ECONNRESET')
+    })
 })
 
 describe('isMissingObjectError', () => {
@@ -135,6 +237,13 @@ describe('isMissingObjectError', () => {
         expect(isMissingObjectError(new Error('notExists'))).toBe(true)
         expect(isMissingObjectError(new Error('dynamicFieldNotFound'))).toBe(true)
         expect(isMissingObjectError(new Error('object not found'))).toBe(true)
+        expect(isMissingObjectError(new Error('Object 0xabc not found'))).toBe(true)
+        expect(isMissingObjectError(new Error(`Object 0x${'ab'.repeat(32)} not found`))).toBe(true)
+        expect(isMissingObjectError(new Error('Object 0xabc with version 1 not found'))).toBe(true)
+        expect(isMissingObjectError(new Error('Object 0xabc does not exist'))).toBe(true)
+        expect(isMissingObjectError(new Error('Dynamic field not found for object 0xparent'))).toBe(true)
+        expect(isMissingObjectError(Object.assign(new Error('Object 0xabc does not exist'), { code: 'notExists' }))).toBe(true)
+        expect(isMissingObjectError(Object.assign(new Error('not found'), { code: 'NOT_FOUND' }))).toBe(true)
     })
 
     it('does not treat JSON-RPC Method not found as a missing object', () => {
@@ -143,6 +252,7 @@ describe('isMissingObjectError', () => {
                 new Error('Method not found. JSON-RPC on public fullnodes has been deprecated.'),
             ),
         ).toBe(false)
+        expect(isMissingObjectError(Object.assign(new Error('Method not found'), { code: -32601 }))).toBe(false)
     })
 })
 

--- a/apps/app/src/utils/suiClientCompat.test.ts
+++ b/apps/app/src/utils/suiClientCompat.test.ts
@@ -1,4 +1,5 @@
 import { SuiGrpcClient } from '@mysten/sui/grpc'
+import { bcs } from '@mysten/sui/bcs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -128,6 +129,23 @@ describe('JSON-RPC registry lookup', () => {
     })
 })
 
+describe('isMissingObjectError', () => {
+    it('treats HTTP 404 and notExists as a miss', () => {
+        expect(isMissingObjectError(Object.assign(new Error('Unexpected status code: 404 ()'), { status: 404 }))).toBe(true)
+        expect(isMissingObjectError(new Error('notExists'))).toBe(true)
+        expect(isMissingObjectError(new Error('dynamicFieldNotFound'))).toBe(true)
+        expect(isMissingObjectError(new Error('object not found'))).toBe(true)
+    })
+
+    it('does not treat JSON-RPC Method not found as a missing object', () => {
+        expect(
+            isMissingObjectError(
+                new Error('Method not found. JSON-RPC on public fullnodes has been deprecated.'),
+            ),
+        ).toBe(false)
+    })
+})
+
 describe('findCreatedAccountId', () => {
     it('falls back to the AccountCreated event when objectChanges omit the account', () => {
         expect(
@@ -141,6 +159,41 @@ describe('findCreatedAccountId', () => {
                 ],
             }),
         ).toBe('0xaccount-from-event')
+    })
+
+    it('reads gRPC eventType + BCS AccountCreated', () => {
+        const AccountCreatedBcs = bcs.struct('AccountCreated', {
+            account_id: bcs.Address,
+            owner: bcs.Address,
+        })
+        const accountId = `0x${'11'.repeat(32)}`
+        const owner = `0x${'22'.repeat(32)}`
+        const eventBcs = AccountCreatedBcs.serialize({ account_id: accountId, owner }).toBytes()
+
+        expect(
+            findCreatedAccountId({
+                Transaction: {
+                    events: [
+                        {
+                            eventType: '0xpackage::account::AccountCreated',
+                            bcs: eventBcs,
+                        },
+                    ],
+                },
+            }),
+        ).toBe(accountId)
+    })
+
+    it('reads gRPC created objects via objectTypes', () => {
+        const accountId = '0xgrpc-account'
+        expect(
+            findCreatedAccountId({
+                effects: {
+                    changedObjects: [{ objectId: accountId, idOperation: 'Created' }],
+                },
+                objectTypes: { [accountId]: '0xpackage::account::MemWalAccount' },
+            }),
+        ).toBe(accountId)
     })
 })
 

--- a/apps/app/src/utils/suiClientCompat.test.ts
+++ b/apps/app/src/utils/suiClientCompat.test.ts
@@ -1,6 +1,19 @@
 import { SuiGrpcClient } from '@mysten/sui/grpc'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchAccountIdForOwner, fetchObjectJson, isGrpcClient } from './suiClientCompat'
+import {
+    fetchAccountIdForOwner,
+    fetchObjectJson,
+    findCreatedAccountId,
+    isGrpcClient,
+    isMissingObjectError,
+    pollAccountIdForOwner,
+    resetRegistryTableIdCache,
+} from './suiClientCompat'
+
+afterEach(() => {
+    resetRegistryTableIdCache()
+})
 
 describe('gRPC Sui client compatibility', () => {
     it('uses the gRPC getObject request shape', async () => {
@@ -32,3 +45,102 @@ describe('gRPC Sui client compatibility', () => {
         expect(request.name.bcs).toEqual(new Uint8Array(32).fill(0).map((_, i) => i === 31 ? 1 : 0))
     })
 })
+
+describe('JSON-RPC registry lookup', () => {
+    it('unwraps accounts.id.id before getDynamicFieldObject', async () => {
+        const tableId = '0xtable'
+        const accountId = '0xaccount'
+        let requestedParentId: string | undefined
+        const client = {
+            async getObject() {
+                return {
+                    data: {
+                        content: {
+                            fields: {
+                                accounts: {
+                                    type: '0x2::table::Table<address, 0x2::object::ID>',
+                                    fields: {
+                                        id: { id: tableId },
+                                        size: '1',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }
+            },
+            async getDynamicFieldObject({ parentId }: { parentId: string }) {
+                requestedParentId = parentId
+                return { data: { content: { fields: { value: accountId } } } }
+            },
+        }
+
+        await expect(fetchAccountIdForOwner(client, '0xregistry-json', '0xowner')).resolves.toBe(accountId)
+        expect(requestedParentId).toBe(tableId)
+    })
+
+    it('returns null instead of throwing a GetObject 404', async () => {
+        const client = {
+            async getObject() {
+                throw Object.assign(new Error('Unexpected status code: 404 ()'), { status: 404 })
+            },
+        }
+
+        await expect(fetchObjectJson(client, '0xmissing')).resolves.toBeNull()
+        expect(isMissingObjectError(Object.assign(new Error('Unexpected status code: 404 ()'), { status: 404 }))).toBe(true)
+    })
+
+    it('returns null when the dynamic field 404s', async () => {
+        const client = {
+            async getObject() {
+                return { data: { content: { fields: { accounts: { fields: { id: { id: '0xtable3' } } } } } } }
+            },
+            async getDynamicFieldObject() {
+                throw Object.assign(new Error('Unexpected status code: 404 ()'), { status: 404 })
+            },
+        }
+
+        await expect(fetchAccountIdForOwner(client, '0xregistry-404', '0xowner')).resolves.toBeNull()
+    })
+
+    it('retries a transient miss then returns the account id', async () => {
+        let lookups = 0
+        const client = {
+            async getObject() {
+                return { data: { content: { fields: { accounts: { fields: { id: { id: '0xtable4' } } } } } } }
+            },
+            async getDynamicFieldObject() {
+                lookups += 1
+                if (lookups < 3) {
+                    throw Object.assign(new Error('Unexpected status code: 404 ()'), { status: 404 })
+                }
+                return { data: { content: { fields: { value: '0xaccount-ready' } } } }
+            },
+        }
+
+        await expect(
+            pollAccountIdForOwner(client, '0xregistry-retry', '0xowner', {
+                attempts: 4,
+                sleep: async () => undefined,
+            }),
+        ).resolves.toBe('0xaccount-ready')
+        expect(lookups).toBe(3)
+    })
+})
+
+describe('findCreatedAccountId', () => {
+    it('falls back to the AccountCreated event when objectChanges omit the account', () => {
+        expect(
+            findCreatedAccountId({
+                objectChanges: [],
+                events: [
+                    {
+                        type: '0xpackage::account::AccountCreated',
+                        parsedJson: { account_id: '0xaccount-from-event' },
+                    },
+                ],
+            }),
+        ).toBe('0xaccount-from-event')
+    })
+})
+

--- a/apps/app/src/utils/suiClientCompat.ts
+++ b/apps/app/src/utils/suiClientCompat.ts
@@ -52,17 +52,25 @@ function unwrapJsonRpcFields(value: unknown): unknown {
     return value
 }
 
+const MISSING_OBJECT_CODES = new Set(['notexists', 'dynamicfieldnotfound', 'notfound', 'not_found'])
+
 /** RPC 404 / NotExists — the object is not readable yet, not a fatal setup failure. */
 export function isMissingObjectError(error: unknown): boolean {
-    const status =
-        error && typeof error === 'object' && 'status' in error
-            ? Number((error as { status: unknown }).status)
-            : undefined
-    if (status === 404) return true
+    if (error && typeof error === 'object') {
+        const rec = error as { status?: unknown; code?: unknown }
+        if (Number(rec.status) === 404) return true
+        // gRPC Code.NotFound is 5; protobuf-ts RpcError uses 'NOT_FOUND'.
+        if (rec.code === 404 || rec.code === 5) return true
+        if (typeof rec.code === 'string' && MISSING_OBJECT_CODES.has(rec.code.toLowerCase())) return true
+    }
     const message = error instanceof Error ? error.message : String(error)
     // Do not match a bare "not found" — that also hits JSON-RPC's
     // "Method not found" deprecation error on public fullnodes.
-    return /unexpected status code:\s*404|status code:\s*404|notExists|dynamicFieldNotFound|object not found/i.test(message)
+    // gRPC ObjectNotFoundError is "Object {id} not found" (optional
+    // " with version {n}"). JSON-RPC ObjectError is "Object {id} does not exist".
+    return /unexpected status code:\s*404|status code:\s*404|notExists|dynamicFieldNotFound|dynamic field not found|object(?:\s+\S+)*\s+not found|object(?:\s+\S+)+\s+does not exist/i.test(
+        message,
+    )
 }
 
 /** Fetch a Move object's fields as a flat JS object, regardless of client transport. */
@@ -241,8 +249,16 @@ export async function pollAccountIdForOwner(
     const attempts = options?.attempts ?? 6
     const sleep = options?.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
     for (let i = 0; i < attempts; i++) {
-        const accountId = await fetchAccountIdForOwner(suiClient, registryId, ownerAddress)
-        if (accountId) return accountId
+        try {
+            const accountId = await fetchAccountIdForOwner(suiClient, registryId, ownerAddress)
+            if (accountId) return accountId
+        } catch (error) {
+            // Known miss: treat as unreadability and keep polling.
+            // Unrecognized throw: still spend the remaining attempts so a
+            // miss variant that slips past isMissingObjectError cannot abort
+            // the first try. Fail closed only on the last attempt.
+            if (!isMissingObjectError(error) && i === attempts - 1) throw error
+        }
         if (i < attempts - 1) {
             await sleep(ACCOUNT_LOOKUP_RETRY_MS[Math.min(i, ACCOUNT_LOOKUP_RETRY_MS.length - 1)])
         }

--- a/apps/app/src/utils/suiClientCompat.ts
+++ b/apps/app/src/utils/suiClientCompat.ts
@@ -46,22 +46,76 @@ function unwrapJsonRpcFields(value: unknown): unknown {
     return value
 }
 
+/** RPC 404 / NotExists — the object is not readable yet, not a fatal setup failure. */
+export function isMissingObjectError(error: unknown): boolean {
+    const status =
+        error && typeof error === 'object' && 'status' in error
+            ? Number((error as { status: unknown }).status)
+            : undefined
+    if (status === 404) return true
+    const message = error instanceof Error ? error.message : String(error)
+    return /unexpected status code:\s*404|status code:\s*404|notExists|not found/i.test(message)
+}
+
 /** Fetch a Move object's fields as a flat JS object, regardless of client transport. */
 export async function fetchObjectJson(suiClient: unknown, objectId: string): Promise<Record<string, unknown> | null> {
-    if (isGrpcClient(suiClient)) {
-        const res = await suiClient.getObject({ objectId, include: { json: true } })
-        return res.object.json ?? null
-    }
+    try {
+        if (isGrpcClient(suiClient)) {
+            const res = await suiClient.getObject({ objectId, include: { json: true } })
+            return res.object.json ?? null
+        }
 
-    const res = await (suiClient as JsonRpcClientLike).getObject({ id: objectId, options: { showContent: true } })
-    const content = res?.data?.content
-    if (!content?.fields) return null
-    return unwrapJsonRpcFields(content.fields) as Record<string, unknown>
+        const res = await (suiClient as JsonRpcClientLike).getObject({ id: objectId, options: { showContent: true } })
+        const content = res?.data?.content
+        if (!content?.fields) return null
+        return unwrapJsonRpcFields(content.fields) as Record<string, unknown>
+    } catch (error) {
+        if (isMissingObjectError(error)) return null
+        throw error
+    }
 }
 
 // The registry's inner Table object ID is an immutable on-chain constant —
 // cache it so repeat account lookups skip the registry round trip.
 const registryTableIdCache = new Map<string, string>()
+
+const ACCOUNT_LOOKUP_RETRY_MS = [200, 500, 1000, 2000, 2000]
+
+/** Test-only: drop the registry Table id cache. */
+export function resetRegistryTableIdCache(): void {
+    registryTableIdCache.clear()
+}
+
+function extractTableId(accounts: unknown): string | undefined {
+    const rawId = (accounts as { id?: string | { id?: string } } | undefined)?.id
+    return typeof rawId === 'string' ? rawId : rawId?.id
+}
+
+/** Extract the account created by create_account across JSON-RPC response variants. */
+export function findCreatedAccountId(transaction: {
+    objectChanges?: Array<Record<string, unknown>> | null
+    events?: Array<Record<string, unknown>> | null
+}): string | null {
+    const createdAccount = transaction.objectChanges?.find(
+        (change) =>
+            change.type === 'created' &&
+            typeof change.objectType === 'string' &&
+            change.objectType.includes('::account::MemWalAccount'),
+    )
+    if (typeof createdAccount?.objectId === 'string') return createdAccount.objectId
+
+    const accountCreatedEvent = transaction.events?.find(
+        (event) =>
+            typeof event.type === 'string' && event.type.endsWith('::account::AccountCreated'),
+    )
+    const parsedJson = accountCreatedEvent?.parsedJson
+    if (parsedJson && typeof parsedJson === 'object') {
+        const accountId = (parsedJson as { account_id?: unknown }).account_id
+        if (typeof accountId === 'string') return accountId
+    }
+
+    return null
+}
 
 /** Resolve a MemWalAccount object ID for `ownerAddress` via the registry's Table<address, ID>. */
 export async function fetchAccountIdForOwner(
@@ -69,35 +123,61 @@ export async function fetchAccountIdForOwner(
     registryId: string,
     ownerAddress: string,
 ): Promise<string | null> {
-    let tableId = registryTableIdCache.get(registryId)
-    if (!tableId) {
-        const registryJson = await fetchObjectJson(suiClient, registryId)
-        // gRPC json flattens the Table's UID to a plain string. Keep the nested
-        // form solely for the explicit local JSON-RPC browser suite.
-        const rawId = (registryJson?.accounts as { id?: string | { id?: string } } | undefined)?.id
-        tableId = typeof rawId === 'string' ? rawId : rawId?.id
-        if (!tableId) return null
-        registryTableIdCache.set(registryId, tableId)
-    }
+    try {
+        let tableId = registryTableIdCache.get(registryId)
+        if (!tableId) {
+            const registryJson = await fetchObjectJson(suiClient, registryId)
+            // gRPC json flattens the Table's UID to a plain string. Keep the nested
+            // form solely for the explicit local JSON-RPC browser suite.
+            tableId = extractTableId(registryJson?.accounts)
+            if (!tableId) return null
+            registryTableIdCache.set(registryId, tableId)
+        }
 
-    if (isGrpcClient(suiClient)) {
-        const dynFieldRes = await suiClient.getDynamicField({
+        if (isGrpcClient(suiClient)) {
+            const dynFieldRes = await suiClient.getDynamicField({
+                parentId: tableId,
+                name: { type: 'address', bcs: fromHex(normalizeSuiAddress(ownerAddress)) },
+            })
+            const valueBytes = dynFieldRes?.dynamicField?.value?.bcs
+            if (!valueBytes || valueBytes.length !== 32) return null
+            return '0x' + toHex(valueBytes)
+        }
+
+        const dynField = await (suiClient as JsonRpcClientLike).getDynamicFieldObject({
             parentId: tableId,
-            name: { type: 'address', bcs: fromHex(normalizeSuiAddress(ownerAddress)) },
+            name: { type: 'address', value: ownerAddress },
         })
-        const valueBytes = dynFieldRes?.dynamicField?.value?.bcs
-        if (!valueBytes || valueBytes.length !== 32) return null
-        return '0x' + toHex(valueBytes)
+        const content = dynField?.data?.content
+        if (!content?.fields || typeof content.fields !== 'object') return null
+        const value = (content.fields as Record<string, unknown>).value
+        return typeof value === 'string' ? value : null
+    } catch (error) {
+        if (isMissingObjectError(error)) return null
+        throw error
     }
+}
 
-    const dynField = await (suiClient as JsonRpcClientLike).getDynamicFieldObject({
-        parentId: tableId,
-        name: { type: 'address', value: ownerAddress },
-    })
-    const content = dynField?.data?.content
-    if (!content?.fields || typeof content.fields !== 'object') return null
-    const value = (content.fields as Record<string, unknown>).value
-    return typeof value === 'string' ? value : null
+/** Poll the registry until the account is readable, or the attempt budget is spent. */
+export async function pollAccountIdForOwner(
+    suiClient: unknown,
+    registryId: string,
+    ownerAddress: string,
+    options?: {
+        attempts?: number
+        sleep?: (ms: number) => Promise<void>
+    },
+): Promise<string | null> {
+    const attempts = options?.attempts ?? 6
+    const sleep = options?.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+    for (let i = 0; i < attempts; i++) {
+        const accountId = await fetchAccountIdForOwner(suiClient, registryId, ownerAddress)
+        if (accountId) return accountId
+        if (i < attempts - 1) {
+            await sleep(ACCOUNT_LOOKUP_RETRY_MS[Math.min(i, ACCOUNT_LOOKUP_RETRY_MS.length - 1)])
+        }
+    }
+    return null
 }
 
 /** Normalize a delegate key's public_key field to hex — gRPC encodes it as base64, JSON-RPC as number[]. */

--- a/apps/app/src/utils/suiClientCompat.ts
+++ b/apps/app/src/utils/suiClientCompat.ts
@@ -8,8 +8,14 @@
  * one shape unconditionally.
  */
 
+import { bcs } from '@mysten/sui/bcs'
 import { isSuiGrpcClient, type SuiGrpcClient } from '@mysten/sui/grpc'
 import { fromBase64, fromHex, normalizeSuiAddress, toHex } from '@mysten/sui/utils'
+
+const AccountCreatedBcs = bcs.struct('AccountCreated', {
+    account_id: bcs.Address,
+    owner: bcs.Address,
+})
 
 interface JsonRpcClientLike {
     getObject(input: { id: string; options: { showContent: boolean } }): Promise<{
@@ -54,7 +60,9 @@ export function isMissingObjectError(error: unknown): boolean {
             : undefined
     if (status === 404) return true
     const message = error instanceof Error ? error.message : String(error)
-    return /unexpected status code:\s*404|status code:\s*404|notExists|not found/i.test(message)
+    // Do not match a bare "not found" — that also hits JSON-RPC's
+    // "Method not found" deprecation error on public fullnodes.
+    return /unexpected status code:\s*404|status code:\s*404|notExists|dynamicFieldNotFound|object not found/i.test(message)
 }
 
 /** Fetch a Move object's fields as a flat JS object, regardless of client transport. */
@@ -91,27 +99,89 @@ function extractTableId(accounts: unknown): string | undefined {
     return typeof rawId === 'string' ? rawId : rawId?.id
 }
 
-/** Extract the account created by create_account across JSON-RPC response variants. */
-export function findCreatedAccountId(transaction: {
-    objectChanges?: Array<Record<string, unknown>> | null
-    events?: Array<Record<string, unknown>> | null
-}): string | null {
-    const createdAccount = transaction.objectChanges?.find(
-        (change) =>
-            change.type === 'created' &&
-            typeof change.objectType === 'string' &&
-            change.objectType.includes('::account::MemWalAccount'),
-    )
-    if (typeof createdAccount?.objectId === 'string') return createdAccount.objectId
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
 
-    const accountCreatedEvent = transaction.events?.find(
-        (event) =>
-            typeof event.type === 'string' && event.type.endsWith('::account::AccountCreated'),
-    )
-    const parsedJson = accountCreatedEvent?.parsedJson
+function transactionBody(transaction: unknown): Record<string, unknown> {
+    const root = asRecord(transaction) ?? {}
+    return asRecord(root.Transaction) ?? asRecord(root.FailedTransaction) ?? root
+}
+
+function eventBcsBytes(event: Record<string, unknown>): Uint8Array | null {
+    const raw = event.bcs
+    if (raw instanceof Uint8Array) return raw
+    if (typeof raw === 'string') {
+        try {
+            return fromBase64(raw)
+        } catch {
+            return null
+        }
+    }
+    return null
+}
+
+function accountIdFromCreatedEvent(event: Record<string, unknown>): string | null {
+    const parsedJson = event.parsedJson
     if (parsedJson && typeof parsedJson === 'object') {
         const accountId = (parsedJson as { account_id?: unknown }).account_id
         if (typeof accountId === 'string') return accountId
+    }
+    const bytes = eventBcsBytes(event)
+    if (!bytes) return null
+    try {
+        const parsed = AccountCreatedBcs.parse(bytes)
+        return typeof parsed.account_id === 'string' ? parsed.account_id : null
+    } catch {
+        return null
+    }
+}
+
+/** Extract the account created by create_account across JSON-RPC and gRPC shapes. */
+export function findCreatedAccountId(transaction: unknown): string | null {
+    const body = transactionBody(transaction)
+
+    const objectChanges = body.objectChanges
+    if (Array.isArray(objectChanges)) {
+        const createdAccount = objectChanges.find((change) => {
+            const rec = asRecord(change)
+            return (
+                rec?.type === 'created' &&
+                typeof rec.objectType === 'string' &&
+                rec.objectType.includes('::account::MemWalAccount')
+            )
+        })
+        const objectId = asRecord(createdAccount)?.objectId
+        if (typeof objectId === 'string') return objectId
+    }
+
+    const events = body.events
+    if (Array.isArray(events)) {
+        const accountCreatedEvent = events.find((event) => {
+            const rec = asRecord(event)
+            const type = rec && (typeof rec.type === 'string' ? rec.type : rec.eventType)
+            return typeof type === 'string' && type.endsWith('::account::AccountCreated')
+        })
+        const fromEvent = accountCreatedEvent ? accountIdFromCreatedEvent(asRecord(accountCreatedEvent) ?? {}) : null
+        if (fromEvent) return fromEvent
+    }
+
+    const objectTypes = asRecord(body.objectTypes)
+    const changedObjects = asRecord(body.effects)?.changedObjects
+    if (objectTypes && Array.isArray(changedObjects)) {
+        for (const change of changedObjects) {
+            const rec = asRecord(change)
+            const objectId = rec && typeof rec.objectId === 'string' ? rec.objectId : null
+            const objectType = objectId ? objectTypes[objectId] : undefined
+            if (
+                rec?.idOperation === 'Created' &&
+                objectId &&
+                typeof objectType === 'string' &&
+                objectType.includes('::account::MemWalAccount')
+            ) {
+                return objectId
+            }
+        }
     }
 
     return null

--- a/apps/app/src/utils/suiClientCompat.ts
+++ b/apps/app/src/utils/suiClientCompat.ts
@@ -253,10 +253,7 @@ export async function pollAccountIdForOwner(
             const accountId = await fetchAccountIdForOwner(suiClient, registryId, ownerAddress)
             if (accountId) return accountId
         } catch (error) {
-            // Known miss: treat as unreadability and keep polling.
-            // Unrecognized throw: still spend the remaining attempts so a
-            // miss variant that slips past isMissingObjectError cannot abort
-            // the first try. Fail closed only on the last attempt.
+            // Unrecognized throws still spend the remaining attempts; rethrow on the last try.
             if (!isMissingObjectError(error) && i === attempts - 1) throw error
         }
         if (i < attempts - 1) {


### PR DESCRIPTION
## Ticket

WALM-596 — https://linear.app/mysten-labs/issue/WALM-596
GH #390 — https://github.com/MystenLabs/MemWal/issues/390

## What changed?

- `fetchObjectJson` / `fetchAccountIdForOwner` treat GetObject and dynamic-field 404 / NotExists as not readable yet (`null`) instead of throwing.
- After `create_account`, the setup wizard reads `AccountCreated` / object changes from `waitForTransaction`, then polls the registry until the account id appears.
- Pre-create lookup and dashboard account resolve poll a few times so a lagging RPC does not look like "no account".
- Unit tests cover nested JSON-RPC table id unwrap, 404 → null, retry-then-success, and the AccountCreated fallback.

## Why is this needed?

The onboarding block in #390 was a bad registry lookup: `getDynamicFieldObject` was called with `accounts.id = { id: tableId }` and returned `Invalid params`, so the UI treated an existing account as missing. That unwrap is already on `origin/dev`.

What was still missing: after a successful `create_account`, SetupWizard did a single registry read and did not take `account_id` from `AccountCreated`. A late GetObject could still surface as a hard 404. This PR is that remaining retry / event fallback, not a re-fix of the table-id bug.

## Scope

Dashboard web app account lookup (`suiClientCompat`, SetupWizard, Dashboard).

### Out of scope

- Relayer / SDK on-chain account verification
- Changing create_account Move logic

## Test plan

- [x] `pnpm test src/utils/suiClientCompat.test.ts` in `apps/app`
- [x] Wallet setup on testnet: generate key → Register key onchain & continue completes without a 404 banner
- [x] After create_account, a lagging GetObject is retried rather than shown as a fatal 404

### Manual test (testnet, `https://relayer.dev.memwal.ai`)

Existing-account path (wallet already had a `MemWalAccount`): **Register key onchain & continue** showed `account found! adding delegate key...`, then dashboard with 1 **Web App** / **This browser** key. No 404 banner.

New-account path (fresh MemWal owner `0x6f2b7d20ac8bba49e67a0a5ca4ffcdb64270a6af462eb440e401d427806c6a39`): two sponsored txs, no console errors, dashboard 1 key.

| | |
|---|---|
| `create_account` | [`4Wq2MR2kfXNFmLdarap4YZECmJH1MESB4ete2UyrUzUz`](https://suiscan.xyz/testnet/tx/4Wq2MR2kfXNFmLdarap4YZECmJH1MESB4ete2UyrUzUz) — `AccountCreated` |
| `add_delegate_key` | [`3AKBaoGFcAdgc74ikZChT5WV5X3xF4Eag5NaA74HkQ4q`](https://suiscan.xyz/testnet/tx/3AKBaoGFcAdgc74ikZChT5WV5X3xF4Eag5NaA74HkQ4q) — `DelegateKeyAdded` |
| account object | `0xd0c1ee22568bc7916a55dcf4f48ec858ed00b0938319f09f7805d517c44c2b38` |

RPC returned the object in time, so a delayed GetObject was not forced. Create-path still completed without a 404 / "object ID not found" banner.

Fixes #390