### PR TITLE
docs: show recall() scoringWeights on SKILL.md (WALM-616)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -212,7 +212,15 @@ interface RecallOptions {
   scoringWeights?: ScoringWeights; // sent as scoring_weights; omit to keep cosine order
 }
 
+interface ScoringWeights {
+  semantic?: number; // default 1
+  recency?: number; // default 0
+  recencyHalfLifeDays?: number; // default 30
+  importance?: number; // default 0
+}
+
 // `topK` and `limit` are aliases for the same value; if both are provided, `topK` takes precedence.
+// `sort: "recent"` is newest-wins (over-fetch then write-time). `scoringWeights` only re-ranks the cosine window.
 
 interface RememberBulkAcceptedResult {
   job_ids: string[];

--- a/SKILL.md
+++ b/SKILL.md
@@ -152,7 +152,7 @@ const stored = await memwal.waitForRememberJob(accepted.job_id, {
 |---|---|---|
 | `remember(text, namespace?)` | Accept one memory job immediately | `{ job_id, status }` |
 | `rememberAndWait(text, namespace?, opts?)` | Store one memory and wait for completion | `{ id, job_id, blob_id, owner, namespace }` |
-| `recall({ query, limit?, topK?, namespace?, maxDistance? })` *(preferred)* or `recall(query, limit?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
+| `recall({ query, limit?, topK?, namespace?, maxDistance?, sort?, scoringWeights? })` *(preferred)* or `recall(query, limit?, namespace?)` | Semantic search for memories | `{ results: [{ blob_id, text, distance }], total }` |
 | `analyze(text, namespace?)` | Extract facts and accept one memory job per fact | `{ job_ids, facts, fact_count, status, owner }` |
 | `analyzeAndWait(text, namespace?, opts?)` | Extract facts and wait for all fact jobs to complete | `{ results, facts, total, succeeded, failed, owner }` |
 | `restore(namespace, limit?)` | Rebuild missing index entries from Walrus | `{ restored, skipped, failed, total, namespace, owner, truncated }` |
@@ -208,6 +208,8 @@ interface RecallOptions {
   topK?: number; // alias of limit; if both are set, topK wins
   namespace?: string;
   maxDistance?: number;
+  sort?: "relevance" | "recent";
+  scoringWeights?: ScoringWeights; // sent as scoring_weights; omit to keep cosine order
 }
 
 // `topK` and `limit` are aliases for the same value; if both are provided, `topK` takes precedence.


### PR DESCRIPTION
## Ticket

WALM-616 — https://linear.app/mysten-labs/issue/WALM-616
GH #708 — https://github.com/MystenLabs/MemWal/issues/708

## What changed?

- TypeScript `recall()` already sends `scoring_weights` when `RecallOptions.scoringWeights` is set (shipped in 0.1.6). Existing tests in `recall-created-at.test.mjs` pin the wire body.
- `SKILL.md` still listed the old `recall({ query, limit?, topK?, namespace?, maxDistance? })` / `RecallOptions` without `scoringWeights` or `sort`. That is the copy GH #708 used to conclude recency ranking was unreachable.

## Why is this needed?

Agents reading `SKILL.md` still cannot see `scoringWeights` on `recall()`. The SDK gap is already closed; this is the remaining advertised contract.

## Scope

`SKILL.md` only. No MCP `memwal_recall` change (WALM-428).

### Out of scope

- MCP `sort=recent` (WALM-428)
- Python `recall()` still does not send `scoring_weights`

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands: `npm test --prefix packages/sdk` (includes `recall sends scoringWeights as snake_case scoring_weights`)

## Verify

- `recall({ query, scoringWeights: { semantic: 1, recency: 0.5 } })` POSTs `scoring_weights`
- Omit `scoringWeights` and the body has no `scoring_weights` key
- MCP `memwal_recall` schema unchanged

## Risks

Docs-only. No runtime change.

## Author checklist

- [x] I ran the relevant tests (`npm test --prefix packages/sdk`)
- [x] I did not bump the unpublished 0.1.7 changelog (behavior already in 0.1.6)
- [x] No secrets committed