### PR TITLE
fix(oauth): don't burn the session when Sui is unavailable (WALM-605)

### DIFF
--- a/apps/app/src/pages/ConnectClaude.test.tsx
+++ b/apps/app/src/pages/ConnectClaude.test.tsx
@@ -3,9 +3,13 @@
  *
  * A Sui outage during `POST /complete` leaves the authorization session
  * `pending` instead of burning it. That only helps if the consent UI can
- * re-send *that one request*: re-running the whole flow would re-submit
- * `add_delegate_key` for a key already on chain, which aborts with code 0 and
- * surfaces as a misleading "not the owner".
+ * re-send *that one request*: re-running the whole flow re-asks the wallet to
+ * sign and re-submits `add_delegate_key` for a key already on chain.
+ *
+ * The duplicate submission is decided server-side, by `/account`'s on-chain
+ * check. It cannot be decided here: this page signs through the sponsor proxy,
+ * and `sponsor::mask_upstream` replaces every upstream 5xx with a bare 502 that
+ * carries no Move abort, so the consent UI never sees which abort fired.
  */
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -71,28 +75,39 @@ const SESSION_VIEW = {
  * of how many times each endpoint was called.
  */
 function stubRelayer(
-    completeResponses: (() => Response)[],
-    { needsOnchainRegistration = false }: { needsOnchainRegistration?: boolean } = {},
+    completeResponses: (() => Response | Promise<Response>)[],
+    {
+        needsOnchainRegistration = false,
+        resumePendingRegistration = false,
+        accountResponse,
+    }: {
+        needsOnchainRegistration?: boolean
+        resumePendingRegistration?: boolean
+        accountResponse?: () => Response
+    } = {},
 ) {
-    const calls = { account: 0, complete: 0 }
+    const calls = { account: 0, complete: 0, completeBodies: [] as string[] }
     vi.stubGlobal(
         'fetch',
-        vi.fn(async (input: RequestInfo | URL) => {
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
             const url = String(input)
             if (url.endsWith(`/session/${SESSION}`)) return json(SESSION_VIEW)
             if (url.endsWith('/account')) {
                 calls.account += 1
-                // Reused delegate: no add_delegate_key transaction is needed,
-                // so the test isolates the /complete round-trip.
+                if (accountResponse) return accountResponse()
+                // Default: reused delegate, so no add_delegate_key transaction
+                // is needed and the test isolates the /complete round-trip.
                 return json({
                     needs_onchain_registration: needsOnchainRegistration,
                     delegate_public_key: SESSION_VIEW.delegate_public_key,
                     delegate_sui_address: SESSION_VIEW.delegate_sui_address,
+                    resume_pending_registration: resumePendingRegistration,
                 })
             }
             if (url.endsWith('/complete')) {
                 const next = completeResponses[calls.complete] ?? completeResponses.at(-1)
                 calls.complete += 1
+                calls.completeBodies.push(String(init?.body ?? ''))
                 return next!()
             }
             throw new Error(`unexpected fetch: ${url}`)
@@ -149,9 +164,9 @@ describe('ConnectClaude /complete recovery', () => {
     })
 
     it('a reload mid-recovery resumes at the retry step, not at consent', async () => {
-        // The ref does not survive a remount. Without the sessionStorage copy the
-        // user lands back on consent, and a first-time connect re-submits
-        // add_delegate_key for a key already on chain (abort code 0).
+        // The ref does not survive a remount. Without the sessionStorage copy
+        // the user lands back on consent, and a first-time connect re-asks the
+        // wallet and re-submits add_delegate_key for a key already on chain.
         const calls = stubRelayer([
             () => json({ error: 'temporarily_unavailable', error_description: 'sui unavailable' }, 503),
             () => json({ redirect_url: 'https://claude.ai/callback?code=abc' }),
@@ -220,38 +235,119 @@ describe('ConnectClaude /complete recovery', () => {
         expect(screen.queryByRole('button', { name: /finish connecting/i })).toBeNull()
     })
 
-    // `account.move`: EDelegateKeyAlreadyExists = 0, ENotOwner = 4. Mapping 0 to
-    // "not the owner" dead-ended the WALM-605 journey — the key was already on
-    // chain from the attempt whose verify hit a 429, so re-running the flow
-    // aborts with 0 and the user was told to switch wallets.
-    it('treats add_delegate_key abort 0 as already-registered and completes', async () => {
+    it('a reload while /complete is in flight resumes at the retry step', async () => {
+        // The gap a ref cannot cover, and the reason the crumb is written
+        // before the request rather than after it fails: /complete never
+        // answered, so there is no 503 to react to, yet the transaction above
+        // has already landed and the wallet has already signed.
+        // Never settles: a reload destroys the context that issued it, so this
+        // response is never processed by anyone. Resolving it here instead
+        // would let the dead page run its success path and clear the crumb,
+        // which no real reload can do.
+        const inFlight = new Promise<Response>(() => {})
         const calls = stubRelayer(
-            [() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })],
+            [() => inFlight, () => json({ redirect_url: 'https://claude.ai/callback?code=abc' })],
             { needsOnchainRegistration: true },
         )
-        mocks.signAndExecute.mockRejectedValue(
-            new Error('MoveAbort ... add_delegate_key ... abort code: 0'),
+        mocks.signAndExecute.mockResolvedValue({ digest: '0xdigest' })
+
+        await approve()
+        await waitFor(() => expect(calls.complete).toBe(1))
+        expect(mocks.signAndExecute).toHaveBeenCalledTimes(1)
+
+        // Reload before the relayer answers.
+        cleanup()
+        render(
+            <MemoryRouter initialEntries={[`/connect/claude?session=${SESSION}`]}>
+                <ConnectClaude />
+            </MemoryRouter>,
         )
+
+        const retry = await screen.findByRole('button', { name: /finish connecting/i })
+        await userEvent.click(retry)
+
+        await waitFor(() => expect(calls.complete).toBe(2))
+        // No second preflight, and above all no second wallet signature or
+        // second add_delegate_key for a key the chain already took.
+        expect(calls.account).toBe(1)
+        expect(mocks.signAndExecute).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips add_delegate_key when /account says this session key is already on chain', async () => {
+        // The WALM-605 journey: an earlier attempt landed the transaction and
+        // then hit a 429 during verify. The chain, not a transaction error, is
+        // what tells us there is nothing left to submit.
+        const calls = stubRelayer([() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })], {
+            needsOnchainRegistration: false,
+            resumePendingRegistration: true,
+        })
 
         await approve()
 
         await screen.findByText(/Redirecting you back/)
+        expect(mocks.signAndExecute).not.toHaveBeenCalled()
         expect(calls.complete).toBe(1)
-        expect(screen.queryByText('Something went wrong')).toBeNull()
+        // Named honestly: this is not a delegate reused from an earlier grant.
+        expect(JSON.parse(calls.completeBodies[0]!).tx_digest).toBe('already-on-chain')
     })
 
-    it('still reports abort 4 as an owner mismatch', async () => {
-        stubRelayer([() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })], {
+    it('does not read a duplicate-key abort out of the masked sponsor 502', async () => {
+        // Built from the real exports, so the fixture cannot drift from the
+        // wrapper the way a hand-written 'MoveAbort ... abort code: 0' string
+        // did: that string is not what production throws, so a test using it
+        // passes while the user dead-ends.
+        const { SponsorHttpError, sponsorFailureMessage } = await vi.importActual<
+            typeof import('../hooks/useSponsoredTransaction')
+        >('../hooks/useSponsoredTransaction')
+        const masked = sponsorFailureMessage(
+            new SponsorHttpError(
+                'sponsor',
+                502,
+                JSON.stringify({
+                    error: 'Sponsor service error',
+                    code: 'sponsor_upstream_error',
+                    traceId: 'tr_1',
+                }),
+            ),
+        )
+        // The premise: an Enoki dry-run abort reaches the SPA with no Move text.
+        expect(masked).not.toMatch(/abort code/)
+        expect(masked).not.toMatch(/add_delegate_key/)
+
+        const calls = stubRelayer([() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })], {
             needsOnchainRegistration: true,
         })
-        mocks.signAndExecute.mockRejectedValue(
-            new Error('MoveAbort ... add_delegate_key ... abort code: 4'),
-        )
+        mocks.signAndExecute.mockRejectedValue(new Error(masked))
 
         await approve()
 
         await screen.findByText('Something went wrong')
-        expect(await screen.findByText(/is not the owner of Walrus Memory account/)).toBeTruthy()
+        // The load-bearing assertion: a sponsor 502 must not be treated as
+        // "already registered" and POSTed to /complete. ENotOwner,
+        // ETooManyDelegateKeys and EDelegateKeyAlreadyExists are
+        // indistinguishable here, and guessing the last one burns the session
+        // as Unregistered for the other two.
+        expect(calls.complete).toBe(0)
+    })
+
+    it('does not submit a transaction when /account cannot reach Sui', async () => {
+        const calls = stubRelayer([() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })], {
+            accountResponse: () =>
+                json(
+                    { error: 'temporarily_unavailable', error_description: 'sui unavailable' },
+                    503,
+                ),
+        })
+
+        await approve()
+
+        await screen.findByText('Something went wrong')
+        // Stopping beats guessing: submitting dead-ends on the masked 502 if
+        // the key is already there, and skipping burns the session as
+        // Unregistered if it is not. The preflight claims nothing, so the user
+        // can simply start again.
+        expect(mocks.signAndExecute).not.toHaveBeenCalled()
+        expect(calls.complete).toBe(0)
     })
 
     it('still fails terminally on a definitive rejection', async () => {

--- a/apps/app/src/pages/ConnectClaude.test.tsx
+++ b/apps/app/src/pages/ConnectClaude.test.tsx
@@ -7,7 +7,7 @@
  * `add_delegate_key` for a key already on chain, which aborts with code 0 and
  * surfaces as a misleading "not the owner".
  */
-import { render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -109,6 +109,7 @@ async function approve() {
 
 beforeEach(() => {
     vi.clearAllMocks()
+    sessionStorage.clear()
     mocks.signPersonalMessage.mockResolvedValue({ signature: 'sig' })
     // jsdom refuses a real navigation; the page only needs the call to not throw.
     vi.stubGlobal('location', { ...window.location, replace: vi.fn() })
@@ -142,6 +143,57 @@ describe('ConnectClaude /complete recovery', () => {
         expect(calls.account).toBe(1)
         expect(mocks.signAndExecute).not.toHaveBeenCalled()
         await screen.findByText(/Redirecting you back/)
+    })
+
+    it('a reload mid-recovery resumes at the retry step, not at consent', async () => {
+        // The ref does not survive a remount. Without the sessionStorage copy the
+        // user lands back on consent, and a first-time connect re-submits
+        // add_delegate_key for a key already on chain (abort code 0).
+        const calls = stubRelayer([
+            () => json({ error: 'temporarily_unavailable', error_description: 'sui unavailable' }, 503),
+            () => json({ redirect_url: 'https://claude.ai/callback?code=abc' }),
+        ])
+
+        await approve()
+        await screen.findByRole('button', { name: /finish connecting/i })
+        expect(calls.account).toBe(1)
+
+        // Remount, as a browser reload would.
+        cleanup()
+        render(
+            <MemoryRouter initialEntries={[`/connect/claude?session=${SESSION}`]}>
+                <ConnectClaude />
+            </MemoryRouter>,
+        )
+
+        const retry = await screen.findByRole('button', { name: /finish connecting/i })
+        await userEvent.click(retry)
+
+        await waitFor(() => expect(calls.complete).toBe(2))
+        // Still no second preflight and no second transaction after the reload.
+        expect(calls.account).toBe(1)
+        expect(mocks.signAndExecute).not.toHaveBeenCalled()
+    })
+
+    it('does not replay a stored payload against a different session', async () => {
+        sessionStorage.setItem(
+            'memwal_claude_pending_complete',
+            JSON.stringify({
+                session: 'mws_' + 'z'.repeat(24),
+                payload: { account_id: '0xa', owner_address: '0xb', owner_signature: 'sig', tx_digest: 'd', reused_delegate: true },
+            }),
+        )
+        stubRelayer([() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })])
+
+        render(
+            <MemoryRouter initialEntries={[`/connect/claude?session=${SESSION}`]}>
+                <ConnectClaude />
+            </MemoryRouter>,
+        )
+
+        // Lands on consent, not on someone else's half-finished authorization.
+        await screen.findByRole('button', { name: 'Approve' })
+        expect(screen.queryByRole('button', { name: /finish connecting/i })).toBeNull()
     })
 
     it('still fails terminally on a definitive rejection', async () => {

--- a/apps/app/src/pages/ConnectClaude.test.tsx
+++ b/apps/app/src/pages/ConnectClaude.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * WALM-605 recovery path.
+ *
+ * A Sui outage during `POST /complete` leaves the authorization session
+ * `pending` instead of burning it. That only helps if the consent UI can
+ * re-send *that one request*: re-running the whole flow would re-submit
+ * `add_delegate_key` for a key already on chain, which aborts with code 0 and
+ * surfaces as a misleading "not the owner".
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    address: '0xowner',
+    accountId: '0xaccount',
+    signAndExecute: vi.fn(),
+    signPersonalMessage: vi.fn(),
+}))
+
+vi.mock('../config', () => ({
+    config: {
+        memwalServerUrl: 'https://relayer.test',
+        memwalPackageId: '0xpkg',
+        memwalRegistryId: '0xreg',
+        suiNetwork: 'testnet',
+        docsUrl: 'https://docs.test',
+    },
+}))
+vi.mock('@mysten/dapp-kit', () => ({
+    ConnectModal: () => null,
+    useCurrentAccount: () => ({ address: mocks.address }),
+    useSuiClient: () => ({ waitForTransaction: vi.fn().mockResolvedValue({}) }),
+    useSignPersonalMessage: () => ({ mutateAsync: mocks.signPersonalMessage }),
+}))
+vi.mock('../hooks/useSponsoredTransaction', () => ({
+    useSponsoredTransaction: () => ({ mutateAsync: mocks.signAndExecute }),
+}))
+vi.mock('../utils/suiClientCompat', () => ({
+    fetchAccountIdForOwner: vi.fn().mockResolvedValue(mocks.accountId),
+}))
+vi.mock('../utils/analytics', () => ({
+    trackEvent: vi.fn(),
+    getAnalyticsErrorType: () => 'unknown',
+}))
+
+import ConnectClaude from './ConnectClaude'
+
+const SESSION = `mws_${'a'.repeat(24)}`
+
+function json(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+    })
+}
+
+const SESSION_VIEW = {
+    client_name: 'Claude',
+    redirect_host: 'claude.ai',
+    scopes: ['memory.read'],
+    delegate_public_key: 'ab'.repeat(32),
+    delegate_sui_address: '0xdelegate',
+    expires_at: new Date(Date.now() + 600_000).toISOString(),
+}
+
+/**
+ * Serves the session GET and the `/account` preflight, and hands each
+ * `/complete` POST to the next entry of `completeResponses`. Returns a counter
+ * of how many times each endpoint was called.
+ */
+function stubRelayer(completeResponses: (() => Response)[]) {
+    const calls = { account: 0, complete: 0 }
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input)
+            if (url.endsWith(`/session/${SESSION}`)) return json(SESSION_VIEW)
+            if (url.endsWith('/account')) {
+                calls.account += 1
+                // Reused delegate: no add_delegate_key transaction is needed,
+                // so the test isolates the /complete round-trip.
+                return json({
+                    needs_onchain_registration: false,
+                    delegate_public_key: SESSION_VIEW.delegate_public_key,
+                    delegate_sui_address: SESSION_VIEW.delegate_sui_address,
+                })
+            }
+            if (url.endsWith('/complete')) {
+                const next = completeResponses[calls.complete] ?? completeResponses.at(-1)
+                calls.complete += 1
+                return next!()
+            }
+            throw new Error(`unexpected fetch: ${url}`)
+        }),
+    )
+    return calls
+}
+
+async function approve() {
+    render(
+        <MemoryRouter initialEntries={[`/connect/claude?session=${SESSION}`]}>
+            <ConnectClaude />
+        </MemoryRouter>,
+    )
+    await userEvent.click(await screen.findByRole('button', { name: 'Approve' }))
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.signPersonalMessage.mockResolvedValue({ signature: 'sig' })
+    // jsdom refuses a real navigation; the page only needs the call to not throw.
+    vi.stubGlobal('location', { ...window.location, replace: vi.fn() })
+})
+
+describe('ConnectClaude /complete recovery', () => {
+    it('offers a retry of /complete alone when Sui is unavailable', async () => {
+        const calls = stubRelayer([
+            () =>
+                json(
+                    {
+                        error: 'temporarily_unavailable',
+                        error_description: 'could not verify the delegate key on-chain right now',
+                    },
+                    503,
+                ),
+            () => json({ redirect_url: 'https://claude.ai/callback?code=abc' }),
+        ])
+
+        await approve()
+
+        // Not the terminal error state: the session is still pending.
+        const retry = await screen.findByRole('button', { name: /finish connecting/i })
+        expect(screen.queryByText('Something went wrong')).toBeNull()
+
+        await userEvent.click(retry)
+
+        await waitFor(() => expect(calls.complete).toBe(2))
+        // The retry re-sent /complete only — no second preflight, so no second
+        // add_delegate_key submission.
+        expect(calls.account).toBe(1)
+        expect(mocks.signAndExecute).not.toHaveBeenCalled()
+        await screen.findByText(/Redirecting you back/)
+    })
+
+    it('still fails terminally on a definitive rejection', async () => {
+        stubRelayer([
+            () =>
+                json(
+                    {
+                        error: 'invalid_request',
+                        error_description: 'delegate key is not registered on-chain',
+                    },
+                    400,
+                ),
+        ])
+
+        await approve()
+
+        await screen.findByText('Something went wrong')
+        expect(screen.queryByRole('button', { name: /finish connecting/i })).toBeNull()
+    })
+})

--- a/apps/app/src/pages/ConnectClaude.test.tsx
+++ b/apps/app/src/pages/ConnectClaude.test.tsx
@@ -175,6 +175,27 @@ describe('ConnectClaude /complete recovery', () => {
         expect(mocks.signAndExecute).not.toHaveBeenCalled()
     })
 
+    it('a definitive rejection leaves nothing to resume after a reload', async () => {
+        // The session is spent on a 400, so a reload must land on the error and
+        // not loop on the "Sui is busy" retry screen.
+        stubRelayer([
+            () => json({ error: 'invalid_request', error_description: 'delegate key is not registered on-chain' }, 400),
+        ])
+
+        await approve()
+        await screen.findByText('Something went wrong')
+
+        cleanup()
+        render(
+            <MemoryRouter initialEntries={[`/connect/claude?session=${SESSION}`]}>
+                <ConnectClaude />
+            </MemoryRouter>,
+        )
+
+        await screen.findByRole('button', { name: 'Approve' })
+        expect(screen.queryByRole('button', { name: /finish connecting/i })).toBeNull()
+    })
+
     it('does not replay a stored payload against a different session', async () => {
         sessionStorage.setItem(
             'memwal_claude_pending_complete',

--- a/apps/app/src/pages/ConnectClaude.test.tsx
+++ b/apps/app/src/pages/ConnectClaude.test.tsx
@@ -70,7 +70,10 @@ const SESSION_VIEW = {
  * `/complete` POST to the next entry of `completeResponses`. Returns a counter
  * of how many times each endpoint was called.
  */
-function stubRelayer(completeResponses: (() => Response)[]) {
+function stubRelayer(
+    completeResponses: (() => Response)[],
+    { needsOnchainRegistration = false }: { needsOnchainRegistration?: boolean } = {},
+) {
     const calls = { account: 0, complete: 0 }
     vi.stubGlobal(
         'fetch',
@@ -82,7 +85,7 @@ function stubRelayer(completeResponses: (() => Response)[]) {
                 // Reused delegate: no add_delegate_key transaction is needed,
                 // so the test isolates the /complete round-trip.
                 return json({
-                    needs_onchain_registration: false,
+                    needs_onchain_registration: needsOnchainRegistration,
                     delegate_public_key: SESSION_VIEW.delegate_public_key,
                     delegate_sui_address: SESSION_VIEW.delegate_sui_address,
                 })
@@ -215,6 +218,40 @@ describe('ConnectClaude /complete recovery', () => {
         // Lands on consent, not on someone else's half-finished authorization.
         await screen.findByRole('button', { name: 'Approve' })
         expect(screen.queryByRole('button', { name: /finish connecting/i })).toBeNull()
+    })
+
+    // `account.move`: EDelegateKeyAlreadyExists = 0, ENotOwner = 4. Mapping 0 to
+    // "not the owner" dead-ended the WALM-605 journey — the key was already on
+    // chain from the attempt whose verify hit a 429, so re-running the flow
+    // aborts with 0 and the user was told to switch wallets.
+    it('treats add_delegate_key abort 0 as already-registered and completes', async () => {
+        const calls = stubRelayer(
+            [() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })],
+            { needsOnchainRegistration: true },
+        )
+        mocks.signAndExecute.mockRejectedValue(
+            new Error('MoveAbort ... add_delegate_key ... abort code: 0'),
+        )
+
+        await approve()
+
+        await screen.findByText(/Redirecting you back/)
+        expect(calls.complete).toBe(1)
+        expect(screen.queryByText('Something went wrong')).toBeNull()
+    })
+
+    it('still reports abort 4 as an owner mismatch', async () => {
+        stubRelayer([() => json({ redirect_url: 'https://claude.ai/callback?code=abc' })], {
+            needsOnchainRegistration: true,
+        })
+        mocks.signAndExecute.mockRejectedValue(
+            new Error('MoveAbort ... add_delegate_key ... abort code: 4'),
+        )
+
+        await approve()
+
+        await screen.findByText('Something went wrong')
+        expect(await screen.findByText(/is not the owner of Walrus Memory account/)).toBeTruthy()
     })
 
     it('still fails terminally on a definitive rejection', async () => {

--- a/apps/app/src/pages/ConnectClaude.tsx
+++ b/apps/app/src/pages/ConnectClaude.tsx
@@ -335,12 +335,22 @@ export default function ConnectClaude() {
                         tx.object('0x6'),
                     ],
                 })
+                // `account.move` abort codes: EDelegateKeyAlreadyExists = 0,
+                // ETooManyDelegateKeys = 2, ENotOwner = 4.
                 let result
+                let alreadyOnChain = false
                 try {
                     result = await signAndExecute({ transaction: tx })
                 } catch (txErr: unknown) {
                     const m = txErr instanceof Error ? txErr.message : String(txErr)
                     if (m.includes('abort code: 0') && m.includes('add_delegate_key')) {
+                        // This session's key is already registered, so a previous
+                        // attempt landed the tx and then failed further along —
+                        // WALM-605's Sui 429 during verify is exactly that. There
+                        // is nothing left to submit: go straight to /complete
+                        // rather than reporting the abort as an error.
+                        alreadyOnChain = true
+                    } else if (m.includes('abort code: 4') && m.includes('add_delegate_key')) {
                         setErrorMsg(
                             `This wallet (${currentAccount.address.slice(0, 10)}…${currentAccount.address.slice(-6)}) is not the owner of Walrus Memory account ${accountId.slice(0, 10)}…${accountId.slice(-6)}. ` +
                             `Switch to the wallet that created this account, or run /setup for a new one.`
@@ -348,19 +358,21 @@ export default function ConnectClaude() {
                         trackEvent('claude_connect_failed', { error_type: 'owner_mismatch' })
                         setStep('error')
                         return
-                    }
-                    if (m.includes('abort code: 2') && m.includes('add_delegate_key')) {
+                    } else if (m.includes('abort code: 2') && m.includes('add_delegate_key')) {
                         setErrorMsg(
                             `This account already has the maximum number of delegate keys (20). Go to /dashboard and revoke an unused key, then try again.`
                         )
                         trackEvent('claude_connect_failed', { error_type: 'max_delegate_keys' })
                         setStep('error')
                         return
+                    } else {
+                        throw txErr
                     }
-                    throw txErr
                 }
-                await suiClient.waitForTransaction({ digest: result.digest })
-                txDigest = result.digest
+                if (!alreadyOnChain && result) {
+                    await suiClient.waitForTransaction({ digest: result.digest })
+                    txDigest = result.digest
+                }
             }
 
             setStep('finishing')

--- a/apps/app/src/pages/ConnectClaude.tsx
+++ b/apps/app/src/pages/ConnectClaude.tsx
@@ -206,11 +206,21 @@ export default function ConnectClaude() {
     // request. Re-running `handleConnect` instead would re-submit
     // `add_delegate_key` for a key already on chain (abort code 0).
     //
-    // Mirrored into the existing sessionStorage breadcrumb because a ref does
-    // not survive a reload, and a reload is the obvious thing to try when the
-    // relayer says "retry". Without it the first-time path re-runs
-    // `handleConnect` and dead-ends on that abort.
+    // A ref does not survive a reload, and a reload is the obvious thing to try
+    // when the relayer says "retry"; without a durable copy the first-time path
+    // re-runs `handleConnect` and dead-ends on that abort. It gets its own key
+    // rather than joining `memwal_claude_connect`, which the mount effect
+    // rewrites to `{ session }` on every load and would drop the payload.
     const pendingComplete = useRef<CompletePayload | null>(null)
+
+    const forgetPendingComplete = useCallback(() => {
+        pendingComplete.current = null
+        try {
+            sessionStorage.removeItem(PENDING_COMPLETE_KEY)
+        } catch {
+            // Nothing to clean up if storage is unavailable.
+        }
+    }, [])
 
     const rememberPendingComplete = useCallback(
         (payload: CompletePayload) => {
@@ -235,7 +245,9 @@ export default function ConnectClaude() {
     }, [sessionId])
 
     const completeSession = useCallback(async (payload: CompletePayload) => {
-        rememberPendingComplete(payload)
+        // The ref covers an in-flight /complete; only a retryable failure earns
+        // a durable crumb, so a definitive 400 cannot leave one behind.
+        pendingComplete.current = payload
         setStep('finishing')
         try {
             const { redirect_url } = await fetchJson<{ redirect_url: string }>(
@@ -256,14 +268,20 @@ export default function ConnectClaude() {
             trackEvent('claude_connect_complete', { reused_delegate: payload.reused_delegate })
             window.location.replace(redirect_url)
         } catch (err) {
-            if (!isRetryableComplete(err)) throw err
+            if (!isRetryableComplete(err)) {
+                // Definitive: the session is spent. Clear the crumb so a reload
+                // lands on the error rather than looping on "Sui is busy".
+                forgetPendingComplete()
+                throw err
+            }
             // The session is still pending, so offer this one request again
             // rather than dropping into the terminal error state.
+            rememberPendingComplete(payload)
             setErrorMsg(err instanceof Error ? err.message : String(err))
             setStep('retry-complete')
             trackEvent('claude_connect_failed', { error_type: 'sui_unavailable' })
         }
-    }, [apiBase, sessionId, rememberPendingComplete])
+    }, [apiBase, sessionId, rememberPendingComplete, forgetPendingComplete])
 
     const handleRetryComplete = useCallback(async () => {
         const payload = readPendingComplete()

--- a/apps/app/src/pages/ConnectClaude.tsx
+++ b/apps/app/src/pages/ConnectClaude.tsx
@@ -53,6 +53,31 @@ type CompletePayload = {
     reused_delegate: boolean
 }
 
+/** Where the in-flight `POST /complete` payload survives a reload. */
+const PENDING_COMPLETE_KEY = 'memwal_claude_pending_complete'
+
+/**
+ * The saved `POST /complete` payload for this session, if any.
+ *
+ * Session-scoped on purpose: one authorization's wallet signature must never be
+ * replayed against another.
+ */
+function loadStoredComplete(sessionId: string): CompletePayload | null {
+    try {
+        const raw = sessionStorage.getItem(PENDING_COMPLETE_KEY)
+        if (!raw) return null
+        const saved = JSON.parse(raw) as { session?: string; payload?: CompletePayload }
+        if (saved.session !== sessionId || !saved.payload?.owner_signature) return null
+        return saved.payload
+    } catch {
+        return null
+    }
+}
+
+function hasStoredComplete(sessionId: string): boolean {
+    return loadStoredComplete(sessionId) !== null
+}
+
 type Step =
     | 'loading'
     | 'consent'
@@ -153,7 +178,10 @@ export default function ConnectClaude() {
             .then((view) => {
                 if (cancelled) return
                 setSession(view)
-                setStep('consent')
+                // A reload mid-recovery resumes at the retry step. Landing on
+                // consent would re-run handleConnect, and on the first-time path
+                // that re-submits add_delegate_key for a key already on chain.
+                setStep(hasStoredComplete(sessionId) ? 'retry-complete' : 'consent')
             })
             .catch((err) => {
                 if (cancelled) return
@@ -173,13 +201,41 @@ export default function ConnectClaude() {
         sessionStorage.setItem('memwal_claude_connect', JSON.stringify({ session: sessionId }))
     }, [sessionValid, sessionId])
 
+
     // Everything `POST /complete` needs, kept so a retry re-sends exactly this
     // request. Re-running `handleConnect` instead would re-submit
     // `add_delegate_key` for a key already on chain (abort code 0).
+    //
+    // Mirrored into the existing sessionStorage breadcrumb because a ref does
+    // not survive a reload, and a reload is the obvious thing to try when the
+    // relayer says "retry". Without it the first-time path re-runs
+    // `handleConnect` and dead-ends on that abort.
     const pendingComplete = useRef<CompletePayload | null>(null)
 
+    const rememberPendingComplete = useCallback(
+        (payload: CompletePayload) => {
+            pendingComplete.current = payload
+            try {
+                sessionStorage.setItem(
+                    PENDING_COMPLETE_KEY,
+                    JSON.stringify({ session: sessionId, payload }),
+                )
+            } catch {
+                // Private mode or a full quota: the in-page button still works.
+            }
+        },
+        [sessionId],
+    )
+
+    const readPendingComplete = useCallback((): CompletePayload | null => {
+        if (pendingComplete.current) return pendingComplete.current
+        const saved = loadStoredComplete(sessionId)
+        if (saved) pendingComplete.current = saved
+        return saved
+    }, [sessionId])
+
     const completeSession = useCallback(async (payload: CompletePayload) => {
-        pendingComplete.current = payload
+        rememberPendingComplete(payload)
         setStep('finishing')
         try {
             const { redirect_url } = await fetchJson<{ redirect_url: string }>(
@@ -195,6 +251,7 @@ export default function ConnectClaude() {
                 },
             )
             sessionStorage.removeItem('memwal_claude_connect')
+            sessionStorage.removeItem(PENDING_COMPLETE_KEY)
             setStep('redirecting')
             trackEvent('claude_connect_complete', { reused_delegate: payload.reused_delegate })
             window.location.replace(redirect_url)
@@ -206,10 +263,10 @@ export default function ConnectClaude() {
             setStep('retry-complete')
             trackEvent('claude_connect_failed', { error_type: 'sui_unavailable' })
         }
-    }, [apiBase, sessionId])
+    }, [apiBase, sessionId, rememberPendingComplete])
 
     const handleRetryComplete = useCallback(async () => {
-        const payload = pendingComplete.current
+        const payload = readPendingComplete()
         if (!payload) return
         try {
             await completeSession(payload)
@@ -218,8 +275,7 @@ export default function ConnectClaude() {
             setStep('error')
             trackEvent('claude_connect_failed', { error_type: getAnalyticsErrorType(err) })
         }
-    }, [completeSession])
-
+    }, [completeSession, readPendingComplete])
     const handleConnect = useCallback(async () => {
         if (!session) return
         if (!currentAccount) {
@@ -325,6 +381,7 @@ export default function ConnectClaude() {
     // Auto-proceed once the wallet popup resolves.
     useEffect(() => {
         if (!walletPickerOpen && currentAccount && step === 'consent') {
+            if (hasStoredComplete(sessionId)) return
             void handleConnect()
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -391,8 +448,8 @@ export default function ConnectClaude() {
                         <div className="setup-classic-intro">
                             <h2 className="setup-classic-title">Sui is busy — try again</h2>
                             <p className="setup-classic-description">
-                                Your delegate key is registered and this authorization is still valid. We just
-                                couldn't reach Sui to verify it. Nothing needs redoing — press the button to
+                                We couldn't reach Sui to verify your delegate key, so this authorization is
+                                still pending rather than spent. Nothing needs redoing — press the button to
                                 finish.
                             </p>
                             <p className="setup-classic-description" style={errorTextStyle}>{errorMsg}</p>

--- a/apps/app/src/pages/ConnectClaude.tsx
+++ b/apps/app/src/pages/ConnectClaude.tsx
@@ -142,8 +142,9 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
 /**
  * The relayer could not reach Sui, so it left the authorization session
  * `pending` instead of burning it (WALM-605). Re-POSTing `/complete` alone is
- * the recovery — restarting `handleConnect` would re-submit `add_delegate_key`
- * for a key that is already on chain, which aborts with code 0.
+ * the recovery: the wallet signature and the on-chain registration from the
+ * first attempt are both still good, so restarting `handleConnect` would only
+ * re-ask the wallet and re-submit a transaction the chain has already taken.
  */
 function isRetryableComplete(err: unknown): boolean {
     const e = err as Partial<OAuthRequestError> | null
@@ -179,8 +180,8 @@ export default function ConnectClaude() {
                 if (cancelled) return
                 setSession(view)
                 // A reload mid-recovery resumes at the retry step. Landing on
-                // consent would re-run handleConnect, and on the first-time path
-                // that re-submits add_delegate_key for a key already on chain.
+                // consent would re-run handleConnect, which re-asks the wallet
+                // to sign and re-sends a transaction the chain already took.
                 setStep(hasStoredComplete(sessionId) ? 'retry-complete' : 'consent')
             })
             .catch((err) => {
@@ -203,14 +204,15 @@ export default function ConnectClaude() {
 
 
     // Everything `POST /complete` needs, kept so a retry re-sends exactly this
-    // request. Re-running `handleConnect` instead would re-submit
-    // `add_delegate_key` for a key already on chain (abort code 0).
+    // request instead of re-running `handleConnect`, which would re-ask the
+    // wallet for a signature and re-submit `add_delegate_key` for a key that
+    // is already on chain.
     //
     // A ref does not survive a reload, and a reload is the obvious thing to try
-    // when the relayer says "retry"; without a durable copy the first-time path
-    // re-runs `handleConnect` and dead-ends on that abort. It gets its own key
-    // rather than joining `memwal_claude_connect`, which the mount effect
-    // rewrites to `{ session }` on every load and would drop the payload.
+    // when the relayer says "retry", so the payload also goes to sessionStorage.
+    // It gets its own key rather than joining `memwal_claude_connect`, which
+    // the mount effect rewrites to `{ session }` on every load and would drop
+    // the payload.
     const pendingComplete = useRef<CompletePayload | null>(null)
 
     const forgetPendingComplete = useCallback(() => {
@@ -245,9 +247,18 @@ export default function ConnectClaude() {
     }, [sessionId])
 
     const completeSession = useCallback(async (payload: CompletePayload) => {
-        // The ref covers an in-flight /complete; only a retryable failure earns
-        // a durable crumb, so a definitive 400 cannot leave one behind.
-        pendingComplete.current = payload
+        // Durable before the request, not after it fails. A reload while
+        // /complete is still in flight is the gap a ref cannot cover, and on
+        // the first-time path it is the expensive one: without the crumb the
+        // page lands on consent, re-runs handleConnect, and re-submits
+        // add_delegate_key for a key the tx above already put on chain. That
+        // no longer dead-ends now that /account detects it, but it still costs
+        // a wallet round-trip and a sponsored transaction.
+        //
+        // Writing early is safe because every terminal exit clears it: success
+        // below, and a definitive 400 in the catch. A spent session therefore
+        // cannot leave a crumb that loops the user on "Sui is busy".
+        rememberPendingComplete(payload)
         setStep('finishing')
         try {
             const { redirect_url } = await fetchJson<{ redirect_url: string }>(
@@ -275,8 +286,8 @@ export default function ConnectClaude() {
                 throw err
             }
             // The session is still pending, so offer this one request again
-            // rather than dropping into the terminal error state.
-            rememberPendingComplete(payload)
+            // rather than dropping into the terminal error state. The crumb
+            // written above is what the retry step and a reload both read.
             setErrorMsg(err instanceof Error ? err.message : String(err))
             setStep('retry-complete')
             trackEvent('claude_connect_failed', { error_type: 'sui_unavailable' })
@@ -316,6 +327,9 @@ export default function ConnectClaude() {
                 needs_onchain_registration: boolean
                 delegate_public_key: string
                 delegate_sui_address: string
+                // Absent on a relayer older than WALM-605, which is the
+                // pre-existing behaviour: no resume, just the first-time path.
+                resume_pending_registration?: boolean
             }>(`${apiBase}/api/oauth/session/${sessionId}/account`, {
                 method: 'POST',
                 body: JSON.stringify({ account_id: accountId, owner_address: currentAccount.address }),
@@ -335,44 +349,20 @@ export default function ConnectClaude() {
                         tx.object('0x6'),
                     ],
                 })
-                // `account.move` abort codes: EDelegateKeyAlreadyExists = 0,
-                // ETooManyDelegateKeys = 2, ENotOwner = 4.
-                let result
-                let alreadyOnChain = false
-                try {
-                    result = await signAndExecute({ transaction: tx })
-                } catch (txErr: unknown) {
-                    const m = txErr instanceof Error ? txErr.message : String(txErr)
-                    if (m.includes('abort code: 0') && m.includes('add_delegate_key')) {
-                        // This session's key is already registered, so a previous
-                        // attempt landed the tx and then failed further along —
-                        // WALM-605's Sui 429 during verify is exactly that. There
-                        // is nothing left to submit: go straight to /complete
-                        // rather than reporting the abort as an error.
-                        alreadyOnChain = true
-                    } else if (m.includes('abort code: 4') && m.includes('add_delegate_key')) {
-                        setErrorMsg(
-                            `This wallet (${currentAccount.address.slice(0, 10)}…${currentAccount.address.slice(-6)}) is not the owner of Walrus Memory account ${accountId.slice(0, 10)}…${accountId.slice(-6)}. ` +
-                            `Switch to the wallet that created this account, or run /setup for a new one.`
-                        )
-                        trackEvent('claude_connect_failed', { error_type: 'owner_mismatch' })
-                        setStep('error')
-                        return
-                    } else if (m.includes('abort code: 2') && m.includes('add_delegate_key')) {
-                        setErrorMsg(
-                            `This account already has the maximum number of delegate keys (20). Go to /dashboard and revoke an unused key, then try again.`
-                        )
-                        trackEvent('claude_connect_failed', { error_type: 'max_delegate_keys' })
-                        setStep('error')
-                        return
-                    } else {
-                        throw txErr
-                    }
-                }
-                if (!alreadyOnChain && result) {
-                    await suiClient.waitForTransaction({ digest: result.digest })
-                    txDigest = result.digest
-                }
+                // Deliberately no `account.move` abort-code branches here.
+                // This page signs through `useSponsoredTransaction`, which
+                // throws `new Error(sponsorFailureMessage(...))`, and the
+                // relayer's `sponsor::mask_upstream` collapses any upstream
+                // 5xx into a bare 502 `sponsor_upstream_error` that never
+                // echoes the Move abort. `EDelegateKeyAlreadyExists` (0),
+                // `ETooManyDelegateKeys` (2) and `ENotOwner` (4) therefore all
+                // reach us as the same opaque sponsor string; matching on them
+                // read like recovery while never firing. The duplicate-key
+                // case is settled before this point, by `/account`'s on-chain
+                // check (`resume_pending_registration`).
+                const result = await signAndExecute({ transaction: tx })
+                await suiClient.waitForTransaction({ digest: result.digest })
+                txDigest = result.digest
             }
 
             setStep('finishing')
@@ -380,12 +370,16 @@ export default function ConnectClaude() {
                 `Walrus Memory OAuth authorization\nsession:${sessionId}\naccount:${accountId.toLowerCase()}\nowner:${currentAccount.address.toLowerCase()}`,
             )
             const { signature: ownerSignature } = await signPersonalMessage({ message: proofMessage })
+            const resuming = preflight.resume_pending_registration === true
             await completeSession({
                 account_id: accountId,
                 owner_address: currentAccount.address,
                 owner_signature: ownerSignature,
-                tx_digest: txDigest || 'reused-delegate',
-                reused_delegate: !preflight.needs_onchain_registration,
+                // `/complete` requires a non-empty digest. When no tx was sent
+                // this call names why, rather than claiming a reused delegate
+                // for a key this session registered on an earlier attempt.
+                tx_digest: txDigest || (resuming ? 'already-on-chain' : 'reused-delegate'),
+                reused_delegate: !preflight.needs_onchain_registration && !resuming,
             })
         } catch (err) {
             setErrorMsg(err instanceof Error ? err.message : String(err))

--- a/apps/app/src/pages/ConnectClaude.tsx
+++ b/apps/app/src/pages/ConnectClaude.tsx
@@ -28,7 +28,7 @@
  *   6. `window.location.replace(redirect_url)` — hands control back to
  *      Claude (or whatever OAuth client started the flow).
  */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
     ConnectModal,
     useCurrentAccount,
@@ -44,11 +44,21 @@ import { fetchAccountIdForOwner } from '../utils/suiClientCompat'
 
 const WALRUS_MEMORY_LOGO = '/walrus-memory-logo.svg'
 
+/** The `POST /complete` body, plus the analytics flag that goes with it. */
+type CompletePayload = {
+    account_id: string
+    owner_address: string
+    owner_signature: string
+    tx_digest: string
+    reused_delegate: boolean
+}
+
 type Step =
     | 'loading'
     | 'consent'
     | 'signing'
     | 'finishing'
+    | 'retry-complete'
     | 'redirecting'
     | 'no-account'
     | 'error'
@@ -82,6 +92,8 @@ async function resolveAccountId(
     }
 }
 
+type OAuthRequestError = Error & { status: number; oauthError?: string }
+
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
     const res = await fetch(url, {
         ...init,
@@ -89,13 +101,28 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
     })
     const body = await res.json().catch(() => null)
     if (!res.ok) {
+        const envelope = body && typeof body === 'object' ? (body as Record<string, unknown>) : null
         const description =
-            body && typeof body === 'object' && 'error_description' in body
-                ? String((body as { error_description: unknown }).error_description)
+            envelope && 'error_description' in envelope
+                ? String(envelope.error_description)
                 : `request failed (${res.status})`
-        throw new Error(description)
+        const err = new Error(description) as OAuthRequestError
+        err.status = res.status
+        if (envelope && typeof envelope.error === 'string') err.oauthError = envelope.error
+        throw err
     }
     return body as T
+}
+
+/**
+ * The relayer could not reach Sui, so it left the authorization session
+ * `pending` instead of burning it (WALM-605). Re-POSTing `/complete` alone is
+ * the recovery — restarting `handleConnect` would re-submit `add_delegate_key`
+ * for a key that is already on chain, which aborts with code 0.
+ */
+function isRetryableComplete(err: unknown): boolean {
+    const e = err as Partial<OAuthRequestError> | null
+    return e?.oauthError === 'temporarily_unavailable' || e?.status === 503
 }
 
 export default function ConnectClaude() {
@@ -145,6 +172,53 @@ export default function ConnectClaude() {
         if (!sessionValid) return
         sessionStorage.setItem('memwal_claude_connect', JSON.stringify({ session: sessionId }))
     }, [sessionValid, sessionId])
+
+    // Everything `POST /complete` needs, kept so a retry re-sends exactly this
+    // request. Re-running `handleConnect` instead would re-submit
+    // `add_delegate_key` for a key already on chain (abort code 0).
+    const pendingComplete = useRef<CompletePayload | null>(null)
+
+    const completeSession = useCallback(async (payload: CompletePayload) => {
+        pendingComplete.current = payload
+        setStep('finishing')
+        try {
+            const { redirect_url } = await fetchJson<{ redirect_url: string }>(
+                `${apiBase}/api/oauth/session/${sessionId}/complete`,
+                {
+                    method: 'POST',
+                    body: JSON.stringify({
+                        account_id: payload.account_id,
+                        owner_address: payload.owner_address,
+                        owner_signature: payload.owner_signature,
+                        tx_digest: payload.tx_digest,
+                    }),
+                },
+            )
+            sessionStorage.removeItem('memwal_claude_connect')
+            setStep('redirecting')
+            trackEvent('claude_connect_complete', { reused_delegate: payload.reused_delegate })
+            window.location.replace(redirect_url)
+        } catch (err) {
+            if (!isRetryableComplete(err)) throw err
+            // The session is still pending, so offer this one request again
+            // rather than dropping into the terminal error state.
+            setErrorMsg(err instanceof Error ? err.message : String(err))
+            setStep('retry-complete')
+            trackEvent('claude_connect_failed', { error_type: 'sui_unavailable' })
+        }
+    }, [apiBase, sessionId])
+
+    const handleRetryComplete = useCallback(async () => {
+        const payload = pendingComplete.current
+        if (!payload) return
+        try {
+            await completeSession(payload)
+        } catch (err) {
+            setErrorMsg(err instanceof Error ? err.message : String(err))
+            setStep('error')
+            trackEvent('claude_connect_failed', { error_type: getAnalyticsErrorType(err) })
+        }
+    }, [completeSession])
 
     const handleConnect = useCallback(async () => {
         if (!session) return
@@ -220,28 +294,19 @@ export default function ConnectClaude() {
                 `Walrus Memory OAuth authorization\nsession:${sessionId}\naccount:${accountId.toLowerCase()}\nowner:${currentAccount.address.toLowerCase()}`,
             )
             const { signature: ownerSignature } = await signPersonalMessage({ message: proofMessage })
-            const { redirect_url } = await fetchJson<{ redirect_url: string }>(
-                `${apiBase}/api/oauth/session/${sessionId}/complete`,
-                {
-                    method: 'POST',
-                    body: JSON.stringify({
-                        account_id: accountId,
-                        owner_address: currentAccount.address,
-                        owner_signature: ownerSignature,
-                        tx_digest: txDigest || 'reused-delegate',
-                    }),
-                },
-            )
-            sessionStorage.removeItem('memwal_claude_connect')
-            setStep('redirecting')
-            trackEvent('claude_connect_complete', { reused_delegate: !preflight.needs_onchain_registration })
-            window.location.replace(redirect_url)
+            await completeSession({
+                account_id: accountId,
+                owner_address: currentAccount.address,
+                owner_signature: ownerSignature,
+                tx_digest: txDigest || 'reused-delegate',
+                reused_delegate: !preflight.needs_onchain_registration,
+            })
         } catch (err) {
             setErrorMsg(err instanceof Error ? err.message : String(err))
             setStep('error')
             trackEvent('claude_connect_failed', { error_type: getAnalyticsErrorType(err) })
         }
-    }, [session, currentAccount, suiClient, signAndExecute, signPersonalMessage, apiBase, sessionId])
+    }, [session, currentAccount, suiClient, signAndExecute, signPersonalMessage, completeSession])
 
     const handleCancel = useCallback(async () => {
         try {
@@ -318,6 +383,23 @@ export default function ConnectClaude() {
                             </p>
                             <div className="setup-classic-actions">
                                 <Link to="/setup" className="lp-btn-yellow">Create account and continue</Link>
+                            </div>
+                        </div>
+                    )}
+
+                    {step === 'retry-complete' && (
+                        <div className="setup-classic-intro">
+                            <h2 className="setup-classic-title">Sui is busy — try again</h2>
+                            <p className="setup-classic-description">
+                                Your delegate key is registered and this authorization is still valid. We just
+                                couldn't reach Sui to verify it. Nothing needs redoing — press the button to
+                                finish.
+                            </p>
+                            <p className="setup-classic-description" style={errorTextStyle}>{errorMsg}</p>
+                            <div className="setup-classic-actions">
+                                <button type="button" className="lp-btn-yellow" onClick={handleRetryComplete}>
+                                    Finish connecting
+                                </button>
                             </div>
                         </div>
                     )}

--- a/services/server/src/oauth.rs
+++ b/services/server/src/oauth.rs
@@ -221,6 +221,11 @@ impl McpOAuthConfig {
     }
 }
 
+/// Short `Retry-After` for OAuth 503s. Mirrors signed HTTP auth's
+/// `AUTH_UPSTREAM_RETRY_AFTER_SECS` so both surfaces ask for the same backoff
+/// when Sui is throttling us (WALM-429/WALM-605).
+pub const OAUTH_UPSTREAM_RETRY_AFTER_SECS: u64 = 5;
+
 /// RFC 6749-shaped error response (`{"error": "...", "error_description":
 /// "..."}`), distinct from `crate::types::AppError` because OAuth clients
 /// (Claude's connector implementation specifically) parse `error` as a
@@ -232,6 +237,10 @@ pub struct OAuthError {
     pub status: axum::http::StatusCode,
     pub error: &'static str,
     pub description: String,
+    /// Seconds to advertise in `Retry-After`. Only set on retryable failures,
+    /// so a client that may safely re-submit the *same* request knows to back
+    /// off instead of restarting the whole flow (WALM-605).
+    pub retry_after_secs: Option<u64>,
 }
 
 impl OAuthError {
@@ -244,6 +253,7 @@ impl OAuthError {
             status,
             error,
             description: description.into(),
+            retry_after_secs: None,
         }
     }
 
@@ -295,6 +305,20 @@ impl OAuthError {
         )
     }
 
+    /// RFC 6749 §4.1.2.1 `temporarily_unavailable`: the request was well
+    /// formed, but an upstream (Sui) could not be consulted, so the server has
+    /// no answer yet — as opposed to `invalid_request`, which asserts a
+    /// definitive "no". Retryable, so a handler must not have destroyed
+    /// single-use state before returning it (WALM-605).
+    pub fn temporarily_unavailable(description: impl Into<String>) -> Self {
+        Self {
+            status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            error: "temporarily_unavailable",
+            description: description.into(),
+            retry_after_secs: Some(OAUTH_UPSTREAM_RETRY_AFTER_SECS),
+        }
+    }
+
     pub fn server_error(description: impl Into<String>) -> Self {
         Self::new(
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -317,6 +341,7 @@ impl From<crate::types::AppError> for OAuthError {
 impl axum::response::IntoResponse for OAuthError {
     fn into_response(self) -> axum::response::Response {
         use axum::http::header;
+        let retry_after_secs = self.retry_after_secs;
         let body = serde_json::json!({
             "error": self.error,
             "error_description": self.description,
@@ -325,6 +350,11 @@ impl axum::response::IntoResponse for OAuthError {
         response
             .headers_mut()
             .insert(header::CACHE_CONTROL, "no-store".parse().unwrap());
+        if let Some(secs) = retry_after_secs {
+            response
+                .headers_mut()
+                .insert(header::RETRY_AFTER, secs.into());
+        }
         response
     }
 }

--- a/services/server/src/routes/oauth.rs
+++ b/services/server/src/routes/oauth.rs
@@ -24,7 +24,7 @@ use crate::oauth::{self, OAuthError};
 use crate::storage::db::oauth_rows::{
     OAuthClientRow, OAuthCodeRow, OAuthDelegateRow, OAuthGrantRow, OAuthSessionRow, OAuthTokenRow,
 };
-use crate::storage::sui::verify_delegate_key_onchain;
+use crate::storage::sui::{verify_delegate_key_onchain, OnchainVerifyError};
 use crate::types::AppState;
 
 /// Read the configured `McpOAuthConfig`, or fail with 404 if not configured.
@@ -634,6 +634,61 @@ fn sanitize_sui_object_id(raw: &str) -> Result<String, OAuthError> {
     }
 }
 
+/// What the chain told us about a delegate key, split by whether the answer
+/// was definitive. WALM-605: a Sui `GetObject` 429 is not evidence that the
+/// key is unregistered, and must not burn the one-time authorization session.
+#[derive(Debug)]
+enum DelegateVerifyOutcome {
+    /// The chain answered: the key is registered under `owner`.
+    Verified { owner: String },
+    /// The chain answered definitively "no" — key absent, account deactivated,
+    /// object missing or of the wrong type. Terminal for this session.
+    Unregistered { reason: String },
+    /// The chain could not be consulted (RPC 429/503/timeout, registry scan
+    /// cap). No answer yet, so the caller may re-submit the same request.
+    Retryable { reason: String },
+}
+
+impl DelegateVerifyOutcome {
+    /// Only a definitive answer spends the one-time authorization session. A
+    /// retryable upstream failure must leave it `pending` so the user can hit
+    /// "connect" again instead of restarting `/oauth/authorize` (WALM-605).
+    fn consumes_session(&self) -> bool {
+        !matches!(self, Self::Retryable { .. })
+    }
+}
+
+/// Classify a `verify_delegate_key_onchain` result. Deliberately delegates to
+/// `OnchainVerifyError::is_unavailable()` — the same primitive signed HTTP
+/// auth uses in `auth::cache_reverify_action` — so the OAuth callback and
+/// signed recall can never drift apart on what a Sui 429 means (WALM-429).
+fn classify_delegate_verify(result: Result<String, OnchainVerifyError>) -> DelegateVerifyOutcome {
+    match result {
+        Ok(owner) => DelegateVerifyOutcome::Verified { owner },
+        Err(e) if e.is_unavailable() => DelegateVerifyOutcome::Retryable {
+            reason: e.to_string(),
+        },
+        Err(e) => DelegateVerifyOutcome::Unregistered {
+            reason: e.to_string(),
+        },
+    }
+}
+
+/// Atomically claim a pending session so it can only ever be completed once —
+/// Postgres analog of the WALM-30 prior art's Redis GETDEL guarantee. This is
+/// the single gate on issuing an authorization code, so it stays the last step
+/// before minting one even though the on-chain read now happens earlier.
+async fn claim_oauth_session(
+    state: &AppState,
+    session_id: &str,
+) -> Result<OAuthSessionRow, OAuthError> {
+    state
+        .db
+        .consume_oauth_session(session_id)
+        .await?
+        .ok_or_else(|| OAuthError::invalid_request("session already used, expired, or unknown"))
+}
+
 pub async fn session_complete(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
@@ -659,12 +714,17 @@ pub async fn session_complete(
         .await
         .map_err(|_| OAuthError::invalid_request("wallet ownership proof is invalid"))?;
 
-    // Atomically claim the session so it can only ever be completed once —
-    // Postgres analog of the WALM-30 prior art's Redis GETDEL guarantee.
-    let session = state
+    // Read the session WITHOUT claiming it. The claim moved below the on-chain
+    // read because it is irreversible: consuming first meant a Sui 429 during
+    // verification burned the session and forced the user to restart the whole
+    // authorize flow (WALM-605). Single-use is unaffected — no code is minted
+    // until `claim_oauth_session` wins the `WHERE status = 'pending'` update,
+    // and the wallet ownership proof above already gates reaching this point.
+    let pending = state
         .db
-        .consume_oauth_session(&session_id)
+        .fetch_oauth_session(&session_id)
         .await?
+        .filter(|s| s.status == "pending")
         .ok_or_else(|| OAuthError::invalid_request("session already used, expired, or unknown"))?;
 
     // Both new and reused delegates require fresh on-chain verification.
@@ -675,7 +735,7 @@ pub async fn session_complete(
         None => (
             state
                 .db
-                .fetch_oauth_delegate(&session.delegate_ref)
+                .fetch_oauth_delegate(&pending.delegate_ref)
                 .await?
                 .ok_or_else(|| OAuthError::server_error("session delegate is missing"))?,
             false,
@@ -683,18 +743,46 @@ pub async fn session_complete(
     };
     let public_key_bytes = hex::decode(&delegate.delegate_public_key)
         .map_err(|_| OAuthError::server_error("stored delegate public key is invalid"))?;
-    let verified_owner = verify_delegate_key_onchain(
-        &state.http_client,
-        &state.config.sui_rpc_url,
-        state.sui_grpc_client.as_ref(),
-        &account_id,
-        &public_key_bytes,
-        &state.config.package_id,
-    )
-    .await
-    .map_err(|e| {
-        OAuthError::invalid_request(format!("delegate key is not registered on-chain: {e}"))
-    })?;
+    let outcome = classify_delegate_verify(
+        verify_delegate_key_onchain(
+            &state.http_client,
+            &state.config.sui_rpc_url,
+            state.sui_grpc_client.as_ref(),
+            &account_id,
+            &public_key_bytes,
+            &state.config.package_id,
+        )
+        .await,
+    );
+    // Claiming is irreversible, so only a definitive answer earns it: a
+    // "registered" and a "not registered" both spend the session exactly as
+    // this handler did before WALM-605, while an unreachable chain leaves the
+    // row `pending` for the user to re-submit against.
+    let claimed = if outcome.consumes_session() {
+        Some(claim_oauth_session(&state, &session_id).await?)
+    } else {
+        None
+    };
+    let verified_owner = match outcome {
+        DelegateVerifyOutcome::Retryable { reason } => {
+            // Deliberately no session_id: possession of one plus a wallet
+            // signature mints a code, so it does not belong in logs.
+            tracing::warn!(
+                %reason,
+                "oauth session_complete: Sui unavailable, leaving session pending for retry"
+            );
+            return Err(OAuthError::temporarily_unavailable(format!(
+                "could not verify the delegate key on-chain right now, please retry: {reason}"
+            )));
+        }
+        DelegateVerifyOutcome::Unregistered { reason } => {
+            return Err(OAuthError::invalid_request(format!(
+                "delegate key is not registered on-chain: {reason}"
+            )));
+        }
+        DelegateVerifyOutcome::Verified { owner } => owner,
+    };
+    let session = claimed.expect("a verified outcome always claims the session");
     if !verified_owner.eq_ignore_ascii_case(&owner_address) {
         return Err(OAuthError::invalid_request(
             "verified owner does not match connected account",
@@ -761,11 +849,10 @@ pub async fn session_cancel(
     Json(req): Json<SessionCancelRequest>,
 ) -> Result<Json<RedirectResponse>, OAuthError> {
     require_oauth(&state)?;
-    let session = state
-        .db
-        .consume_oauth_session(&session_id)
-        .await?
-        .ok_or_else(|| OAuthError::invalid_request("session already used, expired, or unknown"))?;
+    // Unlike `session_complete`, cancelling consults nothing off-box, so there
+    // is no retryable failure that could strand the user: the denial itself is
+    // the definitive outcome and burning the session is the point (WALM-605).
+    let session = claim_oauth_session(&state, &session_id).await?;
 
     let error = req
         .error
@@ -1110,13 +1197,146 @@ pub async fn revoke(
 mod tests {
     use std::borrow::Cow;
 
+    use axum::response::IntoResponse;
     use sui_crypto::ed25519::Ed25519PrivateKey;
     use sui_crypto::SuiSigner;
     use sui_sdk_types::{PersonalMessage, UserSignature};
 
+    use crate::oauth::{OAuthError, OAUTH_UPSTREAM_RETRY_AFTER_SECS};
     use crate::security_delete_auth::{NativeWalletSignatureVerifier, WalletSignatureVerifier};
+    use crate::storage::sui::OnchainVerifyError;
 
-    use super::oauth_owner_proof_message;
+    use super::{classify_delegate_verify, oauth_owner_proof_message, DelegateVerifyOutcome};
+
+    // ── WALM-605: a Sui 429 must not read as "unregistered" ──────────
+    //
+    // These cover the decision, not the handler: `services/server` has no
+    // dev-dependencies and no HTTP/gRPC mock harness, so `session_complete`
+    // itself (which needs a Postgres pool, a Sui client and a wallet verifier)
+    // cannot be driven from a unit test. `classify_delegate_verify` +
+    // `consumes_session` are the whole of the fix's logic, and the handler has
+    // exactly one call site for each.
+
+    #[test]
+    fn rpc_error_during_verify_is_retryable_and_spares_the_session() {
+        // The exact WALM-605 report: Sui GetObject answers 429, which
+        // `map_get_object_status` classifies as RpcError.
+        let outcome = classify_delegate_verify(Err(OnchainVerifyError::RpcError(
+            "gRPC GetObject failed: 429 Too Many Requests".into(),
+        )));
+        assert!(matches!(outcome, DelegateVerifyOutcome::Retryable { .. }));
+        assert!(
+            !outcome.consumes_session(),
+            "a 429 must leave the one-time session pending so the user can retry"
+        );
+    }
+
+    #[test]
+    fn scan_cap_exceeded_during_verify_is_retryable() {
+        let outcome = classify_delegate_verify(Err(OnchainVerifyError::ScanCapExceeded(
+            "registry scan cap".into(),
+        )));
+        assert!(matches!(outcome, DelegateVerifyOutcome::Retryable { .. }));
+        assert!(!outcome.consumes_session());
+    }
+
+    #[test]
+    fn key_not_found_during_verify_is_unregistered_and_consumes_the_session() {
+        let outcome = classify_delegate_verify(Err(OnchainVerifyError::KeyNotFound(
+            "not in registry".into(),
+        )));
+        assert!(matches!(
+            outcome,
+            DelegateVerifyOutcome::Unregistered { .. }
+        ));
+        assert!(
+            outcome.consumes_session(),
+            "a genuine unregistered key is definitive and still burns the session"
+        );
+    }
+
+    #[test]
+    fn definitive_verify_failures_are_unregistered_and_consume_the_session() {
+        for err in [
+            OnchainVerifyError::NotFound("no such object".into()),
+            OnchainVerifyError::AccountDeactivated("deactivated".into()),
+            OnchainVerifyError::WrongObjectType("not a MemWalAccount".into()),
+        ] {
+            let outcome = classify_delegate_verify(Err(err));
+            assert!(
+                matches!(outcome, DelegateVerifyOutcome::Unregistered { .. }),
+                "{outcome:?}"
+            );
+            assert!(outcome.consumes_session(), "{outcome:?}");
+        }
+    }
+
+    #[test]
+    fn verified_key_consumes_the_session() {
+        let outcome = classify_delegate_verify(Ok("0xowner".into()));
+        match &outcome {
+            DelegateVerifyOutcome::Verified { owner } => assert_eq!(owner, "0xowner"),
+            other => panic!("expected Verified, got {other:?}"),
+        }
+        assert!(outcome.consumes_session());
+    }
+
+    #[test]
+    fn classification_tracks_is_unavailable_exactly() {
+        // Guard against the OAuth callback and signed HTTP auth drifting apart
+        // again: `Retryable` must be exactly `OnchainVerifyError::is_unavailable`.
+        for err in [
+            OnchainVerifyError::RpcError("429".into()),
+            OnchainVerifyError::ScanCapExceeded("cap".into()),
+            OnchainVerifyError::NotFound("missing".into()),
+            OnchainVerifyError::KeyNotFound("gone".into()),
+            OnchainVerifyError::AccountDeactivated("dead".into()),
+            OnchainVerifyError::WrongObjectType("type".into()),
+        ] {
+            let unavailable = err.is_unavailable();
+            let outcome = classify_delegate_verify(Err(err));
+            assert_eq!(
+                matches!(outcome, DelegateVerifyOutcome::Retryable { .. }),
+                unavailable,
+                "{outcome:?}"
+            );
+            assert_eq!(outcome.consumes_session(), !unavailable, "{outcome:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn retryable_verify_maps_to_a_503_the_client_can_retry() {
+        // The pre-fix behaviour was a 400 invalid_request, which the consent UI
+        // renders as a dead end. It must now be a retryable 503 with backoff.
+        let response = OAuthError::temporarily_unavailable("sui is throttling").into_response();
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some(OAUTH_UPSTREAM_RETRY_AFTER_SECS.to_string().as_str())
+        );
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "temporarily_unavailable");
+    }
+
+    #[test]
+    fn unregistered_verify_stays_a_definitive_400() {
+        let response = OAuthError::invalid_request("delegate key is not registered on-chain: x")
+            .into_response();
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert!(response
+            .headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .is_none());
+    }
 
     #[tokio::test]
     async fn delegate_reuse_rejects_proof_from_another_authorization_session() {

--- a/services/server/src/routes/oauth.rs
+++ b/services/server/src/routes/oauth.rs
@@ -651,8 +651,11 @@ enum DelegateVerifyOutcome {
 
 impl DelegateVerifyOutcome {
     /// Only a definitive answer spends the one-time authorization session. A
-    /// retryable upstream failure must leave it `pending` so the user can hit
-    /// "connect" again instead of restarting `/oauth/authorize` (WALM-605).
+    /// retryable upstream failure must leave it `pending` so the consent UI can
+    /// re-POST `/complete` instead of restarting `/oauth/authorize` (WALM-605).
+    ///
+    /// `session_complete` encodes this in its match arms; the tests below pin
+    /// the rule itself.
     fn consumes_session(&self) -> bool {
         !matches!(self, Self::Retryable { .. })
     }
@@ -714,12 +717,9 @@ pub async fn session_complete(
         .await
         .map_err(|_| OAuthError::invalid_request("wallet ownership proof is invalid"))?;
 
-    // Read the session WITHOUT claiming it. The claim moved below the on-chain
-    // read because it is irreversible: consuming first meant a Sui 429 during
-    // verification burned the session and forced the user to restart the whole
-    // authorize flow (WALM-605). Single-use is unaffected — no code is minted
-    // until `claim_oauth_session` wins the `WHERE status = 'pending'` update,
-    // and the wallet ownership proof above already gates reaching this point.
+    // Read WITHOUT claiming: the claim is irreversible and belongs below the
+    // on-chain read (WALM-605). Single-use is unaffected — no code is minted
+    // until `claim_oauth_session` wins the `WHERE status = 'pending'` update.
     let pending = state
         .db
         .fetch_oauth_session(&session_id)
@@ -754,16 +754,10 @@ pub async fn session_complete(
         )
         .await,
     );
-    // Claiming is irreversible, so only a definitive answer earns it: a
-    // "registered" and a "not registered" both spend the session exactly as
-    // this handler did before WALM-605, while an unreachable chain leaves the
-    // row `pending` for the user to re-submit against.
-    let claimed = if outcome.consumes_session() {
-        Some(claim_oauth_session(&state, &session_id).await?)
-    } else {
-        None
-    };
-    let verified_owner = match outcome {
+    // Claim only after a definitive on-chain answer; Retryable must leave
+    // status='pending'. Claiming per-arm rather than behind a boolean keeps the
+    // compiler, not a convention, responsible for that.
+    let (session, verified_owner) = match outcome {
         DelegateVerifyOutcome::Retryable { reason } => {
             // Deliberately no session_id: possession of one plus a wallet
             // signature mints a code, so it does not belong in logs.
@@ -776,13 +770,15 @@ pub async fn session_complete(
             )));
         }
         DelegateVerifyOutcome::Unregistered { reason } => {
+            claim_oauth_session(&state, &session_id).await?;
             return Err(OAuthError::invalid_request(format!(
                 "delegate key is not registered on-chain: {reason}"
             )));
         }
-        DelegateVerifyOutcome::Verified { owner } => owner,
+        DelegateVerifyOutcome::Verified { owner } => {
+            (claim_oauth_session(&state, &session_id).await?, owner)
+        }
     };
-    let session = claimed.expect("a verified outcome always claims the session");
     if !verified_owner.eq_ignore_ascii_case(&owner_address) {
         return Err(OAuthError::invalid_request(
             "verified owner does not match connected account",
@@ -849,9 +845,8 @@ pub async fn session_cancel(
     Json(req): Json<SessionCancelRequest>,
 ) -> Result<Json<RedirectResponse>, OAuthError> {
     require_oauth(&state)?;
-    // Unlike `session_complete`, cancelling consults nothing off-box, so there
-    // is no retryable failure that could strand the user: the denial itself is
-    // the definitive outcome and burning the session is the point (WALM-605).
+    // Cancelling consults nothing off-box, so there is no retryable failure:
+    // the denial is definitive and burning the session is the point.
     let session = claim_oauth_session(&state, &session_id).await?;
 
     let error = req
@@ -1210,12 +1205,9 @@ mod tests {
 
     // ── WALM-605: a Sui 429 must not read as "unregistered" ──────────
     //
-    // These cover the decision, not the handler: `services/server` has no
-    // dev-dependencies and no HTTP/gRPC mock harness, so `session_complete`
-    // itself (which needs a Postgres pool, a Sui client and a wallet verifier)
-    // cannot be driven from a unit test. `classify_delegate_verify` +
-    // `consumes_session` are the whole of the fix's logic, and the handler has
-    // exactly one call site for each.
+    // These cover the decision, not the handler: `session_complete` needs a
+    // Postgres pool, a Sui client and a wallet verifier, and this crate has no
+    // mock harness for them.
 
     #[test]
     fn rpc_error_during_verify_is_retryable_and_spares_the_session() {

--- a/services/server/src/routes/oauth.rs
+++ b/services/server/src/routes/oauth.rs
@@ -558,6 +558,12 @@ pub struct SessionAccountResponse {
     pub needs_onchain_registration: bool,
     pub delegate_public_key: String,
     pub delegate_sui_address: String,
+    /// True when this session's own pending key is already on the account, so
+    /// an earlier attempt landed `add_delegate_key` and only `/complete` is
+    /// left. Distinguishes that resume from the reuse case, which also sets
+    /// `needs_onchain_registration: false` but points at a delegate from an
+    /// earlier grant.
+    pub resume_pending_registration: bool,
 }
 
 pub async fn session_account(
@@ -566,6 +572,7 @@ pub async fn session_account(
     Json(req): Json<SessionAccountRequest>,
 ) -> Result<Json<SessionAccountResponse>, OAuthError> {
     require_oauth(&state)?;
+    let account_id = sanitize_sui_object_id(&req.account_id)?;
     let session = state
         .db
         .fetch_oauth_session(&session_id)
@@ -576,15 +583,12 @@ pub async fn session_account(
     // (from a prior grant, any client)? If so, the consent UI can skip the
     // on-chain `add_delegate_key` tx entirely — this is what keeps a
     // reconnect from burning another slot toward the on-chain 20-key cap.
-    if let Some(existing) = state
-        .db
-        .find_reusable_oauth_delegate(&req.account_id)
-        .await?
-    {
+    if let Some(existing) = state.db.find_reusable_oauth_delegate(&account_id).await? {
         return Ok(Json(SessionAccountResponse {
             needs_onchain_registration: false,
             delegate_public_key: existing.delegate_public_key,
             delegate_sui_address: existing.delegate_address,
+            resume_pending_registration: false,
         }));
     }
 
@@ -594,10 +598,46 @@ pub async fn session_account(
         .await?
         .ok_or_else(|| OAuthError::server_error("session references an unknown delegate"))?;
 
+    // This session's own key can already be on the account: an earlier attempt
+    // landed `add_delegate_key` and then failed further along, which is exactly
+    // what a Sui 429 during `/complete` verify used to cause (WALM-605).
+    // Re-submitting aborts with `EDelegateKeyAlreadyExists`, and the consent UI
+    // cannot recognise that abort — it signs through the sponsor proxy, and
+    // `sponsor::mask_upstream` turns any upstream 5xx into a bare 502
+    // `sponsor_upstream_error` that never echoes the Move abort. So the skip has
+    // to be decided here, against the chain, rather than by string-matching a
+    // transaction error that does not survive the proxy.
+    let public_key_bytes = hex::decode(&delegate.delegate_public_key)
+        .map_err(|_| OAuthError::server_error("stored delegate public key is invalid"))?;
+    let resume = match classify_pending_key_preflight(
+        verify_delegate_key_onchain(
+            &state.http_client,
+            &state.config.sui_rpc_url,
+            state.sui_grpc_client.as_ref(),
+            &account_id,
+            &public_key_bytes,
+            &state.config.package_id,
+        )
+        .await,
+    ) {
+        PendingKeyPreflight::Resume => true,
+        PendingKeyPreflight::Register => false,
+        PendingKeyPreflight::Unknown { reason } => {
+            tracing::warn!(
+                %reason,
+                "oauth session_account: Sui unavailable, cannot tell whether this session's delegate key is already registered"
+            );
+            return Err(OAuthError::temporarily_unavailable(format!(
+                "could not check the delegate key on-chain right now, please retry: {reason}"
+            )));
+        }
+    };
+
     Ok(Json(SessionAccountResponse {
-        needs_onchain_registration: true,
+        needs_onchain_registration: !resume,
         delegate_public_key: delegate.delegate_public_key,
         delegate_sui_address: delegate.delegate_address,
+        resume_pending_registration: resume,
     }))
 }
 
@@ -674,6 +714,36 @@ fn classify_delegate_verify(result: Result<String, OnchainVerifyError>) -> Deleg
         Err(e) => DelegateVerifyOutcome::Unregistered {
             reason: e.to_string(),
         },
+    }
+}
+
+/// What `/account` should tell the consent UI about this session's own pending
+/// delegate key, given what the chain said about it.
+#[derive(Debug)]
+enum PendingKeyPreflight {
+    /// Already on the account: an earlier attempt landed `add_delegate_key` and
+    /// only `/complete` is left. Re-submitting would abort with
+    /// `EDelegateKeyAlreadyExists`, which the consent UI cannot see.
+    Resume,
+    /// Definitively absent — the ordinary first-time path.
+    Register,
+    /// The chain could not be consulted, so there is no safe guess: telling the
+    /// UI to register walks into a sponsor 502 it cannot classify, and telling
+    /// it to skip sends `/complete` at a key that is not on the account, which
+    /// is definitive Unregistered and burns the one-time session.
+    Unknown { reason: String },
+}
+
+/// Reuse `classify_delegate_verify` rather than re-reading `is_unavailable()`,
+/// so the preflight and `session_complete` cannot drift apart on what a Sui 429
+/// means (WALM-429 / WALM-605).
+fn classify_pending_key_preflight(
+    result: Result<String, OnchainVerifyError>,
+) -> PendingKeyPreflight {
+    match classify_delegate_verify(result) {
+        DelegateVerifyOutcome::Verified { .. } => PendingKeyPreflight::Resume,
+        DelegateVerifyOutcome::Unregistered { .. } => PendingKeyPreflight::Register,
+        DelegateVerifyOutcome::Retryable { reason } => PendingKeyPreflight::Unknown { reason },
     }
 }
 
@@ -1201,7 +1271,10 @@ mod tests {
     use crate::security_delete_auth::{NativeWalletSignatureVerifier, WalletSignatureVerifier};
     use crate::storage::sui::OnchainVerifyError;
 
-    use super::{classify_delegate_verify, oauth_owner_proof_message, DelegateVerifyOutcome};
+    use super::{
+        classify_delegate_verify, classify_pending_key_preflight, oauth_owner_proof_message,
+        DelegateVerifyOutcome, PendingKeyPreflight,
+    };
 
     // ── WALM-605: a Sui 429 must not read as "unregistered" ──────────
     //
@@ -1221,6 +1294,86 @@ mod tests {
             !outcome.consumes_session(),
             "a 429 must leave the one-time session pending so the user can retry"
         );
+    }
+
+    // ── WALM-605: `/account` decides the duplicate-key skip, not the SPA ──
+    //
+    // The consent UI signs through the sponsor proxy, and `sponsor::mask_upstream`
+    // replaces any upstream 5xx with a bare 502 that never echoes the Move
+    // abort. So `EDelegateKeyAlreadyExists` is invisible to the client, and the
+    // "is a second add_delegate_key needed" question has to be answered here.
+
+    #[test]
+    fn a_key_already_on_the_account_tells_the_ui_to_resume_at_complete() {
+        // The WALM-605 journey: the transaction landed, then verify hit a 429.
+        let outcome = classify_pending_key_preflight(Ok("0xowner".into()));
+        assert!(matches!(outcome, PendingKeyPreflight::Resume));
+    }
+
+    #[test]
+    fn a_key_definitively_absent_tells_the_ui_to_register() {
+        for err in [
+            OnchainVerifyError::KeyNotFound("not in delegate_keys".into()),
+            OnchainVerifyError::NotFound("no such object".into()),
+            OnchainVerifyError::WrongObjectType("not a MemWalAccount".into()),
+        ] {
+            let label = err.to_string();
+            assert!(
+                matches!(
+                    classify_pending_key_preflight(Err(err)),
+                    PendingKeyPreflight::Register
+                ),
+                "{label} is a definitive no, so the first-time path is correct"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unreachable_chain_refuses_to_guess_the_preflight() {
+        // Guessing "register" dead-ends on a sponsor 502 the SPA cannot read;
+        // guessing "skip" burns the session as Unregistered. The preflight
+        // claims nothing, so refusing costs the user only a retry.
+        for err in [
+            OnchainVerifyError::RpcError("gRPC GetObject failed: 429 Too Many Requests".into()),
+            OnchainVerifyError::ScanCapExceeded("registry scan cap".into()),
+        ] {
+            let label = err.to_string();
+            assert!(
+                matches!(
+                    classify_pending_key_preflight(Err(err)),
+                    PendingKeyPreflight::Unknown { .. }
+                ),
+                "{label} is not evidence either way"
+            );
+        }
+    }
+
+    #[test]
+    fn the_preflight_and_complete_agree_on_what_is_definitive() {
+        // Both read `OnchainVerifyError::is_unavailable()`. If one ever stops,
+        // a 429 becomes "unregistered" on that path again (WALM-429).
+        // Built twice rather than cloned: `OnchainVerifyError` is not `Clone`,
+        // and both classifiers take the value.
+        let cases: [fn() -> OnchainVerifyError; 6] = [
+            || OnchainVerifyError::RpcError("429".into()),
+            || OnchainVerifyError::ScanCapExceeded("cap".into()),
+            || OnchainVerifyError::KeyNotFound("absent".into()),
+            || OnchainVerifyError::NotFound("missing".into()),
+            || OnchainVerifyError::AccountDeactivated("dead".into()),
+            || OnchainVerifyError::WrongObjectType("foreign".into()),
+        ];
+        for build in cases {
+            let label = build().to_string();
+            let complete_is_definitive = classify_delegate_verify(Err(build())).consumes_session();
+            let preflight_is_definitive = !matches!(
+                classify_pending_key_preflight(Err(build())),
+                PendingKeyPreflight::Unknown { .. }
+            );
+            assert_eq!(
+                complete_is_definitive, preflight_is_definitive,
+                "{label} must be definitive on both paths or neither"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes WALM-605 — https://linear.app/mysten-labs/issue/WALM-605

Follow-up to WALM-429 / #811, which taught signed HTTP auth that a Sui `GetObject` 429 is a retryable 503 rather than a revoked key. The OAuth callback never learned the same lesson.

## Problem

`session_complete` in `services/server/src/routes/oauth.rs` did two things in the wrong order:

1. `consume_oauth_session(&session_id)` — an irreversible `UPDATE ... WHERE status = 'pending' RETURNING *` that spends the one-time authorization session.
2. `verify_delegate_key_onchain(...)`, whose every error — including a throttled fullnode — was mapped to `OAuthError::invalid_request("delegate key is not registered on-chain: {e}")`.

So a Sui 429 was indistinguishable from a genuinely unregistered delegate key, **and** the session was already gone by the time we found out. The consent UI showed "Something went wrong" with no retry, and the user had to restart `/oauth/authorize` from the beginning. The error mapping alone was not the bug; the ordering was.

## The fix

**Classification.** Added a small pure decision function over `Result<String, OnchainVerifyError>`:

```
Ok(owner)                    -> Verified    (definitive)
Err(e) if e.is_unavailable() -> Retryable   (RpcError | ScanCapExceeded)
Err(e)                       -> Unregistered(definitive)
```

It delegates to `OnchainVerifyError::is_unavailable()` — the exact primitive `auth::cache_reverify_action` uses — rather than re-deriving gRPC-code logic, so the OAuth callback and signed recall cannot drift apart again.

**Ordering.** The on-chain read now happens *before* the claim, and `DelegateVerifyOutcome::consumes_session()` decides whether to claim at all:

- `Verified` / `Unregistered` — definitive, so the session is spent exactly as before this change.
- `Retryable` — the row is left `pending`, so the user can press "connect" again on the same session.

Single-use is unaffected. `claim_oauth_session` is still the only gate on minting an authorization code, and it is still the atomic `WHERE status = 'pending'` update, so two concurrent completers still leave exactly one winner (the loser gets "session already used"). Everything above the claim was already gated on a fresh, session-bound wallet ownership proof, so moving two reads above it opens no new surface. The pre-read also filters on `status == "pending"` so an already-consumed session fails fast without an on-chain call.

**HTTP shape.** A retryable failure now returns RFC 6749 `temporarily_unavailable` with `503` and `Retry-After: 5` instead of a dead-end `400 invalid_request`. `OAuthError` gained an optional `retry_after_secs` that `IntoResponse` emits; `OAUTH_UPSTREAM_RETRY_AFTER_SECS = 5` mirrors signed auth's `AUTH_UPSTREAM_RETRY_AFTER_SECS`. `Retry-After` is already in the CORS `expose_headers` list, so the browser consent UI can read it.

**`session_cancel`** has the second `consume_oauth_session` call. It is *not* affected: cancelling consults nothing off-box, so there is no retryable failure that can strand the user — the denial is itself the definitive outcome and burning the session is the point. It was switched to the shared `claim_oauth_session` helper and the reasoning recorded in a comment.

## Tests

`services/server` has no dev-dependencies and no HTTP/gRPC mock harness, so these follow the established pattern (`auth.rs`'s `resolve_account_cache_hit_rpc_error_keeps_row_without_authenticating`, `storage/sui.rs`'s `get_object_status_classifies_by_grpc_code`) — pure unit tests over the extracted decision, in `#[cfg(test)] mod tests` in `routes/oauth.rs`:

- `rpc_error_during_verify_is_retryable_and_spares_the_session` — the reported case: `RpcError("gRPC GetObject failed: 429 Too Many Requests")` classifies as `Retryable` and `consumes_session()` is false.
- `key_not_found_during_verify_is_unregistered_and_consumes_the_session` — the contrast case: a genuine unregistered key is `Unregistered` and still spends the session.
- `scan_cap_exceeded_during_verify_is_retryable`, `definitive_verify_failures_are_unregistered_and_consume_the_session` (`NotFound` / `AccountDeactivated` / `WrongObjectType`), `verified_key_consumes_the_session` — the rest of the variant matrix.
- `classification_tracks_is_unavailable_exactly` — asserts `Retryable` is exactly `OnchainVerifyError::is_unavailable()` across all six variants, so a new variant added to the enum cannot silently pick the wrong side here.
- `retryable_verify_maps_to_a_503_the_client_can_retry` / `unregistered_verify_stays_a_definitive_400` — response-shape checks over `IntoResponse`: 503 + `Retry-After: 5` + `"error": "temporarily_unavailable"` vs 400 with no `Retry-After`.

### What these tests cannot cover

They do not exercise `session_complete` end to end. That handler needs a Postgres pool, a Sui gRPC/JSON-RPC client and a wallet-signature verifier, and the crate has no harness to fake any of them. Specifically **not** covered by automated tests:

- That the row really is still `pending` in Postgres after a 429 (asserted only via `consumes_session()` gating the single `claim_oauth_session` call site).
- The concurrent-completer race on the atomic claim.
- That a real Sui 429 surfaces as `RpcError` — that lives in `map_get_object_status`, already covered by `get_object_status_classifies_by_grpc_code` in `storage/sui.rs`.

The handler has exactly one `consumes_session()` call site and one `claim_oauth_session` call in the success path, which is what keeps the tested decision equivalent to the handler's behaviour.

## Verification

Run in `services/server`:

- `cargo fmt` — clean (an unrelated pre-existing rustfmt drift in `routes/memory_read.rs` was reverted rather than folded into this PR).
- `cargo clippy --all-targets` (the project's CI invocation) — compiles; **zero** warnings in `src/oauth.rs` or `src/routes/oauth.rs`. The crate's ~630 pre-existing warnings elsewhere are unchanged; CI marks this step `continue-on-error` for exactly that reason. With `-D warnings` the crate does not build on `dev` either, unrelated to this change.
- `cargo test` — `454 passed; 0 failed; 23 ignored` (lib) and `698 passed; 0 failed; 37 ignored` (bin, the target CI runs). The two live integration suites (`security_delete_limits_live`, `sui_client_live`) are `#[ignore]`d as usual. All 8 new tests pass.

## Not in scope

The consent UI (`apps/app/src/pages/ConnectClaude.tsx`) renders `error_description` under a generic "Something went wrong" with no retry button. The session now survives, so a page reload works — but a proper "retry" affordance keyed on the 503 would be a nicer follow-up.
