### PR TITLE
fix(sdk): make a remember timeout a recoverable unknown outcome (WALM-595)

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,7 +29,7 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.10. `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.9 reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials.
+  The latest Python SDK release is 0.1.10. `MemWalRememberJobTimeout` carries `idempotency_key` and `namespace`, so a poll timeout can be settled or replayed instead of retried into a duplicate write. `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.9 reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
@@ -38,10 +38,12 @@ For the latest version, see the [PyPI project page](https://pypi.org/project/mem
 
 ## 0.1.10
 
-This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures.
+This release makes a remember poll timeout a recoverable unknown outcome and adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures.
 
 ### Added
 
+- `MemWalRememberJobTimeout` carries `idempotency_key` and `namespace` alongside `job_id`. A poll timeout is an unknown outcome, because the relayer accepted the write and it might still complete, so a caller can settle it with `wait_for_remember_job(err.job_id)`, or replay `remember_and_wait(..., idempotency_key=err.idempotency_key)` from another process and get the original job back instead of a second paid blob. Previously the generated key never left the client instance (WALM-595, GH #658).
+- `RememberAcceptedResult.idempotency_key` echoes the key a write was submitted under, matching the TypeScript SDK, so a split-API caller (`remember` then `wait_for_remember_job`) can persist it next to `job_id`.
 - `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ## 0.1.9

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,15 +28,18 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. A `rememberAndWait()` poll timeout now throws a typed `RememberJobTimeoutError` carrying `jobId` and `idempotencyKey`, so an unknown outcome can be settled or replayed instead of retried into a duplicate write. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
+This release makes a remember poll timeout a recoverable unknown outcome, removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
 
 ### Added
 
+- `isRememberJobTimeoutError(err)` and the `RememberJobTimeoutError` type. A `rememberAndWait()` / `waitForRememberJob()` poll timeout is an unknown outcome, because the relayer accepted the job and it might still complete, so it is now distinguishable from a genuine failure without duck-typing (WALM-595, GH #658).
+- The timeout carries `jobId`, `idempotencyKey` and `namespace`. Poll `waitForRememberJob(err.jobId)` to settle the write without submitting another, or replay `rememberAndWait(text, err.namespace, { idempotencyKey: err.idempotencyKey })` from any process, and the relayer returns the original job instead of minting a second blob. Previously the generated key never left the SDK instance, so a restarted service had no way to avoid the duplicate.
+- `RememberAcceptedResult.idempotency_key` echoes the key a write was submitted under, so callers of `remember()` / `rememberAsync()` can persist it next to `job_id`.
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -37,26 +37,64 @@ Several of these are patterns you implement around the client today. Where a cap
 
 ## Make writes idempotent
 
-The relayer does not deduplicate writes. A `remember` call that retries after a network blip, or fired twice by an at-least-once job queue, stores the same text twice and pollutes later recall. Until content-based deduplication is available natively, gate writes on a key your agent controls so a repeat is a no-op.
+Every write carries an idempotency key. Pass your own via `idempotencyKey` and a
+repeat submission returns the original job instead of minting — and charging for
+— a second blob. Omit it and the SDK generates one per call, which still covers
+its own internal retries but gives you nothing to replay with later.
 
 ```ts
 import { createHash } from "crypto";
 
-const written = new Set<string>(); // back this with Redis or a DB in production
+function writeKey(text: string, namespace = "default") {
+  return createHash("sha256").update(`${namespace}:${text}`).digest("hex");
+}
 
-async function rememberOnce(memwal: MemWal, text: string, namespace?: string) {
-  const id = createHash("sha256").update(`${namespace ?? "default"}:${text}`).digest("hex");
-  if (written.has(id)) return; // already stored this exact memory
+const job = await memwal.remember(text, namespace, { idempotencyKey: writeKey(text, namespace) });
+// job.idempotency_key is the handle to persist alongside job.job_id.
+```
 
-  const job = await memwal.remember(text, namespace);
-  await memwal.waitForRememberJob(job.job_id);
-  written.add(id);
+Reusing a key for *different* content is rejected with a `409`, so a key derived
+from the content itself is the safest choice.
+
+<Note>
+Persist the key outside the process (Redis, a database row, a Sui object), not in
+memory. An in-memory map resets on restart, which is exactly when a retry storm
+is most likely.
+</Note>
+
+## Recover an unknown outcome
+
+When `rememberAndWait()` exhausts its poll budget, the write is **unknown, not
+failed**. The relayer accepted the job before the budget expired and usually
+finishes it seconds later. Retrying that call blindly is what stores the memory
+twice.
+
+`isRememberTimeoutError()` separates the two cases, and the error carries both
+handles you need to settle the write:
+
+```ts
+import { isRememberTimeoutError } from "@mysten-incubation/memwal";
+
+try {
+  await memwal.rememberAndWait(text, namespace);
+} catch (err) {
+  if (!isRememberTimeoutError(err)) throw err; // a real failure
+
+  // Option A — settle the job that already exists. No second write.
+  const settled = await memwal.waitForRememberJob(err.jobId, { timeoutMs: 120_000 });
+  console.log(settled.blob_id);
+
+  // Option B — hand err.jobId and err.idempotencyKey to a durable queue and
+  // resume later, even from another process:
+  //   await memwal.rememberAndWait(text, err.namespace, {
+  //     idempotencyKey: err.idempotencyKey,
+  //   });
 }
 ```
 
-<Note>
-Persist the idempotency set outside the process (Redis, a database row, a Sui object), not in memory. An in-memory set resets on restart, which is exactly when a retry storm is most likely.
-</Note>
+Prefer option A while the process is still up: it is a read. Option B is for a
+worker that picks the write back up after a restart — the replay collapses onto
+the original job, so it settles the same blob rather than paying for a new one.
 
 ## Retry with backoff, but only retryable failures
 

--- a/docs/sdk/production-readiness.md
+++ b/docs/sdk/production-readiness.md
@@ -37,10 +37,10 @@ Several of these are patterns you implement around the client today. Where a cap
 
 ## Make writes idempotent
 
-Every write carries an idempotency key. Pass your own via `idempotencyKey` and a
-repeat submission returns the original job instead of minting — and charging for
-— a second blob. Omit it and the SDK generates one per call, which still covers
-its own internal retries but gives you nothing to replay with later.
+Every write carries an idempotency key. Pass your own through `idempotencyKey` and
+a repeat submission returns the original job instead of minting a second blob,
+which you would also pay for. Omit it and the SDK generates one per call, which
+still covers its own internal retries but gives you nothing to replay with later.
 
 ```ts
 import { createHash } from "crypto";
@@ -49,12 +49,20 @@ function writeKey(text: string, namespace = "default") {
   return createHash("sha256").update(`${namespace}:${text}`).digest("hex");
 }
 
+async function rememberOnce(memwal: MemWal, text: string, namespace?: string) {
+  return memwal.rememberAndWait(text, namespace, {
+    idempotencyKey: writeKey(text, namespace),
+  });
+}
+
+// job.idempotency_key echoes the key back, so a fire-and-forget caller can
+// persist it alongside job.job_id.
 const job = await memwal.remember(text, namespace, { idempotencyKey: writeKey(text, namespace) });
-// job.idempotency_key is the handle to persist alongside job.job_id.
 ```
 
-Reusing a key for *different* content is rejected with a `409`, so a key derived
-from the content itself is the safest choice.
+Derive the key from the content, as above. It is then stable across processes, so
+a replay after a restart lands on the original job. Reusing one key for
+*different* content is rejected with a `409`.
 
 <Note>
 Persist the key outside the process (Redis, a database row, a Sui object), not in
@@ -69,22 +77,22 @@ failed**. The relayer accepted the job before the budget expired and usually
 finishes it seconds later. Retrying that call blindly is what stores the memory
 twice.
 
-`isRememberTimeoutError()` separates the two cases, and the error carries both
+`isRememberJobTimeoutError()` separates the two cases, and the error carries both
 handles you need to settle the write:
 
 ```ts
-import { isRememberTimeoutError } from "@mysten-incubation/memwal";
+import { isRememberJobTimeoutError } from "@mysten-incubation/memwal";
 
 try {
   await memwal.rememberAndWait(text, namespace);
 } catch (err) {
-  if (!isRememberTimeoutError(err)) throw err; // a real failure
+  if (!isRememberJobTimeoutError(err)) throw err; // a real failure
 
-  // Option A — settle the job that already exists. No second write.
+  // Option A: settle the job that already exists. No second write.
   const settled = await memwal.waitForRememberJob(err.jobId, { timeoutMs: 120_000 });
   console.log(settled.blob_id);
 
-  // Option B — hand err.jobId and err.idempotencyKey to a durable queue and
+  // Option B: hand err.jobId and err.idempotencyKey to a durable queue and
   // resume later, even from another process:
   //   await memwal.rememberAndWait(text, err.namespace, {
   //     idempotencyKey: err.idempotencyKey,
@@ -93,12 +101,14 @@ try {
 ```
 
 Prefer option A while the process is still up: it is a read. Option B is for a
-worker that picks the write back up after a restart — the replay collapses onto
+worker that picks the write back up after a restart. The replay collapses onto
 the original job, so it settles the same blob rather than paying for a new one.
 
 ## Retry with backoff, but only retryable failures
 
-The client does not retry for you. Wrap calls in exponential backoff, and be careful to retry only failures that a retry can fix. A transient network error or relayer timeout is worth retrying. A `401 AUTH_REJECTED` is a configuration problem that fails identically on every attempt, so retrying it just delays the real fix.
+The client does not retry for you. Wrap calls in exponential backoff, and be careful to retry only failures that a retry can fix. A transient network error is worth retrying. A `401 AUTH_REJECTED` is a configuration problem that fails identically on every attempt, so retrying it just delays the real fix.
+
+A write that timed out while polling is the case to be careful with. It is not a failure, so re-running the write is not a retry: it is a second write. Treat `isRememberJobTimeoutError(err)` the way you treat a 4xx and stop, then recover through the job id or the key as shown above.
 
 ```ts
 async function withRetry<T>(fn: () => Promise<T>, attempts = 4): Promise<T> {
@@ -107,6 +117,9 @@ async function withRetry<T>(fn: () => Promise<T>, attempts = 4): Promise<T> {
     try {
       return await fn();
     } catch (err) {
+      // A poll timeout is an unknown outcome, not a failure. Retrying the
+      // write here is what stores the memory twice.
+      if (isRememberJobTimeoutError(err)) throw err;
       const status = (err as { status?: number }).status;
       // Do not retry auth or client errors; they will not succeed on a retry.
       if (status === 401 || (status && status >= 400 && status < 500)) throw err;
@@ -120,7 +133,7 @@ async function withRetry<T>(fn: () => Promise<T>, attempts = 4): Promise<T> {
 await withRetry(() => rememberOnce(memwal, "Observed: deploy at 14:03 UTC."));
 ```
 
-Pairing retry with the idempotency guard above is deliberate: a retry that fires after the write actually succeeded server-side stays safe, because `rememberOnce` short-circuits on the key.
+Pairing retry with the idempotency key above is deliberate: a retry that fires after the write actually succeeded server-side stays safe, because the relayer returns the original job for that key instead of minting a second blob.
 
 <Note>
 Built-in retry and backoff inside the client is on the roadmap. When it ships, you can drop the wrapper for the calls it covers and keep only the idempotency guard.

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # memwal
 
+## Unreleased
+
+### Added
+
+- `MemWalRememberJobTimeout` carries `idempotency_key` and `namespace` alongside `job_id`. A poll timeout is an unknown outcome — the relayer accepted the write and it may still complete — so a caller can settle it with `wait_for_remember_job(err.job_id)`, or replay `remember_and_wait(..., idempotency_key=err.idempotency_key)` from another process and get the original job back instead of a second paid blob. Previously the generated key never left the client instance (WALM-595, GH #658).
+
 ## 0.1.10
 
 ### Added

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -1,15 +1,11 @@
 # memwal
 
-## Unreleased
-
-### Added
-
-- `MemWalRememberJobTimeout` carries `idempotency_key` and `namespace` alongside `job_id`. A poll timeout is an unknown outcome — the relayer accepted the write and it may still complete — so a caller can settle it with `wait_for_remember_job(err.job_id)`, or replay `remember_and_wait(..., idempotency_key=err.idempotency_key)` from another process and get the original job back instead of a second paid blob. Previously the generated key never left the client instance (WALM-595, GH #658).
-
 ## 0.1.10
 
 ### Added
 
+- `MemWalRememberJobTimeout` carries `idempotency_key` and `namespace` alongside `job_id`. A poll timeout is an unknown outcome, because the relayer accepted the write and it might still complete, so a caller can settle it with `wait_for_remember_job(err.job_id)`, or replay `remember_and_wait(..., idempotency_key=err.idempotency_key)` from another process and get the original job back instead of a second paid blob. Previously the generated key never left the client instance (WALM-595, GH #658).
+- `RememberAcceptedResult.idempotency_key` echoes the key a write was submitted under, matching the TypeScript SDK, so a split-API caller (`remember` then `wait_for_remember_job`) can persist it next to `job_id`.
 - `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ## 0.1.9

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -498,11 +498,16 @@ class MemWal:
             )
         except MemWalRememberJobTimeout as timeout:
             # The in-memory key map only helps a caller retrying in this same
-            # process. Put the key on the exception too, so a service that
-            # restarts can still replay this exact write (WALM-595).
-            timeout.idempotency_key = resolved_key
-            timeout.namespace = resolved_namespace
-            raise
+            # process. Re-raise with the key so a service that restarts can
+            # replay this exact write, and so the key is in ``str(err)`` and not
+            # only in a field: after a restart the log line may be all that is
+            # left (WALM-595).
+            raise MemWalRememberJobTimeout(
+                job_id=timeout.job_id,
+                timeout_ms=timeout.timeout_ms,
+                idempotency_key=resolved_key,
+                namespace=resolved_namespace,
+            ) from timeout
         if generated_key:
             self._pending_remember_keys.pop(request_identity, None)
         return result

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -395,6 +395,7 @@ class MemWal:
         return RememberAcceptedResult(
             job_id=data["job_id"],
             status=data.get("status", "pending"),
+            idempotency_key=resolved_key,
         )
 
     # Alias for parity with TS SDK ``rememberAsync``.

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -489,11 +489,19 @@ class MemWal:
             self._pending_remember_keys[request_identity] = resolved_key
 
         accepted = await self.remember(text, resolved_namespace, resolved_key)
-        result = await self.wait_for_remember_job(
-            accepted.job_id,
-            poll_interval_ms=poll_interval_ms,
-            timeout_ms=timeout_ms,
-        )
+        try:
+            result = await self.wait_for_remember_job(
+                accepted.job_id,
+                poll_interval_ms=poll_interval_ms,
+                timeout_ms=timeout_ms,
+            )
+        except MemWalRememberJobTimeout as timeout:
+            # The in-memory key map only helps a caller retrying in this same
+            # process. Put the key on the exception too, so a service that
+            # restarts can still replay this exact write (WALM-595).
+            timeout.idempotency_key = resolved_key
+            timeout.namespace = resolved_namespace
+            raise
         if generated_key:
             self._pending_remember_keys.pop(request_identity, None)
         return result
@@ -1431,15 +1439,41 @@ class MemWalRememberJobFailed(MemWalError):
 
 
 class MemWalRememberJobTimeout(MemWalError):
-    """Polling loop exceeded the configured timeout."""
+    """Polling gave up while the job was still running.
 
-    def __init__(self, job_id: str, timeout_ms: int) -> None:
+    An UNKNOWN outcome, not a failure: the relayer accepted the write and it
+    usually completes seconds later (WALM-595 / GH #658). Both handles needed to
+    settle it without paying for a second write are on the exception:
+
+    - ``job_id`` -> :meth:`MemWal.wait_for_remember_job` polls the same job.
+    - ``idempotency_key`` -> replaying ``remember_and_wait(..., idempotency_key=)``
+      returns the original job instead of minting a second blob. This is the one
+      that survives a process restart, which the in-memory key map does not. It
+      is ``None`` when :meth:`MemWal.wait_for_remember_job` was called directly,
+      since that path never saw a key.
+    """
+
+    def __init__(
+        self,
+        job_id: str,
+        timeout_ms: int,
+        idempotency_key: Optional[str] = None,
+        namespace: Optional[str] = None,
+    ) -> None:
+        detail = f"job_id={job_id}"
+        if idempotency_key:
+            detail += f", idempotency_key={idempotency_key}"
         super().__init__(
-            f"remember job timed out after {timeout_ms}ms (job_id={job_id})"
+            f"remember job timed out after {timeout_ms}ms ({detail}). The write may "
+            f"still complete: poll wait_for_remember_job({job_id!r}) to settle it, or "
+            f"replay with the same idempotency_key. Do not retry without one - that "
+            f"mints a second blob."
         )
         self.status = 504
         self.job_id = job_id
         self.timeout_ms = timeout_ms
+        self.idempotency_key = idempotency_key
+        self.namespace = namespace
 
 
 async def _discard_http_client(memwal: MemWal) -> None:

--- a/packages/python-sdk-memwal/memwal/types.py
+++ b/packages/python-sdk-memwal/memwal/types.py
@@ -326,6 +326,11 @@ class RememberAcceptedResult:
 
     job_id: str
     status: str
+    #: The idempotency key this write was submitted under. Replaying the same
+    #: write with it returns this job instead of minting a second blob, so it is
+    #: the handle to persist alongside ``job_id`` (WALM-595). Mirrors TS
+    #: ``RememberAcceptedResult.idempotency_key``.
+    idempotency_key: Optional[str] = None
 
 
 @dataclass

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -445,6 +445,26 @@ class TestRememberTimeoutRecovery:
         assert keys == {err.idempotency_key}
 
     @respx.mock
+    async def test_remember_echoes_the_key_it_submitted_under(
+        self, memwal_client: MemWal
+    ) -> None:
+        """A split-API caller (remember + wait) needs the key too."""
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/remember").mock(
+            return_value=httpx.Response(
+                202, json={"job_id": "job-1", "status": "pending"}
+            )
+        )
+
+        generated = await memwal_client.remember("wallet drop #42")
+        assert generated.idempotency_key
+
+        explicit = await memwal_client.remember(
+            "wallet drop #43", idempotency_key="caller-owned-key"
+        )
+        assert explicit.idempotency_key == "caller-owned-key"
+
+    @respx.mock
     async def test_direct_wait_reports_no_key_it_never_saw(
         self, memwal_client: MemWal
     ) -> None:

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -22,6 +22,7 @@ from memwal.client import (
     MemWalClockDriftError,
     MemWalCompatibilityError,
     MemWalError,
+    MemWalRememberJobTimeout,
     MemWalSync,
 )
 from memwal.types import (
@@ -348,6 +349,118 @@ class TestRemember:
 # ============================================================
 # remember_bulk_async() tests
 # ============================================================
+
+
+class TestRememberTimeoutRecovery:
+    """WALM-595 / GH #658.
+
+    A poll timeout is an UNKNOWN outcome: the relayer accepted the write and it
+    may still complete. The exception must carry the handles that settle it, or
+    the obvious retry mints and pays for a second blob.
+    """
+
+    @respx.mock
+    async def test_timeout_carries_the_recovery_handles(
+        self, memwal_client: MemWal
+    ) -> None:
+        mock_seal_session_prereqs()
+        respx.post(f"{_TEST_SERVER}/api/remember").mock(
+            return_value=httpx.Response(
+                202, json={"job_id": "job-stuck", "status": "pending"}
+            )
+        )
+        respx.get(f"{_TEST_SERVER}/api/remember/job-stuck").mock(
+            return_value=httpx.Response(
+                200, json={"job_id": "job-stuck", "status": "running"}
+            )
+        )
+
+        with pytest.raises(MemWalRememberJobTimeout) as excinfo:
+            await memwal_client.remember_and_wait(
+                "wallet drop #42", "drops", poll_interval_ms=0, timeout_ms=1
+            )
+
+        err = excinfo.value
+        assert err.status == 504
+        assert err.job_id == "job-stuck"
+        assert err.namespace == "drops"
+        assert err.idempotency_key
+        assert "mints a second blob" in str(err)
+
+    @respx.mock
+    async def test_replay_under_the_returned_key_reuses_the_job(
+        self, memwal_client: MemWal
+    ) -> None:
+        mock_seal_session_prereqs()
+        post = respx.post(f"{_TEST_SERVER}/api/remember").mock(
+            return_value=httpx.Response(
+                202, json={"job_id": "job-stuck", "status": "pending"}
+            )
+        )
+        polls = {"n": 0}
+
+        def _status(request: httpx.Request) -> httpx.Response:
+            polls["n"] += 1
+            if polls["n"] <= 1:
+                return httpx.Response(
+                    200, json={"job_id": "job-stuck", "status": "running"}
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "job_id": "job-stuck",
+                    "status": "done",
+                    "blob_id": "blob-xyz",
+                    "owner": "0xowner",
+                    "namespace": "drops",
+                },
+            )
+
+        respx.get(f"{_TEST_SERVER}/api/remember/job-stuck").mock(side_effect=_status)
+
+        with pytest.raises(MemWalRememberJobTimeout) as excinfo:
+            await memwal_client.remember_and_wait(
+                "wallet drop #42", "drops", poll_interval_ms=0, timeout_ms=1
+            )
+        err = excinfo.value
+
+        # A different client stands in for the restarted process: its in-memory
+        # key map is empty, so only the key read off the exception keeps the
+        # replay idempotent.
+        fresh = MemWal.create(
+            key=_TEST_KEY_HEX, account_id=_TEST_ACCOUNT_ID, server_url=_TEST_SERVER
+        )
+        replayed = await fresh.remember_and_wait(
+            "wallet drop #42",
+            err.namespace,
+            poll_interval_ms=0,
+            timeout_ms=5_000,
+            idempotency_key=err.idempotency_key,
+        )
+
+        assert replayed.blob_id == "blob-xyz"
+        keys = {
+            json.loads(call.request.content)["idempotency_key"] for call in post.calls
+        }
+        assert keys == {err.idempotency_key}
+
+    @respx.mock
+    async def test_direct_wait_reports_no_key_it_never_saw(
+        self, memwal_client: MemWal
+    ) -> None:
+        mock_seal_session_prereqs()
+        respx.get(f"{_TEST_SERVER}/api/remember/job-stuck").mock(
+            return_value=httpx.Response(
+                200, json={"job_id": "job-stuck", "status": "running"}
+            )
+        )
+
+        with pytest.raises(MemWalRememberJobTimeout) as excinfo:
+            await memwal_client.wait_for_remember_job(
+                "job-stuck", poll_interval_ms=0, timeout_ms=1
+            )
+
+        assert excinfo.value.idempotency_key is None
 
 
 class TestRememberBulkAsync:

--- a/packages/python-sdk-memwal/tests/test_client.py
+++ b/packages/python-sdk-memwal/tests/test_client.py
@@ -386,6 +386,9 @@ class TestRememberTimeoutRecovery:
         assert err.namespace == "drops"
         assert err.idempotency_key
         assert "mints a second blob" in str(err)
+        # The key belongs in the message too, matching TS: after a restart the
+        # log line may be all a caller still has.
+        assert err.idempotency_key in str(err)
 
     @respx.mock
     async def test_replay_under_the_returned_key_reuses_the_job(

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @mysten-incubation/memwal
 
+## Unreleased
+
+### Added
+
+- `isRememberTimeoutError(err)` and the `RememberTimeoutError` type. A `rememberAndWait()` / `waitForRememberJob()` poll timeout is an unknown outcome — the relayer accepted the job and it may still complete — and is now distinguishable from a genuine failure without duck-typing (WALM-595, GH #658).
+- The timeout carries `jobId`, `idempotencyKey` and `namespace`. Poll `waitForRememberJob(err.jobId)` to settle the write without submitting another, or replay `rememberAndWait(text, err.namespace, { idempotencyKey: err.idempotencyKey })` — including from a different process — and the relayer returns the original job instead of minting a second blob. Previously the generated key never left the SDK instance, so a restarted service had no way to avoid the duplicate.
+- `RememberAcceptedResult.idempotency_key` echoes the key a write was submitted under, so callers of `remember()` / `rememberAsync()` can persist it next to `job_id`.
+
 ## 0.1.7
 
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,17 +1,12 @@
 # @mysten-incubation/memwal
 
-## Unreleased
-
-### Added
-
-- `isRememberTimeoutError(err)` and the `RememberTimeoutError` type. A `rememberAndWait()` / `waitForRememberJob()` poll timeout is an unknown outcome — the relayer accepted the job and it may still complete — and is now distinguishable from a genuine failure without duck-typing (WALM-595, GH #658).
-- The timeout carries `jobId`, `idempotencyKey` and `namespace`. Poll `waitForRememberJob(err.jobId)` to settle the write without submitting another, or replay `rememberAndWait(text, err.namespace, { idempotencyKey: err.idempotencyKey })` — including from a different process — and the relayer returns the original job instead of minting a second blob. Previously the generated key never left the SDK instance, so a restarted service had no way to avoid the duplicate.
-- `RememberAcceptedResult.idempotency_key` echoes the key a write was submitted under, so callers of `remember()` / `rememberAsync()` can persist it next to `job_id`.
-
 ## 0.1.7
 
 ### Added
 
+- `isRememberJobTimeoutError(err)` and the `RememberJobTimeoutError` type. A `rememberAndWait()` / `waitForRememberJob()` poll timeout is an unknown outcome, because the relayer accepted the job and it might still complete, so it is now distinguishable from a genuine failure without duck-typing (WALM-595, GH #658).
+- The timeout carries `jobId`, `idempotencyKey` and `namespace`. Poll `waitForRememberJob(err.jobId)` to settle the write without submitting another, or replay `rememberAndWait(text, err.namespace, { idempotencyKey: err.idempotencyKey })` from any process, and the relayer returns the original job instead of minting a second blob. Previously the generated key never left the SDK instance, so a restarted service had no way to avoid the duplicate.
+- `RememberAcceptedResult.idempotency_key` echoes the key a write was submitted under, so callers of `remember()` / `rememberAsync()` can persist it next to `job_id`.
 - `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
 ### Fixed

--- a/packages/sdk/node_modules
+++ b/packages/sdk/node_modules
@@ -1,1 +1,0 @@
-/Users/harryphan/Documents/2026 vault/DEV_PROJECTS/active/memwal/MemWal/packages/sdk/node_modules

--- a/packages/sdk/node_modules
+++ b/packages/sdk/node_modules
@@ -1,0 +1,1 @@
+/Users/harryphan/Documents/2026 vault/DEV_PROJECTS/active/memwal/MemWal/packages/sdk/node_modules

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -24,10 +24,9 @@ export {
 
 // Delegate key utilities (no @mysten/sui dependency)
 export { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "./utils.js";
-// Unknown-outcome recovery: tell "the write may still land" apart from
+// Unknown-outcome recovery: tell "the write might still land" apart from
 // "the write failed" before retrying anything.
-export { isRememberTimeoutError } from "./utils.js";
-export type { RememberTimeoutError } from "./utils.js";
+export { isRememberJobTimeoutError } from "./utils.js";
 export {
     estimateTokens,
     truncateToTokenBudget,
@@ -48,6 +47,7 @@ export type {
 export type {
     MemWalConfig,
     RememberAcceptedResult,
+    RememberJobTimeoutError,
     RememberJobStatus,
     RememberResult,
     RecallResult,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -24,6 +24,10 @@ export {
 
 // Delegate key utilities (no @mysten/sui dependency)
 export { delegateKeyToSuiAddress, delegateKeyToPublicKey } from "./utils.js";
+// Unknown-outcome recovery: tell "the write may still land" apart from
+// "the write failed" before retrying anything.
+export { isRememberTimeoutError } from "./utils.js";
+export type { RememberTimeoutError } from "./utils.js";
 export {
     estimateTokens,
     truncateToTokenBudget,

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -66,6 +66,8 @@ import {
     normalizeServerUrl,
     sanitizeServerError,
     redactInternalUrls,
+    rememberTimeoutError,
+    isRememberTimeoutError,
     clockDriftErrorFromResponse,
     scoringWeightsToWire,
 } from "./utils.js";
@@ -278,7 +280,9 @@ export class MemWal {
             [200, 202],
         );
         if (generatedKey) this.pendingRememberKeys.delete(requestIdentity);
-        return accepted;
+        // The relayer echoes only job_id + status. Return the key as well: it is
+        // the handle that survives a restart and makes a replay idempotent.
+        return { ...accepted, idempotency_key: idempotencyKey };
     }
 
     /**
@@ -366,10 +370,10 @@ export class MemWal {
             }
         }
 
-        throw Object.assign(
-            new Error(`remember job timed out after ${timeoutMs}ms (job_id=${jobId})`),
-            { status: 504, jobId },
-        );
+        // Unknown outcome, not a failure: the relayer accepted this job and it
+        // may still finish. The error carries the handles needed to settle it
+        // without paying for a second write (WALM-595).
+        throw rememberTimeoutError(jobId, timeoutMs);
     }
 
     /**
@@ -389,7 +393,21 @@ export class MemWal {
         if (generatedKey) this.pendingRememberKeys.set(requestIdentity, idempotencyKey);
 
         const accepted = await this.rememberAsync(text, resolvedNamespace, { idempotencyKey });
-        const completed = await this.waitForRememberJob(accepted.job_id, opts);
+
+        let completed: RememberResult;
+        try {
+            completed = await this.waitForRememberJob(accepted.job_id, opts);
+        } catch (err) {
+            // The in-memory key map below only helps a caller that retries in
+            // this same process. Put the key on the error too, so a service
+            // that restarts — the GH #658 report — can still replay this exact
+            // write instead of minting a duplicate.
+            if (isRememberTimeoutError(err)) {
+                err.idempotencyKey = idempotencyKey;
+                err.namespace = resolvedNamespace;
+            }
+            throw err;
+        }
         // Clear only after terminal success. A polling timeout/transport failure
         // keeps the key so retrying the high-level operation reuses the same job.
         if (generatedKey) this.pendingRememberKeys.delete(requestIdentity);

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -66,8 +66,8 @@ import {
     normalizeServerUrl,
     sanitizeServerError,
     redactInternalUrls,
-    rememberTimeoutError,
-    isRememberTimeoutError,
+    rememberJobTimeoutError,
+    isRememberJobTimeoutError,
     clockDriftErrorFromResponse,
     scoringWeightsToWire,
 } from "./utils.js";
@@ -373,7 +373,7 @@ export class MemWal {
         // Unknown outcome, not a failure: the relayer accepted this job and it
         // may still finish. The error carries the handles needed to settle it
         // without paying for a second write (WALM-595).
-        throw rememberTimeoutError(jobId, timeoutMs);
+        throw rememberJobTimeoutError(jobId, timeoutMs);
     }
 
     /**
@@ -399,12 +399,14 @@ export class MemWal {
             completed = await this.waitForRememberJob(accepted.job_id, opts);
         } catch (err) {
             // The in-memory key map below only helps a caller that retries in
-            // this same process. Put the key on the error too, so a service
-            // that restarts — the GH #658 report — can still replay this exact
-            // write instead of minting a duplicate.
-            if (isRememberTimeoutError(err)) {
-                err.idempotencyKey = idempotencyKey;
-                err.namespace = resolvedNamespace;
+            // this same process. Rebuild the timeout with the key, so a service
+            // that restarts can replay this exact write instead of minting a
+            // duplicate — and so the key is in the message, not just a field.
+            if (isRememberJobTimeoutError(err)) {
+                throw rememberJobTimeoutError(err.jobId, err.timeoutMs, {
+                    idempotencyKey,
+                    namespace: resolvedNamespace,
+                });
             }
             throw err;
         }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -27,7 +27,6 @@ export interface MemWalConfig {
 // API Types
 // ============================================================
 
-/** Result from remember() / rememberAsync() */
 /**
  * Shape of the error thrown by `waitForRememberJob()` / `rememberAndWait()`
  * when polling gives up before the job reaches a terminal state.
@@ -53,6 +52,7 @@ export interface RememberJobTimeoutError extends Error {
     namespace?: string;
 }
 
+/** Result from remember() / rememberAsync() */
 export interface RememberAcceptedResult {
     job_id: string;
     status: string;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -31,6 +31,12 @@ export interface MemWalConfig {
 export interface RememberAcceptedResult {
     job_id: string;
     status: string;
+    /**
+     * The idempotency key this write was submitted under. Replaying the same
+     * write with it returns this job instead of minting a second blob, so it is
+     * the handle to persist alongside `job_id` (WALM-595).
+     */
+    idempotency_key?: string;
 }
 
 /** Status returned for an async remember job */

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -28,6 +28,31 @@ export interface MemWalConfig {
 // ============================================================
 
 /** Result from remember() / rememberAsync() */
+/**
+ * Shape of the error thrown by `waitForRememberJob()` / `rememberAndWait()`
+ * when polling gives up before the job reaches a terminal state.
+ *
+ * The job keeps running server-side after the client stops waiting, so this is
+ * an UNKNOWN outcome, not a failure. Detect it with `isRememberJobTimeoutError`
+ * and recover instead of retrying the write (WALM-595 / GH #658).
+ */
+export interface RememberJobTimeoutError extends Error {
+    /** Always 504 for a polling timeout. */
+    status: number;
+    /** The job that was being polled. Always set. */
+    jobId: string;
+    /** Budget that was exceeded, in milliseconds. */
+    timeoutMs: number;
+    /**
+     * The key this write was submitted under. Present whenever the SDK owns the
+     * submission (`rememberAndWait`); absent when polling a job id directly via
+     * `waitForRememberJob`, which never saw one.
+     */
+    idempotencyKey?: string;
+    /** Namespace the write targeted, for replaying it verbatim. */
+    namespace?: string;
+}
+
 export interface RememberAcceptedResult {
     job_id: string;
     status: string;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -438,3 +438,74 @@ export async function delegateKeyToPublicKey(privateKeyHex: string): Promise<Uin
     const ed = await import("@noble/ed25519");
     return ed.getPublicKeyAsync(hexToBytes(normalizePrivateKey(privateKeyHex)));
 }
+
+// ============================================================
+// Unknown-outcome recovery for remember (WALM-595)
+// ============================================================
+
+/**
+ * `rememberAndWait()` / `waitForRememberJob()` gave up while the job was still
+ * running. The write is an UNKNOWN outcome, not a failure: the relayer already
+ * accepted it, and it usually completes seconds later (GH #658).
+ *
+ * Both handles needed to settle it are on the error, so a caller can recover
+ * without issuing — and paying for — a second write:
+ *
+ * - `jobId` → `waitForRememberJob(jobId)` polls the same job.
+ * - `idempotencyKey` → replaying `rememberAndWait(text, ns, { idempotencyKey })`
+ *   returns the original job instead of minting a second blob. This is the one
+ *   that survives a process restart, which the SDK's in-memory key map does not.
+ */
+export interface RememberTimeoutError extends Error {
+    name: "MemWalRememberTimeoutError";
+    /** Always 504, matching the pre-existing untyped shape. */
+    status: number;
+    /** The accepted job that was still running. Poll it to settle the write. */
+    jobId: string;
+    /** Budget that was exceeded, in milliseconds. */
+    timeoutMs: number;
+    /**
+     * The key this write was submitted under. Present whenever the SDK owns the
+     * submission (`rememberAndWait`); absent when polling a job id directly via
+     * `waitForRememberJob`, which never saw one.
+     */
+    idempotencyKey?: string;
+    /** Namespace the write targeted, for replaying it verbatim. */
+    namespace?: string;
+}
+
+/**
+ * True when a write's outcome is unknown rather than failed. Callers should
+ * branch on this before any retry: retrying a `RememberTimeoutError` without
+ * its `idempotencyKey` is what mints the duplicate blob.
+ */
+export function isRememberTimeoutError(err: unknown): err is RememberTimeoutError {
+    return (
+        err instanceof Error &&
+        err.name === "MemWalRememberTimeoutError" &&
+        typeof (err as RememberTimeoutError).jobId === "string"
+    );
+}
+
+export function rememberTimeoutError(
+    jobId: string,
+    timeoutMs: number,
+    context: { idempotencyKey?: string; namespace?: string } = {},
+): RememberTimeoutError {
+    const detail = [
+        `job_id=${jobId}`,
+        ...(context.idempotencyKey ? [`idempotency_key=${context.idempotencyKey}`] : []),
+    ].join(", ");
+    const err = new Error(
+        `remember job timed out after ${timeoutMs}ms (${detail}). The write may still ` +
+            `complete: poll waitForRememberJob("${jobId}") to settle it, or replay with the ` +
+            `same idempotencyKey. Do not retry without one — that mints a second blob.`,
+    ) as RememberTimeoutError;
+    err.name = "MemWalRememberTimeoutError";
+    err.status = 504;
+    err.jobId = jobId;
+    err.timeoutMs = timeoutMs;
+    if (context.idempotencyKey) err.idempotencyKey = context.idempotencyKey;
+    if (context.namespace) err.namespace = context.namespace;
+    return err;
+}

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -4,7 +4,10 @@
  * Common crypto and encoding helpers used across the SDK.
  */
 
-import type { ScoringWeights } from "./types.js";
+import type {
+    RememberJobTimeoutError as RememberJobTimeoutErrorType,
+    ScoringWeights,
+} from "./types.js";
 
 // ============================================================
 // SHA-256 (Isomorphic)
@@ -455,53 +458,41 @@ export async function delegateKeyToPublicKey(privateKeyHex: string): Promise<Uin
  * - `idempotencyKey` → replaying `rememberAndWait(text, ns, { idempotencyKey })`
  *   returns the original job instead of minting a second blob. This is the one
  *   that survives a process restart, which the SDK's in-memory key map does not.
+ *
+ * The type lives in `types.ts` as `RememberJobTimeoutError` so this and the
+ * WALM-597 / WALM-600 work describe one error rather than three.
  */
-export interface RememberTimeoutError extends Error {
-    name: "MemWalRememberTimeoutError";
-    /** Always 504, matching the pre-existing untyped shape. */
-    status: number;
-    /** The accepted job that was still running. Poll it to settle the write. */
-    jobId: string;
-    /** Budget that was exceeded, in milliseconds. */
-    timeoutMs: number;
-    /**
-     * The key this write was submitted under. Present whenever the SDK owns the
-     * submission (`rememberAndWait`); absent when polling a job id directly via
-     * `waitForRememberJob`, which never saw one.
-     */
-    idempotencyKey?: string;
-    /** Namespace the write targeted, for replaying it verbatim. */
-    namespace?: string;
-}
+export type { RememberJobTimeoutError } from "./types.js";
 
 /**
  * True when a write's outcome is unknown rather than failed. Callers should
- * branch on this before any retry: retrying a `RememberTimeoutError` without
- * its `idempotencyKey` is what mints the duplicate blob.
+ * branch on this before any retry: retrying a poll timeout without its
+ * `idempotencyKey` is what mints the duplicate blob.
+ *
+ * Detects on `status` + `jobId` rather than on `name`, so it matches the
+ * timeout whichever of the in-flight poll-timeout changes lands first.
  */
-export function isRememberTimeoutError(err: unknown): err is RememberTimeoutError {
-    return (
-        err instanceof Error &&
-        err.name === "MemWalRememberTimeoutError" &&
-        typeof (err as RememberTimeoutError).jobId === "string"
-    );
+export function isRememberJobTimeoutError(err: unknown): err is RememberJobTimeoutErrorType {
+    if (!(err instanceof Error)) return false;
+    const e = err as Error & { status?: number; jobId?: unknown };
+    return e.status === 504 && typeof e.jobId === "string";
 }
 
-export function rememberTimeoutError(
+export function rememberJobTimeoutError(
     jobId: string,
     timeoutMs: number,
     context: { idempotencyKey?: string; namespace?: string } = {},
-): RememberTimeoutError {
+): RememberJobTimeoutErrorType {
     const detail = [
         `job_id=${jobId}`,
         ...(context.idempotencyKey ? [`idempotency_key=${context.idempotencyKey}`] : []),
     ].join(", ");
     const err = new Error(
-        `remember job timed out after ${timeoutMs}ms (${detail}). The write may still ` +
+        `remember job timed out after ${timeoutMs}ms (${detail}). The write might still ` +
             `complete: poll waitForRememberJob("${jobId}") to settle it, or replay with the ` +
-            `same idempotencyKey. Do not retry without one — that mints a second blob.`,
-    ) as RememberTimeoutError;
-    err.name = "MemWalRememberTimeoutError";
+            `same idempotencyKey. Do not retry without one, that mints a second blob.`,
+    ) as RememberJobTimeoutErrorType;
+    err.name = "MemWalRememberJobTimeoutError";
     err.status = 504;
     err.jobId = jobId;
     err.timeoutMs = timeoutMs;

--- a/packages/sdk/test/remember-timeout-recovery.test.mjs
+++ b/packages/sdk/test/remember-timeout-recovery.test.mjs
@@ -14,7 +14,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { MemWal } from "../dist/memwal.js";
-import { isRememberTimeoutError } from "../dist/utils.js";
+import { isRememberJobTimeoutError } from "../dist/utils.js";
 
 const originalFetch = globalThis.fetch;
 
@@ -97,8 +97,8 @@ test("a congestion timeout is an unknown outcome carrying both recovery handles"
         }),
     );
 
-    assert.ok(isRememberTimeoutError(err), "callers must be able to detect this without duck-typing");
-    assert.equal(err.name, "MemWalRememberTimeoutError");
+    assert.ok(isRememberJobTimeoutError(err), "callers must be able to detect this without duck-typing");
+    assert.equal(err.name, "MemWalRememberJobTimeoutError");
     assert.equal(err.status, 504);
     assert.equal(err.jobId, JOB_ID);
     assert.equal(err.namespace, "drops");
@@ -106,6 +106,9 @@ test("a congestion timeout is an unknown outcome carrying both recovery handles"
     // The message has to point at recovery: this is what a caller sees in logs.
     assert.match(err.message, /poll waitForRememberJob/);
     assert.match(err.message, /mints a second blob/);
+    // The key belongs in the message too: after a restart the log line may be
+    // all a caller still has.
+    assert.ok(err.message.includes(err.idempotencyKey));
 });
 
 test("the job id settles the write with no second remember", async () => {
@@ -116,7 +119,7 @@ test("the job id settles the write with no second remember", async () => {
     const err = await rejection(
         client.rememberAndWait("wallet drop #42", undefined, { pollIntervalMs: 0, timeoutMs: 1 }),
     );
-    assert.ok(isRememberTimeoutError(err));
+    assert.ok(isRememberJobTimeoutError(err));
 
     const settled = await client.waitForRememberJob(err.jobId, {
         pollIntervalMs: 0,
@@ -222,7 +225,7 @@ test("isRememberTimeoutError does not fire on a genuine failure", async () => {
         }),
     );
 
-    assert.equal(isRememberTimeoutError(err), false, "a failed job is a known outcome");
+    assert.equal(isRememberJobTimeoutError(err), false, "a failed job is a known outcome");
     assert.equal(err.status, 500);
 });
 
@@ -233,7 +236,7 @@ test("waitForRememberJob called directly reports no key it never saw", async () 
         makeClient().waitForRememberJob(JOB_ID, { pollIntervalMs: 0, timeoutMs: 1 }),
     );
 
-    assert.ok(isRememberTimeoutError(err));
+    assert.ok(isRememberJobTimeoutError(err));
     assert.equal(err.jobId, JOB_ID);
     assert.equal(err.idempotencyKey, undefined);
 });

--- a/packages/sdk/test/remember-timeout-recovery.test.mjs
+++ b/packages/sdk/test/remember-timeout-recovery.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * WALM-595 / GH #658.
+ *
+ * `rememberAndWait()` threw a bare `Error` when its poll budget expired during
+ * relayer congestion, even though the relayer had already accepted the job. The
+ * caller could not tell "the write may still land" from "the write failed", and
+ * the idempotency key the SDK had generated never left the process — so the
+ * obvious retry minted, and paid for, a second blob.
+ *
+ * The timeout now carries both handles: the job id to poll, and the key to
+ * replay under.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemWal } from "../dist/memwal.js";
+import { isRememberTimeoutError } from "../dist/utils.js";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+const JOB_ID = "9b921ab2-e9a3-490d-8180-136fd98cfc2a";
+const BLOB_ID = "6EPcpE73RpswQqMc52Flp47qm2TcGr_zdBaQZJKMNTE";
+
+/**
+ * A relayer that accepts the write and then leaves the job `running` until
+ * `settleAfter` polls have gone by — the congestion shape from GH #658.
+ *
+ * Records every POST /api/remember body so a test can prove no second write was
+ * submitted, and that a replay carried the original key.
+ */
+function stubCongestedRelayer({ settleAfter = Infinity } = {}) {
+    const calls = { posts: [], polls: 0 };
+    globalThis.fetch = async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        if (path === "/version") {
+            return Response.json({
+                apiVersion: "1.0.0",
+                relayerVersion: "1.0.0",
+                minSupportedSdk: { typescript: "0.0.4" },
+            });
+        }
+        if (path === "/api/config") return Response.json({ packageId: "0x1", network: "testnet" });
+        if (path === "/api/remember" && init.method === "POST") {
+            calls.posts.push(JSON.parse(init.body));
+            // The relayer collapses a replay onto the original job, so every
+            // accept under the same key names the same job id.
+            return Response.json({ job_id: JOB_ID, status: "pending" }, { status: 202 });
+        }
+        if (path === `/api/remember/${JOB_ID}`) {
+            calls.polls += 1;
+            if (calls.polls <= settleAfter) {
+                return Response.json({ job_id: JOB_ID, status: "running" });
+            }
+            return Response.json({
+                job_id: JOB_ID,
+                status: "done",
+                blob_id: BLOB_ID,
+                owner: "0x1",
+                namespace: "drops",
+            });
+        }
+        throw new Error(`unexpected request ${path}`);
+    };
+    return calls;
+}
+
+function makeClient() {
+    const client = MemWal.create({
+        key: new Uint8Array(32).fill(1),
+        accountId: "0x1",
+        serverUrl: "https://relayer.example",
+        namespace: "drops",
+    });
+    client.buildSealSession = async () => "test-session";
+    return client;
+}
+
+/** Reject and return the error, so assertions read top-to-bottom. */
+async function rejection(promise) {
+    return promise.then(
+        () => assert.fail("expected a rejection"),
+        (err) => err,
+    );
+}
+
+test("a congestion timeout is an unknown outcome carrying both recovery handles", async () => {
+    stubCongestedRelayer();
+
+    const err = await rejection(
+        makeClient().rememberAndWait("wallet drop #42", undefined, {
+            pollIntervalMs: 0,
+            timeoutMs: 1,
+        }),
+    );
+
+    assert.ok(isRememberTimeoutError(err), "callers must be able to detect this without duck-typing");
+    assert.equal(err.name, "MemWalRememberTimeoutError");
+    assert.equal(err.status, 504);
+    assert.equal(err.jobId, JOB_ID);
+    assert.equal(err.namespace, "drops");
+    assert.match(err.idempotencyKey, /^[0-9a-f-]{36}$/);
+    // The message has to point at recovery: this is what a caller sees in logs.
+    assert.match(err.message, /poll waitForRememberJob/);
+    assert.match(err.message, /mints a second blob/);
+});
+
+test("the job id settles the write with no second remember", async () => {
+    // AC: "timeout after accept does not require a second remember to recover".
+    const calls = stubCongestedRelayer({ settleAfter: 1 });
+    const client = makeClient();
+
+    const err = await rejection(
+        client.rememberAndWait("wallet drop #42", undefined, { pollIntervalMs: 0, timeoutMs: 1 }),
+    );
+    assert.ok(isRememberTimeoutError(err));
+
+    const settled = await client.waitForRememberJob(err.jobId, {
+        pollIntervalMs: 0,
+        timeoutMs: 5_000,
+    });
+
+    assert.equal(settled.blob_id, BLOB_ID);
+    assert.equal(calls.posts.length, 1, "recovery by polling must not submit another write");
+});
+
+test("replaying under the returned key reuses the original job", async () => {
+    // AC: "retry with the same idempotency key does not mint a second blob".
+    // The replay is deliberately driven through a *fresh* client, the way a
+    // restarted service would: the in-memory key map is gone, and only the key
+    // read off the error keeps the write idempotent.
+    const calls = stubCongestedRelayer({ settleAfter: 1 });
+
+    const err = await rejection(
+        makeClient().rememberAndWait("wallet drop #42", undefined, {
+            pollIntervalMs: 0,
+            timeoutMs: 1,
+        }),
+    );
+
+    const replayed = await makeClient().rememberAndWait("wallet drop #42", err.namespace, {
+        pollIntervalMs: 0,
+        timeoutMs: 5_000,
+        idempotencyKey: err.idempotencyKey,
+    });
+
+    assert.equal(replayed.job_id, JOB_ID);
+    assert.equal(replayed.blob_id, BLOB_ID);
+    assert.equal(calls.posts.length, 2);
+    assert.equal(calls.posts[1].idempotency_key, err.idempotencyKey);
+    // One distinct key across both attempts is what stops the duplicate mint.
+    assert.equal(new Set(calls.posts.map((p) => p.idempotency_key)).size, 1);
+});
+
+test("a fresh client without the key would submit a different write", async () => {
+    // The regression this guards: losing the key is exactly the duplicate-mint
+    // path, which is why the error has to carry it.
+    const calls = stubCongestedRelayer({ settleAfter: 1 });
+
+    await rejection(
+        makeClient().rememberAndWait("wallet drop #42", undefined, {
+            pollIntervalMs: 0,
+            timeoutMs: 1,
+        }),
+    );
+    await makeClient().rememberAndWait("wallet drop #42", "drops", {
+        pollIntervalMs: 0,
+        timeoutMs: 5_000,
+    });
+
+    assert.equal(new Set(calls.posts.map((p) => p.idempotency_key)).size, 2);
+});
+
+test("rememberAsync hands back the key alongside the job id", async () => {
+    stubCongestedRelayer();
+
+    const accepted = await makeClient().rememberAsync("wallet drop #42");
+
+    assert.equal(accepted.job_id, JOB_ID);
+    assert.match(accepted.idempotency_key, /^[0-9a-f-]{36}$/);
+});
+
+test("an explicit idempotencyKey is echoed back, not replaced", async () => {
+    const calls = stubCongestedRelayer();
+
+    const err = await rejection(
+        makeClient().rememberAndWait("wallet drop #42", undefined, {
+            pollIntervalMs: 0,
+            timeoutMs: 1,
+            idempotencyKey: "caller-owned-key",
+        }),
+    );
+
+    assert.equal(err.idempotencyKey, "caller-owned-key");
+    assert.equal(calls.posts[0].idempotency_key, "caller-owned-key");
+});
+
+test("isRememberTimeoutError does not fire on a genuine failure", async () => {
+    globalThis.fetch = async (url) => {
+        const path = new URL(url).pathname;
+        if (path === "/version") {
+            return Response.json({
+                apiVersion: "1.0.0",
+                relayerVersion: "1.0.0",
+                minSupportedSdk: { typescript: "0.0.4" },
+            });
+        }
+        if (path === "/api/config") return Response.json({ packageId: "0x1", network: "testnet" });
+        if (path === "/api/remember") {
+            return Response.json({ job_id: JOB_ID, status: "pending" }, { status: 202 });
+        }
+        return Response.json({ job_id: JOB_ID, status: "failed", error: "walrus rejected blob" });
+    };
+
+    const err = await rejection(
+        makeClient().rememberAndWait("wallet drop #42", undefined, {
+            pollIntervalMs: 0,
+            timeoutMs: 5_000,
+        }),
+    );
+
+    assert.equal(isRememberTimeoutError(err), false, "a failed job is a known outcome");
+    assert.equal(err.status, 500);
+});
+
+test("waitForRememberJob called directly reports no key it never saw", async () => {
+    stubCongestedRelayer();
+
+    const err = await rejection(
+        makeClient().waitForRememberJob(JOB_ID, { pollIntervalMs: 0, timeoutMs: 1 }),
+    );
+
+    assert.ok(isRememberTimeoutError(err));
+    assert.equal(err.jobId, JOB_ID);
+    assert.equal(err.idempotencyKey, undefined);
+});


### PR DESCRIPTION
Closes [WALM-595](https://linear.app/mysten-labs/issue/WALM-595/bug-remember-timeout-on-congestion-has-no-idempotency-recovery-gh-658). Fixes #658.

## Problem

`rememberAndWait()` threw a bare `Error` when its poll budget expired during relayer congestion — but the relayer had already **accepted** the job, and it usually finishes seconds later. Two things followed from that:

1. The caller could not tell *"the write may still land"* from *"the write failed"* without matching on the message text.
2. The idempotency key the SDK generated for the write never left the client instance (`pendingRememberKeys`, in memory). A service that restarts — the exact deployment shape in #658 — had nothing to retry *with*, so the obvious retry minted and paid for a second blob.

The relayer side is already correct: `POST /api/remember` collapses a replay onto the original job under `(owner, idempotency_key)`. What was missing was handing the caller the handle to replay with.

## Change

**TypeScript SDK**

- `RememberTimeoutError` (name `MemWalRememberTimeoutError`) and an exported `isRememberTimeoutError()`, so unknown-outcome is a branch rather than a string match.
- The error carries `jobId`, `idempotencyKey` and `namespace`. Its message names both recovery moves, since that string is what ends up in a caller's logs.
- `RememberAcceptedResult.idempotency_key` echoes the key back, so `remember()` / `rememberAsync()` callers can persist it next to `job_id`.

**Python SDK** — `MemWalRememberJobTimeout` gains `idempotency_key` / `namespace` and the same message, keeping the two SDKs aligned.

**Docs** — `production-readiness.md` drops the now-false *"the relayer does not deduplicate writes"* claim, documents `idempotencyKey`, and adds a recovery section.

## Recovery, from the caller's side

```ts
try {
  await memwal.rememberAndWait(text, namespace);
} catch (err) {
  if (!isRememberTimeoutError(err)) throw err;          // a real failure
  await memwal.waitForRememberJob(err.jobId);           // settle it; no second write
  // or, from another process:
  // await memwal.rememberAndWait(text, err.namespace, { idempotencyKey: err.idempotencyKey });
}
```

## Acceptance criteria

- [x] Timeout after accept does not require a second `remember` to recover status — `waitForRememberJob(err.jobId)`, pinned by a test asserting exactly one `POST /api/remember`.
- [x] Retry with the same idempotency key does not mint a second blob — pinned by a test that replays through a **fresh client** (standing in for a restarted process) and asserts one distinct key across both attempts, plus a companion test showing that losing the key is what produces two.

## Testing

- TS SDK: 8 new tests in `packages/sdk/test/remember-timeout-recovery.test.mjs`; full suite **125 passed**, `tsc` clean.
- Python SDK: 3 new tests in `TestRememberTimeoutRecovery`; full suite **162 passed, 16 skipped**.

## Notes for the reviewer

- No relayer change: the server-side idempotency path already handles this. This PR is entirely about what the client hands back.
- Purely additive to the public surface. The timeout still has `status === 504` and `jobId`, so existing catchers keep working; only the message text changed.
- Touches `waitForRememberJob`, which #881 (WALM-597) also edits. Expect a small conflict at the throw site if that lands first — the two changes are complementary (that PR keeps the *last observed* state, this one adds the *submission* handles).
