### PR TITLE
fix(sdk): drop dead @mysten/walrus import from /manual (WALM-145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pnpm add @mysten-incubation/memwal
 Peer dependencies (install as needed):
 
 ```bash
-pnpm add @mysten/sui @mysten/seal @mysten/walrus ai zod
+pnpm add @mysten/sui @mysten/seal ai zod
 ```
 
 ## Quick Start

--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ pnpm add @mysten-incubation/memwal
 pnpm add ai zod
 
 # Optional: for manual client (client-side SEAL encryption)
-pnpm add @mysten/sui @mysten/seal @mysten/walrus
+pnpm add @mysten/sui @mysten/seal
 ```
 
 ---
@@ -574,7 +574,7 @@ Lifecycle hooks run automatically:
 | `recall()` returns unrelated filler | Recall is top-K without a default relevance threshold; filter by `distance`, for example `distance < 0.7` |
 | `401 Unauthorized` | Usually wrong `MEMWAL_PRIVATE_KEY`, key not registered on the account, account ID mismatch, or staging/mainnet mismatch. Check `.env.local` and dashboard credentials |
 | SDK import errors | Run `pnpm add @mysten-incubation/memwal` — check Node.js ≥ 18 |
-| Manual client errors | Install peer deps: `@mysten/sui @mysten/seal @mysten/walrus` |
+| Manual client errors | Install peer deps: `@mysten/sui @mysten/seal` |
 | Direct Sui reads fail or examples look stale | Prefer `SuiGrpcClient` from `@mysten/sui/grpc`; JSON-RPC snippets using `SuiClient` / `getFullnodeUrl` may be stale |
 | `forget` expectations are unclear | Current relayer `POST /api/forget` removes vector index rows so memories are unrecallable; Walrus blobs persist until epoch expiry |
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -101,22 +101,22 @@ The fastest way to get Walrus Memory running is through the TypeScript SDK.
     <Tabs>
       <Tab title="pnpm">
         ```bash
-        pnpm add @mysten/sui @mysten/seal @mysten/walrus
+        pnpm add @mysten/sui @mysten/seal
         ```
       </Tab>
       <Tab title="npm">
         ```bash
-        npm install @mysten/sui @mysten/seal @mysten/walrus
+        npm install @mysten/sui @mysten/seal
         ```
       </Tab>
       <Tab title="yarn">
         ```bash
-        yarn add @mysten/sui @mysten/seal @mysten/walrus
+        yarn add @mysten/sui @mysten/seal
         ```
       </Tab>
       <Tab title="bun">
         ```bash
-        bun add @mysten/sui @mysten/seal @mysten/walrus
+        bun add @mysten/sui @mysten/seal
         ```
       </Tab>
     </Tabs>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -87,9 +87,7 @@ Walrus and network fields:
 | `sealServerConfigs` | no | Full SEAL configs for independent or committee servers. Committee entries require `aggregatorUrl` |
 | `sealKeyServers` | no | Legacy override for independent SEAL key server object IDs |
 | `sealThreshold` | no | Default: `2`, capped to total configured server weight |
-| `walrusEpochs` | no | Default: `50` |
 | `walrusAggregatorUrl` | no | Walrus download endpoint. Defaults follow `suiNetwork` |
-| `walrusPublisherUrl` | no | Walrus upload endpoint. Defaults follow `suiNetwork` |
 
 ## `WithMemWalOptions`
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,12 +28,12 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. `@mysten-incubation/memwal/manual` no longer imports `@mysten/walrus` WASM; downloads use HTTP. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. `@mysten-incubation/memwal/manual` no longer imports `@mysten/walrus` WASM; downloads use HTTP, and the optional walrus peer plus unused publisher/epochs knobs are gone. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, switches account and manual PTBs to typed `tx.pure` helpers, and drops the dead `@mysten/walrus` import from `/manual`.
+This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, switches account and manual PTBs to typed `tx.pure` helpers, and drops the dead `@mysten/walrus` import and optional peer from `/manual`.
 
 ### Added
 
@@ -45,7 +45,7 @@ This release removes the Node `crypto` import that crashed bundled browser build
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
-- `MemWalManual` no longer imports `@mysten/walrus`. Dead `getWalrusClient()` / `walrusUpload()` are gone; blob download stays on HTTP `fetch` so Turbopack/Vite do not pull Walrus WASM.
+- `MemWalManual` no longer imports `@mysten/walrus`. Dead `getWalrusClient()` / `walrusUpload()` are gone; blob download stays on HTTP `fetch` so Turbopack/Vite do not pull Walrus WASM. Optional peer `@mysten/walrus` and unused `walrusEpochs` / `walrusPublisherUrl` are gone; `/manual` is `@mysten/seal` + `@mysten/sui` only.
 
 ## 0.1.6
 

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,12 +28,12 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. `@mysten-incubation/memwal/manual` no longer imports `@mysten/walrus` WASM; downloads use HTTP. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
+This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, switches account and manual PTBs to typed `tx.pure` helpers, and drops the dead `@mysten/walrus` import from `/manual`.
 
 ### Added
 
@@ -45,6 +45,7 @@ This release removes the Node `crypto` import that crashed bundled browser build
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
+- `MemWalManual` no longer imports `@mysten/walrus`. Dead `getWalrusClient()` / `walrusUpload()` are gone; blob download stays on HTTP `fetch` so Turbopack/Vite do not pull Walrus WASM.
 
 ## 0.1.6
 

--- a/docs/sdk/cloudflare-workers.md
+++ b/docs/sdk/cloudflare-workers.md
@@ -48,7 +48,7 @@ Without `nodejs_compat` the build fails outright: `wrangler deploy` stops with `
 Even the default `MemWal` client requires `@mysten/seal` and `@mysten/sui` as peer dependencies (it builds a Seal session key on the client to authenticate each request), so it pulls in a sizeable dependency graph. A Worker bundling just the default client totals roughly **1.2 MB raw (around 225 KB gzipped)**, measured with `wrangler deploy --dry-run` against `@mysten/sui` 2.x. That is comfortably within the Workers size limit, but worth knowing:
 
 - A single incompatible peer version can break the build for the **entire** Worker, not just the memory feature. Pin your `@mysten/*` versions and treat the memory dependency as a unit.
-- The default `@mysten-incubation/memwal` entry point is the lightest to bundle. The relayer handles embeddings and Walrus storage server-side, so the client only needs `@mysten/seal` and `@mysten/sui` (both required peers). The `@mysten-incubation/memwal/manual` entry point additionally pulls in `@mysten/walrus` and client-side encryption and upload, adding more to the bundle. Prefer the default entry point on Workers unless you specifically need the manual flow.
+- The default `@mysten-incubation/memwal` entry point is the lightest to bundle. The relayer handles embeddings and Walrus storage server-side, so the client only needs `@mysten/seal` and `@mysten/sui` (both required peers). The `@mysten-incubation/memwal/manual` entry point adds client-side SEAL encrypt/decrypt and HTTP aggregator downloads; it does not import `@mysten/walrus`. Prefer the default entry point on Workers unless you specifically need the manual flow.
 
 ## Crash isolation with dynamic import
 

--- a/docs/sdk/quick-start.md
+++ b/docs/sdk/quick-start.md
@@ -57,26 +57,26 @@ yarn add @mysten-incubation/memwal
 
 </CodeGroup>
 
-For `MemWalManual`, you also need the optional peer dependencies:
+For `MemWalManual`, you also need `@mysten/seal` and `@mysten/sui`:
 
 <CodeGroup>
 
 ```bash npm
-npm install @mysten/sui @mysten/seal @mysten/walrus
+npm install @mysten/sui @mysten/seal
 ```
 
 ```bash pnpm
-pnpm add @mysten/sui @mysten/seal @mysten/walrus
+pnpm add @mysten/sui @mysten/seal
 ```
 
 ```bash yarn
-yarn add @mysten/sui @mysten/seal @mysten/walrus
+yarn add @mysten/sui @mysten/seal
 ```
 
 </CodeGroup>
 
 <Note>
-**Version compatibility:** `@mysten/seal` and `@mysten/walrus` must both accept the same `@mysten/sui` major. Known-good versions: `@mysten/sui@^2.16.2`, `@mysten/seal@^1.1.3`, `@mysten/walrus@^1.1.7`. Avoid `@mysten/walrus@0.x` — it bundles `@mysten/sui@1.x` and conflicts with `@mysten/seal@1.x`. If installation fails with `ERESOLVE` on `@mysten/sui`, upgrade `@mysten/walrus` and run `npm why @mysten/sui` to find which dependency still pins sui v1.
+**Version compatibility:** `@mysten/seal` requires `@mysten/sui` ^2.x. Known-good versions: `@mysten/sui@^2.16.2`, `@mysten/seal@^1.1.3`.
 </Note>
 
 For `withMemWal`, you also need:

--- a/docs/sdk/usage/memwal-manual.md
+++ b/docs/sdk/usage/memwal-manual.md
@@ -127,9 +127,8 @@ const manual = MemWalManual.create({
   compatible upgrade, set `sealPolicyPackageId` to the current policy package
 - `sealServerConfigs` lets the client configure independent or committee SEAL servers; committee entries require `aggregatorUrl`
 - `sealKeyServers` remains supported as a legacy independent key server object ID override
-- Walrus publisher, aggregator, and upload relay defaults follow `suiNetwork`
+- Walrus aggregator defaults follow `suiNetwork`
 - `embeddingModel` defaults to `text-embedding-3-small` (or `openai/text-embedding-3-small` for OpenRouter)
-- `walrusEpochs` defaults to `50` (storage duration)
 - All `@mysten/*` peer dependencies are loaded dynamically, so users who only use the default `MemWal` client do not need them installed
 
 ## Agent state: holding your own keys

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
-- `MemWalManual` no longer imports `@mysten/walrus`. Dead `getWalrusClient()` / `walrusUpload()` are gone; blob download stays on HTTP `fetch` so Turbopack/Vite do not pull Walrus WASM.
+- `MemWalManual` no longer imports `@mysten/walrus`. Dead `getWalrusClient()` / `walrusUpload()` are gone; blob download stays on HTTP `fetch` so Turbopack/Vite do not pull Walrus WASM. Optional peer `@mysten/walrus` and unused `walrusEpochs` / `walrusPublisherUrl` are gone; `/manual` is `@mysten/seal` + `@mysten/sui` only.
 
 ## 0.1.6
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
+- `MemWalManual` no longer imports `@mysten/walrus`. Dead `getWalrusClient()` / `walrusUpload()` are gone; blob download stays on HTTP `fetch` so Turbopack/Vite do not pull Walrus WASM.
 
 ## 0.1.6
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -17,20 +17,19 @@ pnpm add @mysten-incubation/memwal
 Peer dependencies (install as needed):
 
 ```bash
-pnpm add @mysten/sui @mysten/seal @mysten/walrus ai zod
+pnpm add @mysten/sui @mysten/seal ai zod
 ```
+
+`/manual` needs `@mysten/seal` and `@mysten/sui` only. `ai` / `zod` are for `withMemWal`.
 
 ### Version compatibility
 
-`@mysten/seal` and `@mysten/walrus` must both resolve to versions that accept the same `@mysten/sui` major. Known-good matrix:
+`@mysten/seal` requires `@mysten/sui` ^2.x. Known-good matrix:
 
 | Package | Version |
 | --- | --- |
 | `@mysten/sui` | `^2.16.2` |
 | `@mysten/seal` | `^1.1.3` |
-| `@mysten/walrus` | `^1.1.7` |
-
-`@mysten/walrus@0.x` bundles `@mysten/sui@1.x` and cannot coexist with `@mysten/seal@1.x`, which requires `@mysten/sui@^2.x`. If `npm install` fails with `ERESOLVE` mentioning `@mysten/sui@^1.x`, upgrade `@mysten/walrus` to `^1.1.7`, refresh your lockfile, and run `npm why @mysten/sui` to find any remaining dependency that pins sui v1.
 
 ## Quick Start
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -46,17 +46,13 @@
         "ai": ">=4.0.0",
         "zod": "^3.23.0 || ^4.0.0",
         "@mysten/sui": ">=2.5.0",
-        "@mysten/seal": ">=1.1.0",
-        "@mysten/walrus": ">=1.0.3"
+        "@mysten/seal": ">=1.1.0"
     },
     "peerDependenciesMeta": {
         "ai": {
             "optional": true
         },
         "zod": {
-            "optional": true
-        },
-        "@mysten/walrus": {
             "optional": true
         }
     },

--- a/packages/sdk/src/manual-entry.ts
+++ b/packages/sdk/src/manual-entry.ts
@@ -2,7 +2,7 @@
  * @mysten-incubation/memwal/manual
  *
  * Manual (client-side) mode entry point.
- * Requires: @mysten/seal, @mysten/walrus, @mysten/sui
+ * Requires: @mysten/seal, @mysten/sui
  *
  * Usage:
  *   import { MemWalManual } from "@mysten-incubation/memwal/manual";

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -3,7 +3,7 @@
  *
  * User-side flow where the SDK handles everything locally:
  * - SEAL encrypt/decrypt via @mysten/seal (user's own Sui wallet)
- * - Walrus upload/download via @mysten/walrus
+ * - Walrus download via HTTP aggregator; remember uploads through the relayer
  * - Embedding via OpenAI-compatible API (user's own key)
  * - Vector registration via Walrus Memory server (Ed25519 signed)
  *
@@ -160,7 +160,6 @@ export class MemWalManual {
     // Lazily initialized heavy clients (typed as any to avoid peer dep compile errors)
     private _suiClient: any = null;
     private _sealClient: any = null;
-    private _walrusClient: any = null;
     private _keypair: any = null;
 
     private constructor(config: MemWalManualConfig) {
@@ -185,7 +184,7 @@ export class MemWalManual {
     /**
      * Create a new MemWalManual client.
      *
-     * Requires peer dependencies: @mysten/sui, @mysten/seal, @mysten/walrus
+     * Requires peer dependencies: @mysten/sui, @mysten/seal
      *
      * @param config.key - Ed25519 delegate private key (hex) for server auth
      * @param config.suiPrivateKey - Sui private key (bech32) for SEAL + Walrus (OR walletSigner)
@@ -316,28 +315,6 @@ export class MemWalManual {
         const network = this.config.suiNetwork ?? "mainnet";
         const totalWeight = sealServerConfigTotalWeight(resolveSealServerConfigs(this.config, network));
         return totalWeight > 0 ? Math.min(2, totalWeight) : 2;
-    }
-
-    private async getWalrusClient() {
-        if (!this._walrusClient) {
-            // @ts-ignore — optional peer dependency
-            const { WalrusClient } = await import("@mysten/walrus");
-            const suiClient = await this.getSuiClient();
-            const network = this.config.suiNetwork ?? "mainnet";
-            const uploadRelayHost =
-                network === "testnet"
-                    ? "https://upload-relay.testnet.walrus.space"
-                    : "https://upload-relay.mainnet.walrus.space";
-            this._walrusClient = new WalrusClient({
-                network: network as any,
-                suiClient,
-                uploadRelay: {
-                    host: uploadRelayHost,
-                    sendTip: { max: 10_000_000 },
-                },
-            });
-        }
-        return this._walrusClient;
     }
 
     // ============================================================
@@ -734,45 +711,10 @@ export class MemWalManual {
     }
 
     // ============================================================
-    // Internal: Walrus Upload/Download
+    // Internal: Walrus Download
     // ============================================================
 
-    private async walrusUpload(data: Uint8Array): Promise<string> {
-        // Direct HTTP PUT to Walrus publisher (works in both browser and Node.js,
-        // unlike @mysten/walrus SDK which uses WASM and requires Node.js)
-        const network = this.config.suiNetwork ?? "mainnet";
-        const defaultPublisher =
-            network === "testnet"
-                ? "https://publisher.walrus-testnet.walrus.space"
-                : "https://publisher.walrus-mainnet.walrus.space";
-        const publisherUrl = this.config.walrusPublisherUrl ?? defaultPublisher;
-        const epochs = this.config.walrusEpochs ?? 50;
-
-        const resp = await fetch(`${publisherUrl}/v1/blobs?epochs=${epochs}&deletable=true`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/octet-stream" },
-            body: data as unknown as BodyInit,
-        });
-
-        if (!resp.ok) {
-            const errText = await resp.text();
-            throw new Error(`Walrus upload failed (${resp.status}): ${errText}`);
-        }
-
-        const result = (await resp.json()) as any;
-        // Response can be { newlyCreated: { blobObject: { blobId } } }
-        // or { alreadyCertified: { blobId } }
-        const blobId = result.newlyCreated?.blobObject?.blobId ?? result.alreadyCertified?.blobId;
-
-        if (!blobId) {
-            throw new Error(`Walrus upload: unexpected response: ${JSON.stringify(result)}`);
-        }
-        return blobId;
-    }
-
     private async walrusDownload(blobId: string): Promise<Uint8Array> {
-        // Direct HTTP fetch to Walrus aggregator (works in both browser and Node.js,
-        // unlike @mysten/walrus SDK which requires Node.js APIs)
         const network = this.config.suiNetwork ?? "mainnet";
         const defaultAggregator =
             network === "testnet"

--- a/packages/sdk/src/manual.ts
+++ b/packages/sdk/src/manual.ts
@@ -13,14 +13,14 @@
  *
  * const memwal = MemWalManual.create({
  *     key: process.env.MEMWAL_DELEGATE_KEY!,      // Ed25519 delegate key
- *     suiPrivateKey: process.env.SUI_PRIVATE_KEY!, // suiprivkey1... for SEAL + Walrus
+ *     suiPrivateKey: process.env.SUI_PRIVATE_KEY!, // suiprivkey1... for SEAL
  *     embeddingApiKey: process.env.OPENAI_API_KEY!,
  *     packageId: "0x...",
  *     accountId: "0x...",
  *     registryId: "0x...",
  * })
  *
- * // Remember — all client-side: embed → SEAL encrypt → Walrus upload → register
+ * // Remember — embed → SEAL encrypt → relayer upload
  * await memwal.rememberManual("I'm allergic to peanuts")
  *
  * // Recall — all client-side: embed → search → download → SEAL decrypt

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -552,12 +552,8 @@ export interface MemWalManualConfig {
      * Default: 2, capped to the total configured SEAL server weight.
      */
     sealThreshold?: number;
-    /** Walrus storage epochs (default: 50) */
-    walrusEpochs?: number;
     /** Walrus aggregator URL for direct blob downloads (default: mainnet aggregator) */
     walrusAggregatorUrl?: string;
-    /** Walrus publisher URL for direct blob uploads (default: mainnet publisher) */
-    walrusPublisherUrl?: string;
     /** Default namespace for memory isolation (default: "default") */
     namespace?: string;
 }

--- a/packages/sdk/test/no-walrus-wasm.test.mjs
+++ b/packages/sdk/test/no-walrus-wasm.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { MemWalManual } from "../dist/manual.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(__dirname, "../src");
+const DIST = resolve(__dirname, "../dist");
+
+const WALRUS_IMPORT = /import\s*\(\s*["']@mysten\/walrus["']\s*\)/;
+
+function filesWithExt(dir, ext) {
+    const out = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...filesWithExt(full, ext));
+        else if (entry.name.endsWith(ext)) out.push(full);
+    }
+    return out;
+}
+
+function manualConfig() {
+    return {
+        key: new Uint8Array(32).fill(1),
+        walletSigner: {
+            address: "0x4",
+            signAndExecuteTransaction: async () => ({ digest: "unused" }),
+            signPersonalMessage: async () => ({ signature: "unused" }),
+        },
+        embeddingApiKey: "test",
+        packageId: "0x1",
+        accountId: "0x2",
+        registryId: "0x3",
+        suiNetwork: "testnet",
+    };
+}
+
+test("the SDK has no @mysten/walrus specifier", () => {
+    assert.ok(existsSync(DIST), `dist/ missing — run build first (looked in ${DIST})`);
+
+    const offenders = [];
+    for (const file of [...filesWithExt(SRC, ".ts"), ...filesWithExt(DIST, ".js")]) {
+        const src = readFileSync(file, "utf8");
+        if (WALRUS_IMPORT.test(src) || src.includes('from "@mysten/walrus"')) {
+            const root = file.startsWith(DIST) ? DIST : SRC;
+            offenders.push(relative(root, file));
+        }
+    }
+
+    assert.deepEqual(offenders, [], `SDK still imports @mysten/walrus:\n  ${offenders.join("\n  ")}`);
+});
+
+test("manual.ts dropped the dead Walrus WASM client", () => {
+    const src = readFileSync(join(SRC, "manual.ts"), "utf8");
+    assert.equal(src.includes("getWalrusClient"), false);
+    assert.equal(src.includes("_walrusClient"), false);
+    assert.equal(src.includes("walrusUpload"), false);
+    assert.equal(src.includes("via @mysten/walrus"), false);
+});
+
+test("walrusDownload fetches the aggregator over HTTP", async () => {
+    const originalFetch = globalThis.fetch;
+    const requested = [];
+    globalThis.fetch = async (input) => {
+        requested.push(String(input));
+        return new Response(new Uint8Array([9, 8, 7]), { status: 200 });
+    };
+    try {
+        const manual = MemWalManual.create(manualConfig());
+        const bytes = await manual.walrusDownload("abc");
+        assert.deepEqual([...bytes], [9, 8, 7]);
+        assert.deepEqual(requested, [
+            "https://aggregator.walrus-testnet.walrus.space/v1/blobs/abc",
+        ]);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test("walrusDownload honors walrusAggregatorUrl", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input) => {
+        assert.equal(String(input), "https://agg.example/v1/blobs/blob-1");
+        return new Response(new Uint8Array([1]), { status: 200 });
+    };
+    try {
+        const manual = MemWalManual.create({
+            ...manualConfig(),
+            walrusAggregatorUrl: "https://agg.example",
+        });
+        await manual.walrusDownload("blob-1");
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});

--- a/packages/sdk/test/no-walrus-wasm.test.mjs
+++ b/packages/sdk/test/no-walrus-wasm.test.mjs
@@ -59,6 +59,21 @@ test("manual.ts dropped the dead Walrus WASM client", () => {
     assert.equal(src.includes("_walrusClient"), false);
     assert.equal(src.includes("walrusUpload"), false);
     assert.equal(src.includes("via @mysten/walrus"), false);
+    assert.equal(src.includes("Walrus upload → register"), false);
+    assert.match(src, /embed → SEAL encrypt → relayer upload/);
+});
+
+test("package.json does not advertise @mysten/walrus", () => {
+    const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf8"));
+    assert.equal(pkg.peerDependencies["@mysten/walrus"], undefined);
+    assert.equal(pkg.peerDependenciesMeta?.["@mysten/walrus"], undefined);
+});
+
+test("MemWalManualConfig has no unused publisher or epochs knobs", () => {
+    const src = readFileSync(join(SRC, "types.ts"), "utf8");
+    assert.equal(src.includes("walrusEpochs"), false);
+    assert.equal(src.includes("walrusPublisherUrl"), false);
+    assert.equal(src.includes("walrusAggregatorUrl"), true);
 });
 
 test("walrusDownload fetches the aggregator over HTTP", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,9 +1131,6 @@ importers:
       '@mysten/sui':
         specifier: '>=2.5.0'
         version: 2.8.0(typescript@5.9.3)
-      '@mysten/walrus':
-        specifier: '>=1.0.3'
-        version: 1.0.4(@mysten/sui@2.8.0(typescript@5.9.3))
       '@noble/ed25519':
         specifier: ^2.3.0
         version: 2.3.0


### PR DESCRIPTION
## Ticket

WALM-145 — https://linear.app/mysten-labs/issue/WALM-145
GH #330 — https://github.com/MystenLabs/MemWal/issues/330

## What changed?

- Removed unused `getWalrusClient()`, `_walrusClient`, and `walrusUpload()` from `MemWalManual`.
- No remaining `import("@mysten/walrus")` in the SDK. Blob download stays on HTTP `fetch` to the aggregator.
- Docs no longer claim `/manual` uploads/downloads via `@mysten/walrus`.

## Why is this needed?

The live remember path uploads through the relayer. The live recall path downloads over HTTP. `getWalrusClient()` still did `await import("@mysten/walrus")` with no call sites, so Next.js 15 Turbopack put Walrus WASM in the `/manual` module graph and hit `/ROOT/` resolution errors.

## Test plan

- [ ] SDK tests, including `packages/sdk/test/no-walrus-wasm.test.mjs`
- [ ] Import `@mysten-incubation/memwal/manual` under Turbopack/Vite without `@mysten/walrus`
- [ ] `recallManual` still downloads blobs over HTTP