### PR TITLE
fix(sdk): stop preflights from consuming recall's abort budget (WALM-598)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -50,6 +50,10 @@ Used by:
 | `accountId` | yes | MemWalAccount object ID on Sui |
 | `serverUrl` | no | Relayer URL. Default: `https://relayer.memory.walrus.xyz` |
 | `namespace` | no | Default memory boundary. Default: `"default"` |
+| `recallTimeoutMs` | no | Abort budget for the `/api/recall` request itself. Default: `15000`. `0` disables the deadline |
+| `preflightTimeoutMs` | no | Per-round-trip budget for the unauthenticated preflights (`GET /version`, `/health`, `/config`). Default: `5000` |
+
+`RecallOptions.timeoutMs` overrides `recallTimeoutMs` for a single `recall()` call. The recall clock starts after the preflights resolve, so a slow `/health` is never charged against it.
 
 ## `MemWalManualConfig`
 
@@ -70,6 +74,7 @@ Core fields:
 | `registryId` | yes | `AccountRegistry` shared object ID on Sui |
 | `accountId` | yes | `MemWalAccount` object ID |
 | `namespace` | no | Default namespace |
+| `preflightTimeoutMs` | no | Per-round-trip budget for the compatibility preflight. Default: `5000` |
 
 Sui signer fields:
 
@@ -105,6 +110,7 @@ Walrus and network fields:
 ## Rules That Matter
 
 - `namespace` defaults to `"default"` when omitted.
+- A blown deadline throws a `TimeoutError` whose `phase` names the round-trip that stalled; `isTimeoutError()` distinguishes it from a transport failure.
 - `MemWal` is the default relayer-handled path.
 - `MemWalManual` is the manual client path, but it still uses the relayer for registration, search, and restore.
 - `withMemWal` builds on top of `MemWal`, so it uses the same relayer-backed config shape.

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -56,7 +56,7 @@ Config:
 For the full config surface, see [Configuration](/reference/configuration).
 
 `recallTimeoutMs` covers the recall request alone. The preflights that run
-before it — the relayer compatibility check and the SEAL session build — are
+before it (the relayer compatibility check and the SEAL session build) are
 bounded separately by `preflightTimeoutMs`, so a slow relayer preflight cannot
 consume recall's budget.
 
@@ -125,7 +125,7 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 - `scoringWeights` blends recency and importance into the ranking (see [Ordering](#ordering) below)
 - `timeoutMs` overrides the client's `recallTimeoutMs` for this call. On expiry
   recall throws a `TimeoutError` whose `phase` names the round-trip that
-  stalled — `"POST /api/recall"`, or `"preflight GET /version"` when it was the
+  stalled: `"POST /api/recall"`, or `"preflight GET /version"` when it was the
   compatibility check. Use the exported `isTimeoutError(err)` to detect it.
 
 **Returns:**

--- a/docs/sdk/api-reference.md
+++ b/docs/sdk/api-reference.md
@@ -50,8 +50,15 @@ Config:
 | `accountId` | `string` | Yes | — | MemWalAccount object ID on Sui |
 | `serverUrl` | `string` | No | `https://relayer.memory.walrus.xyz` | Relayer URL |
 | `namespace` | `string` | No | `"default"` | Default namespace for memory isolation |
+| `recallTimeoutMs` | `number` | No | `15000` | Deadline for the `/api/recall` request. Per-call `RecallOptions.timeoutMs` overrides it |
+| `preflightTimeoutMs` | `number` | No | `5000` | Deadline for each preflight round-trip (`GET /version`, `GET /health`, `GET /config`) |
 
 For the full config surface, see [Configuration](/reference/configuration).
+
+`recallTimeoutMs` covers the recall request alone. The preflights that run
+before it — the relayer compatibility check and the SEAL session build — are
+bounded separately by `preflightTimeoutMs`, so a slow relayer preflight cannot
+consume recall's budget.
 
 ## `MemWal` Methods
 
@@ -116,6 +123,10 @@ Search for memories matching a natural language query, scoped to `owner + namesp
 - `maxDistance` filters weak matches client-side by dropping results where `distance >= maxDistance`
 - `sort` picks the ordering: `"relevance"` (default) or `"recent"` for newest-among-matches
 - `scoringWeights` blends recency and importance into the ranking (see [Ordering](#ordering) below)
+- `timeoutMs` overrides the client's `recallTimeoutMs` for this call. On expiry
+  recall throws a `TimeoutError` whose `phase` names the round-trip that
+  stalled — `"POST /api/recall"`, or `"preflight GET /version"` when it was the
+  compatibility check. Use the exported `isTimeoutError(err)` to detect it.
 
 **Returns:**
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,21 +28,26 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. Recall's abort budget is configurable through `recallTimeoutMs` and no longer spent by relayer preflights, a blown budget throws a `TimeoutError` naming the round-trip that stalled, and a request's deadline now covers the response body rather than stopping at its headers. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
+This release stops relayer preflights from consuming recall's abort budget, removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
 
 ### Added
 
+- `MemWalConfig.recallTimeoutMs` and `RecallOptions.timeoutMs` make recall's abort budget configurable (default: 15000, unchanged). `MemWalConfig.preflightTimeoutMs` / `MemWalManualConfig.preflightTimeoutMs` bound each preflight round-trip (default: 5000).
+- `isTimeoutError()` and the `TimeoutError` type are exported. A blown budget throws a `TimeoutError` whose `phase` names the round-trip that stalled instead of an unlabeled `AbortError`.
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 
 - Hash request bodies with `@noble/hashes` instead of WebCrypto-or-`node:crypto`, so the package no longer imports a Node builtin on a browser-reachable path. Vite externalises such an import without warning: the app builds clean and the browser crashes the first time the path runs. The fallback could never have helped a browser anyway — `crypto.subtle` is absent precisely when the page is not a secure context, where `node:crypto` is absent too — so it only served Node <19 while being the sole source of the exposure. `sha256hex` sits on the signed-request path, so every remember and recall reached it. (#322, WALM-136)
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
+- `recall()`'s timeout budget covers only the recall request. It previously started before the relayer compatibility check and the SEAL session build, so a slow preflight silently consumed the budget and recall raised an `AbortError` even when recall itself was healthy.
+- `GET /version`, `GET /health` and `GET /config` carry an `AbortSignal` and a deadline. They previously ran with neither and could hang indefinitely.
+- A request's deadline now covers the response body, not just its headers.
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Added
 
+- `MemWalConfig.recallTimeoutMs` and `RecallOptions.timeoutMs` make recall's abort budget configurable (default: 15000, unchanged). `MemWalConfig.preflightTimeoutMs` / `MemWalManualConfig.preflightTimeoutMs` bound each preflight round-trip (default: 5000).
+- `isTimeoutError()` and the `TimeoutError` type are exported. A blown budget now throws a `TimeoutError` whose `phase` names the round-trip that stalled (`"preflight GET /version"`, `"POST /api/recall"`) instead of an unlabeled `AbortError`.
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed
 
 - Hash request bodies with `@noble/hashes` instead of WebCrypto-or-`node:crypto`, so the package no longer imports a Node builtin on a browser-reachable path. Vite externalises such an import without warning: the app builds clean and the browser crashes the first time the path runs. The fallback could never have helped a browser anyway — `crypto.subtle` is absent precisely when the page is not a secure context, where `node:crypto` is absent too — so it only served Node <19 while being the sole source of the exposure. `sha256hex` sits on the signed-request path, so every remember and recall reached it. (#322, WALM-136)
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
+- `recall()`'s timeout budget covers only the recall request. It previously started before `ensureCompatibleRelayer()` (`GET /version`, falling back to `GET /health`) and `buildSealSession()` (`GET /config` + Sui RPC), so a slow relayer preflight silently consumed the budget and recall raised an `AbortError` even when recall itself was healthy.
+- `GET /version`, `GET /health` and `GET /config` carry an `AbortSignal` and a deadline. They previously ran with neither and could hang indefinitely.
+- A request's deadline now covers the response body, not just its headers. `fetch()` resolves when headers arrive, so a server that then trickled the body could outlive the budget the caller named.
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
 

--- a/packages/sdk/node_modules
+++ b/packages/sdk/node_modules
@@ -1,1 +1,0 @@
-/Users/harryphan/Documents/2026 vault/DEV_PROJECTS/active/memwal/MemWal/packages/sdk/node_modules

--- a/packages/sdk/node_modules
+++ b/packages/sdk/node_modules
@@ -1,0 +1,1 @@
+/Users/harryphan/Documents/2026 vault/DEV_PROJECTS/active/memwal/MemWal/packages/sdk/node_modules

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -24,6 +24,15 @@ export {
 
 // Delegate key utilities (no @mysten/sui dependency)
 export { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "./utils.js";
+// WALM-598: request-deadline surface. `isTimeoutError` lets callers tell a
+// blown budget apart from a transport failure, and `phase` says which
+// round-trip blew it.
+export {
+    isTimeoutError,
+    DEFAULT_RECALL_TIMEOUT_MS,
+    DEFAULT_PREFLIGHT_TIMEOUT_MS,
+} from "./utils.js";
+export type { TimeoutError } from "./utils.js";
 export {
     estimateTokens,
     truncateToTokenBudget,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -24,9 +24,8 @@ export {
 
 // Delegate key utilities (no @mysten/sui dependency)
 export { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "./utils.js";
-// WALM-598: request-deadline surface. `isTimeoutError` lets callers tell a
-// blown budget apart from a transport failure, and `phase` says which
-// round-trip blew it.
+// Request deadlines. `isTimeoutError` tells a blown budget apart from a
+// transport failure; `phase` says which round-trip blew it.
 export {
     isTimeoutError,
     DEFAULT_RECALL_TIMEOUT_MS,

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -158,7 +158,7 @@ export class MemWalManual {
     private namespace: string;
     private relayerVersionMetadata: RelayerVersionMetadata | null = null;
     private compatibilityPromise: Promise<RelayerVersionMetadata> | null = null;
-    /** WALM-598: per-round-trip budget for the compatibility preflight. */
+    /** Per-round-trip budget for the compatibility preflight (WALM-598). */
     private preflightTimeoutMs: number;
 
     // Lazily initialized heavy clients (typed as any to avoid peer dep compile errors)
@@ -815,9 +815,8 @@ export class MemWalManual {
     }
 
     private async fetchCompatibilityMetadata(): Promise<RelayerVersionMetadata> {
-        // WALM-598: bounded like the relayer-mode client's preflight — these
-        // run inside whatever signed request triggered them, so an untimed
-        // fetch here drains that caller's budget (and can hang forever).
+        // Bounded like the relayer-mode client's preflight: these run inside
+        // whatever signed request triggered them.
         const versionRes = await fetchWithDeadline(
             `${this.serverUrl}/version`,
             { method: "GET" },

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -49,6 +49,8 @@ import {
     sanitizeServerError,
     clockDriftErrorFromResponse,
     scoringWeightsToWire,
+    fetchWithDeadline,
+    DEFAULT_PREFLIGHT_TIMEOUT_MS,
 } from "./utils.js";
 import { assertCompatibleRelayer, compatibilityErrorFromStatus } from "./compatibility.js";
 
@@ -156,6 +158,8 @@ export class MemWalManual {
     private namespace: string;
     private relayerVersionMetadata: RelayerVersionMetadata | null = null;
     private compatibilityPromise: Promise<RelayerVersionMetadata> | null = null;
+    /** WALM-598: per-round-trip budget for the compatibility preflight. */
+    private preflightTimeoutMs: number;
 
     // Lazily initialized heavy clients (typed as any to avoid peer dep compile errors)
     private _suiClient: any = null;
@@ -180,6 +184,7 @@ export class MemWalManual {
         this.walletSigner = config.walletSigner ?? null;
         this.config = config;
         this.namespace = config.namespace ?? "default";
+        this.preflightTimeoutMs = config.preflightTimeoutMs ?? DEFAULT_PREFLIGHT_TIMEOUT_MS;
     }
 
     /**
@@ -810,17 +815,26 @@ export class MemWalManual {
     }
 
     private async fetchCompatibilityMetadata(): Promise<RelayerVersionMetadata> {
-        const versionRes = await fetch(`${this.serverUrl}/version`, {
-            method: "GET",
-        });
+        // WALM-598: bounded like the relayer-mode client's preflight — these
+        // run inside whatever signed request triggered them, so an untimed
+        // fetch here drains that caller's budget (and can hang forever).
+        const versionRes = await fetchWithDeadline(
+            `${this.serverUrl}/version`,
+            { method: "GET" },
+            this.preflightTimeoutMs,
+            "preflight GET /version",
+        );
         let body: Partial<RelayerVersionMetadata>;
 
         if (versionRes.ok) {
             body = (await versionRes.json()) as Partial<RelayerVersionMetadata>;
         } else if (versionRes.status === 404 || versionRes.status === 405) {
-            const healthRes = await fetch(`${this.serverUrl}/health`, {
-                method: "GET",
-            });
+            const healthRes = await fetchWithDeadline(
+                `${this.serverUrl}/health`,
+                { method: "GET" },
+                this.preflightTimeoutMs,
+                "preflight GET /health",
+            );
             if (!healthRes.ok) {
                 throw new Error(
                     `Walrus Memory compatibility check failed: GET /version returned ` +

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -68,6 +68,9 @@ import {
     redactInternalUrls,
     clockDriftErrorFromResponse,
     scoringWeightsToWire,
+    fetchWithDeadline,
+    DEFAULT_PREFLIGHT_TIMEOUT_MS,
+    DEFAULT_RECALL_TIMEOUT_MS,
 } from "./utils.js";
 import {
     assertCompatibleRelayer,
@@ -114,6 +117,21 @@ const SEAL_SESSION_TTL_MIN = 5;
 // the client thinks the session is valid but a just-received request hits
 // a key server that sees it as expired.
 const SEAL_SESSION_SAFETY_MARGIN_MS = 30_000;
+
+/** Per-call knobs for `MemWal.signedRequest`. */
+interface SignedRequestOptions {
+    /** ENG-1696: omit the SEAL credential on Manual-mode routes. */
+    includeDelegateKey?: boolean;
+    /** Caller-owned cancellation, honoured alongside `timeoutMs`. */
+    signal?: AbortSignal;
+    /**
+     * WALM-598: deadline for the signed request itself. The clock starts
+     * after the preflights resolve, so this is never charged for a slow
+     * `/version`, `/health` or `/config`. Omit (or pass 0) for no deadline —
+     * which is what every route other than recall does today.
+     */
+    timeoutMs?: number;
+}
 
 type RememberStatusResponse = RememberJobStatus | { error?: string };
 
@@ -185,6 +203,14 @@ export class MemWal {
     private serverUrl: string;
     private namespace: string;
     private accountId: string;
+    /**
+     * WALM-598: recall's abort budget, and the independent per-round-trip
+     * budget for the unauthenticated preflights that precede it. Kept
+     * separate so a slow `/version`, `/health` or `/config` can no longer
+     * be charged against the recall request it precedes.
+     */
+    private recallTimeoutMs: number;
+    private preflightTimeoutMs: number;
 
     // ENG-1697 state — all internal, never surfaced to user code.
     // The public API (`MemWal.create({ key, accountId })`) is unchanged.
@@ -219,6 +245,8 @@ export class MemWal {
         // non-localhost host.
         this.serverUrl = normalizeServerUrl(config.serverUrl ?? "https://relayer.memory.walrus.xyz");
         this.namespace = config.namespace ?? "default";
+        this.recallTimeoutMs = config.recallTimeoutMs ?? DEFAULT_RECALL_TIMEOUT_MS;
+        this.preflightTimeoutMs = config.preflightTimeoutMs ?? DEFAULT_PREFLIGHT_TIMEOUT_MS;
     }
 
     /**
@@ -666,59 +694,61 @@ export class MemWal {
         const limit = options.topK ?? options.limit ?? 10;
         const resolvedNamespace = options.namespace ?? this.namespace;
 
-        const ac = new AbortController();
-        const tid = setTimeout(() => ac.abort(), 15000);
-        try {
-            const result = await this.signedRequest<RecallResult>("POST", "/api/recall", {
-                query,
-                limit,
-                namespace: resolvedNamespace,
-                // `undefined` when no weights were supplied, which
-                // JSON.stringify drops — so a default-weighted recall stays
-                // byte-identical on the wire and the relayer keeps
-                // short-circuiting to the plain pgvector cosine order.
-                scoring_weights: scoringWeightsToWire(options.scoringWeights),
-                // Same `undefined`-is-dropped trick: an unset sort leaves the
-                // request byte-identical and the relayer applies its own
-                // "relevance" default.
-                sort: options.sort,
-            }, { signal: ac.signal });
+        // WALM-598: this budget is handed to `signedRequest`, which starts the
+        // clock on the `/api/recall` fetch itself — after `ensureCompatibleRelayer`
+        // (`/version`, falling back to `/health`) and `buildSealSession`
+        // (`/config` + Sui RPC) have already resolved. Those preflights carry
+        // their own independent deadlines, so a relayer whose `/health` p50 had
+        // crept to ~9s can no longer eat most of recall's window and make a
+        // perfectly healthy recall surface an `AbortError` (GH #438).
+        const timeoutMs = options.timeoutMs ?? this.recallTimeoutMs;
+        const result = await this.signedRequest<RecallResult>("POST", "/api/recall", {
+            query,
+            limit,
+            namespace: resolvedNamespace,
+            // `undefined` when no weights were supplied, which
+            // JSON.stringify drops — so a default-weighted recall stays
+            // byte-identical on the wire and the relayer keeps
+            // short-circuiting to the plain pgvector cosine order.
+            scoring_weights: scoringWeightsToWire(options.scoringWeights),
+            // Same `undefined`-is-dropped trick: an unset sort leaves the
+            // request byte-identical and the relayer applies its own
+            // "relevance" default.
+            sort: options.sort,
+        }, { timeoutMs });
 
-            let processed = result;
-            if (typeof options.maxDistance === "number") {
-                const filtered = result.results.filter(
-                    (memory) => memory.distance < options.maxDistance!,
-                );
-                processed = {
-                    ...processed,
-                    results: filtered,
-                    total: filtered.length,
-                };
-            }
-
-            // Client-side token budgeting: trim the (already distance-sorted)
-            // payload to fit maxTokens per the chosen strategy, and attach the
-            // token estimate + truncated flag. Omitting maxTokens leaves the
-            // result byte-identical to the pre-budget behavior (no meta).
-            if (typeof options.maxTokens === "number") {
-                const { results: budgeted, meta } = applyTokenBudget(
-                    processed.results,
-                    options.maxTokens,
-                    options.truncationStrategy,
-                    options.countTokens,
-                );
-                processed = {
-                    ...processed,
-                    results: budgeted,
-                    total: budgeted.length,
-                    meta,
-                };
-            }
-
-            return processed;
-        } finally {
-            clearTimeout(tid);
+        let processed = result;
+        if (typeof options.maxDistance === "number") {
+            const filtered = result.results.filter(
+                (memory) => memory.distance < options.maxDistance!,
+            );
+            processed = {
+                ...processed,
+                results: filtered,
+                total: filtered.length,
+            };
         }
+
+        // Client-side token budgeting: trim the (already distance-sorted)
+        // payload to fit maxTokens per the chosen strategy, and attach the
+        // token estimate + truncated flag. Omitting maxTokens leaves the
+        // result byte-identical to the pre-budget behavior (no meta).
+        if (typeof options.maxTokens === "number") {
+            const { results: budgeted, meta } = applyTokenBudget(
+                processed.results,
+                options.maxTokens,
+                options.truncationStrategy,
+                options.countTokens,
+            );
+            processed = {
+                ...processed,
+                results: budgeted,
+                total: budgeted.length,
+                meta,
+            };
+        }
+
+        return processed;
     }
 
     // ============================================================
@@ -1015,7 +1045,12 @@ export class MemWal {
      * Check server health. The endpoint is public and does not require request signing.
      */
     async health(): Promise<HealthResult> {
-        const res = await fetch(`${this.serverUrl}/health`);
+        const res = await fetchWithDeadline(
+            `${this.serverUrl}/health`,
+            {},
+            this.preflightTimeoutMs,
+            "GET /health",
+        );
         if (!res.ok) {
             throw new Error(`Health check failed: ${res.status}`);
         }
@@ -1060,13 +1095,27 @@ export class MemWal {
     }
 
     private async fetchCompatibilityMetadata(): Promise<RelayerVersionMetadata> {
-        const versionRes = await fetch(`${this.serverUrl}/version`, { method: "GET" });
+        // WALM-598: both round-trips get their own bounded budget. They run
+        // inside whatever signed request triggered the compatibility probe, so
+        // leaving them untimed let a stalled relayer silently drain that
+        // caller's deadline (and, with no signal at all, hang indefinitely).
+        const versionRes = await fetchWithDeadline(
+            `${this.serverUrl}/version`,
+            { method: "GET" },
+            this.preflightTimeoutMs,
+            "preflight GET /version",
+        );
         let body: Partial<RelayerVersionMetadata>;
 
         if (versionRes.ok) {
             body = (await versionRes.json()) as Partial<RelayerVersionMetadata>;
         } else if (versionRes.status === 404 || versionRes.status === 405) {
-            const healthRes = await fetch(`${this.serverUrl}/health`, { method: "GET" });
+            const healthRes = await fetchWithDeadline(
+                `${this.serverUrl}/health`,
+                { method: "GET" },
+                this.preflightTimeoutMs,
+                "preflight GET /health",
+            );
             if (!healthRes.ok) {
                 throw new Error(
                     `Walrus Memory compatibility check failed: GET /version returned ` +
@@ -1109,7 +1158,14 @@ export class MemWal {
 
     private async fetchServerConfig(): Promise<ServerConfig> {
         if (this.serverConfig) return this.serverConfig;
-        const res = await fetch(`${this.serverUrl}/config`, { method: "GET" });
+        // WALM-598: bounded like the other preflights — this one is awaited
+        // inside `buildSealSession`, itself awaited inside a caller's budget.
+        const res = await fetchWithDeadline(
+            `${this.serverUrl}/config`,
+            { method: "GET" },
+            this.preflightTimeoutMs,
+            "preflight GET /config",
+        );
         if (!res.ok) {
             throw new Error(`GET /config returned ${res.status}`);
         }
@@ -1326,8 +1382,8 @@ export class MemWal {
         method: string,
         path: string,
         body: object,
-        acceptedStatusesOrOptions: number[] | { includeDelegateKey?: boolean; signal?: AbortSignal } = [200],
-        requestOptions: { includeDelegateKey?: boolean; signal?: AbortSignal } = {},
+        acceptedStatusesOrOptions: number[] | SignedRequestOptions = [200],
+        requestOptions: SignedRequestOptions = {},
     ): Promise<T> {
         const acceptedStatuses = Array.isArray(acceptedStatusesOrOptions)
             ? acceptedStatusesOrOptions
@@ -1374,12 +1430,23 @@ export class MemWal {
         if (options.includeDelegateKey !== false) {
             headers["x-seal-session"] = await this.buildSealSession();
         }
-        const res = await fetch(url, {
-            method,
-            headers,
-            body: method === "GET" ? undefined : bodyStr,
-            signal: options.signal,
-        });
+        // WALM-598: the caller's deadline starts HERE, not at the top of the
+        // call. Everything above — `ensureCompatibleRelayer()` (`/version` ->
+        // `/health`) and `buildSealSession()` (`/config`, dynamic imports, a
+        // Sui RPC round-trip for `SessionKey.create`) — is preflight work that
+        // used to run inside the caller's budget while being unabortable
+        // itself. Each of those now carries its own independent deadline.
+        const res = await fetchWithDeadline(
+            url,
+            {
+                method,
+                headers,
+                body: method === "GET" ? undefined : bodyStr,
+            },
+            options.timeoutMs ?? 0,
+            `${method} ${path}`,
+            options.signal,
+        );
 
         if (!acceptedStatuses.includes(res.status)) {
             // LOW-26: sanitize server error bodies before surfacing to callers.

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -125,10 +125,10 @@ interface SignedRequestOptions {
     /** Caller-owned cancellation, honoured alongside `timeoutMs`. */
     signal?: AbortSignal;
     /**
-     * WALM-598: deadline for the signed request itself. The clock starts
-     * after the preflights resolve, so this is never charged for a slow
-     * `/version`, `/health` or `/config`. Omit (or pass 0) for no deadline —
-     * which is what every route other than recall does today.
+     * Deadline for the signed request itself. The clock starts after the
+     * preflights resolve, so this is never charged for a slow `/version`,
+     * `/health` or `/config`. Omit (or pass 0) for no deadline — which is what
+     * every route other than recall does today (WALM-598).
      */
     timeoutMs?: number;
 }
@@ -204,10 +204,9 @@ export class MemWal {
     private namespace: string;
     private accountId: string;
     /**
-     * WALM-598: recall's abort budget, and the independent per-round-trip
-     * budget for the unauthenticated preflights that precede it. Kept
-     * separate so a slow `/version`, `/health` or `/config` can no longer
-     * be charged against the recall request it precedes.
+     * Recall's abort budget, and the independent per-round-trip budget for the
+     * unauthenticated preflights that precede it. Separate so a slow
+     * `/version`, `/health` or `/config` is never charged against recall.
      */
     private recallTimeoutMs: number;
     private preflightTimeoutMs: number;
@@ -694,13 +693,8 @@ export class MemWal {
         const limit = options.topK ?? options.limit ?? 10;
         const resolvedNamespace = options.namespace ?? this.namespace;
 
-        // WALM-598: this budget is handed to `signedRequest`, which starts the
-        // clock on the `/api/recall` fetch itself — after `ensureCompatibleRelayer`
-        // (`/version`, falling back to `/health`) and `buildSealSession`
-        // (`/config` + Sui RPC) have already resolved. Those preflights carry
-        // their own independent deadlines, so a relayer whose `/health` p50 had
-        // crept to ~9s can no longer eat most of recall's window and make a
-        // perfectly healthy recall surface an `AbortError` (GH #438).
+        // The clock starts on the `/api/recall` fetch itself, after the
+        // preflights resolve on their own deadlines.
         const timeoutMs = options.timeoutMs ?? this.recallTimeoutMs;
         const result = await this.signedRequest<RecallResult>("POST", "/api/recall", {
             query,
@@ -1095,10 +1089,8 @@ export class MemWal {
     }
 
     private async fetchCompatibilityMetadata(): Promise<RelayerVersionMetadata> {
-        // WALM-598: both round-trips get their own bounded budget. They run
-        // inside whatever signed request triggered the compatibility probe, so
-        // leaving them untimed let a stalled relayer silently drain that
-        // caller's deadline (and, with no signal at all, hang indefinitely).
+        // Both round-trips run inside whatever signed request triggered the
+        // probe, so each needs its own budget rather than that caller's.
         const versionRes = await fetchWithDeadline(
             `${this.serverUrl}/version`,
             { method: "GET" },
@@ -1158,8 +1150,7 @@ export class MemWal {
 
     private async fetchServerConfig(): Promise<ServerConfig> {
         if (this.serverConfig) return this.serverConfig;
-        // WALM-598: bounded like the other preflights — this one is awaited
-        // inside `buildSealSession`, itself awaited inside a caller's budget.
+        // Awaited inside `buildSealSession`, itself inside a caller's budget.
         const res = await fetchWithDeadline(
             `${this.serverUrl}/config`,
             { method: "GET" },
@@ -1430,12 +1421,8 @@ export class MemWal {
         if (options.includeDelegateKey !== false) {
             headers["x-seal-session"] = await this.buildSealSession();
         }
-        // WALM-598: the caller's deadline starts HERE, not at the top of the
-        // call. Everything above — `ensureCompatibleRelayer()` (`/version` ->
-        // `/health`) and `buildSealSession()` (`/config`, dynamic imports, a
-        // Sui RPC round-trip for `SessionKey.create`) — is preflight work that
-        // used to run inside the caller's budget while being unabortable
-        // itself. Each of those now carries its own independent deadline.
+        // The caller's deadline starts HERE, not at the top of the call:
+        // everything above is preflight work on its own deadline (WALM-598).
         const res = await fetchWithDeadline(
             url,
             {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -21,6 +21,23 @@ export interface MemWalConfig {
     serverUrl?: string;
     /** Default namespace for memory isolation (default: "default") */
     namespace?: string;
+    /**
+     * Deadline for the `/api/recall` request itself, in milliseconds
+     * (default: 15000). Per-call `RecallOptions.timeoutMs` overrides it.
+     *
+     * This budget covers only the recall round-trip. The preflights that
+     * precede it (`/version`, `/config`, the SEAL session build) are bounded
+     * separately by `preflightTimeoutMs`, so a slow relayer preflight can no
+     * longer consume recall's budget and surface as a spurious abort.
+     */
+    recallTimeoutMs?: number;
+    /**
+     * Deadline for each unauthenticated preflight fetch — `GET /version`,
+     * `GET /health`, `GET /config` — in milliseconds (default: 5000).
+     *
+     * Applied per round-trip, not to the preflight phase as a whole.
+     */
+    preflightTimeoutMs?: number;
 }
 
 // ============================================================
@@ -181,6 +198,19 @@ export interface RecallOptions {
      * the window.
      */
     sort?: "relevance" | "recent";
+    /**
+     * Deadline for the `/api/recall` request, in milliseconds. Defaults to
+     * `MemWalConfig.recallTimeoutMs`, itself 15000.
+     *
+     * The clock starts once the preflights (`/version`, `/config`, the SEAL
+     * session build) have completed, so this is a budget for recall alone.
+     * Pass `0` (or `Infinity`) to opt out of the deadline entirely.
+     *
+     * On expiry recall throws a `TimeoutError` whose `phase` is
+     * `"POST /api/recall"`; a preflight that blows its own budget throws one
+     * naming that preflight instead.
+     */
+    timeoutMs?: number;
 }
 
 /** Recommended object-style recall input — preferred over positional args. */
@@ -560,6 +590,12 @@ export interface MemWalManualConfig {
     walrusPublisherUrl?: string;
     /** Default namespace for memory isolation (default: "default") */
     namespace?: string;
+    /**
+     * Deadline for the unauthenticated compatibility preflight (`GET /version`,
+     * falling back to `GET /health`), in milliseconds (default: 5000).
+     * Applied per round-trip.
+     */
+    preflightTimeoutMs?: number;
 }
 
 /**

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -399,13 +399,9 @@ export function clockDriftErrorFromResponse(
  * (`GET /version`, `GET /health`, `GET /config`) the SDK makes before it can
  * dispatch a signed request.
  *
- * These used to run with no signal and no timeout at all. Because they are
- * awaited *inside* a caller's request budget, a relayer whose `/health` p50
- * had drifted to ~9s silently consumed most of `recall()`'s 15s
- * `AbortController` window, and the resulting `AbortError` surfaced on the
- * `/api/recall` fetch even though recall itself was healthy (GH #438).
- * Each preflight now carries its own independent budget so it can neither
- * hang forever nor eat someone else's.
+ * Each preflight carries its own budget: they are awaited inside a caller's
+ * request budget, so an unbounded one both hangs forever and spends someone
+ * else's deadline (WALM-598).
  */
 export const DEFAULT_PREFLIGHT_TIMEOUT_MS = 5_000;
 
@@ -478,15 +474,60 @@ export async function fetchWithDeadline(
           }, timeoutMs)
         : undefined;
 
-    try {
-        return await fetch(url, { ...init, signal: ac.signal });
-    } catch (err) {
-        if (timedOut) throw timeoutError(phase, timeoutMs, err);
-        throw err;
-    } finally {
+    // A response nobody reads must not hold the event loop open.
+    (tid as unknown as { unref?: () => void } | undefined)?.unref?.();
+
+    const release = () => {
         if (tid !== undefined) clearTimeout(tid);
         external?.removeEventListener("abort", onExternalAbort);
+    };
+    const relabel = (err: unknown) => (timedOut ? timeoutError(phase, timeoutMs, err) : err);
+
+    let res: Response;
+    try {
+        res = await fetch(url, { ...init, signal: ac.signal });
+    } catch (err) {
+        release();
+        throw relabel(err);
     }
+    return armBodyDeadline(res, release, relabel);
+}
+
+/**
+ * Keep the deadline armed until the response body settles.
+ *
+ * `fetch()` resolves when the response *headers* arrive, so clearing the timer
+ * there would leave `res.json()` / `res.text()` unbounded: a server that sends
+ * headers promptly and then trickles the body could outlive the budget the
+ * caller named. The read methods carry the timer instead, and relabel an abort
+ * our own timer caused so a slow body still surfaces as a phase-tagged
+ * `TimeoutError` rather than a bare `AbortError`.
+ */
+function armBodyDeadline(
+    res: Response,
+    release: () => void,
+    relabel: (err: unknown) => unknown,
+): Response {
+    const target = res as unknown as Record<string, unknown>;
+    for (const name of ["json", "text", "arrayBuffer", "blob", "formData"]) {
+        const original = target[name];
+        if (typeof original !== "function") continue;
+        const read = (original as (...args: unknown[]) => Promise<unknown>).bind(res);
+        Object.defineProperty(target, name, {
+            configurable: true,
+            writable: true,
+            value: async (...args: unknown[]) => {
+                try {
+                    return await read(...args);
+                } catch (err) {
+                    throw relabel(err);
+                } finally {
+                    release();
+                }
+            },
+        });
+    }
+    return res;
 }
 
 // ============================================================

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -467,15 +467,14 @@ export async function fetchWithDeadline(
         if (external.aborted) ac.abort();
         else external.addEventListener("abort", onExternalAbort, { once: true });
     }
+    // Deliberately not `unref()`d: this timer is what bounds the body read
+    // below, so it has to be able to fire on an otherwise-idle loop.
     const tid = bounded
         ? setTimeout(() => {
               timedOut = true;
               ac.abort();
           }, timeoutMs)
         : undefined;
-
-    // A response nobody reads must not hold the event loop open.
-    (tid as unknown as { unref?: () => void } | undefined)?.unref?.();
 
     const release = () => {
         if (tid !== undefined) clearTimeout(tid);

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -391,6 +391,105 @@ export function clockDriftErrorFromResponse(
 }
 
 // ============================================================
+// Bounded fetch (WALM-598)
+// ============================================================
+
+/**
+ * Default deadline for the unauthenticated preflight round-trips
+ * (`GET /version`, `GET /health`, `GET /config`) the SDK makes before it can
+ * dispatch a signed request.
+ *
+ * These used to run with no signal and no timeout at all. Because they are
+ * awaited *inside* a caller's request budget, a relayer whose `/health` p50
+ * had drifted to ~9s silently consumed most of `recall()`'s 15s
+ * `AbortController` window, and the resulting `AbortError` surfaced on the
+ * `/api/recall` fetch even though recall itself was healthy (GH #438).
+ * Each preflight now carries its own independent budget so it can neither
+ * hang forever nor eat someone else's.
+ */
+export const DEFAULT_PREFLIGHT_TIMEOUT_MS = 5_000;
+
+/** Default deadline for the `/api/recall` request itself. */
+export const DEFAULT_RECALL_TIMEOUT_MS = 15_000;
+
+/**
+ * Error thrown when one of the SDK's bounded fetches blows its deadline.
+ *
+ * `phase` names the round-trip that actually stalled — `"preflight GET
+ * /version"`, `"POST /api/recall"` — which is the diagnostic that was missing
+ * when every stall in the chain surfaced as an unlabeled `AbortError` on the
+ * final request.
+ */
+export interface TimeoutError extends Error {
+    name: "TimeoutError";
+    /** Which round-trip exceeded its budget. */
+    phase: string;
+    /** The budget that was exceeded, in milliseconds. */
+    timeoutMs: number;
+}
+
+/** True when `err` is a `TimeoutError` raised by `fetchWithDeadline`. */
+export function isTimeoutError(err: unknown): err is TimeoutError {
+    return err instanceof Error && err.name === "TimeoutError" && "phase" in err;
+}
+
+function timeoutError(phase: string, timeoutMs: number, cause: unknown): TimeoutError {
+    const err = new Error(
+        `Walrus Memory request timed out after ${timeoutMs}ms during ${phase}.`,
+    ) as TimeoutError;
+    err.name = "TimeoutError";
+    err.phase = phase;
+    err.timeoutMs = timeoutMs;
+    (err as Error & { cause?: unknown }).cause = cause;
+    return err;
+}
+
+/**
+ * `fetch` under an independent abort budget.
+ *
+ * A non-finite or non-positive `timeoutMs` disables the deadline (the caller
+ * opted out); an `external` signal is still honoured in that case.
+ *
+ * Aborts triggered by our own timer are rethrown as a `TimeoutError` tagged
+ * with `phase`; an abort that came from `external` is left alone so callers
+ * keep distinguishing "I cancelled this" from "this timed out".
+ */
+export async function fetchWithDeadline(
+    url: string,
+    init: RequestInit,
+    timeoutMs: number,
+    phase: string,
+    external?: AbortSignal,
+): Promise<Response> {
+    const bounded = Number.isFinite(timeoutMs) && timeoutMs > 0;
+    if (!bounded && !external) return fetch(url, init);
+
+    const ac = new AbortController();
+    let timedOut = false;
+    const onExternalAbort = () => ac.abort();
+    if (external) {
+        if (external.aborted) ac.abort();
+        else external.addEventListener("abort", onExternalAbort, { once: true });
+    }
+    const tid = bounded
+        ? setTimeout(() => {
+              timedOut = true;
+              ac.abort();
+          }, timeoutMs)
+        : undefined;
+
+    try {
+        return await fetch(url, { ...init, signal: ac.signal });
+    } catch (err) {
+        if (timedOut) throw timeoutError(phase, timeoutMs, err);
+        throw err;
+    } finally {
+        if (tid !== undefined) clearTimeout(tid);
+        external?.removeEventListener("abort", onExternalAbort);
+    }
+}
+
+// ============================================================
 // Delegate Key → Sui Address Derivation
 // ============================================================
 

--- a/packages/sdk/test/recall-timeout-budget.test.mjs
+++ b/packages/sdk/test/recall-timeout-budget.test.mjs
@@ -235,16 +235,41 @@ test("the deadline covers the response body, not just the headers", async () => 
     });
 });
 
-test("a body read inside the deadline releases the timer", async () => {
-    globalThis.fetch = async () => new Response(JSON.stringify({ ok: true }), { status: 200 });
+test("the timer survives the headers and is released by the body read", async () => {
+    // Both halves of the fix in one assertion pair: the deadline must still be
+    // armed when fetch() resolves (otherwise a trickled body is unbounded), and
+    // it must be cleared once the body settles (otherwise every request leaks a
+    // pending timer). Asserting only that json() returns would pass either way.
+    const live = new Set();
+    const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
+    globalThis.setTimeout = (...args) => {
+        const id = realSetTimeout(...args);
+        live.add(id);
+        return id;
+    };
+    globalThis.clearTimeout = (id) => {
+        live.delete(id);
+        return realClearTimeout(id);
+    };
 
-    const res = await fetchWithDeadline(
-        "https://relayer.test/version",
-        { method: "GET" },
-        5_000,
-        "preflight GET /version",
-    );
-    assert.deepEqual(await res.json(), { ok: true });
+    try {
+        globalThis.fetch = async () => new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+        const res = await fetchWithDeadline(
+            "https://relayer.test/version",
+            { method: "GET" },
+            5_000,
+            "preflight GET /version",
+        );
+        assert.equal(live.size, 1, "the deadline must outlive the response headers");
+
+        assert.deepEqual(await res.json(), { ok: true });
+        assert.equal(live.size, 0, "reading the body must release the deadline");
+    } finally {
+        globalThis.setTimeout = realSetTimeout;
+        globalThis.clearTimeout = realClearTimeout;
+    }
 });
 
 test("the default recall budget is unchanged at 15s", async () => {

--- a/packages/sdk/test/recall-timeout-budget.test.mjs
+++ b/packages/sdk/test/recall-timeout-budget.test.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { MemWal } from "../dist/memwal.js";
-import { isTimeoutError, DEFAULT_RECALL_TIMEOUT_MS } from "../dist/utils.js";
+import { fetchWithDeadline, isTimeoutError, DEFAULT_RECALL_TIMEOUT_MS } from "../dist/utils.js";
 
 // WALM-598 / GH #438.
 //
@@ -201,6 +201,50 @@ test("health() is bounded by the preflight budget", async () => {
         assert.equal(err.phase, "GET /health");
         return true;
     });
+});
+
+test("the deadline covers the response body, not just the headers", async () => {
+    // fetch() resolves at the headers. A server that answers promptly and then
+    // trickles the body must still blow the budget the caller named, and blow
+    // it as a phase-tagged TimeoutError rather than a bare AbortError.
+    globalThis.fetch = async (_url, init = {}) =>
+        new Response(
+            new ReadableStream({
+                start(controller) {
+                    init.signal?.addEventListener(
+                        "abort",
+                        () => controller.error(abortError()),
+                        { once: true },
+                    );
+                },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        );
+
+    const res = await fetchWithDeadline(
+        "https://relayer.test/api/recall",
+        { method: "POST" },
+        25,
+        "POST /api/recall",
+    );
+    await assert.rejects(res.json(), (err) => {
+        assert.ok(isTimeoutError(err));
+        assert.equal(err.phase, "POST /api/recall");
+        assert.equal(err.timeoutMs, 25);
+        return true;
+    });
+});
+
+test("a body read inside the deadline releases the timer", async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify({ ok: true }), { status: 200 });
+
+    const res = await fetchWithDeadline(
+        "https://relayer.test/version",
+        { method: "GET" },
+        5_000,
+        "preflight GET /version",
+    );
+    assert.deepEqual(await res.json(), { ok: true });
 });
 
 test("the default recall budget is unchanged at 15s", async () => {

--- a/packages/sdk/test/recall-timeout-budget.test.mjs
+++ b/packages/sdk/test/recall-timeout-budget.test.mjs
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { MemWal } from "../dist/memwal.js";
+import { isTimeoutError, DEFAULT_RECALL_TIMEOUT_MS } from "../dist/utils.js";
+
+// WALM-598 / GH #438.
+//
+// `recall()` used to arm a single 15s AbortController *before* calling
+// `signedRequest`, which then awaited two unabortable, untimed preflights —
+// `ensureCompatibleRelayer()` (`GET /version`, falling back to `GET /health`)
+// and `buildSealSession()` (`GET /config` + a Sui RPC round-trip). A relayer
+// whose `/health` p50 had drifted to ~9s therefore spent most of the caller's
+// budget before `/api/recall` was even dispatched, and the resulting
+// `AbortError` surfaced on the recall fetch even though recall was healthy.
+//
+// The budget now starts on the recall request itself; the preflights carry
+// their own independent deadlines.
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+/**
+ * Resolve `factory()` after `ms`, or reject with an `AbortError` if the
+ * caller's signal fires first — i.e. behave like a real `fetch`. Without the
+ * signal handling these tests could not observe an abort at all.
+ */
+function delayed(ms, factory, signal) {
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(abortError());
+            return;
+        }
+        const tid = setTimeout(() => resolve(factory()), ms);
+        signal?.addEventListener(
+            "abort",
+            () => {
+                clearTimeout(tid);
+                reject(abortError());
+            },
+            { once: true },
+        );
+    });
+}
+
+function abortError() {
+    return Object.assign(new Error("This operation was aborted"), { name: "AbortError" });
+}
+
+const VERSION_BODY = {
+    apiVersion: "1.0.0",
+    relayerVersion: "1.0.0",
+    minSupportedSdk: { typescript: "0.0.4" },
+};
+
+/**
+ * Route stub with per-path latency. `never` means "hang until aborted",
+ * which is how a wedged preflight looks to the client.
+ */
+function stubServer({ versionDelayMs = 0, recallDelayMs = 0, hits = [] } = {}) {
+    const seen = [];
+    globalThis.fetch = async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        seen.push(path);
+        if (path === "/version") {
+            if (versionDelayMs === "never") return delayed(1e9, () => null, init.signal);
+            return delayed(versionDelayMs, () => Response.json(VERSION_BODY), init.signal);
+        }
+        if (path === "/api/recall" && init.method === "POST") {
+            return delayed(
+                recallDelayMs,
+                () => Response.json({ results: hits, total: hits.length }),
+                init.signal,
+            );
+        }
+        throw new Error(`unexpected request ${path}`);
+    };
+    return seen;
+}
+
+function client(config = {}) {
+    const c = MemWal.create({
+        key: new Uint8Array(32).fill(1),
+        accountId: "0x1",
+        serverUrl: "https://relayer.example",
+        ...config,
+    });
+    // Standard SEAL stub — building a real SessionKey needs @mysten/seal and
+    // a live Sui RPC. `buildSealSession` is awaited inside `signedRequest`,
+    // i.e. in the same preflight window as `/config`.
+    c.buildSealSession = async () => "test-session";
+    return c;
+}
+
+test("a slow /version preflight does not abort a healthy recall", async () => {
+    // The regression, reproduced at test speed: the preflight takes longer
+    // than the entire recall budget. Before WALM-598 the shared
+    // AbortController had already fired by the time `/api/recall` was
+    // dispatched, so this rejected with an unlabeled AbortError.
+    const seen = stubServer({ versionDelayMs: 120, recallDelayMs: 0 });
+
+    const result = await client({ recallTimeoutMs: 40 }).recall({ query: "food allergies" });
+
+    assert.deepEqual(result.results, []);
+    assert.deepEqual(seen, ["/version", "/api/recall"]);
+});
+
+test("a slow SEAL session build does not abort a healthy recall", async () => {
+    // `buildSealSession()` is the other unabortable preflight inside the old
+    // budget: on a cold cache it fetches /config, dynamic-imports @mysten/seal
+    // and @mysten/sui, and calls SessionKey.create() against Sui RPC.
+    stubServer({ recallDelayMs: 0 });
+
+    const c = client({ recallTimeoutMs: 40 });
+    c.buildSealSession = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        return "test-session";
+    };
+
+    const result = await c.recall({ query: "food allergies" });
+    assert.deepEqual(result.results, []);
+});
+
+test("recall honours a per-call timeoutMs", async () => {
+    stubServer({ recallDelayMs: 5_000 });
+
+    await assert.rejects(
+        client().recall({ query: "food allergies", timeoutMs: 30 }),
+        (err) => {
+            assert.ok(isTimeoutError(err), `expected a TimeoutError, got ${err?.name}`);
+            assert.equal(err.timeoutMs, 30);
+            return true;
+        },
+    );
+});
+
+test("recall honours a client-level recallTimeoutMs", async () => {
+    stubServer({ recallDelayMs: 5_000 });
+
+    await assert.rejects(client({ recallTimeoutMs: 30 }).recall({ query: "q" }), (err) => {
+        assert.ok(isTimeoutError(err));
+        assert.equal(err.timeoutMs, 30);
+        return true;
+    });
+});
+
+test("a per-call timeoutMs overrides the client default", async () => {
+    stubServer({ recallDelayMs: 5_000 });
+
+    await assert.rejects(
+        client({ recallTimeoutMs: 60_000 }).recall({ query: "q", timeoutMs: 25 }),
+        (err) => {
+            assert.equal(err.timeoutMs, 25);
+            return true;
+        },
+    );
+});
+
+test("a recall timeout names the recall request as the phase", async () => {
+    // The diagnostic that was missing: every stall in the chain used to
+    // surface as an unlabeled AbortError on the recall fetch.
+    stubServer({ recallDelayMs: 5_000 });
+
+    await assert.rejects(client().recall({ query: "q", timeoutMs: 25 }), (err) => {
+        assert.equal(err.phase, "POST /api/recall");
+        assert.match(err.message, /timed out after 25ms during POST \/api\/recall/);
+        return true;
+    });
+});
+
+test("a preflight timeout names the preflight as the phase", async () => {
+    // A wedged /version now fails on its own budget instead of hanging
+    // forever (it carried no signal at all before) or being misreported as
+    // a recall abort.
+    stubServer({ versionDelayMs: "never" });
+
+    await assert.rejects(
+        client({ preflightTimeoutMs: 30, recallTimeoutMs: 5_000 }).recall({ query: "q" }),
+        (err) => {
+            assert.ok(isTimeoutError(err));
+            assert.equal(err.phase, "preflight GET /version");
+            assert.equal(err.timeoutMs, 30);
+            return true;
+        },
+    );
+});
+
+test("health() is bounded by the preflight budget", async () => {
+    globalThis.fetch = async (url, init = {}) => {
+        assert.equal(new URL(url).pathname, "/health");
+        return delayed(1e9, () => null, init.signal);
+    };
+
+    await assert.rejects(client({ preflightTimeoutMs: 30 }).health(), (err) => {
+        assert.ok(isTimeoutError(err));
+        assert.equal(err.phase, "GET /health");
+        return true;
+    });
+});
+
+test("the default recall budget is unchanged at 15s", async () => {
+    assert.equal(DEFAULT_RECALL_TIMEOUT_MS, 15_000);
+});
+
+test("RecallOptions and MemWalConfig declare the timeout knobs", () => {
+    // A .mjs test cannot catch a missing type; assert on the emitted .d.ts,
+    // which is what a TypeScript consumer actually resolves.
+    const dts = readFileSync(
+        fileURLToPath(new URL("../dist/types.d.ts", import.meta.url)),
+        "utf8",
+    );
+
+    assert.match(dts, /recallTimeoutMs\?: number;/);
+    assert.match(dts, /preflightTimeoutMs\?: number;/);
+});

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -154,48 +154,99 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> 
     })
 }
 
-const WRITE_READY_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(2);
-const WRITE_READY_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+/// How long a probe result is trusted before `/health` re-probes.
+const WRITE_READY_TTL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Hard cap on the outbound sidecar probe. `/health` is a connectivity check,
+/// so the handler body must stay bounded well under any client's request
+/// budget (WALM-598 / GH #438).
+const SIDECAR_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(300);
+
+/// Cap on the Postgres write-readiness probe, unchanged from WALM-612. The
+/// two probes run concurrently, so this is what bounds `/health`; a slower
+/// query fails open at `warn` rather than reporting a false negative.
+const POSTGRES_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Neon refuses `smgrextend` once cluster size is at the cap; treat less
 /// than 1MB remaining as not writable so `/health` trips before the next
 /// page allocation fails.
 const POSTGRES_EXTEND_HEADROOM_BYTES: i64 = 1024 * 1024;
 
-/// Sidecar liveness AND Postgres can accept writes. Cached together so
-/// unsigned `/health` probes do not fan out on every load-balancer tick.
-async fn write_ready(state: &std::sync::Arc<AppState>) -> bool {
-    {
-        let cache = WRITE_READY_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some((at, ready)) = *cache {
-            if at.elapsed() < WRITE_READY_CACHE_TTL {
-                return ready;
-            }
+/// Memoized `write_ready` value plus the instant it was observed.
+///
+/// `tokio::sync::RwLock`, not `std::sync::Mutex`, for two reasons:
+///
+/// 1. This is taken on an async request path. A blocking mutex parked a
+///    Tokio worker thread for the duration of the outbound probe.
+/// 2. `std::sync::Mutex` poisons. The read side recovered with
+///    `unwrap_or_else(|e| e.into_inner())` but the write side was a bare
+///    `if let Ok(..)`, so a single panic while the lock was held froze the
+///    cached timestamp forever: `elapsed()` stayed past the TTL and *every*
+///    subsequent `/health` fanned out to the sidecar for the life of the
+///    process. Tokio's locks have no poison flag, so an unwind through the
+///    critical section just drops the guard.
+type WriteReadyCache = tokio::sync::RwLock<Option<(std::time::Instant, bool)>>;
+
+static WRITE_READY_CACHE: WriteReadyCache = tokio::sync::RwLock::const_new(None);
+
+/// Cache + single-flight wrapper around a write-readiness probe.
+///
+/// The TTL used to be *checked* under the lock but not *held* across the
+/// probe, so every request that arrived while a probe was in flight started
+/// its own — a stampede at each TTL boundary, which CI's added `/health`
+/// polling made routine. The write guard is now held for the probe, so
+/// concurrent callers either read the fresh value or wait for the single
+/// in-flight probe (bounded by the probe's own timeout).
+///
+/// Generic over the probe so the cache semantics are testable without a live
+/// `AppState` or sidecar.
+async fn write_ready_cached<F, Fut>(
+    cache: &WriteReadyCache,
+    ttl: std::time::Duration,
+    probe: F,
+) -> bool
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    // Fast path: a fresh value is readable in parallel by every caller.
+    if let Some((at, ready)) = *cache.read().await {
+        if at.elapsed() < ttl {
+            return ready;
         }
     }
 
-    let (sidecar, postgres) = tokio::join!(sidecar_write_ready(state), postgres_write_ready(state));
-    let ready = sidecar && postgres;
-    if let Ok(mut cache) = WRITE_READY_CACHE.lock() {
-        *cache = Some((std::time::Instant::now(), ready));
+    let mut guard = cache.write().await;
+    // Re-check: a racing caller may have refreshed while we waited for the
+    // write lock. This is what collapses the stampede onto one probe.
+    if let Some((at, ready)) = *guard {
+        if at.elapsed() < ttl {
+            return ready;
+        }
     }
+
+    let ready = probe().await;
+    *guard = Some((std::time::Instant::now(), ready));
     ready
 }
 
-async fn sidecar_write_ready(state: &std::sync::Arc<AppState>) -> bool {
-    let url = format!("{}/health", state.config.sidecar_url.trim_end_matches('/'));
-    match state
-        .http_client
-        .get(&url)
-        .timeout(WRITE_READY_PROBE_TIMEOUT)
-        .send()
-        .await
-    {
-        Ok(resp) => resp.status().is_success(),
-        Err(err) => {
-            tracing::debug!(error = %err, "sidecar health probe failed");
-            false
-        }
-    }
+/// Sidecar liveness AND Postgres can accept writes. Cached together so
+/// unsigned `/health` probes do not fan out on every load-balancer tick.
+async fn write_ready(state: &std::sync::Arc<AppState>) -> bool {
+    write_ready_cached(&WRITE_READY_CACHE, WRITE_READY_TTL, || {
+        probe_write_ready(state)
+    })
+    .await
+}
+
+/// Both halves of write-readiness, run concurrently so `/health` costs one
+/// probe window rather than two.
+async fn probe_write_ready(state: &std::sync::Arc<AppState>) -> bool {
+    let (sidecar, postgres) = tokio::join!(
+        probe_sidecar_write_ready(state),
+        postgres_write_ready(state)
+    );
+    sidecar && postgres
 }
 
 /// Self-hosted Postgres without `neon.max_cluster_size` stays ready (sidecar
@@ -204,7 +255,7 @@ async fn sidecar_write_ready(state: &std::sync::Arc<AppState>) -> bool {
 /// timeouts fail open at `warn` so CI `wait-for-relayer` is not blocked.
 async fn postgres_write_ready(state: &std::sync::Arc<AppState>) -> bool {
     match tokio::time::timeout(
-        WRITE_READY_PROBE_TIMEOUT,
+        POSTGRES_PROBE_TIMEOUT,
         probe_postgres_write_ready(state.db.pool()),
     )
     .await
@@ -313,8 +364,52 @@ fn postgres_can_accept_writes(used_bytes: i64, max_bytes: i64) -> bool {
     used_bytes.saturating_add(POSTGRES_EXTEND_HEADROOM_BYTES) < max_bytes
 }
 
-static WRITE_READY_CACHE: std::sync::Mutex<Option<(std::time::Instant, bool)>> =
-    std::sync::Mutex::new(None);
+/// One outbound `GET {sidecar}/health`, instrumented like every other sidecar
+/// call in this codebase (`storage/walrus.rs`, `storage/seal.rs`). Before
+/// WALM-598 this path emitted no metric at all and logged failures at
+/// `debug!`, which production log levels filter out — so neither the probe's
+/// latency nor its failure rate was measurable while `/health` p50 was being
+/// blamed for SDK aborts.
+async fn probe_sidecar_write_ready(state: &std::sync::Arc<AppState>) -> bool {
+    let url = format!("{}/health", state.config.sidecar_url.trim_end_matches('/'));
+    let started = std::time::Instant::now();
+    match state
+        .http_client
+        .get(&url)
+        .timeout(SIDECAR_PROBE_TIMEOUT)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let status = resp.status();
+            crate::observability::observe_external(
+                "sidecar",
+                "health_probe",
+                status.as_u16().to_string().as_str(),
+                started.elapsed(),
+            );
+            if !status.is_success() {
+                crate::observability::record_sidecar_failure("health_probe", "http_error");
+                tracing::warn!(
+                    status = %status,
+                    "sidecar health probe returned non-success; reporting write_ready=false"
+                );
+            }
+            status.is_success()
+        }
+        Err(err) => {
+            crate::observability::observe_external(
+                "sidecar",
+                "health_probe",
+                "transport_error",
+                started.elapsed(),
+            );
+            crate::observability::record_sidecar_failure("health_probe", "transport_error");
+            tracing::warn!(error = %err, "sidecar health probe failed");
+            false
+        }
+    }
+}
 
 /// GET /version
 pub async fn version() -> Json<crate::compatibility::VersionResponse> {
@@ -1323,7 +1418,7 @@ mod tests {
     #[test]
     fn postgres_write_ready_probe_timeout_is_one_second() {
         assert_eq!(
-            super::WRITE_READY_PROBE_TIMEOUT,
+            super::POSTGRES_PROBE_TIMEOUT,
             std::time::Duration::from_secs(1)
         );
     }
@@ -1639,5 +1734,116 @@ mod tests {
             !non_empty.is_empty(),
             "non-empty namespace must pass the validation predicate"
         );
+    }
+
+    // ── /health write-readiness cache (WALM-598) ─────────────────
+
+    mod write_ready_cache {
+        use super::super::{write_ready_cached, WriteReadyCache};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        const TTL: Duration = Duration::from_secs(2);
+
+        #[tokio::test]
+        async fn fresh_value_is_served_without_reprobing() {
+            let cache: WriteReadyCache = tokio::sync::RwLock::new(None);
+            let probes = AtomicUsize::new(0);
+            let probe = || async {
+                probes.fetch_add(1, Ordering::SeqCst);
+                true
+            };
+
+            assert!(write_ready_cached(&cache, TTL, probe).await);
+            assert!(write_ready_cached(&cache, TTL, probe).await);
+            assert_eq!(
+                probes.load(Ordering::SeqCst),
+                1,
+                "second call must hit cache"
+            );
+        }
+
+        #[tokio::test]
+        async fn expired_value_reprobes() {
+            let cache: WriteReadyCache = tokio::sync::RwLock::new(None);
+            let probes = AtomicUsize::new(0);
+            let probe = || async {
+                probes.fetch_add(1, Ordering::SeqCst);
+                true
+            };
+
+            // A zero TTL makes every stored value instantly stale.
+            assert!(write_ready_cached(&cache, Duration::ZERO, probe).await);
+            assert!(write_ready_cached(&cache, Duration::ZERO, probe).await);
+            assert_eq!(probes.load(Ordering::SeqCst), 2);
+        }
+
+        /// The stampede this replaced: the old code checked the TTL under the
+        /// lock but released it before probing, so N concurrent `/health`
+        /// requests arriving at a TTL boundary each fired their own outbound
+        /// probe. Holding the write guard across the probe collapses them.
+        #[tokio::test]
+        async fn concurrent_callers_share_one_probe() {
+            let cache: Arc<WriteReadyCache> = Arc::new(tokio::sync::RwLock::new(None));
+            let probes = Arc::new(AtomicUsize::new(0));
+
+            let mut handles = Vec::new();
+            for _ in 0..16 {
+                let cache = Arc::clone(&cache);
+                let probes = Arc::clone(&probes);
+                handles.push(tokio::spawn(async move {
+                    write_ready_cached(&cache, TTL, || async move {
+                        probes.fetch_add(1, Ordering::SeqCst);
+                        // Yield across an await point so the other tasks are
+                        // genuinely in flight while this probe runs.
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        true
+                    })
+                    .await
+                }));
+            }
+
+            for handle in handles {
+                assert!(handle.await.unwrap());
+            }
+            assert_eq!(
+                probes.load(Ordering::SeqCst),
+                1,
+                "concurrent /health requests must not stampede the sidecar"
+            );
+        }
+
+        /// Regression for the poisoned-mutex bug: with `std::sync::Mutex` a
+        /// panic inside the critical section poisoned the lock, the bare
+        /// `if let Ok(mut cache)` write silently stopped refreshing, and the
+        /// frozen timestamp made every later request bypass the cache
+        /// forever. Tokio locks do not poison, so the cache must keep working.
+        #[tokio::test]
+        async fn panicking_probe_does_not_disable_the_cache() {
+            static PANIC_CACHE: WriteReadyCache = tokio::sync::RwLock::const_new(None);
+
+            let panicked = tokio::spawn(async {
+                write_ready_cached(&PANIC_CACHE, TTL, || async {
+                    panic!("probe blew up while holding the cache lock");
+                })
+                .await
+            })
+            .await;
+            assert!(panicked.is_err(), "probe was expected to panic");
+
+            let probes = AtomicUsize::new(0);
+            let probe = || async {
+                probes.fetch_add(1, Ordering::SeqCst);
+                true
+            };
+            assert!(write_ready_cached(&PANIC_CACHE, TTL, probe).await);
+            assert!(write_ready_cached(&PANIC_CACHE, TTL, probe).await);
+            assert_eq!(
+                probes.load(Ordering::SeqCst),
+                1,
+                "cache must still memoize after a panicking probe"
+            );
+        }
     }
 }

--- a/services/server/src/routes/admin.rs
+++ b/services/server/src/routes/admin.rs
@@ -176,8 +176,8 @@ const POSTGRES_EXTEND_HEADROOM_BYTES: i64 = 1024 * 1024;
 ///
 /// `tokio::sync::RwLock`, not `std::sync::Mutex`, for two reasons:
 ///
-/// 1. This is taken on an async request path. A blocking mutex parked a
-///    Tokio worker thread for the duration of the outbound probe.
+/// 1. The write guard now spans the probe (single-flight), and a
+///    `std::sync::Mutex` must not be held across an `.await`.
 /// 2. `std::sync::Mutex` poisons. The read side recovered with
 ///    `unwrap_or_else(|e| e.into_inner())` but the write side was a bare
 ///    `if let Ok(..)`, so a single panic while the lock was held froze the
@@ -365,11 +365,8 @@ fn postgres_can_accept_writes(used_bytes: i64, max_bytes: i64) -> bool {
 }
 
 /// One outbound `GET {sidecar}/health`, instrumented like every other sidecar
-/// call in this codebase (`storage/walrus.rs`, `storage/seal.rs`). Before
-/// WALM-598 this path emitted no metric at all and logged failures at
-/// `debug!`, which production log levels filter out — so neither the probe's
-/// latency nor its failure rate was measurable while `/health` p50 was being
-/// blamed for SDK aborts.
+/// call in this codebase (`storage/walrus.rs`, `storage/seal.rs`) so the
+/// probe's latency and failure rate are measurable.
 async fn probe_sidecar_write_ready(state: &std::sync::Arc<AppState>) -> bool {
     let url = format!("{}/health", state.config.sidecar_url.trim_end_matches('/'));
     let started = std::time::Instant::now();


### PR DESCRIPTION
Fixes WALM-598 — https://linear.app/mysten-labs/issue/WALM-598
Source: https://github.com/MystenLabs/MemWal/issues/438

## The `/health` handler was not the cascade

The report reads as "prod `/health` p50 is ~8–10s, so the SDK's 15s recall abort trips." The handler cannot produce that on its own. `health()` (`services/server/src/routes/admin.rs`) makes exactly one I/O call — `sidecar_write_ready`, a `GET {SIDECAR_URL}/health` bounded by `.timeout(300ms)` and memoized behind a 2s TTL. No DB, Sui, Walrus, Seal or Redis. The handler body is hard-capped at ~300ms.

The cascade was on the client. `recall()` armed a single 15s `AbortController` **before** calling `signedRequest`, which then awaited two preflights that were both unabortable and untimed:

- `ensureCompatibleRelayer()` → `GET /version`, falling back to `GET /health` — no signal, no timeout
- `buildSealSession()` → `GET /config` (no signal, no timeout), dynamic imports of `@mysten/seal` / `@mysten/sui`, then `SessionKey.create()` against Sui RPC/gRPC

Only the final `/api/recall` fetch received the signal. So up to four round-trips ran inside the 15s budget before recall was dispatched, none of them abortable. A ~9s `/health` left ~6s for the actual recall, and the `AbortError` surfaced on the recall fetch even though recall itself was healthy. Both preflights are memoized, so this hit the **first** recall of a process and every recall after the 5-minute SEAL session expiry.

`15000` was also the SDK's only `AbortController` and was not configurable — not exposed on `RecallOptions` or `RecallParams`.

## SDK

**The budget now covers only the request it names.** The deadline moved into `signedRequest`, armed after `ensureCompatibleRelayer()` and `buildSealSession()` have resolved. Preflight latency is no longer charged to recall.

**Each preflight got its own independent deadline.** `GET /version`, `GET /health` and `GET /config` run through a new `fetchWithDeadline` helper with `preflightTimeoutMs` (default 5000, per round-trip). They previously carried no signal at all, so a wedged relayer could hang a caller forever. Worst-case total latency stays bounded.

**The recall timeout is configurable.** `MemWalConfig.recallTimeoutMs` (client-level) and `RecallOptions.timeoutMs` (per-call, wins). Default stays 15000, so existing callers are unaffected. `0` / `Infinity` opts out.

**Timeouts say which phase blew.** A blown budget now throws a `TimeoutError` carrying `phase` (`"preflight GET /version"`, `"POST /api/recall"`, `"GET /health"`) and `timeoutMs`, rather than an unlabeled `AbortError` on the recall fetch regardless of which round-trip actually stalled. `isTimeoutError()` and the `TimeoutError` type are exported.

**Also bounded:** the standalone `MemWal.health()` and the same `/version` → `/health` fallback in `packages/sdk/src/manual.ts`.

### Behaviour change worth a reviewer's eye

Recall used to reject with a DOM `AbortError`; it now rejects with a `TimeoutError`. Nothing in this repo catches recall's `AbortError` by name (checked `packages/`, `apps/`, `docs/`), but it is a visible change for external callers and is called out in the SDK changelog.

## Server

These support AC 1 (keep `/health` cheap and, crucially, *measurable*) rather than fixing the 9s directly — the handler was already 300ms-capped.

- **Single-flight.** The 2s TTL was checked under the lock but not held across the probe, so every request arriving during an in-flight probe started its own — a stampede at each TTL boundary, which the added CI `/health` polling (`4de09d4a`, `48671a57`, `3a79fafa`) made routine. The write guard is now held for the probe.
- **Poisoned-mutex fix.** The read side recovered with `unwrap_or_else(|e| e.into_inner())`; the write side was a bare `if let Ok(mut cache)`. Once poisoned, the timestamp froze, `at.elapsed()` stayed `> 2s` forever, and *every* `/health` fanned out to the sidecar for the life of the process.
- **Async-aware primitive.** `std::sync::Mutex` → `tokio::sync::RwLock`, following the `Arc<tokio::sync::RwLock<..>>` idiom in `services/server/src/storage/sui.rs`. It also cannot poison, which is what makes the previous point structurally impossible rather than merely patched.
- **Instrumentation.** The probe now calls `observe_external("sidecar", "health_probe", ..)` and `record_sidecar_failure`, matching `storage/walrus.rs` / `storage/seal.rs`, and failures log at `warn!` instead of `debug!` (filtered out in production). Probe latency, failure count and cache hit-rate were previously unmeasurable — which is why the actual p50 contributor could not be identified from telemetry.

The `/health` response shape (`services/server/src/types.rs`) and its public, unauthenticated status are unchanged.

## Follow-up bug found, not fixed here

The saturation monitor at `services/server/src/main.rs:1206-1237` reads `queuedWalrusUploads`, `activeWalrusUploads` and `walrusUploadLimits.globalCapacity` from the sidecar's `/health`. Those fields only exist on the sidecar's `/ready` (`services/server/scripts/sidecar/routes/health.ts:103-138`); `/health` returns `{status, uptimeMs}` only. All three `.as_u64().unwrap_or(0)` calls therefore always yield 0, `queued > saturation_threshold` is never true, and **the saturation alert can never fire**. Verified on this branch: `main.rs:726` builds `health_url` as `{sidecar_url}/health` and `main.rs:1206` reuses it directly. Deserves its own ticket.

## Tests

**SDK** — `packages/sdk/test/recall-timeout-budget.test.mjs`, 10 tests:

- a slow `/version` preflight does not abort a healthy recall (the regression: preflight 120ms, recall budget 40ms — this rejected before)
- a slow SEAL session build does not abort a healthy recall (the other preflight inside the old budget)
- per-call `timeoutMs`, client-level `recallTimeoutMs`, and per-call overriding client-level
- a recall timeout names `"POST /api/recall"` as the phase
- a preflight timeout names `"preflight GET /version"` and fires on its own budget rather than hanging
- `health()` is bounded by the preflight budget
- the default budget is still 15000
- the emitted `.d.ts` declares both config knobs

The stub honours `init.signal` (rejecting with a real `AbortError`) so an abort is actually observable; the existing `remember-idempotency.test.mjs` pattern was otherwise followed. Note that file's `/api/config` route is dead code — the SDK fetches `${serverUrl}/config` — so it was not copied.

**Server** — `write_ready_cache` module in `admin.rs`, 4 tests over a probe-generic `write_ready_cached` so the cache semantics are testable without a live `AppState`: fresh value served without re-probing, expired value re-probes, 16 concurrent callers share exactly one probe, and a panicking probe does not disable the cache (the poisoning regression).

### Results

```
pnpm --filter @mysten-incubation/memwal build   # tsc, clean
pnpm --filter @mysten-incubation/memwal test    # tests 121 | pass 121 | fail 0
pnpm --filter @mysten-incubation/memwal typecheck  # clean, exit 0

cargo test (services/server)  # 694 passed; 0 failed; 37 ignored — exit 0
```

### Pre-existing failures on `dev`, unrelated to this PR

`cargo clippy --all-targets -- -D warnings` fails with 612 diagnostics / "256 previous errors" on rustc 1.97.0. Verified pre-existing: reverting `admin.rs` to its `dev` content and re-running produced the **identical** 612-diagnostic, exit-101 result. None reference `admin.rs`. They cluster in `types.rs` (102), `jobs.rs` (63), `storage/security_delete_store.rs` (55), `observability.rs` (46), `alerts.rs` (45) and are mostly `unused import` / `constant is never used` / `too_many_arguments` under `--all-targets`, e.g.:

```
error: unused import: `plaintext::PlaintextEngine`
error: constant `ALERT_TO_SLACK_ENV` is never used
error: unnecessary use of `clone` to create a slice from a reference
   --> src/storage/db.rs:614:34
error: this assertion has a constant value
    --> src/types.rs:3024:9
```

`cargo fmt` likewise reports pre-existing drift in `services/server/src/routes/memory_read.rs` (untouched here). `cargo fmt` was run and then that file's reformatting was reverted to keep this diff scoped; `admin.rs` is clean under `cargo fmt --check`.

## Rebase note

This touches `packages/sdk/src/memwal.ts`, which the sibling WALM-597 and WALM-162 PRs also touch in different regions. Expect a possible rebase. The large `memwal.ts` line count is mostly reindentation from removing the `try`/`finally` that wrapped `recall()`'s old timer.
