### PR TITLE
fix(sdk): keep remember job state across polling timeouts (WALM-597)

### DIFF
--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,21 +28,31 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. A `waitForRememberJob` poll timeout throws a typed `RememberJobTimeoutError` that keeps the job id and last observed blob id, `RememberBulkResult` splits `timedOut` out of `failed`, and a job reporting `done` with no `blob_id` is an error instead of an empty handle. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
+This release stops a remember poll timeout from discarding the job state a caller needs to recover, splits `timedOut` out of `failed` on bulk results, removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
 
 ### Added
 
+- `RememberBulkResult.timedOut` counts jobs that were still running when the poll deadline expired, separately from `failed`.
+- `RememberJobTimeoutError` types the `waitForRememberJob` poll timeout (`status` 504) and carries `jobId` plus the last observed `lastStatus` / `lastBlobId`.
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+
+### Changed
+
+- **`RememberBulkResult.failed` now counts only relayer-reported failures.** Jobs still running when the poll deadline expired are counted in the new `timedOut`. Gate a durability check on `failed + timedOut`, or on `results.some((r) => r.status !== "done")`.
+- **A job reporting `done` without a `blob_id` is now an error, not a result.** `waitForRememberJob` throws `502` instead of resolving with `blob_id: ""`.
 
 ### Fixed
 
 - Hash request bodies with `@noble/hashes` instead of WebCrypto-or-`node:crypto`, so the package no longer imports a Node builtin on a browser-reachable path. Vite externalises such an import without warning: the app builds clean and the browser crashes the first time the path runs. The fallback could never have helped a browser anyway — `crypto.subtle` is absent precisely when the page is not a secure context, where `node:crypto` is absent too — so it only served Node <19 while being the sole source of the exposure. `sha256hex` sits on the signed-request path, so every remember and recall reached it. (#322, WALM-136)
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
+- A `waitForRememberJob` timeout keeps the job id and the last observed `status` / `blob_id` instead of throwing them away, so a caller can poll the job again rather than reissuing a paid write. The 404 and 500 throws carry the same fields.
+- `waitForRememberJobs` no longer resets a `blob_id` an earlier `uploaded` poll observed when a later poll reports `failed`, `not_found`, or `done` without a blob id.
+- A job id repeated in one `waitForRememberJobs` call resolves each occurrence instead of writing every status into the first slot.
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
 

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -96,11 +96,19 @@ An autonomous agent should not make a decision that assumes a write persisted un
 const accepted = await memwal.rememberBulkAsync(items);
 const settled = await memwal.waitForRememberJobs(accepted.job_ids);
 
-if (settled.failed > 0) {
-  const bad = settled.results.filter((r) => r.status !== "done");
-  throw new Error(`${settled.failed} writes did not persist: ${bad.map((b) => b.status).join(", ")}`);
+const bad = settled.results.filter((r) => r.status !== "done");
+if (bad.length > 0) {
+  throw new Error(`${bad.length} writes did not persist: ${bad.map((b) => b.status).join(", ")}`);
 }
 ```
+
+`settled.failed` counts only jobs the relayer itself reported as failed. A job
+that was still running when the poll deadline expired is counted in
+`settled.timedOut` instead, because its outcome is unknown rather than known-bad
+— it may still complete server-side. Gate on `failed + timedOut` (or, as above,
+on every result that is not `done`); `failed > 0` alone would treat a timed-out
+batch as persisted. A timed-out item carries `last_status` and, once the job
+reached `uploaded`, `blob_id`, so you can poll it again instead of rewriting it.
 
 <Warning>
 A job reaching `done` confirms that the relayer stored the memory, but the vector index can briefly lag behind that signal, so a `recall` fired in the same instant might not return the memory yet. For read-after-write critical paths, tolerate a short delay or re-query rather than treating an empty first result as a missing memory.

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -103,12 +103,12 @@ if (bad.length > 0) {
 ```
 
 `settled.failed` counts only jobs the relayer itself reported as failed. A job
-that was still running when the poll deadline expired is counted in
-`settled.timedOut` instead, because its outcome is unknown rather than known-bad
-— it may still complete server-side. Gate on `failed + timedOut` (or, as above,
-on every result that is not `done`); `failed > 0` alone would treat a timed-out
-batch as persisted. A timed-out item carries `last_status` and, once the job
-reached `uploaded`, `blob_id`, so you can poll it again instead of rewriting it.
+that still ran when the poll deadline expired is counted in `settled.timedOut`
+instead, because its outcome is unknown rather than known-bad. It might still
+complete server-side. Gate on `failed + timedOut`, or, as above, on every result
+that is not `done`. `failed > 0` alone would treat a timed-out batch as
+persisted. A timed-out item carries `last_status` and, once the job reached
+`uploaded`, `blob_id`, so you can poll it again instead of rewriting it.
 
 <Warning>
 A job reaching `done` confirms that the relayer stored the memory, but the vector index can briefly lag behind that signal, so a `recall` fired in the same instant might not return the memory yet. For read-after-write critical paths, tolerate a short delay or re-query rather than treating an empty first result as a missing memory.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Added
 
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+- `RememberBulkResult.timedOut` counts jobs that were still running when the poll deadline expired, separately from `failed`.
+- `RememberJobTimeoutError` types the `waitForRememberJob` poll timeout (`status` 504) and carries `jobId` plus the last observed `lastStatus` / `lastBlobId`.
+
+### Changed
+
+- **`RememberBulkResult.failed` now counts only relayer-reported failures.** Jobs still running when the poll deadline expired are counted in the new `timedOut` instead of being folded into `failed`. A timeout is an unknown outcome, not a lost write, so `if (settled.failed > 0)` is no longer a complete "did every write persist" check. Gate on `failed + timedOut`, or on `results.some((r) => r.status !== "done")`. `docs/sdk/production-readiness.md` is updated to match.
+- **A job reporting `done` without a `blob_id` is now an error, not a result.** `waitForRememberJob` throws `502` instead of resolving with `blob_id: ""`, which a caller could store as a valid handle to a memory that was never written. The bulk path reports the same case as `failed`.
 
 ### Fixed
 
@@ -12,6 +19,9 @@
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
+- A `waitForRememberJob` timeout keeps the job id and the last observed `status` / `blob_id` instead of throwing them away, so a caller can poll the job again rather than reissuing a paid write. The 404 (job cleaned up) and 500 (job failed) throws carry the same fields.
+- `waitForRememberJobs` no longer resets a `blob_id` an earlier `uploaded` poll observed when a later poll reports `failed`, `not_found`, or `done` without a blob id.
+- A job id repeated in one `waitForRememberJobs` call resolves each occurrence instead of writing every status into the first slot.
 
 ## 0.1.6
 

--- a/packages/sdk/node_modules
+++ b/packages/sdk/node_modules
@@ -1,1 +1,0 @@
-/Users/harryphan/Documents/2026 vault/DEV_PROJECTS/active/memwal/MemWal/packages/sdk/node_modules

--- a/packages/sdk/node_modules
+++ b/packages/sdk/node_modules
@@ -1,0 +1,1 @@
+/Users/harryphan/Documents/2026 vault/DEV_PROJECTS/active/memwal/MemWal/packages/sdk/node_modules

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -45,6 +45,7 @@ export type {
     MemWalConfig,
     RememberAcceptedResult,
     RememberJobStatus,
+    RememberJobTimeoutError,
     RememberResult,
     RecallResult,
     RecallMemory,

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -363,9 +363,13 @@ export class MemWal {
             }
 
             if (!("status" in status) || status.status === "not_found") {
+                // Job cleanup can retire a row an earlier poll already saw
+                // `uploaded`. Carry that observation out, same as 502/504.
                 throw Object.assign(new Error(`remember job not found: ${jobId}`), {
                     status: 404,
                     jobId,
+                    lastStatus,
+                    lastBlobId,
                 });
             }
 
@@ -376,12 +380,9 @@ export class MemWal {
 
             if (status.status === "done") {
                 if (!status.blob_id) {
-                    // The server sets blob_id and status='done' in the same
-                    // UPDATE, so this cannot happen against a healthy relayer.
-                    // Surface it rather than resolving with blob_id: "" — a
-                    // caller that stores the empty string has silently lost the
-                    // memory. lastBlobId lets a caller recover deliberately if
-                    // an earlier "uploaded" poll did carry the blob id.
+                    // Reject `done` without a blob id rather than resolving
+                    // with blob_id: "". `lastBlobId` carries anything an
+                    // earlier poll saw, so a caller can still recover.
                     throw Object.assign(
                         new Error(
                             `remember job reported done without a blob_id (job_id=${jobId})`,
@@ -402,7 +403,7 @@ export class MemWal {
                     new Error(
                         `remember job failed: ${redactInternalUrls(status.error ?? "unknown error")}`,
                     ),
-                    { status: 500, jobId },
+                    { status: 500, jobId, lastStatus, lastBlobId },
                 );
             }
         }
@@ -537,10 +538,9 @@ export class MemWal {
             namespace: namespaces[idx] ?? this.namespace,
             error: `polling timed out after ${timeoutMs}ms`,
         }));
-        // Track pending work per *occurrence*, not per id. The same job id may
-        // legitimately appear twice in `jobIds`, and resolving it by
-        // `jobIds.indexOf(jobId)` always wrote to the first slot — leaving the
-        // duplicate stuck on its pre-seeded timeout entry.
+        // Track pending work per *occurrence*, not per id: the same job id may
+        // legitimately appear twice in `jobIds`, and each slot needs its own
+        // result.
         let pendingSlots = jobIds.map((jobId, idx) => ({ jobId, idx }));
         let attempt = 0;
 
@@ -593,8 +593,8 @@ export class MemWal {
                     // returns per-item results instead of throwing.
                     if (!status.blob_id) {
                         results[slot.idx] = {
+                            ...results[slot.idx],
                             id: slot.jobId,
-                            blob_id: "",
                             status: "failed",
                             namespace,
                             error: "job reported done without a blob_id",
@@ -610,9 +610,12 @@ export class MemWal {
                     continue;
                 }
                 if (status.status === "failed" || status.status === "not_found") {
+                    // Spread first: a blob id an earlier `uploaded` poll folded
+                    // in is the caller's only handle on a write that may have
+                    // landed. Do not reset it to "".
                     results[slot.idx] = {
+                        ...results[slot.idx],
                         id: slot.jobId,
-                        blob_id: "",
                         status: "failed",
                         namespace,
                         error:
@@ -637,9 +640,9 @@ export class MemWal {
         }
 
         const succeeded = results.filter((r) => r.status === "done").length;
-        // A timeout is an unknown outcome, not a known failure — the job may
-        // well still complete server-side. Counting it as `failed` (which
-        // `results.length - succeeded` did) told callers the write was lost.
+        // A timeout is an unknown outcome, not a known failure: the job may
+        // still complete server-side. Callers who need "did every write land"
+        // must check `failed + timedOut`, not `failed`.
         const failed = results.filter((r) => r.status === "failed").length;
         const timedOut = results.filter((r) => r.status === "timeout").length;
 

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -373,9 +373,6 @@ export class MemWal {
                 });
             }
 
-            // Remember what we saw before branching, so a later timeout can
-            // report the last known state even if this poll is non-terminal.
-            lastStatus = status.status;
             if (status.blob_id) lastBlobId = status.blob_id;
 
             if (status.status === "done") {
@@ -406,6 +403,13 @@ export class MemWal {
                     { status: 500, jobId, lastStatus, lastBlobId },
                 );
             }
+
+            // Non-terminal (pending | running | uploaded). Record it only here,
+            // so `lastStatus` means "how far the job got", the same as the bulk
+            // path's `last_status`. Assigning before the branches made a 500
+            // report "failed" and a 502 report "done" — the terminal poll, not
+            // the progress a caller needs to decide whether to recover.
+            lastStatus = status.status;
         }
 
         const observed = [

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -616,10 +616,13 @@ export class MemWal {
                 if (status.status === "failed" || status.status === "not_found") {
                     // Spread first: a blob id an earlier `uploaded` poll folded
                     // in is the caller's only handle on a write that may have
-                    // landed. Do not reset it to "".
+                    // landed. Do not reset it to "". `mark_remember_job_failed`
+                    // leaves `blob_id` in place, so the failing poll itself can
+                    // also be the first one to carry it.
                     results[slot.idx] = {
                         ...results[slot.idx],
                         id: slot.jobId,
+                        blob_id: status.blob_id || results[slot.idx].blob_id,
                         status: "failed",
                         namespace,
                         error:

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -311,6 +311,22 @@ export class MemWal {
 
     /**
      * Poll an accepted remember job until it reaches a terminal state.
+     *
+     * Non-terminal states (`pending`, `running`, `uploaded`) keep polling — the
+     * job is still progressing server-side. Every observation is retained so a
+     * timeout can report where the job had got to instead of discarding it:
+     * `uploaded` already carries the Walrus `blob_id`, and losing that on
+     * timeout is what made a timed-out job look indistinguishable from one that
+     * never started.
+     *
+     * @throws A {@link RememberJobTimeoutError} (`status: 504`) carrying
+     * `jobId`, plus `lastStatus` / `lastBlobId` when the job was observed at
+     * least once. The job is *not* cancelled — it keeps running server-side, so
+     * callers can resume with `getRememberStatus(err.jobId)`.
+     * @throws `status: 404` when the job id is unknown to the server.
+     * @throws `status: 500` when the server reports the job as failed.
+     * @throws `status: 502` when the server reports `done` without a `blob_id`
+     * — a contract violation that used to resolve as a silent empty string.
      */
     async waitForRememberJob(
         jobId: string,
@@ -319,9 +335,15 @@ export class MemWal {
         const { pollIntervalMs = 1500, timeoutMs = 60_000 } = opts;
         const deadline = Date.now() + timeoutMs;
         let attempt = 0;
+        let lastStatus: RememberJobStatus["status"] | undefined;
+        let lastBlobId: string | undefined;
 
         while (Date.now() < deadline) {
-            await sleep(pollingDelayMs(pollIntervalMs, attempt++));
+            // Poll immediately on the first pass — an already-finished job
+            // should not pay a full backoff interval of latency — then back off
+            // before each subsequent poll.
+            if (attempt > 0) await sleep(pollingDelayMs(pollIntervalMs, attempt - 1));
+            attempt++;
 
             let status: RememberStatusResponse;
 
@@ -347,11 +369,30 @@ export class MemWal {
                 });
             }
 
+            // Remember what we saw before branching, so a later timeout can
+            // report the last known state even if this poll is non-terminal.
+            lastStatus = status.status;
+            if (status.blob_id) lastBlobId = status.blob_id;
+
             if (status.status === "done") {
+                if (!status.blob_id) {
+                    // The server sets blob_id and status='done' in the same
+                    // UPDATE, so this cannot happen against a healthy relayer.
+                    // Surface it rather than resolving with blob_id: "" — a
+                    // caller that stores the empty string has silently lost the
+                    // memory. lastBlobId lets a caller recover deliberately if
+                    // an earlier "uploaded" poll did carry the blob id.
+                    throw Object.assign(
+                        new Error(
+                            `remember job reported done without a blob_id (job_id=${jobId})`,
+                        ),
+                        { status: 502, jobId, lastStatus, lastBlobId },
+                    );
+                }
                 return {
                     id: status.job_id,
                     job_id: status.job_id,
-                    blob_id: status.blob_id ?? "",
+                    blob_id: status.blob_id,
                     owner: status.owner ?? "",
                     namespace: status.namespace ?? this.namespace,
                 };
@@ -366,9 +407,14 @@ export class MemWal {
             }
         }
 
+        const observed = [
+            `job_id=${jobId}`,
+            ...(lastStatus ? [`last_status=${lastStatus}`] : []),
+            ...(lastBlobId ? [`last_blob_id=${lastBlobId}`] : []),
+        ].join(", ");
         throw Object.assign(
-            new Error(`remember job timed out after ${timeoutMs}ms (job_id=${jobId})`),
-            { status: 504, jobId },
+            new Error(`remember job timed out after ${timeoutMs}ms (${observed})`),
+            { status: 504, jobId, lastStatus, lastBlobId },
         );
     }
 
@@ -468,6 +514,15 @@ export class MemWal {
         );
     }
 
+    /**
+     * Poll a batch of accepted remember jobs until each reaches a terminal state.
+     *
+     * Unlike {@link waitForRememberJob} this never throws on timeout: every job
+     * gets a result entry, pre-seeded as `status: "timeout"` and overwritten
+     * once the job settles. Entries still non-terminal at the deadline keep the
+     * last `blob_id` and `last_status` observed while polling, so an `uploaded`
+     * job that outlived `timeoutMs` reports its blob id instead of `""`.
+     */
     async waitForRememberJobs(
         jobIds: string[],
         namespaces: string[] = [],
@@ -482,16 +537,22 @@ export class MemWal {
             namespace: namespaces[idx] ?? this.namespace,
             error: `polling timed out after ${timeoutMs}ms`,
         }));
-        const pending = new Set(jobIds);
+        // Track pending work per *occurrence*, not per id. The same job id may
+        // legitimately appear twice in `jobIds`, and resolving it by
+        // `jobIds.indexOf(jobId)` always wrote to the first slot — leaving the
+        // duplicate stuck on its pre-seeded timeout entry.
+        let pendingSlots = jobIds.map((jobId, idx) => ({ jobId, idx }));
         let attempt = 0;
 
-        while (pending.size > 0 && Date.now() < deadline) {
-            await sleep(pollingDelayMs(pollIntervalMs, attempt++));
+        while (pendingSlots.length > 0 && Date.now() < deadline) {
+            // Poll immediately on the first pass, then back off before each
+            // subsequent poll — see waitForRememberJob.
+            if (attempt > 0) await sleep(pollingDelayMs(pollIntervalMs, attempt - 1));
+            attempt++;
 
-            const pendingIds = jobIds.filter((jobId) => pending.has(jobId));
-            if (pendingIds.length === 0) {
-                break;
-            }
+            // One id per pending occurrence, so a duplicated job id asks for —
+            // and consumes — one status response per slot it occupies.
+            const pendingIds = pendingSlots.map((slot) => slot.jobId);
 
             let batchStatus: RememberBulkStatusResult;
 
@@ -515,44 +576,79 @@ export class MemWal {
                 }
             }
 
-            for (const jobId of pendingIds) {
-                const status = statusById.get(jobId)?.shift();
+            const stillPending: typeof pendingSlots = [];
+            for (const slot of pendingSlots) {
+                const status = statusById.get(slot.jobId)?.shift();
                 if (!status) {
+                    stillPending.push(slot);
                     continue;
                 }
 
-                const idx = jobIds.indexOf(jobId);
+                const namespace = namespaces[slot.idx] ?? this.namespace;
+
                 if (status.status === "done") {
-                    results[idx] = {
-                        id: jobId,
-                        blob_id: status.blob_id ?? "",
+                    // Same contract violation waitForRememberJob rejects on: a
+                    // "done" job must carry its blob_id. Report it as failed
+                    // rather than a "done" whose blob_id is "" — this path
+                    // returns per-item results instead of throwing.
+                    if (!status.blob_id) {
+                        results[slot.idx] = {
+                            id: slot.jobId,
+                            blob_id: "",
+                            status: "failed",
+                            namespace,
+                            error: "job reported done without a blob_id",
+                        };
+                        continue;
+                    }
+                    results[slot.idx] = {
+                        id: slot.jobId,
+                        blob_id: status.blob_id,
                         status: "done",
-                        namespace: namespaces[idx] ?? this.namespace,
+                        namespace,
                     };
-                    pending.delete(jobId);
-                } else if (status.status === "failed" || status.status === "not_found") {
-                    results[idx] = {
-                        id: jobId,
+                    continue;
+                }
+                if (status.status === "failed" || status.status === "not_found") {
+                    results[slot.idx] = {
+                        id: slot.jobId,
                         blob_id: "",
                         status: "failed",
-                        namespace: namespaces[idx] ?? this.namespace,
+                        namespace,
                         error:
                             status.status === "not_found"
                                 ? "job not found"
                                 : redactInternalUrls(status.error ?? "unknown error"),
                     };
-                    pending.delete(jobId);
+                    continue;
                 }
+
+                // Non-terminal (pending | running | uploaded): keep polling, but
+                // fold the observation into the pre-seeded timeout entry so we
+                // still have it if the deadline arrives first.
+                results[slot.idx] = {
+                    ...results[slot.idx],
+                    blob_id: status.blob_id || results[slot.idx].blob_id,
+                    last_status: status.status,
+                };
+                stillPending.push(slot);
             }
+            pendingSlots = stillPending;
         }
 
         const succeeded = results.filter((r) => r.status === "done").length;
+        // A timeout is an unknown outcome, not a known failure — the job may
+        // well still complete server-side. Counting it as `failed` (which
+        // `results.length - succeeded` did) told callers the write was lost.
+        const failed = results.filter((r) => r.status === "failed").length;
+        const timedOut = results.filter((r) => r.status === "timeout").length;
 
         return {
             results,
             total: results.length,
             succeeded,
-            failed: results.length - succeeded,
+            failed,
+            timedOut,
         };
     }
 

--- a/packages/sdk/src/mock.ts
+++ b/packages/sdk/src/mock.ts
@@ -221,11 +221,20 @@ export class MemWalMock {
         const succeeded = results.filter(
             (result) => result.status === "done"
         ).length;
+        // The mock resolves every job synchronously, so nothing can time out —
+        // but the field must be present to match RememberBulkResult.
+        const failed = results.filter(
+            (result) => result.status === "failed"
+        ).length;
+        const timedOut = results.filter(
+            (result) => result.status === "timeout"
+        ).length;
         return {
             results,
             total: results.length,
             succeeded,
-            failed: results.length - succeeded,
+            failed,
+            timedOut,
         };
     }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -81,7 +81,11 @@ export interface RememberJobTimeoutError extends Error {
     status: number;
     /** The job that was being polled. Always set. */
     jobId: string;
-    /** Last non-terminal status observed, if the job was seen at all. */
+    /**
+     * Last non-terminal status observed, if the job was seen at all. This is
+     * how far the job got, not the poll that ended the wait, so it matches the
+     * bulk path's `last_status`.
+     */
     lastStatus?: RememberJobStatus["status"];
     /** Last blob_id observed (set from "uploaded" onwards), if any. */
     lastBlobId?: string;
@@ -275,11 +279,13 @@ export interface RememberBulkItemResult {
     /** job_id returned by the server */
     id: string;
     /**
-     * Walrus blob_id once the job completes ("" if failed).
+     * Walrus blob_id once the job completes.
      *
-     * On `status: "timeout"` this carries the last blob_id observed while
-     * polling — non-empty when the job had reached "uploaded" — so a timeout
-     * no longer throws the blob id away.
+     * On any non-`done` item this carries the last blob_id observed while
+     * polling, so `failed` and `timeout` items keep it too. Empty means the job
+     * was never seen at `uploaded`, NOT that the status is `failed`: a
+     * non-empty value on a failed item is the handle for recovering a blob that
+     * was minted before indexing gave up.
      */
     blob_id: string;
     /** Final status reported by the server: "done" | "failed" | "timeout" */
@@ -289,9 +295,9 @@ export interface RememberBulkItemResult {
     /** Error message if status !== "done" */
     error?: string;
     /**
-     * Last non-terminal job status observed while polling. Only set when
-     * `status` is "timeout" and the job was seen at least once, so callers can
-     * tell "never observed" from "was still uploading when we gave up".
+     * Last non-terminal job status observed while polling, on any non-`done`
+     * item. Unset means the job was never observed, which is how callers tell
+     * that apart from "was still uploading when we gave up".
      */
     last_status?: RememberJobStatus["status"];
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -54,6 +54,39 @@ export interface RememberResult {
     namespace: string;
 }
 
+/**
+ * Shape of the error thrown by `waitForRememberJob()` / `rememberAndWait()`
+ * when polling gives up before the job reaches a terminal state.
+ *
+ * The job keeps running server-side after the client stops waiting, so the
+ * error carries everything needed to resume or reconcile later instead of
+ * discarding the observation:
+ *
+ * ```typescript
+ * try {
+ *     await memwal.rememberAndWait(text)
+ * } catch (err) {
+ *     const timeout = err as RememberJobTimeoutError
+ *     if (timeout.status === 504) {
+ *         // Job id is always present; lastBlobId is set once the relayer has
+ *         // reported "uploaded", i.e. the blob exists even though indexing
+ *         // had not finished when we stopped polling.
+ *         await memwal.getRememberStatus(timeout.jobId)
+ *     }
+ * }
+ * ```
+ */
+export interface RememberJobTimeoutError extends Error {
+    /** Always 504 for a polling timeout. */
+    status: number;
+    /** The job that was being polled. Always set. */
+    jobId: string;
+    /** Last non-terminal status observed, if the job was seen at all. */
+    lastStatus?: RememberJobStatus["status"];
+    /** Last blob_id observed (set from "uploaded" onwards), if any. */
+    lastBlobId?: string;
+}
+
 /** A single recalled memory */
 export interface RecallMemory {
     blob_id: string;
@@ -241,7 +274,13 @@ export interface RememberBulkOptions {
 export interface RememberBulkItemResult {
     /** job_id returned by the server */
     id: string;
-    /** Walrus blob_id once the job completes ("" if failed) */
+    /**
+     * Walrus blob_id once the job completes ("" if failed).
+     *
+     * On `status: "timeout"` this carries the last blob_id observed while
+     * polling — non-empty when the job had reached "uploaded" — so a timeout
+     * no longer throws the blob id away.
+     */
     blob_id: string;
     /** Final status reported by the server: "done" | "failed" | "timeout" */
     status: "done" | "failed" | "timeout";
@@ -249,6 +288,12 @@ export interface RememberBulkItemResult {
     namespace: string;
     /** Error message if status !== "done" */
     error?: string;
+    /**
+     * Last non-terminal job status observed while polling. Only set when
+     * `status` is "timeout" and the job was seen at least once, so callers can
+     * tell "never observed" from "was still uploading when we gave up".
+     */
+    last_status?: RememberJobStatus["status"];
 }
 
 /** Result from rememberBulkAndWait() / waitForRememberJobs() */
@@ -259,8 +304,15 @@ export interface RememberBulkResult {
     total: number;
     /** Count of items that reached status=done */
     succeeded: number;
-    /** Count of items that failed or timed out */
+    /**
+     * Count of items the server reported as failed.
+     *
+     * Items that merely outlived `timeoutMs` are counted in `timedOut`, not
+     * here — a timeout is an unknown outcome, not a known failure.
+     */
     failed: number;
+    /** Count of items still non-terminal when polling gave up (status=timeout) */
+    timedOut: number;
 }
 
 /** Result from embed() */

--- a/packages/sdk/test/remember-job-state-loss.test.mjs
+++ b/packages/sdk/test/remember-job-state-loss.test.mjs
@@ -1,0 +1,352 @@
+/**
+ * WALM-597 / GH #564 — waitForRememberJob and waitForRememberJobs must not
+ * throw away what they observed while polling.
+ *
+ * "uploaded" is a non-terminal state that already carries the Walrus blob_id.
+ * Both wait helpers used to discard every non-terminal observation, so a
+ * timeout reported nothing but the job id and the bulk path reported
+ * blob_id: "" — indistinguishable from a job that never started.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWal } from "../dist/memwal.js";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+const VERSION_BODY = {
+    apiVersion: "1.0.0",
+    relayerVersion: "1.0.0",
+    minSupportedSdk: { typescript: "0.0.4" },
+};
+
+/**
+ * Install a fetch stub. `routes` maps a pathname to a handler receiving the
+ * parsed request body (or undefined for GET).
+ */
+function stubFetch(routes) {
+    globalThis.fetch = async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        if (path === "/version") return Response.json(VERSION_BODY);
+        const handler = routes[path];
+        if (!handler) throw new Error(`unexpected request ${path}`);
+        const body = init.body ? JSON.parse(init.body) : undefined;
+        return handler(body, init);
+    };
+}
+
+function makeClient() {
+    const client = MemWal.create({
+        key: new Uint8Array(32).fill(1),
+        accountId: "0x1",
+        serverUrl: "https://relayer.example",
+    });
+    client.buildSealSession = async () => "test-session";
+    return client;
+}
+
+// pollIntervalMs floors to 100ms inside pollingDelayMs, so the first backoff is
+// 75-125ms. A 20ms budget therefore guarantees exactly one poll before the
+// deadline, with no dependence on wall-clock jitter.
+const ONE_POLL = { pollIntervalMs: 0, timeoutMs: 20 };
+
+// ============================================================
+// waitForRememberJob (single)
+// ============================================================
+
+test("waitForRememberJob timeout reports the job id and the blob id seen at 'uploaded'", async () => {
+    let polls = 0;
+    stubFetch({
+        "/api/remember/stuck-job": () => {
+            polls += 1;
+            // Never reaches "done" — the relayer uploaded the blob but the
+            // indexing step is still running when the client gives up.
+            return Response.json({
+                job_id: "stuck-job",
+                status: "uploaded",
+                blob_id: "blob-uploaded",
+            });
+        },
+    });
+
+    const err = await makeClient()
+        .waitForRememberJob("stuck-job", ONE_POLL)
+        .then(
+            () => assert.fail("expected a timeout"),
+            (e) => e,
+        );
+
+    assert.equal(polls > 0, true, "should have polled at least once");
+    // Backwards compatible: existing callers catch 504 and read .jobId.
+    assert.equal(err.status, 504);
+    assert.equal(err.jobId, "stuck-job");
+    // The new part — the observation is no longer discarded.
+    assert.equal(err.lastStatus, "uploaded");
+    assert.equal(err.lastBlobId, "blob-uploaded");
+    assert.match(err.message, /timed out after 20ms/);
+    assert.match(err.message, /last_blob_id=blob-uploaded/);
+});
+
+test("waitForRememberJob timeout without any successful poll still reports the job id", async () => {
+    stubFetch({
+        // 503 is a transient polling status: keep polling, never observe state.
+        "/api/remember/never-seen": () => new Response("upstream down", { status: 503 }),
+    });
+
+    const err = await makeClient()
+        .waitForRememberJob("never-seen", ONE_POLL)
+        .then(
+            () => assert.fail("expected a timeout"),
+            (e) => e,
+        );
+
+    assert.equal(err.status, 504);
+    assert.equal(err.jobId, "never-seen");
+    // Nothing was observed, so these stay undefined rather than lying with "".
+    assert.equal(err.lastStatus, undefined);
+    assert.equal(err.lastBlobId, undefined);
+});
+
+test("waitForRememberJob resolves across the uploaded -> done transition", async () => {
+    const seen = [];
+    stubFetch({
+        "/api/remember/transition-job": () => {
+            seen.push("poll");
+            if (seen.length === 1) {
+                return Response.json({
+                    job_id: "transition-job",
+                    status: "uploaded",
+                    blob_id: "blob-final",
+                });
+            }
+            return Response.json({
+                job_id: "transition-job",
+                status: "done",
+                blob_id: "blob-final",
+                owner: "0xowner",
+                namespace: "notes",
+            });
+        },
+    });
+
+    const result = await makeClient().waitForRememberJob("transition-job", {
+        pollIntervalMs: 0,
+        timeoutMs: 5000,
+    });
+
+    assert.equal(seen.length >= 2, true, "uploaded must not terminate polling");
+    assert.equal(result.blob_id, "blob-final");
+    assert.equal(result.job_id, "transition-job");
+    assert.equal(result.id, "transition-job");
+    assert.equal(result.owner, "0xowner");
+    assert.equal(result.namespace, "notes");
+});
+
+test("waitForRememberJob errors when the server reports done without a blob_id", async () => {
+    stubFetch({
+        "/api/remember/empty-blob": () =>
+            Response.json({
+                job_id: "empty-blob",
+                status: "done",
+                owner: "0xowner",
+                namespace: "default",
+            }),
+    });
+
+    const err = await makeClient()
+        .waitForRememberJob("empty-blob", { pollIntervalMs: 0, timeoutMs: 5000 })
+        .then(
+            (r) => assert.fail(`expected an error, got blob_id=${JSON.stringify(r.blob_id)}`),
+            (e) => e,
+        );
+
+    // Used to resolve successfully with blob_id: "" — a silently lost memory.
+    assert.equal(err.status, 502);
+    assert.equal(err.jobId, "empty-blob");
+    assert.match(err.message, /done without a blob_id/);
+});
+
+test("waitForRememberJob polls before the first backoff so a finished job returns promptly", async () => {
+    stubFetch({
+        "/api/remember/fast-job": () =>
+            Response.json({
+                job_id: "fast-job",
+                status: "done",
+                blob_id: "blob-fast",
+                owner: "0xowner",
+                namespace: "default",
+            }),
+    });
+
+    const started = Date.now();
+    const result = await makeClient().waitForRememberJob("fast-job", {
+        pollIntervalMs: 0,
+        timeoutMs: 5000,
+    });
+    const elapsed = Date.now() - started;
+
+    assert.equal(result.blob_id, "blob-fast");
+    // The floor on pollingDelayMs is 100ms * 0.75 jitter = 75ms, so anything
+    // under that proves no sleep happened before the first poll.
+    assert.equal(elapsed < 75, true, `expected an immediate first poll, waited ${elapsed}ms`);
+});
+
+// ============================================================
+// waitForRememberJobs (bulk)
+// ============================================================
+
+test("waitForRememberJobs timeout keeps the last observed blob id and status", async () => {
+    stubFetch({
+        "/api/remember/bulk/status": (body) =>
+            Response.json({
+                results: body.job_ids.map((jobId) => ({
+                    job_id: jobId,
+                    status: "uploaded",
+                    blob_id: "blob-slow",
+                })),
+            }),
+    });
+
+    const bulk = await makeClient().waitForRememberJobs(["slow-job"], ["notes"], ONE_POLL);
+
+    assert.equal(bulk.results.length, 1);
+    const [item] = bulk.results;
+    // Discriminator is unchanged so existing branching keeps working.
+    assert.equal(item.status, "timeout");
+    assert.equal(item.id, "slow-job");
+    assert.equal(item.namespace, "notes");
+    assert.match(item.error, /polling timed out/);
+    // Previously "" — the blob id was observed and then thrown away.
+    assert.equal(item.blob_id, "blob-slow");
+    assert.equal(item.last_status, "uploaded");
+});
+
+test("waitForRememberJobs counts a timeout separately from a failure", async () => {
+    stubFetch({
+        "/api/remember/bulk/status": (body) =>
+            Response.json({
+                results: body.job_ids.map((jobId) => {
+                    if (jobId === "ok-job") {
+                        return { job_id: jobId, status: "done", blob_id: "blob-ok" };
+                    }
+                    if (jobId === "bad-job") {
+                        return { job_id: jobId, status: "failed", error: "walrus rejected blob" };
+                    }
+                    return { job_id: jobId, status: "running" };
+                }),
+            }),
+    });
+
+    const bulk = await makeClient().waitForRememberJobs(
+        ["ok-job", "bad-job", "slow-job"],
+        [],
+        ONE_POLL,
+    );
+
+    assert.equal(bulk.total, 3);
+    assert.equal(bulk.succeeded, 1);
+    // `failed` used to be `total - succeeded`, silently reporting the still
+    // running job as a known failure.
+    assert.equal(bulk.failed, 1);
+    assert.equal(bulk.timedOut, 1);
+    assert.equal(bulk.results[1].status, "failed");
+    assert.equal(bulk.results[1].error, "walrus rejected blob");
+    assert.equal(bulk.results[2].status, "timeout");
+    assert.equal(bulk.results[2].last_status, "running");
+});
+
+test("waitForRememberJobs marks a done job with no blob_id as failed, not done", async () => {
+    stubFetch({
+        "/api/remember/bulk/status": (body) =>
+            Response.json({
+                results: body.job_ids.map((jobId) => ({ job_id: jobId, status: "done" })),
+            }),
+    });
+
+    const bulk = await makeClient().waitForRememberJobs(["empty-blob"], [], {
+        pollIntervalMs: 0,
+        timeoutMs: 5000,
+    });
+
+    // Used to be counted as a success carrying blob_id: "".
+    assert.equal(bulk.results[0].status, "failed");
+    assert.equal(bulk.results[0].blob_id, "");
+    assert.match(bulk.results[0].error, /done without a blob_id/);
+    assert.equal(bulk.succeeded, 0);
+    assert.equal(bulk.failed, 1);
+    assert.equal(bulk.timedOut, 0);
+});
+
+test("waitForRememberJobs fills every slot when the same job id appears twice", async () => {
+    stubFetch({
+        // Server echoes one entry per requested id, duplicates included.
+        "/api/remember/bulk/status": (body) =>
+            Response.json({
+                results: body.job_ids.map((jobId) => ({
+                    job_id: jobId,
+                    status: "done",
+                    blob_id: `blob-${jobId}`,
+                })),
+            }),
+    });
+
+    const bulk = await makeClient().waitForRememberJobs(
+        ["dup", "dup", "other"],
+        ["ns-a", "ns-b", "ns-c"],
+        { pollIntervalMs: 0, timeoutMs: 5000 },
+    );
+
+    // `jobIds.indexOf(jobId)` wrote both "dup" observations into slot 0 and
+    // left slot 1 on its pre-seeded timeout entry.
+    assert.deepEqual(
+        bulk.results.map((r) => r.status),
+        ["done", "done", "done"],
+    );
+    assert.deepEqual(
+        bulk.results.map((r) => r.blob_id),
+        ["blob-dup", "blob-dup", "blob-other"],
+    );
+    // Namespaces stay aligned with the caller's input positions.
+    assert.deepEqual(
+        bulk.results.map((r) => r.namespace),
+        ["ns-a", "ns-b", "ns-c"],
+    );
+    assert.equal(bulk.succeeded, 3);
+    assert.equal(bulk.failed, 0);
+    assert.equal(bulk.timedOut, 0);
+});
+
+test("waitForRememberJobs re-polls a duplicated job id when the server dedupes responses", async () => {
+    const requests = [];
+    stubFetch({
+        "/api/remember/bulk/status": (body) => {
+            requests.push(body.job_ids);
+            // Deduping server: one entry per distinct id, however many were asked for.
+            const distinct = [...new Set(body.job_ids)];
+            return Response.json({
+                results: distinct.map((jobId) => ({
+                    job_id: jobId,
+                    status: "done",
+                    blob_id: `blob-${jobId}`,
+                })),
+            });
+        },
+    });
+
+    const bulk = await makeClient().waitForRememberJobs(["dup", "dup"], [], {
+        pollIntervalMs: 0,
+        timeoutMs: 5000,
+    });
+
+    assert.equal(requests.length >= 2, true, "second slot must be re-polled");
+    assert.deepEqual(
+        bulk.results.map((r) => r.status),
+        ["done", "done"],
+    );
+    assert.equal(bulk.succeeded, 2);
+    assert.equal(bulk.timedOut, 0);
+});

--- a/packages/sdk/test/remember-job-state-loss.test.mjs
+++ b/packages/sdk/test/remember-job-state-loss.test.mjs
@@ -172,10 +172,10 @@ test("a server-reported failure after an 'uploaded' poll still reports what was 
         );
 
     assert.equal(err.status, 500);
-    // lastStatus tracks the most recent poll, so a terminal failure names
-    // itself; lastBlobId is the part that survives — the blob may be durable
-    // even though indexing gave up on it.
-    assert.equal(err.lastStatus, "failed");
+    // lastStatus is how far the job got, not the poll that ended the wait, so
+    // it matches the bulk path's last_status. lastBlobId is the recovery
+    // handle: the blob may be durable even though indexing gave up on it.
+    assert.equal(err.lastStatus, "uploaded");
     assert.equal(err.lastBlobId, "blob-uploaded");
 });
 

--- a/packages/sdk/test/remember-job-state-loss.test.mjs
+++ b/packages/sdk/test/remember-job-state-loss.test.mjs
@@ -356,6 +356,35 @@ test("a bulk failure after an 'uploaded' poll keeps the blob id already folded i
     assert.equal(item.last_status, "uploaded");
 });
 
+test("a bulk job first seen as failed keeps the blob id on that same poll", async () => {
+    // The relayer's mark_remember_job_failed updates status and error only, so
+    // an uploaded-then-failed row still carries blob_id. A caller that polls
+    // after other work can see `failed` on the very first poll, with no earlier
+    // observation to fold in.
+    stubFetch({
+        "/api/remember/bulk/status": (body) =>
+            Response.json({
+                results: body.job_ids.map((jobId) => ({
+                    job_id: jobId,
+                    status: "failed",
+                    blob_id: "blob-minted",
+                    error: "indexing rejected the blob",
+                })),
+            }),
+    });
+
+    const bulk = await makeClient().waitForRememberJobs(["first-fail-job"], ["notes"], {
+        pollIntervalMs: 0,
+        timeoutMs: 5_000,
+    });
+
+    const [item] = bulk.results;
+    assert.equal(item.status, "failed");
+    // Empty would contradict the documented meaning: "" means never seen at
+    // uploaded, not "status is failed".
+    assert.equal(item.blob_id, "blob-minted");
+});
+
 test("waitForRememberJobs marks a done job with no blob_id as failed, not done", async () => {
     stubFetch({
         "/api/remember/bulk/status": (body) =>

--- a/packages/sdk/test/remember-job-state-loss.test.mjs
+++ b/packages/sdk/test/remember-job-state-loss.test.mjs
@@ -50,8 +50,10 @@ function makeClient() {
 }
 
 // pollIntervalMs floors to 100ms inside pollingDelayMs, so the first backoff is
-// 75-125ms. A 20ms budget therefore guarantees exactly one poll before the
-// deadline, with no dependence on wall-clock jitter.
+// 75-125ms. A 20ms budget therefore gets at least one immediate poll and then
+// expires during a backoff. The deadline is checked before the sleep, so a stub
+// that returns in a couple of milliseconds can still enter a second iteration —
+// these tests assert `polls >= 1`, never an exact count.
 const ONE_POLL = { pollIntervalMs: 0, timeoutMs: 20 };
 
 // ============================================================
@@ -109,6 +111,72 @@ test("waitForRememberJob timeout without any successful poll still reports the j
     // Nothing was observed, so these stay undefined rather than lying with "".
     assert.equal(err.lastStatus, undefined);
     assert.equal(err.lastBlobId, undefined);
+});
+
+test("a 404 after an 'uploaded' poll still reports what was observed", async () => {
+    // Job cleanup can retire the row between polls. The blob may well be
+    // durable; the caller needs the id to check rather than rewrite.
+    let polls = 0;
+    stubFetch({
+        "/api/remember/cleaned-job": () => {
+            polls += 1;
+            if (polls === 1) {
+                return Response.json({
+                    job_id: "cleaned-job",
+                    status: "uploaded",
+                    blob_id: "blob-uploaded",
+                });
+            }
+            return Response.json({ status: "not_found" }, { status: 404 });
+        },
+    });
+
+    const err = await makeClient()
+        .waitForRememberJob("cleaned-job", { pollIntervalMs: 0, timeoutMs: 5_000 })
+        .then(
+            () => assert.fail("expected a 404"),
+            (e) => e,
+        );
+
+    assert.equal(err.status, 404);
+    assert.equal(err.jobId, "cleaned-job");
+    assert.equal(err.lastStatus, "uploaded");
+    assert.equal(err.lastBlobId, "blob-uploaded");
+});
+
+test("a server-reported failure after an 'uploaded' poll still reports what was observed", async () => {
+    let polls = 0;
+    stubFetch({
+        "/api/remember/late-fail-job": () => {
+            polls += 1;
+            if (polls === 1) {
+                return Response.json({
+                    job_id: "late-fail-job",
+                    status: "uploaded",
+                    blob_id: "blob-uploaded",
+                });
+            }
+            return Response.json({
+                job_id: "late-fail-job",
+                status: "failed",
+                error: "indexing rejected the blob",
+            });
+        },
+    });
+
+    const err = await makeClient()
+        .waitForRememberJob("late-fail-job", { pollIntervalMs: 0, timeoutMs: 5_000 })
+        .then(
+            () => assert.fail("expected a failure"),
+            (e) => e,
+        );
+
+    assert.equal(err.status, 500);
+    // lastStatus tracks the most recent poll, so a terminal failure names
+    // itself; lastBlobId is the part that survives — the blob may be durable
+    // even though indexing gave up on it.
+    assert.equal(err.lastStatus, "failed");
+    assert.equal(err.lastBlobId, "blob-uploaded");
 });
 
 test("waitForRememberJob resolves across the uploaded -> done transition", async () => {
@@ -257,6 +325,35 @@ test("waitForRememberJobs counts a timeout separately from a failure", async () 
     assert.equal(bulk.results[1].error, "walrus rejected blob");
     assert.equal(bulk.results[2].status, "timeout");
     assert.equal(bulk.results[2].last_status, "running");
+});
+
+test("a bulk failure after an 'uploaded' poll keeps the blob id already folded in", async () => {
+    // Timeout was not the only path that discarded state: a terminal overwrite
+    // replaced the whole entry, resetting blob_id to "".
+    let round = 0;
+    stubFetch({
+        "/api/remember/bulk/status": (body) => {
+            round += 1;
+            return Response.json({
+                results: body.job_ids.map((jobId) =>
+                    round === 1
+                        ? { job_id: jobId, status: "uploaded", blob_id: "blob-uploaded" }
+                        : { job_id: jobId, status: "failed", error: "indexing rejected the blob" },
+                ),
+            });
+        },
+    });
+
+    const bulk = await makeClient().waitForRememberJobs(["late-fail-job"], ["notes"], {
+        pollIntervalMs: 0,
+        timeoutMs: 5_000,
+    });
+
+    const [item] = bulk.results;
+    assert.equal(item.status, "failed");
+    assert.equal(item.error, "indexing rejected the blob");
+    assert.equal(item.blob_id, "blob-uploaded");
+    assert.equal(item.last_status, "uploaded");
 });
 
 test("waitForRememberJobs marks a done job with no blob_id as failed, not done", async () => {


### PR DESCRIPTION
## The state-loss mechanism

`waitForRememberJob` and `waitForRememberJobs` both poll with backoff and both **discarded every non-terminal observation**.

The job state machine is `pending → running → uploaded → done` (`services/server/src/types.rs:470`), and `uploaded` is the point where the relayer has already written the blob — `jobs.rs:944` sets `status='uploaded', blob_id=$1`. Both wait helpers correctly treat `uploaded` as non-terminal and keep polling, but neither kept the observation. So when the deadline hit:

- **single** — threw a 504 carrying only `jobId`. The blob id it had already seen was gone.
- **bulk** — returned the pre-seeded entry with `blob_id: ""`, indistinguishable from a job that never started.

Either way the caller could not tell "still uploading, blob exists" from "nothing happened", and recovering the blob needed a manual `getRememberStatus` round trip that most callers do not make.

Three further bugs in the same code compounded it, each of which loses or misreports state on its own.

### 1. `done` with no `blob_id` resolved successfully with `""`

```ts
blob_id: status.blob_id ?? "",
```

The relayer sets `status='done'` and `blob_id` in a single `UPDATE` (`jobs.rs:891`), so a `done` without a blob id is a contract violation, not a valid empty result. A caller persisting that empty string has silently lost the memory. It now rejects with `502` (single) / a `failed` result entry (bulk).

### 2. Duplicate job ids corrupted bulk results

```ts
const idx = jobIds.indexOf(jobId);
```

`indexOf` always resolves to the **first** slot, so `["dup", "dup"]` wrote both observations into `results[0]` and left `results[1]` stranded on its pre-seeded timeout entry — a completed write reported as a timeout. Duplicates are a real case: the `statusById` bucket-array-with-`.shift()` right above it already anticipates duplicate responses.

Pending work is now tracked **per occurrence** rather than per id. As a side effect this also handles a relayer that dedupes its response: the unmatched slot stays pending and is re-polled instead of being abandoned.

### 3. `failed` counted timeouts as failures

```ts
failed: results.length - succeeded,
```

A timeout is an *unknown* outcome — the job normally completes server-side after the client stops waiting. Reporting it as `failed` told callers the write was lost. `failed` now counts only server-reported failures, and timeouts get their own `timedOut` field.

## New shape

Single — the thrown 504 keeps `jobId` and gains the last observation. Exported as `RememberJobTimeoutError`:

```ts
try {
    await memwal.rememberAndWait(text)
} catch (err) {
    const timeout = err as RememberJobTimeoutError
    if (timeout.status === 504) {
        timeout.jobId       // "job-abc"   — unchanged
        timeout.lastStatus  // "uploaded"  — new
        timeout.lastBlobId  // "0xblob..." — new: the blob exists
    }
}
```

Bulk — the last observation is folded into the timeout entry:

```ts
{
    id: "job-abc",
    status: "timeout",        // discriminator unchanged
    blob_id: "0xblob...",     // was "" — now the blob id seen at "uploaded"
    last_status: "uploaded",  // new: how far it got
    namespace: "notes",
    error: "polling timed out after 120000ms",
}
```

`RememberBulkResult` gains `timedOut` alongside `succeeded` / `failed`.

Both loops now also poll **once before the first backoff**, so an already-finished job returns immediately instead of paying 75–125 ms of dead latency.

## Backwards compatibility

- The single-job timeout still throws, still `status: 504`, still carries `.jobId` — existing catch-and-read-`.jobId` callers are unaffected.
- Bulk still returns per-item results and still uses `status: "timeout"` as the discriminator, so existing branching keeps working.
- `lastStatus` / `lastBlobId` / `last_status` are additive and optional.
- `timedOut` is a new required field on `RememberBulkResult`; it is additive for readers, and the only in-repo constructor besides the SDK itself (`mock.ts`) is updated.
- The one behavioural break is deliberate and is the fix: `done` with an empty `blob_id` no longer resolves successfully.

Nothing in-repo reads `RememberBulkResult.failed` off the workspace SDK. The sidecar MCP tools that print `failed=` (`services/server/scripts/mcp/tools/{analyze,remember-bulk}.ts`) pin the **published** `@mysten-incubation/memwal@0.0.3` from npm, not the workspace source, so they are unaffected until that pin is bumped.

## Tests

New `packages/sdk/test/remember-job-state-loss.test.mjs` (10 tests, `node:test`, `globalThis.fetch` path router). **7 of the 10 fail against the pre-fix implementation**; the other 3 lock in behaviour that was already correct (job id present on timeout, `uploaded` not treated as terminal).

- timeout after `uploaded` reports `jobId` + `lastStatus` + `lastBlobId` (single) and `blob_id` + `last_status` (bulk)
- timeout with no successful poll leaves `lastStatus` / `lastBlobId` undefined rather than lying with `""`
- `uploaded → done` transition resolves with the real blob id
- `done` with no blob id errors (502) instead of returning `""` — single and bulk
- duplicate job ids map to the correct result slots, with namespaces still aligned to input positions
- a duplicated id is re-polled when the relayer dedupes its response
- `timeout` is counted in `timedOut`, not `failed`
- an already-done job returns without a first-poll sleep

## Verification

```
pnpm --filter @mysten-incubation/memwal build      # clean
pnpm --filter @mysten-incubation/memwal typecheck  # clean
pnpm --filter @mysten-incubation/memwal test       # 121/121 pass (111 before, +10 new)
```

Also typechecked clean: `@mysten-incubation/oc-memwal`, `apps/app` (`tsc -b`), and `services/server/scripts`.

## Note for the reviewer

This touches `packages/sdk/src/memwal.ts`, which two sibling PRs (WALM-598, WALM-162) also touch in different regions of the same file. Expect a possible rebase depending on merge order.

Fixes WALM-597
https://linear.app/mysten-labs/issue/WALM-597
Source issue: https://github.com/MystenLabs/MemWal/issues/564
