### PR TITLE
fix(sdk): stop importing a Node builtin on a browser path (WALM-136)

### DIFF
--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,12 +28,12 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release adds `failed` on `restore()` results, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
+This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
 
 ### Added
 
@@ -41,6 +41,8 @@ This release adds `failed` on `restore()` results, stops telling headless SDK cl
 
 ### Fixed
 
+- Hash request bodies with `@noble/hashes` instead of WebCrypto-or-`node:crypto`, so the package no longer imports a Node builtin on a browser-reachable path. Vite externalises such an import without warning: the app builds clean and the browser crashes the first time the path runs. The fallback could never have helped a browser anyway — `crypto.subtle` is absent precisely when the page is not a secure context, where `node:crypto` is absent too — so it only served Node <19 while being the sole source of the exposure. `sha256hex` sits on the signed-request path, so every remember and recall reached it. (#322, WALM-136)
+- Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Hash request bodies with `@noble/hashes` instead of WebCrypto-or-`node:crypto`, so the package no longer imports a Node builtin on a browser-reachable path. Vite externalises such an import without warning: the app builds clean and the browser crashes the first time the path runs. The fallback could never have helped a browser anyway — `crypto.subtle` is absent precisely when the page is not a secure context, where `node:crypto` is absent too — so it only served Node <19 while being the sole source of the exposure. `sha256hex` sits on the signed-request path, so every remember and recall reached it. (#322, WALM-136)
+- Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,9 @@
     "version": "0.1.7",
     "description": "Walrus Memory — Privacy-first AI memory SDK with Ed25519 delegate key auth",
     "type": "module",
+    "engines": {
+        "node": ">=20.0.0"
+    },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -11,20 +11,26 @@ import type { ScoringWeights } from "./types.js";
 // ============================================================
 
 /**
- * Isomorphic SHA-256 hash — uses Web Crypto API (browser) or Node.js crypto (server).
+ * Isomorphic SHA-256 hash.
+ *
+ * Hashes in userland rather than reaching for a platform digest, so there is no
+ * Node builtin to import and nothing for a browser bundler to externalise —
+ * the WALM-136 / GH #322 landmine, where Vite quietly stubs `crypto`, the app
+ * builds clean, and the browser crashes the first time the path runs.
+ *
+ * This previously preferred WebCrypto and fell back to `node:crypto`. The
+ * fallback could never help a browser — when `crypto.subtle` is missing it is
+ * because the page is not a secure context, and `node:crypto` is not there
+ * either — so it only served Node <19 (EOL April 2025) while being the sole
+ * source of the bundler exposure. `sha256hex` is on the signed-request path,
+ * so every remember and recall runs through it.
+ *
+ * Stays `async` though `sha256` is synchronous: the signature is public API and
+ * callers already await it.
  */
 export async function sha256hex(data: string): Promise<string> {
-    const bytes = new TextEncoder().encode(data);
-    // Try Web Crypto API first (browser + modern Node.js)
-    if (typeof globalThis.crypto?.subtle?.digest === "function") {
-        const hashBuf = await globalThis.crypto.subtle.digest("SHA-256", bytes);
-        return Array.from(new Uint8Array(hashBuf))
-            .map((b) => b.toString(16).padStart(2, "0"))
-            .join("");
-    }
-    // Fallback to Node.js crypto
-    const crypto = await import("crypto");
-    return crypto.createHash("sha256").update(data).digest("hex");
+    const { sha256 } = await import("@noble/hashes/sha2.js");
+    return bytesToHex(sha256(new TextEncoder().encode(data)));
 }
 
 // ============================================================

--- a/packages/sdk/test/no-node-builtins.test.mjs
+++ b/packages/sdk/test/no-node-builtins.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * WALM-136 (GH #322) — the SDK must not pull Node builtins into a browser bundle.
+ *
+ * The reported failure is a quiet one: Vite externalises an imported Node
+ * builtin without warning, the app builds cleanly, and the browser crashes at
+ * runtime when the code path is finally taken. A green build proves nothing,
+ * so the guard has to be on what the package actually ships.
+ *
+ * `sha256hex` was the last such import — a `crypto` fallback that could never
+ * help a browser anyway (if `crypto.subtle` is missing because the page is not
+ * a secure context, `node:crypto` is not there either) and only served Node
+ * <19, which is EOL. It sits on the signed-request path, so every remember and
+ * recall reached it.
+ *
+ * The first test is the regression guard, and it covers the whole class rather
+ * than one line: any future `fs`/`path`/`crypto` import in the SDK fails it.
+ * The second is a correctness companion — it passed before the swap too (Node
+ * resolved the fallback happily), so it is not the guard, it just proves the
+ * hash itself stayed right once the branch was removed.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { builtinModules } from "node:module";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST = resolve(__dirname, "../dist");
+
+const BUILTINS = new Set(builtinModules);
+
+/** `from "x"`, `import("x")`, `require("x")` — the three ways a specifier can
+ * reach a bundler. Deliberately does NOT match `globalThis.crypto`, which is a
+ * global read and has nothing to resolve. */
+const SPECIFIER = /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*)["']([^"']+)["']/g;
+
+function jsFiles(dir) {
+    const out = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...jsFiles(full));
+        else if (entry.name.endsWith(".js")) out.push(full);
+    }
+    return out;
+}
+
+test("the built SDK imports no Node builtins", () => {
+    assert.ok(existsSync(DIST), `dist/ missing — run \`pnpm run build\` first (looked in ${DIST})`);
+
+    const offenders = [];
+    for (const file of jsFiles(DIST)) {
+        const src = readFileSync(file, "utf8");
+        for (const [, spec] of src.matchAll(SPECIFIER)) {
+            const bare = spec.startsWith("node:") ? spec.slice("node:".length) : spec;
+            if (BUILTINS.has(bare)) {
+                offenders.push(`${relative(DIST, file)} imports "${spec}"`);
+            }
+        }
+    }
+
+    assert.deepEqual(
+        offenders,
+        [],
+        `SDK ships Node builtin imports; a browser bundler will externalise these ` +
+            `silently and the page crashes when the path runs:\n  ${offenders.join("\n  ")}`,
+    );
+});
+
+test("sha256hex hashes correctly without globalThis.crypto", async () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+    // Simulate a browser that is not a secure context: `crypto.subtle` is
+    // undefined there, which is exactly when the old fallback fired.
+    Object.defineProperty(globalThis, "crypto", { value: undefined, configurable: true });
+    try {
+        const { sha256hex } = await import("../dist/utils.js");
+        // Known-answer vectors, so a wrong-but-plausible digest cannot pass.
+        assert.equal(
+            await sha256hex("hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        );
+        assert.equal(
+            await sha256hex(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        );
+    } finally {
+        if (original) Object.defineProperty(globalThis, "crypto", original);
+        else delete globalThis.crypto;
+    }
+});


### PR DESCRIPTION
Closes WALM-136 ([GH #322](https://github.com/MystenLabs/MemWal/issues/322)). Also settles WALM-599.

## The bug

`sha256hex` fell back to `await import("crypto")` when WebCrypto was missing. Vite replaces that with a stub: the app builds clean, then throws in the browser the first time the path runs.

It sat on the signed-request path (`memwal.ts:1347`, `manual.ts:854`) — every remember and recall — reached the browser through all four apps, and was the last bare Node-builtin import in `packages/sdk/src`.

The fallback could never have helped a browser: `crypto.subtle` is missing precisely when the page is not a secure context, and `node:crypto` is not there either. It only ever served Node <19 (EOL April 2025) while being the sole source of the exposure. So the branch is removed, not guarded — prefixing to `node:crypto` would just make a dead branch fail louder.

## Reproduced, before and after

Vite 5.4.21, standalone consumer project importing the built `dist`:

| | before | after |
| -- | -- | -- |
| build | succeeds, warns `Module "crypto" has been externalized` | clean |
| `__vite-browser-external` stubs | 1 | 0 |
| run with `crypto.subtle` undefined | `TypeError: crypto.createHash is not a function` | correct digest |

That `TypeError` is the stub being called — #322's crash reproduced end to end, then gone.

## The change

```ts
export async function sha256hex(data: string): Promise<string> {
    const { sha256 } = await import("@noble/hashes/sha2.js");
    return bytesToHex(sha256(new TextEncoder().encode(data)));
}
```

`@noble/hashes` is already a direct dependency here *and* of `@mysten/sui`, and blake2b two functions down already imports it. Nothing for a bundler to resolve, and it works in the non-secure contexts where both old paths failed. Costs 3.67 kB gzipped.

Measured rather than assumed: at a typical 512 B body noble is **faster** than WebCrypto (0.0034 ms vs 0.0101 ms — async overhead dominates below a few KB); +0.77 ms at 256 KB. Stays `async` because the signature is public API.

## Tests

`test/no-node-builtins.test.mjs` scans built `dist/` for any Node builtin specifier, so a future `fs` or `path` import fails too. Scanning output rather than source is the point — this bug builds cleanly.

Test-first: it failed on `dev` with `utils.js imports "crypto"`. SDK suite **119/119**, CI **18/18**.

## WALM-599

Does not reproduce. `globalThis.crypto` has been a default global since Node 19 (verified in both the main thread and a `worker_threads` worker), and `sponsor-auth.test.mjs` passes with no polyfill. What was real: the SDK had no `engines` field while both sibling packages declare `>=20.0.0`. Added here — suggest closing 599 on that basis.

## Follow-up

The SDK resolves `@noble/hashes@2.0.1` while `@mysten/sui` resolves `2.2.0`. Both satisfy `^2.0.0`, so it is a lockfile artifact rather than a range problem, but a bundle can carry two copies. Worth a dedupe on its own.
