### PR TITLE
fix(researcher): use Sui gRPC in the browser so Enoki login survives JSON-RPC CORS (WALM-604)

### DIFF
--- a/apps/researcher/components/enoki-login-card.tsx
+++ b/apps/researcher/components/enoki-login-card.tsx
@@ -7,15 +7,20 @@ import {
   useCurrentAccount,
   useSignPersonalMessage,
   useSignTransaction,
-  useSuiClient,
 } from "@mysten/dapp-kit";
 import { isEnokiWallet } from "@mysten/enoki";
+import type { SuiGrpcClient } from "@mysten/sui/grpc";
 import { Transaction } from "@mysten/sui/transactions";
 import { createSponsorAuthorization } from "@mysten-incubation/memwal";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { enokiConfig } from "@/lib/enoki/config";
+import { getSuiGrpcClient } from "@/lib/sui/grpc-client";
+import {
+  fetchAccountIdForOwner,
+  findCreatedObjectByType,
+} from "@/lib/sui/account-lookup";
 
 type Step =
   | "idle"
@@ -57,14 +62,14 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
 async function sponsoredSignAndExecute(
   transaction: Transaction,
   sender: string,
-  suiClient: ReturnType<typeof useSuiClient>,
+  suiClient: SuiGrpcClient,
   signTransaction: (args: {
-    transaction: Transaction;
+    transaction: Transaction | string;
   }) => Promise<{ signature: string }>,
   signPersonalMessage: (message: Uint8Array) => Promise<{ signature: string }>,
 ): Promise<{ digest: string }> {
   const kindBytes = await transaction.build({
-    client: suiClient as any,
+    client: suiClient,
     onlyTransactionKind: true,
   });
   const authorization = await createSponsorAuthorization(
@@ -93,7 +98,16 @@ async function sponsoredSignAndExecute(
 
   const sponsored = await sponsorRes.json();
   const sponsoredTx = Transaction.from(sponsored.bytes);
-  const { signature } = await signTransaction({ transaction: sponsoredTx });
+  // dapp-kit's useSignTransaction resolves move-call ABIs via the ambient
+  // client from SuiClientProvider, which is JSON-RPC (deprecated, no longer
+  // CORS-enabled for browser origins) — that resolution is what fails as
+  // `getNormalizedMoveFunction: Failed to fetch`. Pre-serializing with our
+  // gRPC client and handing off the resulting string short-circuits it:
+  // dapp-kit passes a string through as-is.
+  const sponsoredTxJson = await sponsoredTx.toJSON({ client: suiClient });
+  const { signature } = await signTransaction({
+    transaction: sponsoredTxJson,
+  });
 
   const execRes = await fetch(
     `${enokiConfig.memwalServerUrl}/sponsor/execute`,
@@ -127,7 +141,7 @@ export function EnokiLoginCard() {
   const wallets = useWallets();
   const { mutateAsync: connect } = useConnectWallet();
   const currentAccount = useCurrentAccount();
-  const suiClient = useSuiClient();
+  const suiClient = getSuiGrpcClient();
   const { mutateAsync: signTransaction } = useSignTransaction();
   const { mutateAsync: signPersonalMessage } = useSignPersonalMessage();
 
@@ -222,37 +236,18 @@ export function EnokiLoginCard() {
 
         // Check if a Walrus Memory account already exists for this address
         try {
-          const registryObj = await suiClient.getObject({
-            id: enokiConfig.memwalRegistryId,
-            options: { showContent: true },
-          });
-          if (
-            registryObj?.data?.content &&
-            "fields" in registryObj.data.content
-          ) {
-            const fields = registryObj.data.content.fields as any;
-            const tableId = fields?.accounts?.fields?.id?.id;
-            if (tableId) {
-              const dynField = await suiClient.getDynamicFieldObject({
-                parentId: tableId,
-                name: { type: "address", value: address },
-              });
-              if (
-                dynField?.data?.content &&
-                "fields" in dynField.data.content
-              ) {
-                knownAccountId = (dynField.data.content.fields as any)
-                  .value as string;
-              }
-            }
-          }
+          knownAccountId = await fetchAccountIdForOwner(
+            suiClient,
+            enokiConfig.memwalRegistryId,
+            address,
+          );
         } catch {
           // Dynamic field not found → no account yet
         }
 
         const pubKeyBytes = Array.from(publicKeyRaw);
 
-        const sign = (args: { transaction: Transaction }) =>
+        const sign = (args: { transaction: Transaction | string }) =>
           signTransaction(args);
 
         if (knownAccountId) {
@@ -298,19 +293,11 @@ export function EnokiLoginCard() {
           });
 
           // Find the created account object
-          const txDetails = await suiClient.getTransactionBlock({
-            digest: createResult.digest,
-            options: { showObjectChanges: true },
-          });
-          const createdObj = txDetails.objectChanges?.find(
-            (c) =>
-              c.type === "created" &&
-              "objectType" in c &&
-              c.objectType.includes("MemWalAccount"),
+          knownAccountId = await findCreatedObjectByType(
+            suiClient,
+            createResult.digest,
+            "MemWalAccount",
           );
-          if (createdObj && "objectId" in createdObj) {
-            knownAccountId = createdObj.objectId;
-          }
 
           if (!knownAccountId) {
             throw new Error(

--- a/apps/researcher/components/sui-providers.tsx
+++ b/apps/researcher/components/sui-providers.tsx
@@ -5,12 +5,12 @@ import {
   createNetworkConfig,
   SuiClientProvider,
   WalletProvider,
-  useSuiClientContext,
 } from "@mysten/dapp-kit";
 import { isEnokiNetwork, registerEnokiWallets } from "@mysten/enoki";
 import { getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { enokiConfig } from "@/lib/enoki/config";
+import { getSuiGrpcClient } from "@/lib/sui/grpc-client";
 
 const { networkConfig } = createNetworkConfig({
   testnet: { url: getJsonRpcFullnodeUrl("testnet"), network: "testnet" },
@@ -19,11 +19,20 @@ const { networkConfig } = createNetworkConfig({
 
 const queryClient = new QueryClient();
 
-/** Registers Enoki wallets (Google OAuth) with dapp-kit on mount. No-op if env vars are missing. */
+/**
+ * Registers Enoki wallets (Google OAuth) with dapp-kit on mount. No-op if env
+ * vars are missing.
+ *
+ * Uses a standalone SuiGrpcClient rather than SuiClientProvider's client:
+ * dapp-kit's SuiClientProvider is hard-typed to SuiJsonRpcClient (even in the
+ * latest published version), and Sui's public JSON-RPC fullnodes no longer
+ * serve browser JSON-RPC — so useSuiClientContext()'s client can't be used
+ * here. Enoki's `client` option accepts the same ClientWithCoreApi interface a
+ * gRPC client satisfies, so this is otherwise a drop-in swap.
+ */
 function RegisterEnokiWallets() {
-  const { client, network } = useSuiClientContext();
-
   useEffect(() => {
+    const network = enokiConfig.suiNetwork;
     if (!isEnokiNetwork(network)) return;
     if (!enokiConfig.enokiApiKey || !enokiConfig.googleClientId) return;
 
@@ -32,12 +41,12 @@ function RegisterEnokiWallets() {
       providers: {
         google: { clientId: enokiConfig.googleClientId },
       },
-      client,
+      client: getSuiGrpcClient(),
       network,
     });
 
     return unregister;
-  }, [client, network]);
+  }, []);
 
   return null;
 }

--- a/apps/researcher/lib/sui/account-lookup.ts
+++ b/apps/researcher/lib/sui/account-lookup.ts
@@ -1,0 +1,81 @@
+/**
+ * On-chain reads for the Enoki registration flow, over gRPC.
+ *
+ * These deliberately use gRPC's `include: { json: true }` rather than decoding
+ * BCS with hand-written struct schemas (the approach in
+ * apps/noter/lib/sui/account-bcs.ts). BCS schemas must list every field of a
+ * struct in declaration order; when the published package grows a field, a
+ * schema that predates it decodes *silently wrong* rather than erroring.
+ * account.move has already grown fields on both AccountRegistry and
+ * MemWalAccount that noter's schemas don't model — that's a latent bug waiting
+ * on the next publish. Reading `json` keeps these lookups correct across
+ * contract upgrades, since new fields just arrive as extra keys.
+ *
+ * The SDK notes the `json` shape may differ between JSON-RPC/gRPC/GraphQL
+ * backends. That doesn't apply here — this module only ever talks to the gRPC
+ * client from ./grpc-client — but the table-id read below still tolerates both
+ * renderings of a `UID`, since that is the one field whose shape has actually
+ * varied in practice.
+ */
+import type { SuiGrpcClient } from "@mysten/sui/grpc";
+import { fromHex, normalizeSuiAddress, toHex } from "@mysten/sui/utils";
+
+/**
+ * Look up the MemWalAccount object id owned by `ownerAddress`, or null if the
+ * owner has no account yet.
+ */
+export async function fetchAccountIdForOwner(
+  client: SuiGrpcClient,
+  registryId: string,
+  ownerAddress: string,
+): Promise<string | null> {
+  const registry = await client.getObject({
+    objectId: registryId,
+    include: { json: true },
+  });
+
+  // AccountRegistry.accounts is a sui::table::Table; its entries live as
+  // dynamic fields on the table's own UID, not inlined in the struct.
+  const accounts = registry.object.json?.accounts as
+    | { id?: string | { id?: string } }
+    | undefined;
+  const rawTableId = accounts?.id;
+  const tableId = typeof rawTableId === "string" ? rawTableId : rawTableId?.id;
+  if (!tableId) return null;
+
+  const response = await client.getDynamicField({
+    parentId: tableId,
+    name: {
+      type: "address",
+      bcs: fromHex(normalizeSuiAddress(ownerAddress)),
+    },
+  });
+
+  // The value is a Move `ID` — a bare 32-byte address, so it needs no struct
+  // schema to decode.
+  const value = response.dynamicField?.value?.bcs;
+  return value?.length === 32 ? `0x${toHex(value)}` : null;
+}
+
+/**
+ * Find the object created by `digest` whose type contains `objectType`, or null
+ * if the transaction created no such object.
+ */
+export async function findCreatedObjectByType(
+  client: SuiGrpcClient,
+  digest: string,
+  objectType: string,
+): Promise<string | null> {
+  const response = await client.getTransaction({
+    digest,
+    include: { effects: true, objectTypes: true },
+  });
+
+  const transaction = response.Transaction ?? response.FailedTransaction;
+  const created = transaction.effects?.changedObjects.find(
+    (change) =>
+      change.idOperation === "Created" &&
+      transaction.objectTypes?.[change.objectId]?.includes(objectType),
+  );
+  return created?.objectId ?? null;
+}

--- a/apps/researcher/lib/sui/grpc-client.ts
+++ b/apps/researcher/lib/sui/grpc-client.ts
@@ -1,0 +1,36 @@
+/**
+ * Sui gRPC client — used for Enoki's on-chain registration flow.
+ *
+ * Sui's public JSON-RPC fullnodes were deprecated in 2026 in favor of gRPC and
+ * no longer answer browser preflights, so any JSON-RPC read from the browser
+ * fails CORS. @mysten/dapp-kit's SuiClientProvider/useSuiClient are still
+ * hard-typed to SuiJsonRpcClient (confirmed against dapp-kit 1.1.17) and can't
+ * be swapped for a gRPC client, so this bypasses that provider entirely for the
+ * one place researcher needs live chain reads: the on-chain account
+ * lookup/creation in enoki-login-card.tsx.
+ *
+ * Mirrors apps/noter/lib/sui/grpc-client.ts, which has run this way in
+ * production since #684.
+ */
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { enokiConfig } from "@/lib/enoki/config";
+
+// Same hostnames Sui's own JSON-RPC used — gRPC-web is served from the same
+// fullnode, dispatched by content-type/path rather than a separate host.
+const GRPC_BASE_URLS = {
+  testnet: "https://fullnode.testnet.sui.io:443",
+  mainnet: "https://fullnode.mainnet.sui.io:443",
+} as const;
+
+let cached: SuiGrpcClient | null = null;
+let cachedNetwork: keyof typeof GRPC_BASE_URLS | null = null;
+
+/** Memoized SuiGrpcClient for the app's configured network. */
+export function getSuiGrpcClient(): SuiGrpcClient {
+  const network = enokiConfig.suiNetwork;
+  if (cached && cachedNetwork === network) return cached;
+
+  cached = new SuiGrpcClient({ network, baseUrl: GRPC_BASE_URLS[network] });
+  cachedNetwork = network;
+  return cached;
+}


### PR DESCRIPTION
Fixes WALM-604.

Researcher's Google/Enoki sign-in fails in dev, staging and production: Sui's public fullnodes no longer answer browser JSON-RPC preflights, so dapp-kit's ambient client dies on `getNormalizedMoveFunction`. Noter moved to gRPC for this in #684; researcher was left behind.

## Two departures from the ticket

- **Ports noter's merged #684, not the researcher half of `hotfix/noter-mainnet-rpc-cors`.** That branch needs a new `NEXT_PUBLIC_SUI_GRPC_URL` across three environments, and silently falls back to the broken path if one is missed.
- **Skips noter's `account-bcs.ts`**, reading via gRPC `include: { json: true }` instead. BCS schemas decode silently wrong once a struct grows a field, and `account.move` already has.

Also fixes `sui-providers.tsx`, which the ticket doesn't mention — `registerEnokiWallets` was getting the dead JSON-RPC client too.

## Verified

Typecheck, lint, `next build`. Plus live reads against both the testnet and mainnet registries: json and BCS agree, and 6 real owners round-trip to the correct account.

## Not verified

Google sign-in itself — the ticket's *How to verify* step. Blocked locally: the Enoki key is mainnet-only, and the Google OAuth client doesn't authorize `http://localhost:3000/login`. Needs the dev deploy to confirm. Login is already broken on dev today, so deploying this can't regress it.
