### PR TITLE
feat(app): paginate the dashboard namespaces list (WALM-607)

### DIFF
--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -8505,7 +8505,6 @@ h1, h2, h3 {
   border-bottom: 0;
 }
 
-/* Namespaces pagination footer — sits below the table it controls. */
 .dash-page .dashboard-pagination {
   display: flex;
   align-items: center;

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -8505,6 +8505,80 @@ h1, h2, h3 {
   border-bottom: 0;
 }
 
+/* Namespaces pagination footer — sits below the table it controls. */
+.dash-page .dashboard-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.dash-page .dashboard-pagination-size {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dash-page .dashboard-pagination-size label,
+.dash-page .dashboard-pagination-status {
+  color: #b8bbbe;
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.dash-page .dashboard-pagination-select {
+  padding: 6px 10px;
+  border: 1px solid rgba(250, 248, 245, 0.12);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #faf8f5;
+  font-size: 14px;
+  line-height: 1.35;
+  cursor: pointer;
+}
+
+.dash-page .dashboard-pagination-select:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.dash-page .dashboard-pagination-end {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.dash-page .dashboard-pagination-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.dash-page .dashboard-pagination-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid rgba(250, 248, 245, 0.12);
+  border-radius: 10px;
+  background: transparent;
+  color: #b8bbbe;
+  cursor: pointer;
+}
+
+.dash-page .dashboard-pagination-btn:hover:not(:disabled) {
+  border-color: #faf8f5;
+  color: #faf8f5;
+}
+
+.dash-page .dashboard-pagination-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 .dash-page .dashboard-key-table-select {
   width: 62px;
 }
@@ -9133,6 +9207,16 @@ h1, h2, h3 {
 
   .dash-page .dashboard-key-table tbody tr:last-child {
     margin-bottom: 0;
+  }
+
+  .dash-page .dashboard-pagination {
+    align-items: stretch;
+    justify-content: flex-start;
+  }
+
+  .dash-page .dashboard-pagination-end {
+    justify-content: space-between;
+    width: 100%;
   }
 
   .dash-page .dashboard-key-table td {

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -14,7 +14,7 @@ import { useSponsoredTransaction } from '../hooks/useSponsoredTransaction'
 import { generateDelegateKey } from '@mysten-incubation/memwal/account'
 import type { WalletSigner } from '@mysten-incubation/memwal/manual'
 import { Link, useNavigate } from 'react-router-dom'
-import { TriangleAlert, Info, Copy, Eye, EyeOff, Trash2, RefreshCw, Plus, LogOut, Github, MessageCircle } from 'lucide-react'
+import { TriangleAlert, Info, Copy, Eye, EyeOff, Trash2, RefreshCw, Plus, LogOut, Github, MessageCircle, ChevronLeft, ChevronRight } from 'lucide-react'
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
 import js from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript'
 import python from 'react-syntax-highlighter/dist/esm/languages/hljs/python'
@@ -120,6 +120,9 @@ interface OnChainDelegateKey {
 const MAX_DELEGATE_KEYS = 20
 const MAX_DELEGATE_KEYS_MESSAGE = 'This wallet already has 20 delegate keys. Remove an old key before creating a new delegate key.'
 const DELEGATE_KEYS_SECTION_ID = 'delegate-keys'
+// Relayer clamps `limit` (default 100, max 500); these stay well inside that.
+const NAMESPACE_PAGE_SIZES = [20, 50, 100]
+const NAMESPACE_DEFAULT_PAGE_SIZE = 20
 const PRIVATE_KEY_ENV = 'MEMWAL_PRIVATE_KEY'
 const ACCOUNT_ID_ENV = 'MEMWAL_ACCOUNT_ID'
 const SERVER_URL_ENV = 'MEMWAL_SERVER_URL'
@@ -254,7 +257,9 @@ export default function Dashboard({
     const [namespaces, setNamespaces] = useState<{ name: string; memory_count: number }[]>([])
     const [namespacesLoading, setNamespacesLoading] = useState(false)
     const [namespacesError, setNamespacesError] = useState('')
-    const [namespacesTruncated, setNamespacesTruncated] = useState(false)
+    const [namespacesPage, setNamespacesPage] = useState(0)
+    const [namespacesHasMore, setNamespacesHasMore] = useState(false)
+    const [namespacesPageSize, setNamespacesPageSize] = useState(NAMESPACE_DEFAULT_PAGE_SIZE)
     const [loadingKeys, setLoadingKeys] = useState(false)
     const [addingKey, setAddingKey] = useState(false)
     const [removingKey, setRemovingKey] = useState<string | null>(null)
@@ -462,48 +467,44 @@ export default function Dashboard({
     }, [fetchOnChainKeys])
 
     const namespacesFetchGen = useRef(0)
-    const fetchNamespaces = useCallback(async () => {
+    // cursors[i] is the `updated_after` cursor that opens page i; page 0 has none.
+    const namespacesCursors = useRef<(string | undefined)[]>([undefined])
+
+    const fetchNamespacesPage = useCallback(async (page: number) => {
         if (!delegateKey || !effectiveAccountObjectId || !address) return
         const gen = ++namespacesFetchGen.current
         setNamespacesLoading(true)
         setNamespacesError('')
-        setNamespacesTruncated(false)
         try {
             const owner = address.toLowerCase()
-            const collected: { name: string; memory_count: number }[] = []
-            let cursor: string | undefined
-            let truncated = false
-            for (let page = 0; page < 20; page++) {
-                const qs = new URLSearchParams({ limit: '100' })
-                if (cursor) qs.set('updated_after', cursor)
-                const path = `/v1/owners/${owner}/namespaces?${qs.toString()}`
-                const data = await apiGet(
-                    delegateKey,
-                    config.memwalServerUrl.replace(/\/+$/, ''),
-                    path,
-                    effectiveAccountObjectId,
-                ) as {
-                    namespaces?: { name?: string; memory_count?: number }[]
-                    next_cursor?: string | null
-                    has_more?: boolean
-                }
-                if (gen !== namespacesFetchGen.current) return
-                for (const ns of data.namespaces ?? []) {
-                    if (typeof ns.name === 'string') {
-                        collected.push({
-                            name: ns.name,
-                            memory_count: Number(ns.memory_count ?? 0),
-                        })
-                    }
-                }
-                if (!data.has_more) break
-                if (!data.next_cursor) break
-                cursor = data.next_cursor
-                if (page === 19) truncated = true
+            const qs = new URLSearchParams({ limit: String(namespacesPageSize) })
+            const cursor = namespacesCursors.current[page]
+            if (cursor) qs.set('updated_after', cursor)
+            const path = `/v1/owners/${owner}/namespaces?${qs.toString()}`
+            const data = await apiGet(
+                delegateKey,
+                config.memwalServerUrl.replace(/\/+$/, ''),
+                path,
+                effectiveAccountObjectId,
+            ) as {
+                namespaces?: { name?: string; memory_count?: number }[]
+                next_cursor?: string | null
+                has_more?: boolean
             }
             if (gen !== namespacesFetchGen.current) return
-            setNamespaces(collected)
-            setNamespacesTruncated(truncated)
+            const rows: { name: string; memory_count: number }[] = []
+            for (const ns of data.namespaces ?? []) {
+                if (typeof ns.name === 'string') {
+                    rows.push({ name: ns.name, memory_count: Number(ns.memory_count ?? 0) })
+                }
+            }
+            // Trust has_more + next_cursor, never rows.length: the relayer clamps limit.
+            const nextCursor = data.has_more ? (data.next_cursor ?? null) : null
+            namespacesCursors.current = namespacesCursors.current.slice(0, page + 1)
+            if (nextCursor) namespacesCursors.current[page + 1] = nextCursor
+            setNamespaces(rows)
+            setNamespacesPage(page)
+            setNamespacesHasMore(Boolean(nextCursor))
         } catch (err) {
             if (gen !== namespacesFetchGen.current) return
             console.error('Failed to list namespaces:', err)
@@ -511,12 +512,27 @@ export default function Dashboard({
         } finally {
             if (gen === namespacesFetchGen.current) setNamespacesLoading(false)
         }
-    }, [delegateKey, effectiveAccountObjectId, address])
+    }, [delegateKey, effectiveAccountObjectId, address, namespacesPageSize])
 
-    useEffect(() => {
+    // Restart the walk at the first page with no leftover cursor. Also used by Refresh.
+    const refreshNamespaces = useCallback(() => {
+        namespacesCursors.current = [undefined]
         setNamespaces([])
-        void fetchNamespaces()
-    }, [fetchNamespaces])
+        setNamespacesPage(0)
+        setNamespacesHasMore(false)
+        void fetchNamespacesPage(0)
+    }, [fetchNamespacesPage])
+
+    // Changing account, delegate key, or page size restarts the walk.
+    useEffect(() => {
+        refreshNamespaces()
+    }, [refreshNamespaces])
+
+    // Every page before the current one was full, so the running offset is exact.
+    const namespacesRangeStart = namespacesPage * namespacesPageSize + 1
+    const namespacesRangeEnd = namespacesPage * namespacesPageSize + namespaces.length
+    const namespacesPageMemories = namespaces.reduce((n, ns) => n + ns.memory_count, 0)
+    const namespacesIsPaginated = namespacesHasMore || namespacesPage > 0
 
     // ============================================================
     // Generate + add a new delegate key (via SDK)
@@ -1121,12 +1137,14 @@ const result = await generateText({
                                     ? namespacesError
                                     : namespaces.length === 0
                                         ? 'No indexed namespaces yet (or none the relayer can see for this account)'
-                                        : `${namespaces.reduce((n, ns) => n + ns.memory_count, 0)} memories across ${namespaces.length} ${namespaces.length === 1 ? 'namespace' : 'namespaces'}${namespacesTruncated ? ' (list truncated)' : ''}`
+                                        : namespacesIsPaginated
+                                            ? `Showing ${namespacesRangeStart}–${namespacesRangeEnd} · ${namespacesPageMemories} ${namespacesPageMemories === 1 ? 'memory' : 'memories'} on this page`
+                                            : `${namespacesPageMemories} memories across ${namespaces.length} ${namespaces.length === 1 ? 'namespace' : 'namespaces'}`
                         }
                         action={
                             <button
                                 className="btn btn-secondary btn-sm dashboard-keys-refresh"
-                                onClick={() => void fetchNamespaces()}
+                                onClick={refreshNamespaces}
                                 disabled={namespacesLoading}
                                 aria-busy={namespacesLoading}
                             >
@@ -1163,6 +1181,53 @@ const result = await generateText({
                                     </tbody>
                                 </table>
                             </div>
+                        )}
+                        {!namespacesError && namespacesIsPaginated && (
+                            <nav className="dashboard-pagination" aria-label="Namespaces pages">
+                                <div className="dashboard-pagination-size">
+                                    <label htmlFor="namespaces-page-size">Items per page</label>
+                                    <select
+                                        id="namespaces-page-size"
+                                        className="dashboard-pagination-select"
+                                        value={namespacesPageSize}
+                                        onChange={(e) => setNamespacesPageSize(Number(e.target.value))}
+                                        disabled={namespacesLoading}
+                                    >
+                                        {NAMESPACE_PAGE_SIZES.map((size) => (
+                                            <option key={size} value={size}>{size}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="dashboard-pagination-end">
+                                    <span className="dashboard-pagination-status" aria-live="polite">
+                                        {namespaces.length > 0
+                                            ? `${namespacesRangeStart}–${namespacesRangeEnd}`
+                                            : `Page ${namespacesPage + 1}`}
+                                    </span>
+                                    <div className="dashboard-pagination-controls">
+                                        <button
+                                            type="button"
+                                            className="dashboard-pagination-btn"
+                                            onClick={() => void fetchNamespacesPage(namespacesPage - 1)}
+                                            disabled={namespacesPage === 0 || namespacesLoading}
+                                            title="Previous page"
+                                            aria-label="Previous page"
+                                        >
+                                            <ChevronLeft size={16} />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className="dashboard-pagination-btn"
+                                            onClick={() => void fetchNamespacesPage(namespacesPage + 1)}
+                                            disabled={!namespacesHasMore || namespacesLoading}
+                                            title="Next page"
+                                            aria-label="Next page"
+                                        >
+                                            <ChevronRight size={16} />
+                                        </button>
+                                    </div>
+                                </div>
+                            </nav>
                         )}
                     </Card>
                 )}

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -532,7 +532,12 @@ export default function Dashboard({
     const namespacesRangeStart = namespacesPage * namespacesPageSize + 1
     const namespacesRangeEnd = namespacesPage * namespacesPageSize + namespaces.length
     const namespacesPageMemories = namespaces.reduce((n, ns) => n + ns.memory_count, 0)
-    const namespacesIsPaginated = namespacesHasMore || namespacesPage > 0
+    // Hide the footer when everything fits on one page — but keep it once the
+    // user has picked a non-default page size, or raising the size to fit the
+    // whole list would remove the only control that can lower it again.
+    const namespacesIsPaginated = namespacesHasMore
+        || namespacesPage > 0
+        || namespacesPageSize !== NAMESPACE_DEFAULT_PAGE_SIZE
 
     // ============================================================
     // Generate + add a new delegate key (via SDK)

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -477,34 +477,46 @@ export default function Dashboard({
         setNamespacesError('')
         try {
             const owner = address.toLowerCase()
-            const qs = new URLSearchParams({ limit: String(namespacesPageSize) })
-            const cursor = namespacesCursors.current[page]
-            if (cursor) qs.set('updated_after', cursor)
-            const path = `/v1/owners/${owner}/namespaces?${qs.toString()}`
-            const data = await apiGet(
-                delegateKey,
-                config.memwalServerUrl.replace(/\/+$/, ''),
-                path,
-                effectiveAccountObjectId,
-            ) as {
-                namespaces?: { name?: string; memory_count?: number }[]
-                next_cursor?: string | null
-                has_more?: boolean
-            }
-            if (gen !== namespacesFetchGen.current) return
-            const rows: { name: string; memory_count: number }[] = []
-            for (const ns of data.namespaces ?? []) {
-                if (typeof ns.name === 'string') {
-                    rows.push({ name: ns.name, memory_count: Number(ns.memory_count ?? 0) })
+            let target = page
+            for (;;) {
+                const qs = new URLSearchParams({ limit: String(namespacesPageSize) })
+                const cursor = namespacesCursors.current[target]
+                if (cursor) qs.set('updated_after', cursor)
+                const path = `/v1/owners/${owner}/namespaces?${qs.toString()}`
+                const data = await apiGet(
+                    delegateKey,
+                    config.memwalServerUrl.replace(/\/+$/, ''),
+                    path,
+                    effectiveAccountObjectId,
+                ) as {
+                    namespaces?: { name?: string; memory_count?: number }[]
+                    next_cursor?: string | null
+                    has_more?: boolean
                 }
+                if (gen !== namespacesFetchGen.current) return
+                const rows: { name: string; memory_count: number }[] = []
+                for (const ns of data.namespaces ?? []) {
+                    if (typeof ns.name === 'string') {
+                        rows.push({ name: ns.name, memory_count: Number(ns.memory_count ?? 0) })
+                    }
+                }
+                // Trust has_more + next_cursor, never rows.length: the relayer clamps limit.
+                const nextCursor = data.has_more ? (data.next_cursor ?? null) : null
+                namespacesCursors.current = namespacesCursors.current.slice(0, target + 1)
+                if (nextCursor) namespacesCursors.current[target + 1] = nextCursor
+                if (rows.length === 0 && target > 0) {
+                    // A continuation page can come back empty when namespaces move past
+                    // the relayer's snapshot_at while we page. Drop the cursor that opened
+                    // it and land on a real page instead of the first-load empty state.
+                    namespacesCursors.current.length = target
+                    target -= 1
+                    continue
+                }
+                setNamespaces(rows)
+                setNamespacesPage(target)
+                setNamespacesHasMore(Boolean(nextCursor))
+                return
             }
-            // Trust has_more + next_cursor, never rows.length: the relayer clamps limit.
-            const nextCursor = data.has_more ? (data.next_cursor ?? null) : null
-            namespacesCursors.current = namespacesCursors.current.slice(0, page + 1)
-            if (nextCursor) namespacesCursors.current[page + 1] = nextCursor
-            setNamespaces(rows)
-            setNamespacesPage(page)
-            setNamespacesHasMore(Boolean(nextCursor))
         } catch (err) {
             if (gen !== namespacesFetchGen.current) return
             console.error('Failed to list namespaces:', err)
@@ -514,7 +526,6 @@ export default function Dashboard({
         }
     }, [delegateKey, effectiveAccountObjectId, address, namespacesPageSize])
 
-    // Restart the walk at the first page with no leftover cursor. Also used by Refresh.
     const refreshNamespaces = useCallback(() => {
         namespacesCursors.current = [undefined]
         setNamespaces([])
@@ -523,7 +534,6 @@ export default function Dashboard({
         void fetchNamespacesPage(0)
     }, [fetchNamespacesPage])
 
-    // Changing account, delegate key, or page size restarts the walk.
     useEffect(() => {
         refreshNamespaces()
     }, [refreshNamespaces])
@@ -1141,7 +1151,9 @@ const result = await generateText({
                                 : namespacesError
                                     ? namespacesError
                                     : namespaces.length === 0
-                                        ? 'No indexed namespaces yet (or none the relayer can see for this account)'
+                                        ? namespacesPage > 0
+                                            ? 'This page is empty — go back for the namespaces already listed'
+                                            : 'No indexed namespaces yet (or none the relayer can see for this account)'
                                         : namespacesIsPaginated
                                             ? `Showing ${namespacesRangeStart}–${namespacesRangeEnd} · ${namespacesPageMemories} ${namespacesPageMemories === 1 ? 'memory' : 'memories'} on this page`
                                             : `${namespacesPageMemories} memories across ${namespaces.length} ${namespaces.length === 1 ? 'namespace' : 'namespaces'}`

--- a/apps/app/src/pages/Dashboard.tsx
+++ b/apps/app/src/pages/Dashboard.tsx
@@ -121,8 +121,8 @@ const MAX_DELEGATE_KEYS = 20
 const MAX_DELEGATE_KEYS_MESSAGE = 'This wallet already has 20 delegate keys. Remove an old key before creating a new delegate key.'
 const DELEGATE_KEYS_SECTION_ID = 'delegate-keys'
 // Relayer clamps `limit` (default 100, max 500); these stay well inside that.
-const NAMESPACE_PAGE_SIZES = [20, 50, 100]
-const NAMESPACE_DEFAULT_PAGE_SIZE = 20
+const NAMESPACE_PAGE_SIZES = [15, 25, 50, 100]
+const NAMESPACE_DEFAULT_PAGE_SIZE = 15
 const PRIVATE_KEY_ENV = 'MEMWAL_PRIVATE_KEY'
 const ACCOUNT_ID_ENV = 'MEMWAL_ACCOUNT_ID'
 const SERVER_URL_ENV = 'MEMWAL_SERVER_URL'

--- a/apps/app/src/pages/DashboardNamespaces.test.tsx
+++ b/apps/app/src/pages/DashboardNamespaces.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Namespaces card pagination (WALM-607).
+ *
+ * The relayer list endpoint is cursor-paginated: it clamps `limit` and reports
+ * `has_more` + `next_cursor`. These tests pin the card to that contract rather
+ * than to page length, and check that Refresh drops the cursor trail.
+ */
+import { render, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Hook return values must keep a stable identity across renders: Dashboard
+// memoizes callbacks on `suiClient` / `currentAccount`, so fresh objects each
+// render would re-fire their effects forever.
+const mocks = vi.hoisted(() => ({
+    address: '0xOwnerAddress',
+    apiGet: vi.fn(),
+    currentAccount: { address: '0xOwnerAddress' },
+    suiClient: { waitForTransaction: () => Promise.resolve({}) },
+    disconnect: { mutateAsync: () => Promise.resolve() },
+    signPersonalMessage: { mutateAsync: () => Promise.resolve() },
+    sponsoredTransaction: { mutateAsync: () => Promise.resolve() },
+    delegateKeyCtx: {
+        delegateKey: '0xdelegate',
+        delegatePublicKey: '0xpub',
+        accountObjectId: '0xaccount',
+        setDelegateKeys: () => {},
+        clearDelegateKeys: () => {},
+    },
+}))
+
+vi.mock('../config', () => ({
+    config: {
+        memwalServerUrl: 'https://relayer.test',
+        memwalPackageId: '0xpkg',
+        memwalRegistryId: '0xreg',
+        legacyMemwalRegistryId: '0xreg',
+        suiNetwork: 'testnet',
+        docsUrl: 'https://docs.test',
+        enableMemoryDeletion: false,
+        securityDeleteEnabled: false,
+    },
+}))
+vi.mock('@mysten/dapp-kit', () => ({
+    ConnectModal: () => null,
+    useCurrentAccount: () => mocks.currentAccount,
+    useDisconnectWallet: () => mocks.disconnect,
+    useSignPersonalMessage: () => mocks.signPersonalMessage,
+    useSuiClient: () => mocks.suiClient,
+}))
+vi.mock('../hooks/useSponsoredTransaction', () => ({
+    useSponsoredTransaction: () => mocks.sponsoredTransaction,
+}))
+vi.mock('../App', () => ({
+    useDelegateKey: () => mocks.delegateKeyCtx,
+}))
+vi.mock('@mysten-incubation/memwal/account', () => ({
+    generateDelegateKey: vi.fn(),
+}))
+vi.mock('../utils/api', () => ({ apiGet: mocks.apiGet }))
+vi.mock('../utils/suiClientCompat', () => ({
+    fetchAccountIdForOwner: vi.fn().mockResolvedValue('0xaccount'),
+    fetchObjectJson: vi.fn().mockResolvedValue(null),
+    publicKeyToHex: (v: unknown) => String(v),
+}))
+vi.mock('../utils/analytics', () => ({
+    trackEvent: vi.fn(),
+    getAnalyticsErrorType: () => 'unknown',
+}))
+vi.mock('../components/SecurityDeleteSection', () => ({ default: () => null }))
+
+import Dashboard from './Dashboard'
+
+/** One relayer page of `count` namespaces, named `<prefix>-<n>`. */
+function page(prefix: string, count: number, hasMore: boolean, nextCursor: string | null = null) {
+    return {
+        namespaces: Array.from({ length: count }, (_, i) => ({
+            name: `${prefix}-${i}`,
+            memory_count: i + 1,
+        })),
+        has_more: hasMore,
+        next_cursor: nextCursor,
+    }
+}
+
+/** The namespaces list request URL for the Nth apiGet call, or '' if absent. */
+function nsCalls(): string[] {
+    return mocks.apiGet.mock.calls
+        .map((c) => String(c[2] ?? ''))
+        .filter((p) => p.includes('/namespaces'))
+}
+
+function renderDashboard() {
+    return render(
+        <MemoryRouter>
+            <Dashboard />
+        </MemoryRouter>,
+    )
+}
+
+/** Render the dashboard and return its Namespaces card once mounted. */
+async function namespacesCard(): Promise<HTMLElement> {
+    const { container } = renderDashboard()
+    let card: Element | null = null
+    await waitFor(() => {
+        card = container.querySelector('#namespaces')
+        expect(card).not.toBeNull()
+    })
+    if (!(card instanceof HTMLElement)) throw new Error('namespaces card not found')
+    return card
+}
+
+beforeEach(() => {
+    mocks.apiGet.mockReset()
+    // Non-namespace calls (delegate keys etc.) get a harmless empty payload.
+    mocks.apiGet.mockResolvedValue({})
+})
+
+describe('Dashboard namespaces pagination', () => {
+    it('advances on has_more and sends the relayer cursor as updated_after', async () => {
+        const user = userEvent.setup()
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
+            if (!path.includes('/namespaces')) return {}
+            if (path.includes('updated_after=cursor-1')) return page('b', 2, false)
+            return page('a', 20, true, 'cursor-1')
+        })
+
+        const card = await namespacesCard()
+        await within(card).findByText('a-0')
+        expect(nsCalls()[0]).toContain('limit=20')
+        expect(nsCalls()[0]).not.toContain('updated_after')
+
+        await user.click(within(card).getByRole('button', { name: 'Next page' }))
+
+        await within(card).findByText('b-0')
+        expect(within(card).queryByText('a-0')).toBeNull()
+        expect(nsCalls().at(-1)).toContain('updated_after=cursor-1')
+        // Last page: no further cursor to follow.
+        expect(within(card).getByRole('button', { name: 'Next page' })).toBeDisabled()
+        expect(within(card).getByRole('button', { name: 'Previous page' })).toBeEnabled()
+    })
+
+    it('stops at has_more=false even when the page came back full', async () => {
+        // The relayer clamps `limit`, so a full page is not proof of more data.
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) =>
+            path.includes('/namespaces') ? page('a', 20, false, 'ignored-cursor') : {},
+        )
+
+        const card = await namespacesCard()
+        await within(card).findByText('a-0')
+        // Nothing to paginate: the footer stays out of the way entirely.
+        expect(within(card).queryByRole('button', { name: 'Next page' })).toBeNull()
+        expect(within(card).getByText('210 memories across 20 namespaces')).toBeTruthy()
+    })
+
+    it('goes back to the previous page without refetching from scratch', async () => {
+        const user = userEvent.setup()
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
+            if (!path.includes('/namespaces')) return {}
+            if (path.includes('updated_after=cursor-1')) return page('b', 3, false)
+            return page('a', 20, true, 'cursor-1')
+        })
+
+        const card = await namespacesCard()
+        await within(card).findByText('a-0')
+        await user.click(within(card).getByRole('button', { name: 'Next page' }))
+        await within(card).findByText('b-0')
+        expect(within(card).getByText('21–23')).toBeTruthy()
+
+        await user.click(within(card).getByRole('button', { name: 'Previous page' }))
+
+        await within(card).findByText('a-0')
+        expect(within(card).getByText('1–20')).toBeTruthy()
+        expect(nsCalls().at(-1)).not.toContain('updated_after')
+        expect(within(card).getByRole('button', { name: 'Previous page' })).toBeDisabled()
+    })
+
+    it('Refresh restarts the walk with no leftover cursor', async () => {
+        const user = userEvent.setup()
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
+            if (!path.includes('/namespaces')) return {}
+            if (path.includes('updated_after=cursor-1')) return page('b', 3, false)
+            return page('a', 20, true, 'cursor-1')
+        })
+
+        const card = await namespacesCard()
+        await within(card).findByText('a-0')
+        await user.click(within(card).getByRole('button', { name: 'Next page' }))
+        await within(card).findByText('b-0')
+
+        await user.click(within(card).getByRole('button', { name: /Refresh/ }))
+
+        await within(card).findByText('a-0')
+        expect(nsCalls().at(-1)).not.toContain('updated_after')
+        expect(within(card).getByRole('button', { name: 'Previous page' })).toBeDisabled()
+    })
+
+    it('changing page size restarts from the first page', async () => {
+        const user = userEvent.setup()
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
+            if (!path.includes('/namespaces')) return {}
+            if (path.includes('updated_after=cursor-1')) return page('b', 3, false)
+            return page('a', 20, true, 'cursor-1')
+        })
+
+        const card = await namespacesCard()
+        await within(card).findByText('a-0')
+        await user.click(within(card).getByRole('button', { name: 'Next page' }))
+        await within(card).findByText('b-0')
+
+        await user.selectOptions(within(card).getByLabelText('Items per page'), '50')
+
+        await waitFor(() => expect(nsCalls().at(-1)).toContain('limit=50'))
+        expect(nsCalls().at(-1)).not.toContain('updated_after')
+    })
+
+    it('keeps the empty state', async () => {
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) =>
+            path.includes('/namespaces') ? page('a', 0, false) : {},
+        )
+        const card = await namespacesCard()
+        await within(card).findByText(/No indexed namespaces yet/)
+        expect(within(card).queryByRole('button', { name: 'Next page' })).toBeNull()
+    })
+
+    it('keeps the error state and hides the pagination footer', async () => {
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
+            if (path.includes('/namespaces')) throw new Error('relayer down')
+            return {}
+        })
+        const card = await namespacesCard()
+        // Shown twice by design: card subtitle and the inline error paragraph.
+        await within(card).findAllByText('Could not load namespace counts from the relayer.')
+        expect(within(card).queryByRole('button', { name: 'Next page' })).toBeNull()
+    })
+
+    it('links each namespace row into the playground', async () => {
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) =>
+            path.includes('/namespaces')
+                ? { namespaces: [{ name: 'my ns', memory_count: 4 }], has_more: false, next_cursor: null }
+                : {},
+        )
+        const card = await namespacesCard()
+        const link = await within(card).findByTitle('Open this namespace in the playground')
+        expect(link.getAttribute('href')).toBe('/playground?namespace=my%20ns')
+    })
+})

--- a/apps/app/src/pages/DashboardNamespaces.test.tsx
+++ b/apps/app/src/pages/DashboardNamespaces.test.tsx
@@ -123,12 +123,12 @@ describe('Dashboard namespaces pagination', () => {
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
             if (!path.includes('/namespaces')) return {}
             if (path.includes('updated_after=cursor-1')) return page('b', 2, false)
-            return page('a', 20, true, 'cursor-1')
+            return page('a', 15, true, 'cursor-1')
         })
 
         const card = await namespacesCard()
         await within(card).findByText('a-0')
-        expect(nsCalls()[0]).toContain('limit=20')
+        expect(nsCalls()[0]).toContain('limit=15')
         expect(nsCalls()[0]).not.toContain('updated_after')
 
         await user.click(within(card).getByRole('button', { name: 'Next page' }))
@@ -144,14 +144,14 @@ describe('Dashboard namespaces pagination', () => {
     it('stops at has_more=false even when the page came back full', async () => {
         // The relayer clamps `limit`, so a full page is not proof of more data.
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) =>
-            path.includes('/namespaces') ? page('a', 20, false, 'ignored-cursor') : {},
+            path.includes('/namespaces') ? page('a', 15, false, 'ignored-cursor') : {},
         )
 
         const card = await namespacesCard()
         await within(card).findByText('a-0')
         // Nothing to paginate: the footer stays out of the way entirely.
         expect(within(card).queryByRole('button', { name: 'Next page' })).toBeNull()
-        expect(within(card).getByText('210 memories across 20 namespaces')).toBeTruthy()
+        expect(within(card).getByText('120 memories across 15 namespaces')).toBeTruthy()
     })
 
     it('goes back to the previous page without refetching from scratch', async () => {
@@ -159,19 +159,19 @@ describe('Dashboard namespaces pagination', () => {
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
             if (!path.includes('/namespaces')) return {}
             if (path.includes('updated_after=cursor-1')) return page('b', 3, false)
-            return page('a', 20, true, 'cursor-1')
+            return page('a', 15, true, 'cursor-1')
         })
 
         const card = await namespacesCard()
         await within(card).findByText('a-0')
         await user.click(within(card).getByRole('button', { name: 'Next page' }))
         await within(card).findByText('b-0')
-        expect(within(card).getByText('21–23')).toBeTruthy()
+        expect(within(card).getByText('16–18')).toBeTruthy()
 
         await user.click(within(card).getByRole('button', { name: 'Previous page' }))
 
         await within(card).findByText('a-0')
-        expect(within(card).getByText('1–20')).toBeTruthy()
+        expect(within(card).getByText('1–15')).toBeTruthy()
         expect(nsCalls().at(-1)).not.toContain('updated_after')
         expect(within(card).getByRole('button', { name: 'Previous page' })).toBeDisabled()
     })
@@ -181,7 +181,7 @@ describe('Dashboard namespaces pagination', () => {
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
             if (!path.includes('/namespaces')) return {}
             if (path.includes('updated_after=cursor-1')) return page('b', 3, false)
-            return page('a', 20, true, 'cursor-1')
+            return page('a', 15, true, 'cursor-1')
         })
 
         const card = await namespacesCard()
@@ -201,7 +201,7 @@ describe('Dashboard namespaces pagination', () => {
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
             if (!path.includes('/namespaces')) return {}
             if (path.includes('updated_after=cursor-1')) return page('b', 3, false)
-            return page('a', 20, true, 'cursor-1')
+            return page('a', 15, true, 'cursor-1')
         })
 
         const card = await namespacesCard()
@@ -217,12 +217,12 @@ describe('Dashboard namespaces pagination', () => {
 
     it('keeps the page-size selector reachable after the list fits one page', async () => {
         const user = userEvent.setup()
-        // 25 namespaces: two pages at 20, a single page at 50.
+        // 25 namespaces: two pages at 15, a single page at 50.
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
             if (!path.includes('/namespaces')) return {}
             if (path.includes('limit=50')) return page('all', 25, false)
             if (path.includes('updated_after=cursor-1')) return page('b', 5, false)
-            return page('a', 20, true, 'cursor-1')
+            return page('a', 15, true, 'cursor-1')
         })
 
         const card = await namespacesCard()
@@ -230,11 +230,11 @@ describe('Dashboard namespaces pagination', () => {
         await user.selectOptions(within(card).getByLabelText('Items per page'), '50')
 
         await within(card).findByText('all-24')
-        // Everything now fits, but the selector must survive so 20 is reachable.
+        // Everything now fits, but the selector must survive so 15 is reachable.
         const select = within(card).getByLabelText('Items per page')
         expect(select).toBeTruthy()
-        await user.selectOptions(select, '20')
-        await waitFor(() => expect(nsCalls().at(-1)).toContain('limit=20'))
+        await user.selectOptions(select, '15')
+        await waitFor(() => expect(nsCalls().at(-1)).toContain('limit=15'))
     })
 
     it('keeps the empty state', async () => {

--- a/apps/app/src/pages/DashboardNamespaces.test.tsx
+++ b/apps/app/src/pages/DashboardNamespaces.test.tsx
@@ -215,6 +215,28 @@ describe('Dashboard namespaces pagination', () => {
         expect(nsCalls().at(-1)).not.toContain('updated_after')
     })
 
+    it('keeps the page-size selector reachable after the list fits one page', async () => {
+        const user = userEvent.setup()
+        // 25 namespaces: two pages at 20, a single page at 50.
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
+            if (!path.includes('/namespaces')) return {}
+            if (path.includes('limit=50')) return page('all', 25, false)
+            if (path.includes('updated_after=cursor-1')) return page('b', 5, false)
+            return page('a', 20, true, 'cursor-1')
+        })
+
+        const card = await namespacesCard()
+        await within(card).findByText('a-0')
+        await user.selectOptions(within(card).getByLabelText('Items per page'), '50')
+
+        await within(card).findByText('all-24')
+        // Everything now fits, but the selector must survive so 20 is reachable.
+        const select = within(card).getByLabelText('Items per page')
+        expect(select).toBeTruthy()
+        await user.selectOptions(select, '20')
+        await waitFor(() => expect(nsCalls().at(-1)).toContain('limit=20'))
+    })
+
     it('keeps the empty state', async () => {
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) =>
             path.includes('/namespaces') ? page('a', 0, false) : {},

--- a/apps/app/src/pages/DashboardNamespaces.test.tsx
+++ b/apps/app/src/pages/DashboardNamespaces.test.tsx
@@ -246,6 +246,27 @@ describe('Dashboard namespaces pagination', () => {
         expect(within(card).queryByRole('button', { name: 'Next page' })).toBeNull()
     })
 
+    it('steps back when a continuation page comes back empty', async () => {
+        const user = userEvent.setup()
+        // The namespaces behind cursor-1 raced past the relayer snapshot, so the
+        // second page is empty. That is not a fresh empty account.
+        mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
+            if (!path.includes('/namespaces')) return {}
+            if (path.includes('updated_after=cursor-1')) return page('b', 0, false)
+            return page('a', 15, true, 'cursor-1')
+        })
+
+        const card = await namespacesCard()
+        await within(card).findByText('a-0')
+        await user.click(within(card).getByRole('button', { name: 'Next page' }))
+
+        // Back on page 1, with its rows — not the first-load empty copy.
+        await waitFor(() => expect(nsCalls().at(-1)).not.toContain('updated_after'))
+        await within(card).findByText('a-0')
+        expect(within(card).queryByText(/No indexed namespaces yet/)).toBeNull()
+        expect(within(card).getByRole('button', { name: 'Previous page' })).toBeDisabled()
+    })
+
     it('keeps the error state and hides the pagination footer', async () => {
         mocks.apiGet.mockImplementation(async (_k: string, _u: string, path: string) => {
             if (path.includes('/namespaces')) throw new Error('relayer down')


### PR DESCRIPTION
Closes [WALM-607](https://linear.app/mysten-labs/issue/WALM-607/fe-paginate-the-dashboard-namespaces-list).

## Problem

The dashboard Namespaces card already talked to the cursor-paginated relayer endpoint, but the UI did not paginate. `fetchNamespaces` walked `has_more` / `next_cursor` internally — up to 20 pages of 100 — concatenated everything into one table, and past that cap only appended `(list truncated)` to the subtitle. Namespaces beyond ~2000 were unreachable.

## What changed

One page at a time, driven by a cursor stack:

- `namespacesCursors[i]` holds the `updated_after` that opens page *i*, so **Previous replays a stored cursor** instead of re-walking from the start.
- **Next is gated on `has_more`, never on `rows.length`.** The relayer clamps `limit` (default 100, max 500), so a full page is not evidence of more data.
- **Refresh and page-size changes truncate the cursor stack** back to `[undefined]`, so no stale cursor survives into a new walk.
- Dropped the 20-page cap and `(list truncated)`.
- Per-row `/playground?namespace=` link is unchanged.

### Why not numbered pages

The endpoint is *cursor*-paginated — there is no total and no offset — so the [Astryx](https://astryx.atmeta.com/components/Pagination) numbered-pages variant does not apply (it wants `totalItems` *when the total is known*). This uses the count-readout + Prev/Next shape with a page-size selector, which Astryx's own "Page Size Selector" example places in a footer below the table. The footer stays hidden when everything fits on one page.

The second commit fixes a trap I introduced in the first: hiding the footer whenever the list fit one page meant that raising the page size to fit the whole list removed the only control that could lower it again. The footer now also stays while the page size differs from the default.

## Verification

Walked the real dev relayer with 24 seeded namespaces at `limit=20`:

```
page 1: 20 rows  has_more=true   next_cursor=eyJ1cGRhdGVkX2F0…
page 2:  4 rows  has_more=false  next_cursor=eyJ1cGRhdGVkX2F0…   <- still non-null
no duplicates across pages
```

Worth noting: **on the last page the relayer returns `has_more=false` with a non-null `next_cursor`.** Keying Next off the cursor — the more intuitive read — would leave the button enabled forever and fetch empty pages. That is exactly what the acceptance criterion about `has_more` guards against.

- 9 new tests in `DashboardNamespaces.test.tsx` cover each acceptance criterion: cursor sent as `updated_after`, stopping at `has_more=false` despite a full page, Previous, Refresh resetting the cursor, page-size restart, the page-size lockout regression, empty/error states, playground links.
- Full app suite 100 passed (13 files); `tsc -b` and `eslint` clean.
- Rendered the card's markup against the live stylesheet and checked desktop + mobile layout.

## Notes for the reviewer

- The card hides the table while a page loads (pre-existing behaviour), so paging briefly blanks the rows. Buttons disable and the subtitle reads "Loading…", so there is feedback — I kept the card's existing convention rather than inventing a new one. Happy to change it if you'd rather the rows stayed put.
- The error string renders twice (card subtitle *and* the inline paragraph). Pre-existing; left alone as out of scope, but the test uses `findAllByText` because of it.
- Separately, `apps/app/.env.example` pairs `relayer.dev.memwal.ai` with a package ID that relayer rejects, so a fresh checkout cannot register a delegate key (`Transaction kind is not permitted for sponsorship`). Not touched here — tracked separately.

## Out of scope

Playground namespace picker, Python SDK / MCP `listNamespaces`, and WALM-185.