### PR TITLE
fix(sdk): cap remember-job poll backoff (WALM-623)

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -29,7 +29,7 @@ questions:
   - What changes were made in memwal 0.1.4?
   - Where can I find the release history for the Walrus Memory Python SDK?
 answer: >-
-  The latest Python SDK release is 0.1.10. `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. 0.1.9 reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials.
+  The latest Python SDK release is 0.1.10. `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Remember-job polling starts immediately and caps backoff at ~1.5s instead of climbing to 10s. 0.1.9 reports HTTP 503 as a retryable upstream outage instead of a credential failure, rejects empty `remember_bulk_async` batches and misaligned relayer `job_ids`, aligns restore `truncated` docs with WALM-431 retryable semantics, and warns when `server_url` uses plaintext HTTP on a non-localhost host without logging URL credentials.
 ---
 
 Track what's new, changed, and fixed in `memwal` (Python).
@@ -38,11 +38,15 @@ For the latest version, see the [PyPI project page](https://pypi.org/project/mem
 
 ## 0.1.10
 
-This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures.
+This release adds `failed` on `restore()` results for permanent decrypt and UTF-8 failures, and caps remember-job poll backoff at ~1.5s with an immediate first poll.
 
 ### Added
 
 - `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
+
+### Fixed
+
+- Cap `wait_for_remember_job` / `wait_for_remember_jobs` poll delay at ~1.5s with an immediate first poll, instead of exponential backoff that climbed to 10s. `poll_interval_ms: 0` still means no wait. (WALM-623)
 
 ## 0.1.9
 

--- a/docs/python-sdk/usage.md
+++ b/docs/python-sdk/usage.md
@@ -100,4 +100,4 @@ print(done.blob_id)
 done = await memwal.wait_for_remember_job(accepted.job_id)
 ```
 
-Bulk (up to 20 items per call) follows the same pattern with `remember_bulk_async`, `wait_for_remember_jobs`, and `remember_bulk_and_wait`. Polling uses jittered exponential backoff (1.5× capped at 10s, ±25%) to stay relayer-friendly at scale.
+Bulk (up to 20 items per call) follows the same pattern with `remember_bulk_async`, `wait_for_remember_jobs`, and `remember_bulk_and_wait`. Polling starts immediately, then repeats at most ~1.5s with ±25% jitter; `poll_interval_ms: 0` means no wait.

--- a/docs/sdk/changelog.mdx
+++ b/docs/sdk/changelog.mdx
@@ -28,12 +28,12 @@ questions:
   - When was bulk remember added to the Walrus Memory SDK?
   - What security improvements have been made to the MemWal SDK?
 answer: >-
-  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
+  The latest TypeScript SDK release is 0.1.7. Request bodies are hashed with `@noble/hashes` rather than WebCrypto-or-`node:crypto`, so the SDK no longer imports a Node builtin that Vite silently externalises into a runtime crash in the browser, and it declares a Node 20 floor. `restore()` results include `failed` (required like `truncated`; SDK defaults omitted to `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped`. Empty-body 401s use the AUTH_REJECTED troubleshooting message instead of telling callers to run `memwal_login`. Account and manual PTBs use typed `tx.pure` helpers so they work with modern `@mysten/sui`. Remember-job polling starts immediately and caps backoff at ~1.5s instead of climbing to 10s. 0.1.6 added optional `created_at` on `recall()` results, plus `sort` and `scoringWeights` on `RecallOptions`, and reports HTTP 503 as a retryable upstream outage instead of a sign-in failure.
 ---
 
 ## 0.1.7
 
-This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, and switches account and manual PTBs to typed `tx.pure` helpers.
+This release removes the Node `crypto` import that crashed bundled browser builds at runtime, adds `failed` on `restore()` results, declares a Node 20 floor, stops telling headless SDK clients to call `memwal_login` on empty-body 401s, switches account and manual PTBs to typed `tx.pure` helpers, and caps remember-job poll backoff at ~1.5s with an immediate first poll.
 
 ### Added
 
@@ -45,6 +45,7 @@ This release removes the Node `crypto` import that crashed bundled browser build
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
+- Cap `waitForRememberJob` / `waitForRememberJobs` poll delay at ~1.5s with an immediate first poll, instead of exponential backoff that climbed to 10s. `pollIntervalMs: 0` still means no wait. (WALM-623)
 
 ## 0.1.6
 

--- a/packages/python-sdk-memwal/CHANGELOG.md
+++ b/packages/python-sdk-memwal/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `restore()` results include `failed` (default `0`) for permanent decrypt/UTF-8 failures instead of folding them into `skipped` or dropping them silently.
 
+### Fixed
+
+- Cap `wait_for_remember_job` / `wait_for_remember_jobs` poll delay at ~1.5s with an immediate first poll, instead of exponential backoff that climbed to 10s. `poll_interval_ms: 0` still means no wait. (WALM-623)
+
 ## 0.1.9
 
 ### Fixed

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -168,14 +168,18 @@ async def _sleep_ms(ms: int) -> None:
 
 
 def _polling_delay_ms(base_ms: int, attempt: int) -> int:
-    """Jittered exponential backoff matching TS ``pollingDelayMs``.
+    """Jittered poll delay matching TS ``pollingDelayMs``.
 
-    base * 1.5^min(attempt, 6), capped at 10s, with ±25% jitter so
-    concurrent clients don't synchronise.
+    ``base_ms <= 0`` means no wait (``poll_interval_ms: 0``). Attempt 0 is
+    immediate so the first GET is not delayed. Later polls cap at 1500ms
+    with ±25% jitter.
     """
 
-    base = max(100, base_ms)
-    capped = min(10_000, base * (1.5 ** min(attempt, 6)))
+    if base_ms <= 0:
+        return 0
+    if attempt == 0:
+        return 0
+    capped = min(1500, max(100, base_ms))
     jitter = 0.75 + random.random() * 0.5
     return int(capped * jitter)
 
@@ -420,8 +424,7 @@ class MemWal:
           ``status`` field (404 / ``status == "not_found"`` raises).
         - Transient HTTP errors (429, 5xx, network drop) are retried until
           the timeout, not surfaced as polling failures.
-        - Backoff is jittered exponential (1.5x cap 10s, ±25%) to avoid
-          thundering-herd at scale.
+        - First poll is immediate; later polls cap at 1.5s with ±25% jitter.
         """
 
         deadline_ms = _now_ms() + timeout_ms

--- a/packages/python-sdk-memwal/memwal/client.py
+++ b/packages/python-sdk-memwal/memwal/client.py
@@ -171,8 +171,7 @@ def _polling_delay_ms(base_ms: int, attempt: int) -> int:
     """Jittered poll delay matching TS ``pollingDelayMs``.
 
     ``base_ms <= 0`` means no wait (``poll_interval_ms: 0``). Attempt 0 is
-    immediate so the first GET is not delayed. Later polls cap at 1500ms
-    with ±25% jitter.
+    immediate so the first GET is not delayed.
     """
 
     if base_ms <= 0:

--- a/packages/python-sdk-memwal/tests/test_polling_delay.py
+++ b/packages/python-sdk-memwal/tests/test_polling_delay.py
@@ -25,3 +25,5 @@ def test_later_polls_cap_at_1_5s_after_20s_pending(monkeypatch: pytest.MonkeyPat
         assert delay <= 2000
         assert delay == 1875
     assert _polling_delay_ms(5000, 15) == 1875
+    assert _polling_delay_ms(400, 1) == 500
+    assert _polling_delay_ms(400, 1) == _polling_delay_ms(400, 20)

--- a/packages/python-sdk-memwal/tests/test_polling_delay.py
+++ b/packages/python-sdk-memwal/tests/test_polling_delay.py
@@ -1,0 +1,27 @@
+"""Remember-job poll delay (WALM-623). Parity with TS pollingDelayMs."""
+
+from __future__ import annotations
+
+import pytest
+
+from memwal.client import _polling_delay_ms
+
+
+def test_poll_interval_ms_non_positive_is_no_wait() -> None:
+    assert _polling_delay_ms(0, 0) == 0
+    assert _polling_delay_ms(0, 15) == 0
+    assert _polling_delay_ms(-1, 3) == 0
+
+
+def test_first_poll_is_immediate() -> None:
+    assert _polling_delay_ms(1500, 0) == 0
+    assert _polling_delay_ms(5000, 0) == 0
+
+
+def test_later_polls_cap_at_1_5s_after_20s_pending(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("memwal.client.random.random", lambda: 1.0)
+    for attempt in (1, 6, 15, 20):
+        delay = _polling_delay_ms(1500, attempt)
+        assert delay <= 2000
+        assert delay == 1875
+    assert _polling_delay_ms(5000, 15) == 1875

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Declare `engines.node >= 20.0.0`, matching `memwal-mcp` and `openclaw-memory-memwal`. The SDK was the only published package without a floor. (WALM-599)
 - Empty-body 401s now use the same AUTH_REJECTED troubleshooting message as credential 401s instead of telling callers to run `memwal_login`. Headless SDK clients do not have that MCP tool.
 - `account.ts` and `manual.ts` PTBs use typed `tx.pure` helpers instead of the legacy untyped moveCall argument syntax that fails under modern `@mysten/sui`.
+- Cap `waitForRememberJob` / `waitForRememberJobs` poll delay at ~1.5s with an immediate first poll, instead of exponential backoff that climbed to 10s. `pollIntervalMs: 0` still means no wait. (WALM-623)
 
 ## 0.1.6
 

--- a/packages/sdk/src/memwal.ts
+++ b/packages/sdk/src/memwal.ts
@@ -74,6 +74,7 @@ import {
     compatibilityErrorFromStatus,
 } from "./compatibility.js";
 import { applyTokenBudget, estimateTokens } from "./tokens.js";
+import { pollingDelayMs } from "./polling-delay.js";
 
 // ============================================================
 // Ed25519 Signing (lazy-loaded)
@@ -119,13 +120,6 @@ type RememberStatusResponse = RememberJobStatus | { error?: string };
 
 function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function pollingDelayMs(baseMs: number, attempt: number): number {
-    const base = Math.max(100, baseMs);
-    const capped = Math.min(10_000, base * 1.5 ** Math.min(attempt, 6));
-    const jitter = 0.75 + Math.random() * 0.5;
-    return Math.floor(capped * jitter);
 }
 
 function isTransientPollingStatus(status: number): boolean {

--- a/packages/sdk/src/polling-delay.ts
+++ b/packages/sdk/src/polling-delay.ts
@@ -1,0 +1,13 @@
+/**
+ * Delay before a remember-job poll.
+ *
+ * `baseMs <= 0` means no wait (`pollIntervalMs: 0`).
+ * Attempt 0 is immediate so the first GET is not delayed.
+ */
+export function pollingDelayMs(baseMs: number, attempt: number): number {
+    if (baseMs <= 0) return 0;
+    if (attempt === 0) return 0;
+    const capped = Math.min(1500, Math.max(100, baseMs));
+    const jitter = 0.75 + Math.random() * 0.5;
+    return Math.floor(capped * jitter);
+}

--- a/packages/sdk/test/polling-delay.test.mjs
+++ b/packages/sdk/test/polling-delay.test.mjs
@@ -28,4 +28,6 @@ test("later polls cap at 1.5s even after ~20s of pending", () => {
         assert.equal(delay, 1875);
     }
     assert.equal(pollingDelayMs(5000, 15), 1875);
+    assert.equal(pollingDelayMs(400, 1), 500);
+    assert.equal(pollingDelayMs(400, 1), pollingDelayMs(400, 20));
 });

--- a/packages/sdk/test/polling-delay.test.mjs
+++ b/packages/sdk/test/polling-delay.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { pollingDelayMs } from "../dist/polling-delay.js";
+
+const originalRandom = Math.random;
+
+test.afterEach(() => {
+    Math.random = originalRandom;
+});
+
+test("pollIntervalMs <= 0 is no wait", () => {
+    assert.equal(pollingDelayMs(0, 0), 0);
+    assert.equal(pollingDelayMs(0, 15), 0);
+    assert.equal(pollingDelayMs(-1, 3), 0);
+});
+
+test("first poll is immediate", () => {
+    assert.equal(pollingDelayMs(1500, 0), 0);
+    assert.equal(pollingDelayMs(5000, 0), 0);
+});
+
+test("later polls cap at 1.5s even after ~20s of pending", () => {
+    Math.random = () => 1;
+    for (const attempt of [1, 6, 15, 20]) {
+        const delay = pollingDelayMs(1500, attempt);
+        assert.ok(delay <= 2000, `attempt ${attempt} delay ${delay} exceeded 2s cap`);
+        assert.equal(delay, 1875);
+    }
+    assert.equal(pollingDelayMs(5000, 15), 1875);
+});

--- a/packages/sdk/test/remember-idempotency.test.mjs
+++ b/packages/sdk/test/remember-idempotency.test.mjs
@@ -11,7 +11,7 @@ test.afterEach(() => {
 
 test("rememberAndWait reuses its generated key and job after polling timeout", async () => {
     const posted = [];
-    let jobPolls = 0;
+    let rememberPosts = 0;
     globalThis.fetch = async (url, init = {}) => {
         const path = new URL(url).pathname;
         if (path === "/version") {
@@ -26,11 +26,15 @@ test("rememberAndWait reuses its generated key and job after polling timeout", a
         }
         if (path === "/api/remember" && init.method === "POST") {
             posted.push(JSON.parse(init.body));
+            rememberPosts += 1;
             return Response.json({ job_id: "stable-job", status: "pending" }, { status: 202 });
         }
         if (path === "/api/remember/stable-job") {
-            jobPolls += 1;
-            if (jobPolls < 2) return Response.json({ job_id: "stable-job", status: "pending" });
+            // Stay pending for the first rememberAndWait so timeoutMs: 1 still
+            // times out when pollIntervalMs: 0 polls immediately.
+            if (rememberPosts < 2) {
+                return Response.json({ job_id: "stable-job", status: "pending" });
+            }
             return Response.json({
                 job_id: "stable-job",
                 status: "done",


### PR DESCRIPTION
## Ticket

WALM-623 — https://linear.app/mysten-labs/issue/WALM-623/sdk-cap-waitforrememberjob-poll-backoff-no-public-api-change

## What changed?

- `waitForRememberJob` / `waitForRememberJobs` (and Python `wait_for_remember_job` / `wait_for_remember_jobs`) no longer sleep 5–10s after a ~20s write is already `done`.
- First poll is immediate. Later polls cap at 1.5s with ±25% jitter. No exponential climb to 10s.
- `pollIntervalMs: 0` / `poll_interval_ms: 0` still means no wait.
- No new SDK methods or request fields.

## Why is this needed?

Quiet-prod traces (WALM-618 / WALM-621): Walrus+index finished in ~21s; the client polled again 5–8s after `done` because backoff had climbed toward 10s. That idle is entirely client-side. MCP SSE push / webhooks are out of scope — recall is already ~1.6–2.6s once the request arrives.

## Scope

Cap remember-job poll delay in the TypeScript and Python SDKs.

### Out of scope

- MCP handshake / SSE 401 (WALM-618, #900 / #901)
- Relayer upload queue / Walrus duration
- Webhook or SSE job-completion API (WALM-152)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands:
- `node scripts/verify-manual-sdk-release.mjs` (0.1.7 / 0.1.10 / 0.0.13 / 0.0.6)
- `packages/sdk`: `pnpm test` — 122 passed
- `packages/python-sdk-memwal`: `pytest tests/ -m 'not integration'` — 155 passed, 23 deselected

## How can the reviewer verify it?

1. Read `packages/sdk/src/polling-delay.ts` and `packages/python-sdk-memwal/memwal/client.py` `_polling_delay_ms`.
2. Run the commands above.
3. Confirm `packages/sdk/src/index.ts` does not export `pollingDelayMs`.
4. Confirm changelogs sit under existing 0.1.7 / 0.1.10 (no bump; `dev` already ahead of `main`).

## Risks and dependencies

None. Callers that passed a large `pollIntervalMs` now wait at most ~1.5s between polls (the intended cap).

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
