### PR TITLE
fix(mcp): say the handshake failed instead of blaming a dropped reply (WALM-618)

### DIFF
--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -809,6 +809,21 @@ export async function runBridge(
     let reconnectAttempt = 0;
     let reconnectPromise: Promise<void> | null = null;
     let firstConnectDone = false;
+    /** Why the last handshake attempt failed, and when the run of failures
+     * started. Kept so a request that ages out while buffered can say what
+     * it was actually waiting on instead of a generic "unavailable" — the
+     * user-visible half of WALM-618, where the bridge retried in silence and
+     * a `remember` looked like it was just slow. Cleared on every success. */
+    let lastHandshakeError: string | null = null;
+    let handshakeFailingSince: number | null = null;
+    const noteHandshakeFailure = (reason: string): void => {
+        lastHandshakeError = reason;
+        handshakeFailingSince ??= Date.now();
+    };
+    const clearHandshakeFailure = (): void => {
+        lastHandshakeError = null;
+        handshakeFailingSince = null;
+    };
     /** Bumped when the live SSE session is aborted or replaced so queued
      * POSTs captured against a stale URL are skipped (reconnect replays). */
     let sessionEpoch = 0;
@@ -1039,6 +1054,7 @@ export async function runBridge(
                     firstConnectDone = true;
                     activeCredentialGeneration = openingGeneration;
                     reconnectAttempt = 0;
+                    clearHandshakeFailure();
                     log.info("bridge.reconnected", {
                         relayer: openingCreds.relayerUrl,
                         replayCount: inFlight.size,
@@ -1114,9 +1130,9 @@ export async function runBridge(
                     break;
                 }
             } catch (err) {
-                log.error("bridge.reconnect_failed", {
-                    err: err instanceof Error ? err.message : String(err),
-                });
+                const reason = err instanceof Error ? err.message : String(err);
+                noteHandshakeFailure(reason);
+                log.error("bridge.reconnect_failed", { err: reason });
                 // Try again on the next stdin message rather than spinning.
             }
         })();
@@ -1762,6 +1778,61 @@ export async function runBridge(
         for (const entry of Array.from(inFlight.values())) failRequest(entry.msg, reason);
     }
 
+    /** How a request that just hit its deadline should be explained.
+     *
+     * Both cases are the same expiry, but they are not the same event and the
+     * old wording only described one of them. A request still sitting in
+     * `pendingForward` never left this process: no session ever existed to
+     * send it on. Telling the user the connection "dropped before the result
+     * came back" points them at the relayer, or at a half-written memory, when
+     * the truth is that the MCP handshake has been failing and the call never
+     * ran (WALM-618 — the bridge retried in silence, so a `remember` looked
+     * like it was merely slow for minutes).
+     *
+     * Pure: the caller is responsible for dropping a `neverSent` message from
+     * the buffer, which it must, or a later flush would run the call we just
+     * said never ran. */
+    function expiredRequestReport(msg: RpcMessage): {
+        neverSent: boolean;
+        reason: string;
+        opts: { toolText: string; errorMessage: string };
+    } {
+        if (!pendingForward.includes(msg)) {
+            return {
+                neverSent: false,
+                reason: "no response",
+                opts: {
+                    toolText:
+                        "❌ Walrus Memory did not answer this call. The connection to " +
+                        "the relayer dropped before the result came back. Please retry.",
+                    errorMessage:
+                        "Walrus Memory call was orphaned by a reconnect and never " +
+                        "received a response. Please retry.",
+                },
+            };
+        }
+
+        const stalledForMs = handshakeFailingSince ? Date.now() - handshakeFailingSince : null;
+        const waited = stalledForMs
+            ? `for ${Math.round(stalledForMs / 1000)}s`
+            : `for over ${Math.round(callTimeoutMs / 1000)}s`;
+        const detail = lastHandshakeError ? ` Last handshake error: ${lastHandshakeError}` : "";
+        return {
+            neverSent: true,
+            reason: "never reached the relayer",
+            opts: {
+                toolText:
+                    `❌ Walrus Memory could not reach the relayer — the MCP connection has ` +
+                    `been failing ${waited}, so this call never ran and nothing was stored.` +
+                    `${detail} Check the relayer, or run \`memwal-mcp login\` if the delegate ` +
+                    `key was revoked, then retry.`,
+                errorMessage:
+                    `Walrus Memory call never reached the relayer: the MCP connection has ` +
+                    `been failing ${waited}.${detail}`,
+            },
+        };
+    }
+
     /** Close out requests whose deadline has passed. Without this a reply lost
      * on a still-healthy stream leaves its request tracked forever. */
     // Same shape as the SSE watchdog's check interval, but capped.
@@ -1774,19 +1845,27 @@ export async function runBridge(
         for (const [id, entry] of Array.from(inFlight.entries())) {
             const elapsedMs = now - entry.startedAt;
             if (elapsedMs <= callTimeoutMs) continue;
+            const { neverSent, reason, opts } = expiredRequestReport(entry.msg);
+            // Drop it from the buffer before answering: a later successful
+            // connect would otherwise flush and actually run the call we are
+            // about to report as never having run.
+            //
+            // `initialize` is the exception, as everywhere else here: it was
+            // answered locally and is only buffered so the relayer session can
+            // still negotiate capabilities, and `failRequest` writes it no
+            // reply. Removing it would silently cost that negotiation on the
+            // first connect after a long outage.
+            if (neverSent && entry.msg.method !== "initialize") {
+                pendingForward.splice(pendingForward.indexOf(entry.msg), 1);
+            }
             log.warn("bridge.call_orphaned", {
                 id,
                 method: entry.msg.method ?? null,
                 elapsedMs,
+                reason,
+                lastHandshakeError,
             });
-            failRequest(entry.msg, "no response", {
-                toolText:
-                    "❌ Walrus Memory did not answer this call. The connection to " +
-                    "the relayer dropped before the result came back. Please retry.",
-                errorMessage:
-                    "Walrus Memory call was orphaned by a reconnect and never " +
-                    "received a response. Please retry.",
-            });
+            failRequest(entry.msg, reason, opts);
         }
     }, sweepIntervalMs);
     // unref so the sweeper never holds the event loop open during shutdown.
@@ -1846,6 +1925,7 @@ export async function runBridge(
                 sessionEpoch += 1;
                 sse = candidate;
                 firstConnectDone = true;
+                clearHandshakeFailure();
                 note(`Connected. Bridging stdio MCP ↔ ${creds.relayerUrl}`);
                 log.info("bridge.connected", { relayer: creds.relayerUrl });
                 signalFirstConnect();
@@ -1853,6 +1933,7 @@ export async function runBridge(
                 return;
             } catch (err) {
                 const reason = err instanceof Error ? err.message : String(err);
+                noteHandshakeFailure(reason);
                 attempt += 1;
                 log.error("bridge.initial_connect_failed", { err: reason, attempt });
                 if (stdinClosed) break;

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -261,6 +261,35 @@ function resolveCallTimeoutMs(): number {
     return n;
 }
 
+/** Deadline for a request that is still buffered while the handshake has been
+ * failing for at least this long — i.e. one we can prove never left this
+ * process.
+ *
+ * It is much shorter than `callTimeoutMs` because the two cases carry
+ * different risk, not because the wait is less important. A request that was
+ * SENT might have been executed, so failing it early invites the agent to
+ * retry a `remember` that already landed. A request that was never sent
+ * cannot have executed: failing it is provably a no-op, and the agent's retry
+ * costs one round trip.
+ *
+ * 90s is well past a relayer cold start and past six reconnect attempts at the
+ * capped 15s backoff, so it does not fire on a slow-but-recovering relayer —
+ * and it does not apply at all while the handshake is healthy (a request
+ * buffered behind an in-progress flush keeps the full deadline). What it ends
+ * is the case from WALM-618: no working connection, nothing sent, and four
+ * minutes of silence before the user is told anything. */
+const DEFAULT_STALLED_HANDSHAKE_MS = 90_000;
+
+/** Same override shape as the call timeout, mostly for tests. Never longer
+ * than the call timeout itself: this deadline exists to fire sooner. */
+function resolveStalledHandshakeMs(callTimeoutMs: number): number {
+    const raw = process.env.MEMWAL_MCP_STALLED_HANDSHAKE_MS;
+    const n = raw ? Number(raw) : DEFAULT_STALLED_HANDSHAKE_MS;
+    const resolved =
+        Number.isFinite(n) && n >= MIN_CALL_TIMEOUT_MS ? n : DEFAULT_STALLED_HANDSHAKE_MS;
+    return Math.min(resolved, callTimeoutMs);
+}
+
 interface RpcMessage {
     jsonrpc: "2.0";
     id?: number | string | null;
@@ -955,6 +984,7 @@ export async function runBridge(
     // would otherwise keep pushing the deadline out.
     const inFlight = new Map<string | number, InFlightEntry>();
     const callTimeoutMs = resolveCallTimeoutMs();
+    const stalledHandshakeMs = resolveStalledHandshakeMs(callTimeoutMs);
 
     /** IDs of `tools/list` requests we've forwarded to the relayer. When
      * the response comes back through the SSE pump, we splice in the
@@ -1778,21 +1808,31 @@ export async function runBridge(
         for (const entry of Array.from(inFlight.values())) failRequest(entry.msg, reason);
     }
 
+    /** How long the current run of handshake failures has lasted, or `null`
+     * when the last attempt succeeded. */
+    function handshakeStalledForMs(now: number): number | null {
+        return handshakeFailingSince === null ? null : now - handshakeFailingSince;
+    }
+
     /** How a request that just hit its deadline should be explained.
      *
-     * Both cases are the same expiry, but they are not the same event and the
-     * old wording only described one of them. A request still sitting in
-     * `pendingForward` never left this process: no session ever existed to
-     * send it on. Telling the user the connection "dropped before the result
+     * Three cases, where the old wording only described one. A request still
+     * sitting in `pendingForward` never left this process: no session ever
+     * carried it. Telling the user the connection "dropped before the result
      * came back" points them at the relayer, or at a half-written memory, when
-     * the truth is that the MCP handshake has been failing and the call never
-     * ran (WALM-618 — the bridge retried in silence, so a `remember` looked
-     * like it was merely slow for minutes).
+     * the truth is that nothing was attempted (WALM-618 — the bridge retried
+     * in silence, so a `remember` looked like it was merely slow for minutes).
+     * And a buffered request is only evidence of a *failing* connection when
+     * one is actually failing: post-connect, `handleClientLine` also buffers
+     * behind an in-progress flush, on a perfectly healthy session.
      *
      * Pure: the caller is responsible for dropping a `neverSent` message from
      * the buffer, which it must, or a later flush would run the call we just
      * said never ran. */
-    function expiredRequestReport(msg: RpcMessage): {
+    function expiredRequestReport(
+        msg: RpcMessage,
+        now: number,
+    ): {
         neverSent: boolean;
         reason: string;
         opts: { toolText: string; errorMessage: string };
@@ -1812,10 +1852,26 @@ export async function runBridge(
             };
         }
 
-        const stalledForMs = handshakeFailingSince ? Date.now() - handshakeFailingSince : null;
-        const waited = stalledForMs
-            ? `for ${Math.round(stalledForMs / 1000)}s`
-            : `for over ${Math.round(callTimeoutMs / 1000)}s`;
+        const stalledForMs = handshakeStalledForMs(now);
+        if (stalledForMs === null) {
+            // Buffered on a live session (a flush was draining) and still
+            // unsent at the deadline. Nothing ran, but nothing is failing
+            // either — do not invent an outage.
+            return {
+                neverSent: true,
+                reason: "never left the queue",
+                opts: {
+                    toolText:
+                        "❌ Walrus Memory never sent this call — it was still queued when " +
+                        "the call timed out, so nothing was stored. Please retry.",
+                    errorMessage:
+                        "Walrus Memory call was still queued when it timed out and was " +
+                        "never sent. Please retry.",
+                },
+            };
+        }
+
+        const waited = `for ${Math.round(stalledForMs / 1000)}s`;
         const detail = lastHandshakeError ? ` Last handshake error: ${lastHandshakeError}` : "";
         return {
             neverSent: true,
@@ -1842,10 +1898,22 @@ export async function runBridge(
     );
     const orphanSweeper = setInterval(() => {
         const now = Date.now();
+        const handshakeStalledMs = handshakeStalledForMs(now);
         for (const [id, entry] of Array.from(inFlight.entries())) {
             const elapsedMs = now - entry.startedAt;
-            if (elapsedMs <= callTimeoutMs) continue;
-            const { neverSent, reason, opts } = expiredRequestReport(entry.msg);
+            const { neverSent, reason, opts } = expiredRequestReport(entry.msg, now);
+            // A call we can prove never left this process, while no working
+            // connection has existed for `stalledHandshakeMs`, does not need
+            // the full `callTimeoutMs`: it cannot have executed, so answering
+            // it early is a no-op the agent can safely retry. Anything that
+            // was actually sent — or that is queued on a healthy session —
+            // keeps the full deadline, because there a premature failure
+            // invites a duplicate write.
+            const handshakeIsStalled =
+                handshakeStalledMs !== null && handshakeStalledMs > stalledHandshakeMs;
+            const deadlineMs =
+                neverSent && handshakeIsStalled ? stalledHandshakeMs : callTimeoutMs;
+            if (elapsedMs <= deadlineMs) continue;
             // Drop it from the buffer before answering: a later successful
             // connect would otherwise flush and actually run the call we are
             // about to report as never having run.
@@ -1862,7 +1930,9 @@ export async function runBridge(
                 id,
                 method: entry.msg.method ?? null,
                 elapsedMs,
+                deadlineMs,
                 reason,
+                handshakeStalledMs,
                 lastHandshakeError,
             });
             failRequest(entry.msg, reason, opts);
@@ -1880,8 +1950,11 @@ export async function runBridge(
     // NOT fail buffered requests between attempts: a request that the next
     // attempt would serve must not get a spurious "unavailable" error (that
     // would also drop the auth-required hot-handoff request). Buffered tool
-    // calls stay queued and are flushed on the first SUCCESS; if they never
-    // connect, the client's own per-tool timeout fires (graceful) — and on
+    // calls stay queued and are flushed on the first SUCCESS. They are no
+    // longer left to the client's own per-tool timeout, though: once no
+    // connection has existed for `stalledHandshakeMs` the orphan sweeper
+    // answers them (see `DEFAULT_STALLED_HANDSHAKE_MS`), because a call that
+    // was never sent cannot have executed and silence helps nobody. On
     // shutdown `failPendingForward` closes out anything still open. `initialize`
     // is answered locally, so it never blocks and is only forwarded, not failed.
     // First connect stays on `openSseStream` + `flushPendingForward` so a

--- a/packages/mcp/test/pending-forward-stalled.test.mjs
+++ b/packages/mcp/test/pending-forward-stalled.test.mjs
@@ -40,10 +40,16 @@ const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
 const EXPECTED_BEARER = "a".repeat(64);
 const EXPECTED_ACCOUNT_ID = "0x" + "3".repeat(64);
 
-/** The deadline under test. Short enough to run, long enough that several
- * connect-retry cycles fit inside it — otherwise "not eager-failed between
- * retries" would pass for the wrong reason. */
-const CALL_TIMEOUT_MS = 3_000;
+/** The deadline under test: the short one that applies only to a call which
+ * never left the bridge while no connection has existed. Short enough to run,
+ * long enough that several connect-retry cycles fit inside it — otherwise
+ * "not eager-failed between retries" would pass for the wrong reason. */
+const STALLED_HANDSHAKE_MS = 3_000;
+
+/** Deliberately far larger, so an answer arriving near STALLED_HANDSHAKE_MS
+ * proves the stalled-handshake deadline fired and not the ordinary call
+ * timeout, which is what used to leave the user waiting ~4 minutes. */
+const CALL_TIMEOUT_MS = 60_000;
 const CONNECT_TIMEOUT_MS = 400;
 
 function hasBridgeAuth(req) {
@@ -179,6 +185,7 @@ test("a call buffered behind a failing handshake is answered, and says why", asy
             USERPROFILE: home,
             MEMWAL_MCP_CONNECT_TIMEOUT_MS: String(CONNECT_TIMEOUT_MS),
             MEMWAL_MCP_CALL_TIMEOUT_MS: String(CALL_TIMEOUT_MS),
+            MEMWAL_MCP_STALLED_HANDSHAKE_MS: String(STALLED_HANDSHAKE_MS),
         },
         stdio: ["pipe", "pipe", "pipe"],
     });
@@ -252,7 +259,7 @@ test("a call buffered behind a failing handshake is answered, and says why", asy
     // Half the deadline in, several connect attempts have already failed and
     // the call must still be waiting — the fix adds a deadline, it does not
     // eager-fail a call the next attempt might serve.
-    await new Promise((r) => setTimeout(r, CALL_TIMEOUT_MS / 2));
+    await new Promise((r) => setTimeout(r, STALLED_HANDSHAKE_MS / 2));
     assert.ok(
         mock.getSseGetCount() >= 2,
         `expected the handshake to have been retried by now, saw ${mock.getSseGetCount()} attempts`,
@@ -266,8 +273,13 @@ test("a call buffered behind a failing handshake is answered, and says why", asy
     const reply = await waitFor((m) => m.id === 2, 15_000);
     const waitedMs = Date.now() - sentAt;
     assert.ok(
-        waitedMs >= CALL_TIMEOUT_MS,
+        waitedMs >= STALLED_HANDSHAKE_MS,
         `must not be answered before its deadline; waited only ${waitedMs}ms`,
+    );
+    assert.ok(
+        waitedMs < CALL_TIMEOUT_MS,
+        `must be answered on the stalled-handshake deadline, not the ordinary ${CALL_TIMEOUT_MS}ms ` +
+            `call timeout — that long wait with no feedback is the reported bug; waited ${waitedMs}ms`,
     );
 
     assert.equal(

--- a/packages/mcp/test/pending-forward-stalled.test.mjs
+++ b/packages/mcp/test/pending-forward-stalled.test.mjs
@@ -1,0 +1,363 @@
+/**
+ * Regression test for WALM-618 — a tool call that expires while still buffered
+ * must be explained as what it is: a call that never left this process.
+ *
+ * Repro (the shape Dio hit: 15 session opens, 6 calls that ever reached the
+ * relayer, minutes of silence in between):
+ *   - Mock relayer answers GET /version, then 503s every SSE handshake, the
+ *     way the real relayer does when the on-chain delegate verify cannot
+ *     reach a throttled fullnode.
+ *   - A `tools/call` arrives before any session exists, so it lands in
+ *     `pendingForward` and waits there while the bridge retries.
+ *
+ * The orphan sweeper did already bound this wait. What it got wrong was the
+ * answer: every expiry was reported as "the connection to the relayer dropped
+ * before the result came back", which points the user at the relayer — or at a
+ * possibly half-written memory — when in fact nothing was ever sent and the
+ * handshake was the thing failing.
+ *
+ * Asserts:
+ *   - `initialize` is still answered locally, exactly once.
+ *   - the buffered call is NOT eager-failed between retries (the property
+ *     `coldstart-timeout.test.mjs` locks down — this stays a deadline, not a
+ *     per-attempt failure).
+ *   - once the deadline passes it is answered as a tool error naming the
+ *     failing connection, saying nothing was stored, and carrying the last
+ *     handshake error.
+ *   - the process stays alive throughout.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "../dist/bin/memwal-mcp.js");
+const EXPECTED_BEARER = "a".repeat(64);
+const EXPECTED_ACCOUNT_ID = "0x" + "3".repeat(64);
+
+/** The deadline under test. Short enough to run, long enough that several
+ * connect-retry cycles fit inside it — otherwise "not eager-failed between
+ * retries" would pass for the wrong reason. */
+const CALL_TIMEOUT_MS = 3_000;
+const CONNECT_TIMEOUT_MS = 400;
+
+function hasBridgeAuth(req) {
+    return (
+        req.headers.authorization === `Bearer ${EXPECTED_BEARER}` &&
+        req.headers["x-memwal-account-id"] === EXPECTED_ACCOUNT_ID
+    );
+}
+
+/** Mock relayer that 503s every SSE handshake until `heal()` is called — an
+ * infrastructure failure, not an auth rejection, which is exactly what a
+ * throttled fullnode produces via the relayer's `upstream_unavailable()`.
+ * Once healed it behaves like a normal session, and records every JSON-RPC
+ * envelope it is posted so a test can prove what did (and did not) reach it. */
+function startUnavailableRelayer() {
+    let sseGetCount = 0;
+    let healthy = false;
+    const sessions = new Map();
+    const posted = [];
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/version") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    apiVersion: "1.0.0",
+                    relayerVersion: "1.0.0",
+                    minSupportedSdk: { mcp: "0.0.1" },
+                }),
+            );
+            return;
+        }
+        if (req.method === "GET" && url.pathname === "/api/mcp/sse") {
+            if (!hasBridgeAuth(req)) {
+                res.writeHead(401);
+                res.end();
+                return;
+            }
+            sseGetCount += 1;
+            if (!healthy) {
+                res.writeHead(503, { "content-type": "text/plain" });
+                res.end("Account resolution unavailable: on-chain re-verify unavailable");
+                return;
+            }
+            const sessionId = `session-${sseGetCount}`;
+            res.writeHead(200, {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+                connection: "keep-alive",
+            });
+            res.write(`event: endpoint\ndata: /api/mcp/messages?sessionId=${sessionId}\n\n`);
+            sessions.set(sessionId, { res });
+            const hb = setInterval(() => {
+                if (res.writableEnded) {
+                    clearInterval(hb);
+                    return;
+                }
+                res.write(":\n\n");
+            }, 200);
+            hb.unref?.();
+            res.on("close", () => clearInterval(hb));
+            return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/mcp/messages") {
+            const session = sessions.get(url.searchParams.get("sessionId"));
+            let body = "";
+            req.on("data", (c) => (body += c));
+            req.on("end", () => {
+                if (!session) {
+                    res.writeHead(404);
+                    res.end();
+                    return;
+                }
+                try {
+                    posted.push(JSON.parse(body));
+                } catch {
+                    /* not JSON — not something this test asserts on */
+                }
+                res.writeHead(202);
+                res.end();
+            });
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+    return new Promise((res) => {
+        server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address();
+            res({
+                server,
+                base: `http://127.0.0.1:${port}`,
+                getSseGetCount: () => sseGetCount,
+                getPosted: () => posted,
+                heal: () => {
+                    healthy = true;
+                },
+                closeStreams: () =>
+                    sessions.forEach((s) => {
+                        if (!s.res.writableEnded) s.res.end();
+                    }),
+            });
+        });
+    });
+}
+
+function makeCreds(relayerUrl) {
+    return {
+        delegatePrivateKey: EXPECTED_BEARER,
+        delegatePublicKeyHex: "b".repeat(64),
+        delegateAddress: "0x" + "1".repeat(64),
+        walletAddress: "0x" + "2".repeat(64),
+        accountId: EXPECTED_ACCOUNT_ID,
+        packageId: "0x" + "4".repeat(64),
+        relayerUrl,
+        label: "Pending Forward Stalled Test",
+        createdAt: new Date(0).toISOString(),
+        version: 1,
+    };
+}
+
+test("a call buffered behind a failing handshake is answered, and says why", async (t) => {
+    const mock = await startUnavailableRelayer();
+    const home = mkdtempSync(join(tmpdir(), "memwal-pending-stalled-test-"));
+    const credsPath = join(home, ".memwal", "credentials.json");
+    mkdirSync(dirname(credsPath), { recursive: true });
+    writeFileSync(credsPath, JSON.stringify(makeCreds(mock.base)), { mode: 0o600 });
+
+    const child = spawn(process.execPath, [BIN, "--relayer", mock.base, "--web-url", mock.base], {
+        env: {
+            ...process.env,
+            HOME: home,
+            USERPROFILE: home,
+            MEMWAL_MCP_CONNECT_TIMEOUT_MS: String(CONNECT_TIMEOUT_MS),
+            MEMWAL_MCP_CALL_TIMEOUT_MS: String(CALL_TIMEOUT_MS),
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const received = [];
+    const listeners = new Set();
+    let buf = "";
+    child.stdout.on("data", (d) => {
+        buf += d.toString();
+        let nl;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            received.push(msg);
+            for (const l of [...listeners]) l(msg);
+        }
+    });
+    let stderrBuf = "";
+    child.stderr.on("data", (d) => (stderrBuf += d.toString()));
+
+    const send = (obj) => child.stdin.write(JSON.stringify(obj) + "\n");
+    const waitFor = (pred, ms = 15_000) => {
+        const hit = received.find(pred);
+        if (hit) return Promise.resolve(hit);
+        return new Promise((res, rej) => {
+            const timer = setTimeout(() => {
+                listeners.delete(l);
+                rej(
+                    new Error(
+                        `timed out waiting for message\n--- stderr ---\n${stderrBuf}\n--- received ---\n${received.map((m) => JSON.stringify(m)).join("\n")}`,
+                    ),
+                );
+            }, ms);
+            const l = (m) => {
+                if (pred(m)) {
+                    clearTimeout(timer);
+                    listeners.delete(l);
+                    res(m);
+                }
+            };
+            listeners.add(l);
+        });
+    };
+
+    t.after(() => {
+        child.kill("SIGKILL");
+        mock.closeStreams();
+        mock.server.close();
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const init = await waitFor((m) => m.id === 1 && m.result, 5_000);
+    assert.equal(init.result.serverInfo.name, "memwal");
+
+    const sentAt = Date.now();
+    send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "memwal_remember", arguments: { text: "anything" } },
+    });
+
+    // Half the deadline in, several connect attempts have already failed and
+    // the call must still be waiting — the fix adds a deadline, it does not
+    // eager-fail a call the next attempt might serve.
+    await new Promise((r) => setTimeout(r, CALL_TIMEOUT_MS / 2));
+    assert.ok(
+        mock.getSseGetCount() >= 2,
+        `expected the handshake to have been retried by now, saw ${mock.getSseGetCount()} attempts`,
+    );
+    assert.ok(
+        !received.some((m) => m.id === 2),
+        `id=2 must still be buffered mid-deadline, got: ${JSON.stringify(received.find((m) => m.id === 2))}`,
+    );
+
+    // Past the deadline it is answered rather than left hanging forever.
+    const reply = await waitFor((m) => m.id === 2, 15_000);
+    const waitedMs = Date.now() - sentAt;
+    assert.ok(
+        waitedMs >= CALL_TIMEOUT_MS,
+        `must not be answered before its deadline; waited only ${waitedMs}ms`,
+    );
+
+    assert.equal(
+        reply.result?.isError,
+        true,
+        `expected a tool-error envelope, got ${JSON.stringify(reply)}`,
+    );
+    const text = JSON.stringify(reply.result);
+    assert.match(
+        text,
+        /could not reach the relayer/i,
+        `the answer must name the failing connection, got ${text}`,
+    );
+    assert.match(
+        text,
+        /nothing was\\?\s*stored/i,
+        `the answer must say the call never ran, got ${text}`,
+    );
+    assert.match(
+        text,
+        /503/,
+        `the answer must carry the handshake error the call was stuck behind, got ${text}`,
+    );
+
+    assert.equal(child.exitCode, null, "bridge should still be running, not exited");
+
+    // initialize answered exactly once — the sweep must never write a second
+    // envelope for an id that was answered locally.
+    const initReplies = received.filter((m) => m.id === 1 && (m.result || m.error));
+    assert.equal(
+        initReplies.length,
+        1,
+        `initialize (id=1) must be answered exactly once; saw ${initReplies.length}`,
+    );
+
+    // The hazard the expiry has to close: the answered call is still a plain
+    // object sitting in `pendingForward`, and the flush that follows the next
+    // successful connect forwards whatever it finds there. Left in, a
+    // `remember` we just reported as never having run would run for real —
+    // after the agent was told nothing was stored, so it may well have retried
+    // by then. Let the relayer recover and prove the call is gone.
+    mock.heal();
+    const connectedAt = Date.now();
+    while (!stderrBuf.includes("Connected. Bridging") && Date.now() - connectedAt < 15_000) {
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.ok(
+        stderrBuf.includes("Connected. Bridging"),
+        `the relayer must recover for this assertion to mean anything; stderr:\n${stderrBuf}`,
+    );
+
+    // A fresh call proves the session really is carrying traffic, so "id=2
+    // never posted" below is evidence rather than an artefact of a dead link.
+    send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "memwal_remember", arguments: { text: "after recovery" } },
+    });
+    const postedAt = Date.now();
+    while (
+        !mock.getPosted().some((m) => m.id === 3) &&
+        Date.now() - postedAt < 10_000
+    ) {
+        await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.ok(
+        mock.getPosted().some((m) => m.id === 3),
+        `a call sent after recovery must reach the relayer; posted: ${JSON.stringify(mock.getPosted())}`,
+    );
+
+    assert.ok(
+        !mock.getPosted().some((m) => m.id === 2),
+        `the expired call must never reach the relayer after being answered, but saw: ${JSON.stringify(
+            mock.getPosted().filter((m) => m.id === 2),
+        )}`,
+    );
+    const callReplies = received.filter((m) => m.id === 2);
+    assert.equal(
+        callReplies.length,
+        1,
+        `id=2 must be answered exactly once; saw ${callReplies.length}: ${JSON.stringify(callReplies)}`,
+    );
+
+    // `initialize` is buffered, not answered upstream — the expiry must leave
+    // it in place so the recovered session still negotiates capabilities.
+    assert.ok(
+        mock.getPosted().some((m) => m.method === "initialize"),
+        `initialize must still be forwarded once the session comes up; posted: ${JSON.stringify(
+            mock.getPosted().map((m) => m.method ?? m.id),
+        )}`,
+    );
+});


### PR DESCRIPTION
## The bug

A tool call that arrives before the relayer session exists waits in `pendingForward`. Two things were wrong with how that wait ended.

**1. It barely ended.** The orphan sweeper bounded it at `callTimeoutMs` — 240s by default (`SLOWEST_SERVER_TOOL_MS` 180s + 60s). Four minutes of silence, plus one agent-level retry, is exactly the "3–8 min" the ticket reports.

**2. The answer blamed the wrong thing.** Every expiry was reported the same way:

> ❌ Walrus Memory did not answer this call. The connection to the relayer dropped before the result came back. Please retry.

For a buffered call that is wrong twice over. Nothing was sent, so no connection dropped and no reply was lost; and *"before the result came back"* implies a write that may or may not have landed, when none was attempted. Meanwhile the one thing the bridge did know — that the MCP handshake had been failing, and with what error — it kept to its own log.

In Dio's trace: 15 session opens for 6 calls that ever reached the relayer, every call that arrived finishing in 19–34s, and from his side a `memwal_remember` that was simply slow for minutes with nothing reported.

## The fix

**A shorter deadline for a call that provably never left the process.** Once no working connection has existed for `stalledHandshakeMs` (90s, overridable via `MEMWAL_MCP_STALLED_HANDSHAKE_MS`), a still-buffered request is answered on that bound instead of the full 240s.

The two cases can have different deadlines because they carry different risk. A request that was **sent** might have executed, so failing it early invites the agent to retry a `remember` that already landed — that one keeps the full deadline. A request that was **never sent** cannot have executed: answering it is provably a no-op and the retry costs one round trip.

90s is past a relayer cold start and past six reconnect attempts at the capped 15s backoff, so it does not fire on a slow-but-recovering relayer. The login flow is unaffected — the browser wait happens in `runAuthRequiredServer`, *before* `runBridge` is called with the handed-off lines, so no request is buffered across it. `coldstart-timeout.test.mjs`'s property still holds: a call the next attempt could serve is not eager-failed.

**Three cases in the answer, not one.** Track the last handshake failure and how long the run has lasted, cleared on every successful connect:

- never sent, handshake failing → *"could not reach the relayer — the MCP connection has been failing for 94s, so this call never ran and nothing was stored. Last handshake error: … Check the relayer, or run `memwal-mcp login` if the delegate key was revoked, then retry."*
- never sent, **connection healthy** (post-connect, `handleClientLine` also buffers behind an in-progress flush) → *"never sent this call — it was still queued when the call timed out, so nothing was stored."* No invented outage, and this case keeps the full deadline.
- actually sent, no reply → the original wording, unchanged.

Answering a buffered request also means **removing it from the buffer**. Left in, the flush after the next successful connect would run the call we just reported as never having run — with the agent, having been told nothing was stored, likely to have retried by then. `initialize` is exempt, as everywhere else in this file: it is answered locally and buffered only so the session can still negotiate capabilities.

## Tests

`test/pending-forward-stalled.test.mjs` drives the real shape: a relayer that 503s every handshake the way the relayer does when the on-chain delegate verify cannot reach a throttled fullnode, then recovers. It runs a 60s call timeout against a 3s stalled-handshake bound, so an answer near 3s proves the **new** deadline fired and not the ordinary timeout. It also asserts the call is not eager-failed mid-deadline, is answered exactly once, carries the handshake error, never reaches the relayer afterwards, that a call sent after recovery does, and that `initialize` is still forwarded once the session comes up.

Full suite: 79 passed, 0 failed. `tsc --noEmit` clean.

Relayer-side companion (the load that produces those 503s): #900

Linear: [WALM-618](https://linear.app/mysten-labs/issue/WALM-618/investigate-memwal-remember-takes-3-8-min-under-load-handshake-retries)
