### PR TITLE
fix(server): make namespace restore persist its batch atomically (WALM-591)

### DIFF
--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -1162,22 +1162,10 @@ async fn restore_unbounded(
         .flatten()
         .collect();
 
-    // Step 6: Insert only new entries (no delete!), atomically.
-    //
-    // GH #566 / WALM-591: this used to be a plain `for` loop of autocommitted
-    // `insert_vector` calls. `restore()` wraps this future in a 55s
-    // `tokio::time::timeout`, so a slow batch had its future DROPPED mid-loop
-    // and every row inserted up to that point stayed committed — a silently
-    // half-written index that a later `recall` read back as duplicated or
-    // truncated results, with `restored` never reported to the caller. A
-    // mid-loop DB error behaved identically.
-    //
-    // Building the whole batch first and handing it to `insert_vectors_atomic`
-    // makes the step all-or-nothing: SQLx rolls the transaction back both when
-    // a row errors and when the future is dropped, so a failed restore leaves
-    // zero rows and the client can simply retry. `limit` is clamped to at most
-    // 100 (`clamp_restore_limit`) and `results` is a subset of that page, so
-    // this is a bounded, short-lived transaction.
+    // Step 6: Insert only new entries (no delete!), all-or-nothing via
+    // `insert_vectors_atomic` — restore runs under a 55s timeout, and a
+    // partially committed batch is a half-written index (GH #566 / WALM-591).
+    // `limit` is clamped to 100 (`clamp_restore_limit`), so the batch is small.
     transient_unresolved += decrypted_texts.len().saturating_sub(results.len());
     let restored = results.len();
     let truncated =

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -15,6 +15,7 @@ use futures::stream::{self, StreamExt};
 use std::sync::Arc;
 
 use crate::services::llm_chat::{ChatCompletionRequest, ChatCompletionResponse, ChatMessage};
+use crate::storage::db::VectorInsert;
 use crate::storage::{seal, walrus};
 use crate::types::*;
 
@@ -1161,55 +1162,82 @@ async fn restore_unbounded(
         .flatten()
         .collect();
 
-    // Step 6: Insert only new entries (no delete!)
+    // Step 6: Insert only new entries (no delete!), atomically.
+    //
+    // GH #566 / WALM-591: this used to be a plain `for` loop of autocommitted
+    // `insert_vector` calls. `restore()` wraps this future in a 55s
+    // `tokio::time::timeout`, so a slow batch had its future DROPPED mid-loop
+    // and every row inserted up to that point stayed committed — a silently
+    // half-written index that a later `recall` read back as duplicated or
+    // truncated results, with `restored` never reported to the caller. A
+    // mid-loop DB error behaved identically.
+    //
+    // Building the whole batch first and handing it to `insert_vectors_atomic`
+    // makes the step all-or-nothing: SQLx rolls the transaction back both when
+    // a row errors and when the future is dropped, so a failed restore leaves
+    // zero rows and the client can simply retry. `limit` is clamped to at most
+    // 100 (`clamp_restore_limit`) and `results` is a subset of that page, so
+    // this is a bounded, short-lived transaction.
     transient_unresolved += decrypted_texts.len().saturating_sub(results.len());
     let restored = results.len();
     let truncated =
         restore_truncated_after_page(truncated, restored, newly_failed, transient_unresolved);
-    for (blob_id, vector) in &results {
-        let id = uuid::Uuid::new_v4().to_string();
-        let blob_size = blob_sizes.get(blob_id).copied().unwrap_or_else(|| {
-            tracing::warn!(
-                "restore: missing blob size for {}, defaulting to 0 for quota tracking",
-                blob_id
-            );
-            0
-        });
-        let (agent_id, package_id) = blob_provenance
-            .get(blob_id)
-            .cloned()
-            .unwrap_or((None, String::new()));
-        // The sidecar sends "agentId" as a present-but-empty string when no
-        // delegate key was recorded (the common case) — #[serde(default)]
-        // only fires on a MISSING key, so an empty string deserializes to
-        // Some(""), not None. Normalize both provenance fields the same way
-        // so a blob with no known agent gets a real SQL NULL, not "".
-        let agent_id = agent_id.filter(|s| !s.is_empty());
-        state
-            .db
-            .insert_vector(
-                &id,
+    // Owned per-row values first: `VectorInsert` borrows them, so they must
+    // outlive the batch slice built below.
+    let row_values: Vec<(String, i64, Option<String>, String)> = results
+        .iter()
+        .map(|(blob_id, _)| {
+            let id = uuid::Uuid::new_v4().to_string();
+            let blob_size = blob_sizes.get(blob_id).copied().unwrap_or_else(|| {
+                tracing::warn!(
+                    "restore: missing blob size for {}, defaulting to 0 for quota tracking",
+                    blob_id
+                );
+                0
+            });
+            let (agent_id, package_id) = blob_provenance
+                .get(blob_id)
+                .cloned()
+                .unwrap_or((None, String::new()));
+            // The sidecar sends "agentId" as a present-but-empty string when no
+            // delegate key was recorded (the common case) — #[serde(default)]
+            // only fires on a MISSING key, so an empty string deserializes to
+            // Some(""), not None. Normalize both provenance fields the same way
+            // so a blob with no known agent gets a real SQL NULL, not "".
+            let agent_id = agent_id.filter(|s| !s.is_empty());
+            (id, blob_size, agent_id, package_id)
+        })
+        .collect();
+
+    let batch: Vec<VectorInsert<'_>> = results
+        .iter()
+        .zip(row_values.iter())
+        .map(
+            |((blob_id, vector), (id, blob_size, agent_id, package_id))| VectorInsert {
+                id,
                 owner,
                 namespace,
                 blob_id,
                 vector,
-                blob_size,
+                blob_size_bytes: *blob_size,
                 // restore flow re-indexes existing Walrus blobs after
                 // they fell out of pgvector. The original importance value is
                 // not preserved in the blob (it's a row-level signal). Use the
                 // neutral "standard" bucket so restored memories rank as
                 // average — neither boosted nor penalized.
-                crate::services::extractor::IMPORTANCE_STANDARD,
-                agent_id.as_deref(),
-                if package_id.is_empty() {
+                importance: crate::services::extractor::IMPORTANCE_STANDARD,
+                agent_id: agent_id.as_deref(),
+                package_id: if package_id.is_empty() {
                     None
                 } else {
                     Some(package_id.as_str())
                 },
-                None,
-            )
-            .await?;
-    }
+                end_epoch: None,
+            },
+        )
+        .collect();
+
+    state.db.insert_vectors_atomic(&batch).await?;
 
     tracing::info!(
         "restore complete: restored={} skipped={} failed={} total={} owner={} ns={}",

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use pgvector::Vector;
 use sqlx::postgres::PgPoolOptions;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, Transaction};
 
 use crate::alerts::AlertManager;
 use crate::types::{AppError, SearchHit};
@@ -10,6 +10,25 @@ use crate::types::{AppError, SearchHit};
 /// Tombstone retention for both the read-API `must_resync` clock and the
 /// background sweep. Keep a single constant so the two cannot drift.
 pub const TOMBSTONE_RETENTION: chrono::Duration = chrono::Duration::days(30);
+
+/// One `vector_entries` row queued for an all-or-nothing batch insert.
+///
+/// Mirrors the argument list of [`VectorDb::insert_vector`]; see that method
+/// for the meaning of each field. Used by [`VectorDb::insert_vectors_atomic`]
+/// so callers that persist a whole batch (namespace restore) can hand over
+/// every row up front instead of issuing one autocommitted INSERT per row.
+pub struct VectorInsert<'a> {
+    pub id: &'a str,
+    pub owner: &'a str,
+    pub namespace: &'a str,
+    pub blob_id: &'a str,
+    pub vector: &'a [f32],
+    pub blob_size_bytes: i64,
+    pub importance: f32,
+    pub agent_id: Option<&'a str>,
+    pub package_id: Option<&'a str>,
+    pub end_epoch: Option<i32>,
+}
 
 pub struct VectorDb {
     pool: PgPool,
@@ -49,7 +68,7 @@ mod tests {
 
     use sqlx::postgres::PgPoolOptions;
 
-    use super::{oauth_rows, VectorDb};
+    use super::{oauth_rows, VectorDb, VectorInsert};
 
     static VECTOR_SCHEMA_SETUP_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 
@@ -927,6 +946,209 @@ mod tests {
             .unwrap();
     }
 
+    // ── Restore persists its batch atomically (GH #566 / WALM-591) ──
+
+    /// Build one restore-shaped batch row. Passing a `vector` of the wrong
+    /// length plants a row the `vector(1536)` column will reject, which is how
+    /// the rollback test forces a failure partway through the batch.
+    fn restore_row<'a>(
+        id: &'a str,
+        owner: &'a str,
+        namespace: &'a str,
+        blob_id: &'a str,
+        vector: &'a [f32],
+    ) -> VectorInsert<'a> {
+        VectorInsert {
+            id,
+            owner,
+            namespace,
+            blob_id,
+            vector,
+            blob_size_bytes: 1,
+            importance: 0.5,
+            agent_id: None,
+            package_id: None,
+            end_epoch: None,
+        }
+    }
+
+    async fn rows_for_owner(db: &VectorDb, owner: &str, namespace: &str) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM vector_entries WHERE owner = $1 AND namespace = $2",
+        )
+        .bind(owner)
+        .bind(namespace)
+        .fetch_one(db.pool())
+        .await
+        .unwrap()
+    }
+
+    async fn delete_rows_for_owner(db: &VectorDb, owner: &str) {
+        sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
+            .bind(owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    /// GH #566 / WALM-591: restore used to persist its batch with a loop of
+    /// autocommitted inserts, so a row that failed partway through left every
+    /// earlier row committed — a half-written index `recall` would read back.
+    /// The batch must now be all-or-nothing.
+    #[tokio::test]
+    async fn restore_batch_insert_rolls_back_every_row_when_one_fails() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xrestore-rollback-{suffix}");
+        let namespace = format!("ns-{suffix}");
+        let ids: Vec<String> = (0..3)
+            .map(|i| format!("restore-rollback-{i}-{suffix}"))
+            .collect();
+        let blob_ids: Vec<String> = (0..3)
+            .map(|i| format!("blob-rollback-{i}-{suffix}"))
+            .collect();
+        let good = vec![0.1_f32; 1536];
+        // The middle row's embedding has the wrong dimension, so Postgres
+        // rejects it *after* the first row has already been written inside the
+        // transaction. Before the fix that first row stayed committed.
+        let bad = vec![0.1_f32; 8];
+
+        let batch = vec![
+            restore_row(&ids[0], &owner, &namespace, &blob_ids[0], &good),
+            restore_row(&ids[1], &owner, &namespace, &blob_ids[1], &bad),
+            restore_row(&ids[2], &owner, &namespace, &blob_ids[2], &good),
+        ];
+
+        let result = db.insert_vectors_atomic(&batch).await;
+        assert!(
+            result.is_err(),
+            "a batch containing an invalid row must report an explicit error"
+        );
+
+        let landed = rows_for_owner(&db, &owner, &namespace).await;
+        delete_rows_for_owner(&db, &owner).await;
+        assert_eq!(
+            landed, 0,
+            "a failed restore batch must leave zero rows, not a partial index"
+        );
+    }
+
+    /// The success path still has to commit the whole batch — the rollback fix
+    /// must not turn restore into a no-op.
+    #[tokio::test]
+    async fn restore_batch_insert_commits_every_row_on_success() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xrestore-commit-{suffix}");
+        let namespace = format!("ns-{suffix}");
+        let ids: Vec<String> = (0..3)
+            .map(|i| format!("restore-commit-{i}-{suffix}"))
+            .collect();
+        let blob_ids: Vec<String> = (0..3)
+            .map(|i| format!("blob-commit-{i}-{suffix}"))
+            .collect();
+        let vector = vec![0.1_f32; 1536];
+
+        let batch: Vec<VectorInsert<'_>> = ids
+            .iter()
+            .zip(blob_ids.iter())
+            .map(|(id, blob_id)| restore_row(id, &owner, &namespace, blob_id, &vector))
+            .collect();
+
+        db.insert_vectors_atomic(&batch)
+            .await
+            .expect("a valid restore batch must commit");
+
+        let landed = rows_for_owner(&db, &owner, &namespace).await;
+        delete_rows_for_owner(&db, &owner).await;
+        assert_eq!(landed, 3, "every row in a successful batch must be visible");
+    }
+
+    /// The original bug's actual trigger: `POST /api/restore` wraps the restore
+    /// future in `tokio::time::timeout(55s, ..)`, so a slow batch had its future
+    /// DROPPED mid-loop and left every already-inserted row committed.
+    ///
+    /// With one transaction, dropping the future rolls it back — SQLx queues a
+    /// ROLLBACK when the dropped transaction hands its connection back to the
+    /// pool. To make sure the cancellation really lands *mid-batch* (a 1ms
+    /// deadline would just abort before the first row and pass trivially), the
+    /// test first times an uncancelled batch of the same shape and then cancels
+    /// the second one at half that duration.
+    ///
+    /// The assertion is "none or all", not "always none": if the batch wins the
+    /// race and commits before the deadline that is a correct outcome too. What
+    /// must never happen — and did before the fix — is a partial count.
+    #[tokio::test]
+    async fn restore_batch_insert_is_all_or_nothing_when_the_future_is_cancelled() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let namespace = format!("ns-{suffix}");
+        let batch_size: i64 = 40;
+        let vector = vec![0.1_f32; 1536];
+
+        let build = |owner: &str, tag: &str| {
+            let ids: Vec<String> = (0..batch_size)
+                .map(|i| format!("restore-{tag}-{i}-{suffix}"))
+                .collect();
+            let blob_ids: Vec<String> = (0..batch_size)
+                .map(|i| format!("blob-{tag}-{i}-{suffix}"))
+                .collect();
+            (owner.to_string(), ids, blob_ids)
+        };
+
+        // Warm-up run: how long does a full batch of this shape take?
+        let (timed_owner, timed_ids, timed_blob_ids) = build(&format!("0xtimed-{suffix}"), "timed");
+        let timed_batch: Vec<VectorInsert<'_>> = timed_ids
+            .iter()
+            .zip(timed_blob_ids.iter())
+            .map(|(id, blob_id)| restore_row(id, &timed_owner, &namespace, blob_id, &vector))
+            .collect();
+        let started = std::time::Instant::now();
+        db.insert_vectors_atomic(&timed_batch)
+            .await
+            .expect("warm-up batch must commit");
+        let full_batch_time = started.elapsed();
+        delete_rows_for_owner(&db, &timed_owner).await;
+
+        // Cancel the real run halfway through that measured duration, so the
+        // drop lands while rows are still being written.
+        let (owner, ids, blob_ids) = build(&format!("0xcancel-{suffix}"), "cancel");
+        let batch: Vec<VectorInsert<'_>> = ids
+            .iter()
+            .zip(blob_ids.iter())
+            .map(|(id, blob_id)| restore_row(id, &owner, &namespace, blob_id, &vector))
+            .collect();
+        let deadline = (full_batch_time / 2).max(Duration::from_micros(1));
+        let cancelled = tokio::time::timeout(deadline, db.insert_vectors_atomic(&batch)).await;
+
+        let landed = rows_for_owner(&db, &owner, &namespace).await;
+        delete_rows_for_owner(&db, &owner).await;
+
+        match cancelled {
+            // Timed out: the future was dropped. Postgres may still have
+            // committed if the drop landed after COMMIT was flushed, so accept
+            // the full batch — but never a partial one.
+            Err(_) => assert!(
+                landed == 0 || landed == batch_size,
+                "a cancelled restore batch must be all-or-nothing, saw {landed} of {batch_size} rows"
+            ),
+            Ok(Ok(())) => assert_eq!(
+                landed, batch_size,
+                "a batch that finished before the deadline must be fully committed"
+            ),
+            Ok(Err(error)) => panic!("restore batch failed unexpectedly: {error:?}"),
+        }
+    }
+
     async fn remember_jobs_test_db() -> Option<VectorDb> {
         let db = test_db().await?;
         for migration in [
@@ -1551,14 +1773,93 @@ impl VectorDb {
         package_id: Option<&str>,
         end_epoch: Option<i32>,
     ) -> Result<(), AppError> {
-        let embedding = Vector::from(vector.to_vec());
-
-        let started = std::time::Instant::now();
         let mut tx = self
             .pool
             .begin()
             .await
             .map_err(|e| AppError::Internal(format!("Failed to begin insert tx: {}", e)))?;
+        self.insert_vector_in_tx(
+            &mut tx,
+            &VectorInsert {
+                id,
+                owner,
+                namespace,
+                blob_id,
+                vector,
+                blob_size_bytes,
+                importance,
+                agent_id,
+                package_id,
+                end_epoch,
+            },
+        )
+        .await?;
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit insert tx: {}", e)))?;
+        Ok(())
+    }
+
+    /// Persist a whole batch of vector rows in ONE transaction: either every
+    /// row lands or none of them do.
+    ///
+    /// GH #566 / WALM-591 — why this exists. Namespace restore used to persist
+    /// its batch with a plain `for` loop of autocommitted `insert_vector`
+    /// calls. `POST /api/restore` wraps the whole restore in
+    /// `tokio::time::timeout(55s, ..)`, so a slow batch had its future DROPPED
+    /// mid-loop: every row inserted up to that point stayed committed while the
+    /// caller got `UpstreamUnavailable` and never learned how many rows landed.
+    /// A later `recall` then read a silently half-written index. A mid-loop DB
+    /// error had exactly the same effect, because `?` returned after earlier
+    /// rows had already committed.
+    ///
+    /// One transaction closes both paths, including the dropped-future one:
+    /// SQLx queues a `ROLLBACK` when a dropped `Transaction` hands its
+    /// connection back to the pool — the same cancellation-safety property
+    /// `jobs::JobUploadLock` relies on — so cancelling this future at any point
+    /// leaves zero rows behind. Nothing is visible to another session until
+    /// `commit()` returns, so restore is now all-or-nothing rather than
+    /// silently partial.
+    ///
+    /// Callers must keep the batch bounded. The only production caller,
+    /// restore, clamps its page to 100 rows (`clamp_restore_limit`), so this is
+    /// a small, short-lived transaction that holds no user-visible locks beyond
+    /// the rows it writes.
+    pub async fn insert_vectors_atomic(&self, rows: &[VectorInsert<'_>]) -> Result<(), AppError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let mut tx =
+            self.pool.begin().await.map_err(|e| {
+                AppError::Internal(format!("Failed to begin batch insert tx: {}", e))
+            })?;
+        for row in rows {
+            // Deliberately no explicit `tx.rollback()` here: `?` drops `tx`,
+            // and SQLx's Drop impl rolls the transaction back before the
+            // connection is reused. That is also what makes a dropped future
+            // (the restore timeout) safe.
+            self.insert_vector_in_tx(&mut tx, row).await?;
+        }
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit batch insert tx: {}", e)))?;
+
+        tracing::debug!("inserted {} vector rows atomically", rows.len());
+        Ok(())
+    }
+
+    /// Shared statement pair behind [`Self::insert_vector`] and
+    /// [`Self::insert_vectors_atomic`]: upsert the row, then clear any
+    /// tombstone for the same memory id. Runs on the caller's transaction so a
+    /// batch can span many rows without an intermediate commit.
+    async fn insert_vector_in_tx(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        row: &VectorInsert<'_>,
+    ) -> Result<(), AppError> {
+        let embedding = Vector::from(row.vector.to_vec());
+
+        let started = std::time::Instant::now();
         let result = sqlx::query(
             "INSERT INTO vector_entries (id, owner, namespace, blob_id, embedding, blob_size_bytes, importance, agent_id, package_id, end_epoch)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
@@ -1574,44 +1875,40 @@ impl VectorDb {
                 end_epoch = EXCLUDED.end_epoch,
                 updated_at = NOW()",
         )
-        .bind(id)
-        .bind(owner)
-        .bind(namespace)
-        .bind(blob_id)
+        .bind(row.id)
+        .bind(row.owner)
+        .bind(row.namespace)
+        .bind(row.blob_id)
         .bind(embedding)
-        .bind(blob_size_bytes)
-        .bind(importance)
-        .bind(agent_id)
-        .bind(package_id)
-        .bind(end_epoch)
-        .execute(&mut *tx)
+        .bind(row.blob_size_bytes)
+        .bind(row.importance)
+        .bind(row.agent_id)
+        .bind(row.package_id)
+        .bind(row.end_epoch)
+        .execute(&mut **tx)
         .await;
-        if let Err(e) = result {
-            drop(tx);
-            self.maybe_alert_storage_exhausted(&e).await;
-            crate::observability::observe_db("vector.insert", "error", started.elapsed());
-            return Err(AppError::Internal(format!(
-                "Failed to insert vector: {}",
-                e
-            )));
+        // A Postgres storage-exhaustion failure is a write outage, not a user
+        // error, so it pages before it is mapped to a generic 500 (WALM-612).
+        // Reached from the batch path too, unlike the pre-batch code.
+        if let Err(e) = &result {
+            self.maybe_alert_storage_exhausted(e).await;
         }
-        crate::observability::observe_db("vector.insert", "ok", started.elapsed());
+        let result = result.map_err(|e| AppError::Internal(format!("Failed to insert vector: {}", e)));
+        crate::observability::observe_db("vector.insert", db_status(&result), started.elapsed());
+        result?;
         sqlx::query("DELETE FROM memory_tombstones WHERE memory_id = $1")
-            .bind(id)
-            .execute(&mut *tx)
+            .bind(row.id)
+            .execute(&mut **tx)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to clear tombstone: {}", e)))?;
-        tx.commit()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to commit insert tx: {}", e)))?;
 
         tracing::debug!(
             "inserted vector: id={}, blob_id={}, owner={}, ns={}, size={}B",
-            id,
-            blob_id,
-            owner,
-            namespace,
-            blob_size_bytes
+            row.id,
+            row.blob_id,
+            row.owner,
+            row.namespace,
+            row.blob_size_bytes
         );
         Ok(())
     }

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -991,10 +991,7 @@ mod tests {
             .unwrap();
     }
 
-    /// GH #566 / WALM-591: restore used to persist its batch with a loop of
-    /// autocommitted inserts, so a row that failed partway through left every
-    /// earlier row committed — a half-written index `recall` would read back.
-    /// The batch must now be all-or-nothing.
+    /// A row that fails partway through must not leave earlier rows committed.
     #[tokio::test]
     async fn restore_batch_insert_rolls_back_every_row_when_one_fails() {
         let Some(db) = test_db().await else {
@@ -1127,7 +1124,12 @@ mod tests {
             .zip(blob_ids.iter())
             .map(|(id, blob_id)| restore_row(id, &owner, &namespace, blob_id, &vector))
             .collect();
-        let deadline = (full_batch_time / 2).max(Duration::from_micros(1));
+        // Floored at 5ms: on a fast pool half a sub-millisecond warm-up
+        // cancels before `BEGIN` is even sent, and `landed == 0` would then
+        // pass without the rollback ever being exercised. If the floor lets the
+        // batch finish instead, the `Ok(Ok(()))` arm asserts a full commit — a
+        // real check either way.
+        let deadline = (full_batch_time / 2).max(Duration::from_millis(5));
         let cancelled = tokio::time::timeout(deadline, db.insert_vectors_atomic(&batch)).await;
 
         let landed = rows_for_owner(&db, &owner, &namespace).await;
@@ -1803,28 +1805,16 @@ impl VectorDb {
     /// Persist a whole batch of vector rows in ONE transaction: either every
     /// row lands or none of them do.
     ///
-    /// GH #566 / WALM-591 — why this exists. Namespace restore used to persist
-    /// its batch with a plain `for` loop of autocommitted `insert_vector`
-    /// calls. `POST /api/restore` wraps the whole restore in
-    /// `tokio::time::timeout(55s, ..)`, so a slow batch had its future DROPPED
-    /// mid-loop: every row inserted up to that point stayed committed while the
-    /// caller got `UpstreamUnavailable` and never learned how many rows landed.
-    /// A later `recall` then read a silently half-written index. A mid-loop DB
-    /// error had exactly the same effect, because `?` returned after earlier
-    /// rows had already committed.
+    /// One transaction, so neither a mid-batch `?` nor a dropped future can
+    /// commit a prefix: restore runs under `tokio::time::timeout(55s, ..)`, and
+    /// a prefix is a half-written index (GH #566 / WALM-591). SQLx queues a
+    /// `ROLLBACK` when a dropped `Transaction` returns its connection to the
+    /// pool — the property `jobs::JobUploadLock` also relies on — so a drop
+    /// before Postgres has processed `COMMIT` leaves zero rows. A drop after
+    /// that lands the whole batch; either way it is never partial.
     ///
-    /// One transaction closes both paths, including the dropped-future one:
-    /// SQLx queues a `ROLLBACK` when a dropped `Transaction` hands its
-    /// connection back to the pool — the same cancellation-safety property
-    /// `jobs::JobUploadLock` relies on — so cancelling this future at any point
-    /// leaves zero rows behind. Nothing is visible to another session until
-    /// `commit()` returns, so restore is now all-or-nothing rather than
-    /// silently partial.
-    ///
-    /// Callers must keep the batch bounded. The only production caller,
-    /// restore, clamps its page to 100 rows (`clamp_restore_limit`), so this is
-    /// a small, short-lived transaction that holds no user-visible locks beyond
-    /// the rows it writes.
+    /// Callers must keep the batch bounded. Restore clamps its page to 100 rows
+    /// (`clamp_restore_limit`), so this stays short-lived.
     pub async fn insert_vectors_atomic(&self, rows: &[VectorInsert<'_>]) -> Result<(), AppError> {
         if rows.is_empty() {
             return Ok(());


### PR DESCRIPTION
Fixes [WALM-591](https://linear.app/mysten-labs/issue/WALM-591) · Closes #566

## The bug

`POST /api/restore` wraps the entire restore in a deadline:

```rust
// services/server/src/routes/admin.rs
tokio::time::timeout(Duration::from_secs(55), restore_unbounded(state, auth, body)).await
```

Step 6 (persist) then wrote its results with a plain `for` loop of
**autocommitted** `insert_vector` calls — one transaction per row:

```rust
// Step 6: Insert only new entries (no delete!)
let restored = results.len();
for (blob_id, vector) in &results {
    ...
    state.db.insert_vector(&id, owner, namespace, blob_id, vector, blob_size, ...).await?;
}
```

Two ways that leaves a silently half-written index:

1. **Timeout (the reported case).** When the 55s deadline elapses, `timeout`
   **drops the in-flight future**. The loop stops wherever it was, but every
   row already inserted is *already committed* — each iteration had its own
   transaction. The caller gets `UpstreamUnavailable("Restore timed out; …")`
   and never learns how many rows landed, because `restored` is only reported
   on the success path.
2. **Mid-loop DB error.** `?` returns after earlier iterations have committed,
   with the same result.

Either way pgvector ends up holding a partial batch that a later `recall`
reads back as duplicated or truncated results — the "silent half-written
index" from the issue. Nothing reconciles it, and a retry of `restore` skips
the rows that did land (Step 2 filters out already-present blobs), so the
namespace stays inconsistent.

## The fix

Persist the whole batch in **one transaction**.

- `storage/db.rs`: new `VectorInsert` row descriptor and
  `VectorDb::insert_vectors_atomic`, which begins a single transaction, writes
  every row, and commits once. The statement pair (upsert + tombstone clear)
  is factored out of the existing `insert_vector` into `insert_vector_in_tx`,
  so single-row and batch inserts run identical SQL; `insert_vector` keeps its
  signature and behaviour and just wraps the helper in its own transaction.
- `routes/admin.rs`: Step 6 builds the batch up front and hands it over in one
  call.

Both failure modes now roll back:

- **Mid-loop error** — `?` drops the `Transaction`.
- **Dropped future (the timeout)** — SQLx queues a `ROLLBACK` when a dropped
  `Transaction` returns its connection to the pool. This is the same
  cancellation-safety property `jobs::JobUploadLock` already documents and
  relies on for its advisory-lock transaction, which is exactly why a
  transaction is the right fix for a cancelled future rather than, say,
  per-row compensation.

Nothing else changed: discovery, download, SEAL decrypt, re-embed, the
skip/negative-cache behaviour, and the `RestoreResponse { restored, skipped,
total, namespace, owner, truncated }` shape are all untouched.

### Why all-or-nothing rather than "explicit partial"

The AC permits a consistent, queryable partial state with an explicit error,
but all-or-nothing is strictly better here. Restore is idempotent and
re-derivable — Walrus is the source of truth and Step 2 re-computes what is
missing on the next call — so rolling back costs nothing but the re-download,
while a partial commit is *worse* than useless: the rows that landed cause the
retry to skip exactly the blobs it should re-check. Zero rows plus the
existing error is both consistent and trivially queryable, and it needs no new
response field or reconciliation path.

### Why one transaction is safe at this batch size

`clamp_restore_limit` clamps `body.limit` to `1..=100` (the ceiling mirrors
`/api/ask`), and `results` is a subset of that page — rows that were missing,
downloaded, decrypted and re-embedded. So the worst case is 100 single-row
upserts into `vector_entries` in one transaction: a few hundred KB of vectors,
sub-second, touching only rows this owner+namespace is restoring. It takes no
table-level locks and holds no locks another writer contends on. Restore is
also owner-rate-limited before any work starts.

## Tests

Three regression tests in `storage::db::tests`, following the existing
`DATABASE_URL` gate used by the neighbouring DB integration tests
(`forget_clears_idempotency_keys_so_the_same_text_can_be_rewritten`):

```rust
let Some(db) = test_db().await else {
    eprintln!("skipping DB integration test: DATABASE_URL is not configured");
    return;
};
```

- `restore_batch_insert_rolls_back_every_row_when_one_fails` — a 3-row batch
  whose middle row has a wrong-dimension embedding (rejected by the
  `vector(1536)` column). Asserts an explicit error **and zero rows**.
- `restore_batch_insert_commits_every_row_on_success` — the fix must not turn
  restore into a no-op; all rows must be visible.
- `restore_batch_insert_is_all_or_nothing_when_the_future_is_cancelled` —
  reproduces the actual trigger. It first times an uncancelled 40-row batch,
  then cancels a second one at half that duration so the drop genuinely lands
  mid-batch (a fixed 1ms deadline aborts before the first row and passes
  trivially). Asserts none-or-all, never a partial count.

Each test uses UUID-suffixed owners and cleans up its rows, like the tests
around it.

**These tests were verified to actually catch the bug.** Reverting
`insert_vectors_atomic` to the old per-row autocommit loop and re-running:

```
thread '...restore_batch_insert_rolls_back_every_row_when_one_fails' panicked:
assertion `left == right` failed: a failed restore batch must leave zero rows, not a partial index
  left: 1
 right: 0

thread '...restore_batch_insert_is_all_or_nothing_when_the_future_is_cancelled' panicked:
a cancelled restore batch must be all-or-nothing, saw 26 of 40 rows

test result: FAILED. 1 passed; 2 failed
```

`26 of 40 rows` is precisely the silent half-written index this PR fixes.

### Results

Run against `pgvector/pgvector:pg17` (the same image CI's `server-checks` job
uses), with `DATABASE_URL` set — so these tests really executed, they did not
skip:

```
test storage::db::tests::restore_batch_insert_commits_every_row_on_success ... ok
test storage::db::tests::restore_batch_insert_is_all_or_nothing_when_the_future_is_cancelled ... ok
test storage::db::tests::restore_batch_insert_rolls_back_every_row_when_one_fails ... ok

test result: ok. 693 passed; 0 failed; 37 ignored; 0 measured; 0 filtered out
```

Full `cargo test --bins` (CI's exact command). The cancellation test was run 5
consecutive times to check for timing flakiness — 5/5 green. Note the skip
guard still matters: without `DATABASE_URL` all three print the skip line and
return, which is what happens on a laptop with no local Postgres.

`rustfmt --check` is clean on both changed files.

`cargo clippy --all-targets -- -D warnings` reports **613 errors on this
branch vs 612 on `dev` (3da15d36)** — i.e. all pre-existing. CI runs
`cargo clippy --all-targets` with `continue-on-error: true` and an explicit
comment that the crate "emits pre-existing clippy warnings with `-D
warnings`". The single new line is `struct VectorInsert is never constructed`,
which is a false positive from that same pre-existing cascade: `lib.rs`
deliberately declares a reduced module tree that excludes `routes`, so in the
lib target *everything* in `db.rs` is reported unused — including
`VectorDb::new`, `pool()`, `db_status` and `TOMBSTONE_RETENTION`.
`VectorInsert` is constructed in `routes/admin.rs` and in the tests.

`cargo fmt --check` fails on `dev` as well, entirely in
`services/server/src/routes/memory_read.rs` (9 diffs) — pre-existing and
untouched here.
