### PR TITLE
fix(server): return each blob once in recall (WALM-594)

### DIFF
--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -84,12 +84,10 @@ async fn generate_recall_embedding_cached(
 /// `text` (the ranker never reads text; manual recall never decrypts).
 ///
 /// The ranked output is mapped back to the original `SearchHit`s **by
-/// original index, not by `blob_id`**. `search_similar` already collapses
-/// duplicate blob_ids (WALM-594), but this remap still must not key on
-/// `blob_id`: the ranker only reads distance/recency/importance, and we
-/// stash each hit's input index in the throwaway `HydratedMemory`'s
-/// `blob_id` slot so a duplicate-bearing input cannot silently drop or
-/// reorder hits. Indices are unique, so `results.len() == hits.len()`.
+/// original index, not by `blob_id`**. The ranker treats `blob_id` as
+/// opaque carry-through (it scores only distance/recency/importance), so
+/// we stash each hit's input index in that slot. Indices are unique, so a
+/// blob_id-keyed round-trip cannot drop hits and `results.len() == hits.len()`.
 ///
 /// At default weights `rank()` short-circuits, so the input (cosine) order
 /// is returned unchanged.
@@ -529,11 +527,8 @@ mod tests {
         assert_eq!(ranked[0].created_at, t_now() - chrono::Duration::days(7));
     }
 
-    /// Ranker remap is by input index, not `blob_id`. `search_similar`
-    /// collapses duplicate blob_ids (WALM-594); this still pins that a
-    /// blob_id-keyed round-trip would drop/reorder if duplicates ever
-    /// reached the ranker. Tested at BOTH default (short-circuit) and
-    /// active weights.
+    /// Remap is by input index, not blob_id, so two hits sharing a blob_id
+    /// are both kept. Tested at default (short-circuit) and active weights.
     #[test]
     fn manual_ranking_keeps_duplicate_blob_ids() {
         use crate::services::extractor::{IMPORTANCE_TRIVIAL, IMPORTANCE_VITAL};

--- a/services/server/src/routes/recall.rs
+++ b/services/server/src/routes/recall.rs
@@ -84,18 +84,12 @@ async fn generate_recall_embedding_cached(
 /// `text` (the ranker never reads text; manual recall never decrypts).
 ///
 /// The ranked output is mapped back to the original `SearchHit`s **by
-/// original index, not by `blob_id`**. `blob_id` is not unique
-/// (`vector_entries` has no UNIQUE constraint on it and `search_similar`
-/// does not `SELECT DISTINCT`, so `restore` can produce — and a query can
-/// return — multiple hits with the same blob_id). Keying the round-trip on
-/// blob_id would collapse those duplicates, silently dropping hits and
-/// reordering them — re-introducing the very manual-vs-non-manual
-/// divergence this fix removes (the non-manual paths keep duplicates 1:1).
-/// So we stash each hit's input index in the throwaway `HydratedMemory`'s
-/// `blob_id` slot — the ranker treats that field as opaque carry-through
-/// (it scores only distance/recency/importance) — and reorder the original
-/// `Vec<SearchHit>` by the ranked index sequence. Indices are unique, so no
-/// hit is dropped and `results.len() == hits.len()` always.
+/// original index, not by `blob_id`**. `search_similar` already collapses
+/// duplicate blob_ids (WALM-594), but this remap still must not key on
+/// `blob_id`: the ranker only reads distance/recency/importance, and we
+/// stash each hit's input index in the throwaway `HydratedMemory`'s
+/// `blob_id` slot so a duplicate-bearing input cannot silently drop or
+/// reorder hits. Indices are unique, so `results.len() == hits.len()`.
 ///
 /// At default weights `rank()` short-circuits, so the input (cosine) order
 /// is returned unchanged.
@@ -106,7 +100,7 @@ fn rank_search_hits(
     now: chrono::DateTime<chrono::Utc>,
 ) -> Vec<SearchHit> {
     // Carry the original index through the ranker via the (opaque-to-ranker)
-    // blob_id field, so we can reorder duplicate-blob_id hits unambiguously.
+    // blob_id field so reorder is unambiguous even if two hits share a blob_id.
     let hydrated: Vec<crate::engine::HydratedMemory> = hits
         .iter()
         .enumerate()
@@ -535,13 +529,11 @@ mod tests {
         assert_eq!(ranked[0].created_at, t_now() - chrono::Duration::days(7));
     }
 
-    /// Regression guard (deep-review blocker): `blob_id` is NOT
-    /// unique — `search_similar` can return multiple hits with the same
-    /// blob_id. A blob_id-keyed round-trip would collapse them, silently
-    /// dropping hits and reordering — re-introducing the manual-vs-non-manual
-    /// divergence this fix removes (the non-manual paths keep duplicates 1:1).
-    /// The index-based reorder must keep every hit. Tested at BOTH default
-    /// (short-circuit) and active weights.
+    /// Ranker remap is by input index, not `blob_id`. `search_similar`
+    /// collapses duplicate blob_ids (WALM-594); this still pins that a
+    /// blob_id-keyed round-trip would drop/reorder if duplicates ever
+    /// reached the ranker. Tested at BOTH default (short-circuit) and
+    /// active weights.
     #[test]
     fn manual_ranking_keeps_duplicate_blob_ids() {
         use crate::services::extractor::{IMPORTANCE_TRIVIAL, IMPORTANCE_VITAL};

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -479,6 +479,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_similar_fills_limit_when_duplicate_rows_crowd_the_window() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xrecall-dedupe-limit-{suffix}");
+        let namespace = format!("ns-{suffix}");
+        let blob_a = format!("blob-a-{suffix}");
+        let blob_b = format!("blob-b-{suffix}");
+        let query = vec![1.0_f32; 1536];
+        let near = vec![1.0_f32; 1536];
+        let far = {
+            let mut v = vec![0.0_f32; 1536];
+            v[0] = 1.0;
+            v
+        };
+
+        db.insert_vector(
+            &format!("row-a1-{suffix}"),
+            &owner,
+            &namespace,
+            &blob_a,
+            &near,
+            1,
+            0.5,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.insert_vector(
+            &format!("row-a2-{suffix}"),
+            &owner,
+            &namespace,
+            &blob_a,
+            &near,
+            1,
+            0.5,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.insert_vector(
+            &format!("row-b-{suffix}"),
+            &owner,
+            &namespace,
+            &blob_b,
+            &far,
+            1,
+            0.5,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let hits = db
+            .search_similar(&query, &owner, &namespace, 2)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
+            .bind(&owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = hits.iter().map(|h| h.blob_id.as_str()).collect();
+        assert_eq!(ids.len(), 2, "limit=2 must refill after collapsing blob A");
+        assert!(ids.contains(&blob_a.as_str()));
+        assert!(ids.contains(&blob_b.as_str()));
+    }
+
+    #[tokio::test]
     async fn insert_vector_persists_agent_and_package_id() {
         let Some(db) = test_db().await else {
             eprintln!("skipping DB integration test: DATABASE_URL is not configured");
@@ -1815,13 +1893,51 @@ impl VectorDb {
     }
 
     /// Search for similar vectors using pgvector cosine distance (<=>).
-    /// Each `blob_id` appears at most once (closest row wins).
+    /// Each `blob_id` appears at most once (closest row wins). Duplicate
+    /// index rows are over-fetched so `limit` still fills with distinct blobs.
     pub async fn search_similar(
         &self,
         query_vector: &[f32],
         owner: &str,
         namespace: &str,
         limit: usize,
+    ) -> Result<Vec<SearchHit>, AppError> {
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+
+        // First-wins unique after ANN `LIMIT` is HNSW-friendly, but duplicate
+        // index rows consume that window. Widen by the number dropped until
+        // `limit` unique blobs are filled or the namespace is exhausted.
+        let mut fetch_limit = limit;
+        loop {
+            let rows = self
+                .search_similar_rows(query_vector, owner, namespace, fetch_limit)
+                .await?;
+            let fetched = rows.len();
+            let mut unique = unique_hits_by_blob_id(rows);
+            if unique.len() >= limit {
+                unique.truncate(limit);
+                return Ok(unique);
+            }
+            if fetched < fetch_limit {
+                return Ok(unique);
+            }
+            let dropped = fetched - unique.len();
+            let next = limit.saturating_add(dropped);
+            if next <= fetch_limit {
+                return Ok(unique);
+            }
+            fetch_limit = next;
+        }
+    }
+
+    async fn search_similar_rows(
+        &self,
+        query_vector: &[f32],
+        owner: &str,
+        namespace: &str,
+        fetch_limit: usize,
     ) -> Result<Vec<SearchHit>, AppError> {
         let embedding = Vector::from(query_vector.to_vec());
 
@@ -1845,7 +1961,7 @@ impl VectorDb {
         .bind(embedding)
         .bind(owner)
         .bind(namespace)
-        .bind(limit as i64)
+        .bind(fetch_limit as i64)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to search vectors: {}", e)));
@@ -1856,7 +1972,7 @@ impl VectorDb {
         );
         let rows = result?;
 
-        let results = rows
+        Ok(rows
             .into_iter()
             .map(|(blob_id, distance, created_at, importance)| SearchHit {
                 blob_id,
@@ -1864,9 +1980,7 @@ impl VectorDb {
                 created_at,
                 importance,
             })
-            .collect();
-
-        Ok(unique_hits_by_blob_id(results))
+            .collect())
     }
 
     /// Get all blob_ids for a given owner + namespace (used by restore flow)

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -16,6 +16,31 @@ pub(crate) fn unique_hits_by_blob_id(hits: Vec<SearchHit>) -> Vec<SearchHit> {
         .collect()
 }
 
+/// ANN over-fetch ceiling: `fetch_limit <= limit * this`. Stops a
+/// single heavily duplicated nearest blob from walking the whole
+/// namespace one unique-shortfall at a time.
+const SEARCH_SIMILAR_OVERFETCH_FACTOR: usize = 4;
+
+/// Next ANN `LIMIT` after collapsing `dropped` duplicate rows from a
+/// full page. Grows by the observed duplicate count in the current
+/// window (not `limit + dropped`, which only adds the unique shortfall).
+/// `None` means stop: no dups, no growth, or the cap is hit.
+pub(crate) fn next_search_fetch_limit(
+    limit: usize,
+    fetch_limit: usize,
+    dropped: usize,
+) -> Option<usize> {
+    if dropped == 0 {
+        return None;
+    }
+    let cap = limit.saturating_mul(SEARCH_SIMILAR_OVERFETCH_FACTOR).max(limit);
+    if fetch_limit >= cap {
+        return None;
+    }
+    let next = fetch_limit.saturating_add(dropped).min(cap);
+    (next > fetch_limit).then_some(next)
+}
+
 /// Tombstone retention for both the read-API `must_resync` clock and the
 /// background sweep. Keep a single constant so the two cannot drift.
 pub const TOMBSTONE_RETENTION: chrono::Duration = chrono::Duration::days(30);
@@ -395,6 +420,27 @@ mod tests {
         assert!(super::unique_hits_by_blob_id(vec![]).is_empty());
     }
 
+    #[test]
+    fn next_search_fetch_limit_grows_by_dropped_not_unique_shortfall() {
+        // limit=2, two copies of A: first page unique=1, dropped=1 → LIMIT 3.
+        assert_eq!(super::next_search_fetch_limit(2, 2, 1), Some(3));
+        // Three copies of A: LIMIT 3 is still all A (dropped=2) → LIMIT 5,
+        // not stop after the first widen.
+        assert_eq!(super::next_search_fetch_limit(2, 3, 2), Some(5));
+        // Cap at limit * 4.
+        assert_eq!(super::next_search_fetch_limit(2, 5, 4), Some(8));
+        assert_eq!(super::next_search_fetch_limit(2, 8, 7), None);
+    }
+
+    #[test]
+    fn next_search_fetch_limit_uniform_2x_at_http_cap() {
+        // limit=100, half the page duplicate: grow by dropped (50), not
+        // by unique shortfall alone. 100 → 150, then 150 → 225.
+        assert_eq!(super::next_search_fetch_limit(100, 100, 50), Some(150));
+        assert_eq!(super::next_search_fetch_limit(100, 150, 75), Some(225));
+        assert_eq!(super::next_search_fetch_limit(100, 400, 50), None);
+    }
+
     #[tokio::test]
     async fn search_similar_returns_each_blob_id_once() {
         let Some(db) = test_db().await else {
@@ -552,6 +598,67 @@ mod tests {
 
         let ids: Vec<&str> = hits.iter().map(|h| h.blob_id.as_str()).collect();
         assert_eq!(ids.len(), 2, "limit=2 must refill after collapsing blob A");
+        assert!(ids.contains(&blob_a.as_str()));
+        assert!(ids.contains(&blob_b.as_str()));
+    }
+
+    #[tokio::test]
+    async fn search_similar_widens_again_when_three_copies_crowd_limit_two() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xrecall-dedupe-triple-{suffix}");
+        let namespace = format!("ns-{suffix}");
+        let blob_a = format!("blob-a-{suffix}");
+        let blob_b = format!("blob-b-{suffix}");
+        let query = vec![1.0_f32; 1536];
+        let near = vec![1.0_f32; 1536];
+        let far = {
+            let mut v = vec![0.0_f32; 1536];
+            v[0] = 1.0;
+            v
+        };
+
+        for (row, blob, embedding) in [
+            ("a1", blob_a.as_str(), &near),
+            ("a2", blob_a.as_str(), &near),
+            ("a3", blob_a.as_str(), &near),
+            ("b", blob_b.as_str(), &far),
+        ] {
+            db.insert_vector(
+                &format!("row-{row}-{suffix}"),
+                &owner,
+                &namespace,
+                blob,
+                embedding,
+                1,
+                0.5,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let hits = db
+            .search_similar(&query, &owner, &namespace, 2)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
+            .bind(&owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = hits.iter().map(|h| h.blob_id.as_str()).collect();
+        assert_eq!(
+            ids.len(),
+            2,
+            "first widen (LIMIT 3) is still all A; second widen must include B"
+        );
         assert!(ids.contains(&blob_a.as_str()));
         assert!(ids.contains(&blob_b.as_str()));
     }
@@ -1907,8 +2014,8 @@ impl VectorDb {
         }
 
         // First-wins unique after ANN `LIMIT` is HNSW-friendly, but duplicate
-        // index rows consume that window. Widen by the number dropped until
-        // `limit` unique blobs are filled or the namespace is exhausted.
+        // index rows consume that window. Widen by the dropped count in the
+        // current window (duplicate factor), capped at `limit * 4`.
         let mut fetch_limit = limit;
         loop {
             let rows = self
@@ -1924,10 +2031,9 @@ impl VectorDb {
                 return Ok(unique);
             }
             let dropped = fetched - unique.len();
-            let next = limit.saturating_add(dropped);
-            if next <= fetch_limit {
+            let Some(next) = next_search_fetch_limit(limit, fetch_limit, dropped) else {
                 return Ok(unique);
-            }
+            };
             fetch_limit = next;
         }
     }

--- a/services/server/src/storage/db.rs
+++ b/services/server/src/storage/db.rs
@@ -1,8 +1,20 @@
 use pgvector::Vector;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
+use std::collections::HashSet;
 
 use crate::types::{AppError, SearchHit};
+
+/// Keep the first hit for each `blob_id` (closest: callers already order by
+/// cosine distance). `vector_entries` has no UNIQUE on blob_id, so a
+/// remember retry or restore can insert a second row for the same Walrus
+/// blob; returning both spends `limit` on one memory (WALM-594 / GH #694).
+pub(crate) fn unique_hits_by_blob_id(hits: Vec<SearchHit>) -> Vec<SearchHit> {
+    let mut seen = HashSet::with_capacity(hits.len());
+    hits.into_iter()
+        .filter(|hit| seen.insert(hit.blob_id.clone()))
+        .collect()
+}
 
 /// Tombstone retention for both the read-API `must_resync` clock and the
 /// background sweep. Keep a single constant so the two cannot drift.
@@ -354,6 +366,116 @@ mod tests {
             vec![(other_namespace, blob_id)],
             "the cleanup must not delete an identical blob_id in another namespace"
         );
+    }
+
+    fn hit(blob_id: &str, distance: f64) -> crate::types::SearchHit {
+        crate::types::SearchHit {
+            blob_id: blob_id.to_string(),
+            distance,
+            created_at: chrono::Utc::now(),
+            importance: 0.5,
+        }
+    }
+
+    #[test]
+    fn unique_hits_by_blob_id_keeps_first_and_distinct() {
+        let unique = super::unique_hits_by_blob_id(vec![
+            hit("dup", 0.10),
+            hit("dup", 0.10),
+            hit("other", 0.20),
+            hit("dup", 0.30),
+        ]);
+        let ids: Vec<&str> = unique.iter().map(|h| h.blob_id.as_str()).collect();
+        assert_eq!(ids, vec!["dup", "other"]);
+        assert_eq!(unique[0].distance, 0.10);
+    }
+
+    #[test]
+    fn unique_hits_by_blob_id_empty() {
+        assert!(super::unique_hits_by_blob_id(vec![]).is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_similar_returns_each_blob_id_once() {
+        let Some(db) = test_db().await else {
+            eprintln!("skipping DB integration test: DATABASE_URL is not configured");
+            return;
+        };
+        let suffix = uuid::Uuid::new_v4();
+        let owner = format!("0xrecall-dedupe-owner-{suffix}");
+        let namespace = format!("ns-{suffix}");
+        let blob_id = format!("dup-blob-{suffix}");
+        let other_blob = format!("other-blob-{suffix}");
+        let query = vec![1.0_f32; 1536];
+        let near = vec![1.0_f32; 1536];
+        let far = {
+            let mut v = vec![0.0_f32; 1536];
+            v[0] = 1.0;
+            v
+        };
+
+        db.insert_vector(
+            &format!("row-a-{suffix}"),
+            &owner,
+            &namespace,
+            &blob_id,
+            &near,
+            1,
+            0.5,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.insert_vector(
+            &format!("row-b-{suffix}"),
+            &owner,
+            &namespace,
+            &blob_id,
+            &near,
+            1,
+            0.5,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.insert_vector(
+            &format!("row-c-{suffix}"),
+            &owner,
+            &namespace,
+            &other_blob,
+            &far,
+            1,
+            0.5,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let hits = db
+            .search_similar(&query, &owner, &namespace, 10)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM vector_entries WHERE owner = $1")
+            .bind(&owner)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = hits.iter().map(|h| h.blob_id.as_str()).collect();
+        assert_eq!(
+            ids.iter().filter(|id| **id == blob_id).count(),
+            1,
+            "the remembered blob must appear once, not once per index row"
+        );
+        assert!(ids.contains(&blob_id.as_str()));
+        assert!(ids.contains(&other_blob.as_str()));
+        assert_eq!(ids.len(), 2);
     }
 
     #[tokio::test]
@@ -1692,8 +1814,8 @@ impl VectorDb {
         Ok(row.and_then(|(plaintext,)| plaintext))
     }
 
-    /// Search for similar vectors using pgvector cosine distance (<=>)
-    /// Returns blob_id and distance for each match
+    /// Search for similar vectors using pgvector cosine distance (<=>).
+    /// Each `blob_id` appears at most once (closest row wins).
     pub async fn search_similar(
         &self,
         query_vector: &[f32],
@@ -1744,7 +1866,7 @@ impl VectorDb {
             })
             .collect();
 
-        Ok(results)
+        Ok(unique_hits_by_blob_id(results))
     }
 
     /// Get all blob_ids for a given owner + namespace (used by restore flow)


### PR DESCRIPTION
## Ticket

WALM-594 — https://linear.app/mysten-labs/issue/WALM-594
GH #694 — https://github.com/MystenLabs/MemWal/issues/694

## What changed?

- `search_similar` collapses hits that share a `blob_id`, keeping the closest row.
- `/api/recall`, `recall/manual`, and analyze all go through that query, so each blob appears at most once in a result set.
- Unit tests pin first-hit-wins; a DB test inserts two rows for one blob plus a distinct blob and asserts unique ids.

## Why is this needed?

`vector_entries` has no UNIQUE on blob_id. A remember retry after a successful Walrus upload, or restore re-indexing a blob that remember already wrote, inserts a second row with a new `id`. Recall then returned the same blob twice with identical scores and burned `limit` on one memory.

## Scope

Relayer vector search (`search_similar`) and its tests.

### Out of scope

- UNIQUE constraint / upsert on write (duplicate index rows can still exist; recall just will not return both)
- MCP text collapse (`collapseDuplicates`) — already folds identical plaintext

## Test plan

- [x] `cargo test --bins unique_hits_by_blob_id` (2 passed)
- [x] `cargo test --bins search_similar_returns_each_blob_id_once`
- [ ] Remember then immediate recall on a namespace: the new blob appears once

Fixes #694

Made with [Cursor](https://cursor.com)