### PR TITLE
fix(chatbot): stop guest-auth redirect loop on Railway bind address (WALM-611)

### DIFF
--- a/apps/chatbot/app/(auth)/api/auth/guest/route.ts
+++ b/apps/chatbot/app/(auth)/api/auth/guest/route.ts
@@ -1,43 +1,22 @@
 import { NextResponse } from "next/server";
 import { signIn } from "@/app/(auth)/auth";
+import { isSafeRedirectUrl, publicRequestUrl } from "@/lib/public-request-url";
 import { getSessionToken } from "@/lib/session-token";
-
-/**
- * Validate a redirect target before forwarding to auth.
- * Allows only:
- *   - Relative paths beginning with "/" (but not "//", which is protocol-relative)
- *   - Absolute URLs whose origin matches the request origin (same-origin)
- * Anything else (external hosts, javascript:, data:, //evil.com) falls back to "/".
- */
-function isSafeRedirectUrl(redirectUrl: string, requestUrl: string): boolean {
-  // Relative path — safe as long as it isn't protocol-relative ("//host/...")
-  if (redirectUrl.startsWith("/") && !redirectUrl.startsWith("//")) {
-    return true;
-  }
-  // Absolute URL — must share the same origin as the request
-  try {
-    const redirectOrigin = new URL(redirectUrl).origin;
-    const requestOrigin = new URL(requestUrl).origin;
-    return redirectOrigin === requestOrigin;
-  } catch {
-    // Unparseable URL (e.g. "javascript:alert(1)") — reject
-    return false;
-  }
-}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const rawRedirectUrl = searchParams.get("redirectUrl") || "/";
+  const publicUrl = publicRequestUrl(request);
 
-  // Reject cross-origin or protocol-relative redirect targets
-  const redirectUrl = isSafeRedirectUrl(rawRedirectUrl, request.url)
+  // Reject cross-origin, bind-address, or protocol-relative redirect targets
+  const redirectUrl = isSafeRedirectUrl(rawRedirectUrl, request)
     ? rawRedirectUrl
     : "/";
 
   const token = await getSessionToken(request);
 
   if (token) {
-    return NextResponse.redirect(new URL("/", request.url));
+    return NextResponse.redirect(new URL("/", publicUrl));
   }
 
   return signIn("guest", { redirect: true, redirectTo: redirectUrl });

--- a/apps/chatbot/app/(auth)/auth.config.ts
+++ b/apps/chatbot/app/(auth)/auth.config.ts
@@ -1,6 +1,8 @@
 import type { NextAuthConfig } from "next-auth";
 
 export const authConfig = {
+  // Railway / Docker set HOSTNAME=0.0.0.0; trust the incoming Host header.
+  trustHost: true,
   pages: {
     signIn: "/login",
     newUser: "/",

--- a/apps/chatbot/lib/public-request-url.ts
+++ b/apps/chatbot/lib/public-request-url.ts
@@ -1,0 +1,110 @@
+const BIND_HOSTNAMES = new Set(["0.0.0.0", "::", "[::]"]);
+
+function firstHeader(headers: Headers, name: string): string | null {
+  const value = headers.get(name)?.split(",")[0]?.trim();
+  return value ? value : null;
+}
+
+function isBindHostname(hostname: string): boolean {
+  return BIND_HOSTNAMES.has(hostname.toLowerCase());
+}
+
+function hostnameFromHost(host: string): string | null {
+  try {
+    return new URL(`http://${host}`).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/** Host headers that are listen addresses, not browser-reachable origins. */
+function usablePublicHost(host: string | null): string | null {
+  if (!host) {
+    return null;
+  }
+  const hostname = hostnameFromHost(host);
+  if (!hostname || isBindHostname(hostname)) {
+    return null;
+  }
+  return host;
+}
+
+function publicProtocol(headers: Headers, fallbackProtocol: string): string {
+  const proto = firstHeader(headers, "x-forwarded-proto")?.toLowerCase();
+  if (proto === "http" || proto === "https") {
+    return proto;
+  }
+  return fallbackProtocol.replace(/:$/, "");
+}
+
+/**
+ * Rebuild the browser-facing request URL when Next.js reports a bind address
+ * (`HOSTNAME=0.0.0.0`). Prefer `x-forwarded-host` when it is not a bind address.
+ */
+export function publicRequestUrl(request: Request): URL {
+  const url = new URL(request.url);
+  const forwardedHost = usablePublicHost(
+    firstHeader(request.headers, "x-forwarded-host")
+  );
+  const hostHeader = usablePublicHost(firstHeader(request.headers, "host"));
+  const publicHost =
+    forwardedHost ?? (isBindHostname(url.hostname) ? hostHeader : null);
+
+  if (!publicHost) {
+    return url;
+  }
+
+  // Reconstruct rather than mutate `.host` — Node keeps the previous port
+  // (e.g. `:3000`) when the forwarded host has none.
+  try {
+    const protocol = publicProtocol(request.headers, url.protocol);
+    return new URL(
+      `${protocol}://${publicHost}${url.pathname}${url.search}${url.hash}`
+    );
+  } catch {
+    return url;
+  }
+}
+
+/** Pathname+search for guest `redirectUrl`; relative only, never `//`. */
+export function guestReturnPath(request: Request): string {
+  try {
+    const url = new URL(request.url);
+    const path = `${url.pathname}${url.search}`;
+    if (path.startsWith("/") && !path.startsWith("//")) {
+      return path;
+    }
+  } catch {
+    // Unparseable request URL — fall back to home.
+  }
+  return "/";
+}
+
+/**
+ * Allow relative paths (not `//`) and absolute URLs whose origin matches the
+ * public request origin. Bind-address origins are never safe redirect targets.
+ */
+export function isSafeRedirectUrl(
+  redirectUrl: string,
+  request: Request
+): boolean {
+  if (redirectUrl.startsWith("/") && !redirectUrl.startsWith("//")) {
+    return true;
+  }
+
+  try {
+    const redirectOrigin = new URL(redirectUrl);
+    if (isBindHostname(redirectOrigin.hostname)) {
+      return false;
+    }
+
+    const publicOrigin = publicRequestUrl(request);
+    if (isBindHostname(publicOrigin.hostname)) {
+      return false;
+    }
+
+    return redirectOrigin.origin === publicOrigin.origin;
+  } catch {
+    return false;
+  }
+}

--- a/apps/chatbot/lib/public-request-url.ts
+++ b/apps/chatbot/lib/public-request-url.ts
@@ -1,89 +1,60 @@
 const BIND_HOSTNAMES = new Set(["0.0.0.0", "::", "[::]"]);
 
-function firstHeader(headers: Headers, name: string): string | null {
-  const value = headers.get(name)?.split(",")[0]?.trim();
-  return value ? value : null;
-}
-
 function isBindHostname(hostname: string): boolean {
   return BIND_HOSTNAMES.has(hostname.toLowerCase());
 }
 
-function hostnameFromHost(host: string): string | null {
+function firstHeader(headers: Headers, name: string): string | null {
+  return headers.get(name)?.split(",")[0]?.trim() || null;
+}
+
+function usablePublicHost(host: string | null): string | null {
+  if (!host) {
+    return null;
+  }
   try {
-    return new URL(`http://${host}`).hostname;
+    const hostname = new URL(`http://${host}`).hostname;
+    return hostname && !isBindHostname(hostname) ? host : null;
   } catch {
     return null;
   }
 }
 
-/** Host headers that are listen addresses, not browser-reachable origins. */
-function usablePublicHost(host: string | null): string | null {
-  if (!host) {
-    return null;
-  }
-  const hostname = hostnameFromHost(host);
-  if (!hostname || isBindHostname(hostname)) {
-    return null;
-  }
-  return host;
-}
-
-function publicProtocol(headers: Headers, fallbackProtocol: string): string {
-  const proto = firstHeader(headers, "x-forwarded-proto")?.toLowerCase();
-  if (proto === "http" || proto === "https") {
-    return proto;
-  }
-  return fallbackProtocol.replace(/:$/, "");
-}
-
-/**
- * Rebuild the browser-facing request URL when Next.js reports a bind address
- * (`HOSTNAME=0.0.0.0`). Prefer `x-forwarded-host` when it is not a bind address.
- */
 export function publicRequestUrl(request: Request): URL {
   const url = new URL(request.url);
   const forwardedHost = usablePublicHost(
     firstHeader(request.headers, "x-forwarded-host")
   );
-  const hostHeader = usablePublicHost(firstHeader(request.headers, "host"));
   const publicHost =
-    forwardedHost ?? (isBindHostname(url.hostname) ? hostHeader : null);
+    forwardedHost ??
+    (isBindHostname(url.hostname)
+      ? usablePublicHost(firstHeader(request.headers, "host"))
+      : null);
 
   if (!publicHost) {
     return url;
   }
 
-  // Reconstruct rather than mutate `.host` — Node keeps the previous port
-  // (e.g. `:3000`) when the forwarded host has none.
+  const proto = firstHeader(request.headers, "x-forwarded-proto")?.toLowerCase();
+  const protocol =
+    proto === "http" || proto === "https"
+      ? proto
+      : url.protocol.replace(/:$/, "");
+
+  // Reconstruct; assigning URL.host keeps :3000 from the bind address.
   try {
-    const protocol = publicProtocol(request.headers, url.protocol);
-    return new URL(
-      `${protocol}://${publicHost}${url.pathname}${url.search}${url.hash}`
-    );
+    return new URL(`${protocol}://${publicHost}${url.pathname}${url.search}`);
   } catch {
     return url;
   }
 }
 
-/** Pathname+search for guest `redirectUrl`; relative only, never `//`. */
 export function guestReturnPath(request: Request): string {
-  try {
-    const url = new URL(request.url);
-    const path = `${url.pathname}${url.search}`;
-    if (path.startsWith("/") && !path.startsWith("//")) {
-      return path;
-    }
-  } catch {
-    // Unparseable request URL — fall back to home.
-  }
-  return "/";
+  const url = new URL(request.url);
+  const path = `${url.pathname}${url.search}`;
+  return path.startsWith("/") && !path.startsWith("//") ? path : "/";
 }
 
-/**
- * Allow relative paths (not `//`) and absolute URLs whose origin matches the
- * public request origin. Bind-address origins are never safe redirect targets.
- */
 export function isSafeRedirectUrl(
   redirectUrl: string,
   request: Request
@@ -93,17 +64,15 @@ export function isSafeRedirectUrl(
   }
 
   try {
-    const redirectOrigin = new URL(redirectUrl);
-    if (isBindHostname(redirectOrigin.hostname)) {
+    const redirect = new URL(redirectUrl);
+    const publicUrl = publicRequestUrl(request);
+    if (
+      isBindHostname(redirect.hostname) ||
+      isBindHostname(publicUrl.hostname)
+    ) {
       return false;
     }
-
-    const publicOrigin = publicRequestUrl(request);
-    if (isBindHostname(publicOrigin.hostname)) {
-      return false;
-    }
-
-    return redirectOrigin.origin === publicOrigin.origin;
+    return redirect.origin === publicUrl.origin;
   } catch {
     return false;
   }

--- a/apps/chatbot/lib/public-request-url.unit.test.ts
+++ b/apps/chatbot/lib/public-request-url.unit.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  guestReturnPath,
+  isSafeRedirectUrl,
+  publicRequestUrl,
+} from "./public-request-url";
+
+const STAGING_HOST = "chatbot-demo-staging.memory.walrus.xyz";
+
+function bindRequest(path = "/chat/abc", headers?: HeadersInit): Request {
+  return new Request(`https://0.0.0.0:3000${path}`, { headers });
+}
+
+describe("publicRequestUrl", () => {
+  it("uses x-forwarded-host and proto when request.url is a bind address", () => {
+    const request = bindRequest("/chat/abc", {
+      "x-forwarded-host": STAGING_HOST,
+      "x-forwarded-proto": "https",
+    });
+
+    const publicUrl = publicRequestUrl(request);
+    expect(publicUrl.origin).toBe(`https://${STAGING_HOST}`);
+    expect(publicUrl.hostname).not.toBe("0.0.0.0");
+    expect(publicUrl.pathname).toBe("/chat/abc");
+  });
+
+  it("prefers a non-bind forwarded host over request.url", () => {
+    const request = new Request("http://localhost:3000/login", {
+      headers: {
+        "x-forwarded-host": STAGING_HOST,
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(publicRequestUrl(request).origin).toBe(`https://${STAGING_HOST}`);
+  });
+
+  it("falls back to Host when the URL is a bind address", () => {
+    const request = bindRequest("/chat/abc", {
+      host: STAGING_HOST,
+      "x-forwarded-proto": "https",
+    });
+
+    expect(publicRequestUrl(request).origin).toBe(`https://${STAGING_HOST}`);
+  });
+});
+
+describe("guestReturnPath", () => {
+  it("returns pathname and search as a relative path", () => {
+    const forwarded = {
+      "x-forwarded-host": STAGING_HOST,
+      "x-forwarded-proto": "https",
+    };
+
+    expect(guestReturnPath(bindRequest("/chat/abc", forwarded))).toBe(
+      "/chat/abc"
+    );
+    expect(guestReturnPath(bindRequest("/chat/abc?foo=1", forwarded))).toBe(
+      "/chat/abc?foo=1"
+    );
+  });
+
+  it("rejects protocol-relative pathnames and falls back to /", () => {
+    expect(guestReturnPath(bindRequest("//evil.example"))).toBe("/");
+  });
+});
+
+describe("isSafeRedirectUrl", () => {
+  it("allows relative paths", () => {
+    const request = bindRequest("/", {
+      "x-forwarded-host": STAGING_HOST,
+      "x-forwarded-proto": "https",
+    });
+
+    expect(isSafeRedirectUrl("/", request)).toBe(true);
+    expect(isSafeRedirectUrl("/chat/1", request)).toBe(true);
+  });
+
+  it("rejects cross-origin and protocol-relative targets", () => {
+    const request = bindRequest("/chat/abc", {
+      "x-forwarded-host": STAGING_HOST,
+      "x-forwarded-proto": "https",
+    });
+
+    expect(isSafeRedirectUrl("https://evil.example", request)).toBe(false);
+    expect(isSafeRedirectUrl("//evil.example", request)).toBe(false);
+  });
+
+  it("allows same-origin absolute URLs against the public origin", () => {
+    const request = bindRequest("/chat/abc", {
+      "x-forwarded-host": STAGING_HOST,
+      "x-forwarded-proto": "https",
+    });
+
+    expect(
+      isSafeRedirectUrl(`https://${STAGING_HOST}/chat/abc`, request)
+    ).toBe(true);
+    expect(isSafeRedirectUrl("https://0.0.0.0:3000/chat/abc", request)).toBe(
+      false
+    );
+  });
+
+  it("does not treat a bind address as a safe absolute redirect target", () => {
+    const request = bindRequest("/chat/abc");
+
+    expect(isSafeRedirectUrl("https://0.0.0.0:3000/chat/abc", request)).toBe(
+      false
+    );
+    expect(isSafeRedirectUrl("https://0.0.0.0:3000/", request)).toBe(false);
+    expect(isSafeRedirectUrl("/", request)).toBe(true);
+  });
+});

--- a/apps/chatbot/proxy.ts
+++ b/apps/chatbot/proxy.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { guestRegex } from "./lib/constants";
+import { guestReturnPath, publicRequestUrl } from "./lib/public-request-url";
 import { getSessionToken } from "./lib/session-token";
 
 export async function proxy(request: NextRequest) {
@@ -20,17 +21,20 @@ export async function proxy(request: NextRequest) {
   const token = await getSessionToken(request);
 
   if (!token) {
-    const redirectUrl = encodeURIComponent(request.url);
+    const redirectUrl = encodeURIComponent(guestReturnPath(request));
 
     return NextResponse.redirect(
-      new URL(`/api/auth/guest?redirectUrl=${redirectUrl}`, request.url)
+      new URL(
+        `/api/auth/guest?redirectUrl=${redirectUrl}`,
+        publicRequestUrl(request)
+      )
     );
   }
 
   const isGuest = guestRegex.test(token?.email ?? "");
 
   if (token && !isGuest && ["/login", "/register"].includes(pathname)) {
-    return NextResponse.redirect(new URL("/", request.url));
+    return NextResponse.redirect(new URL("/", publicRequestUrl(request)));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Ticket

WALM-611 — https://linear.app/mysten-labs/issue/WALM-611/bug-chatbot-guest-login-loops-on-railway-redirecturl-uses-0000-bind

## What changed?

- Guest `redirectUrl` is now a relative path, not `https://0.0.0.0:3000/...`.
- Redirect `Location` is built from `x-forwarded-host` / `Host` + `x-forwarded-proto` when Next.js reports the Railway bind address (`HOSTNAME=0.0.0.0`).
- Absolute bind-address origins are rejected as redirect targets.
- Auth.js `trustHost: true` so session cookies bind to the public host on Railway.

## Why is this needed?

Unauthenticated visits to staging/prod chatbot 307-loop. The standalone server binds `0.0.0.0`; `proxy.ts` passed `request.url` into `/api/auth/guest`, so the browser never got a cookie on the public host.

## Scope

Stop the chatbot guest-auth redirect loop on Railway.

### Out of scope

Noter, Researcher, AUTH_URL env on Railway.

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `pnpm --filter @memwal/chatbot test:unit` (9 files, 49 passed)

## How can the reviewer verify it?

1. `pnpm --filter @memwal/chatbot test:unit`
2. After deploy to staging: `curl -sI -o /dev/null -w "%{http_code} %{redirect_url}\n" --max-redirs 0 https://chatbot-demo-staging.memory.walrus.xyz/` should not 307-loop, and `Location` must not contain `0.0.0.0`.
3. Open the staging chatbot in a browser: guest session lands on `/`.

## Risks and dependencies

None. Demo app only; no SDK version dump.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
