### PR TITLE
fix(relayer): reconnect Redis so account setup is not 503 (WALM-626)

### DIFF
--- a/services/server/Cargo.lock
+++ b/services/server/Cargo.lock
@@ -430,6 +430,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,8 +2419,10 @@ checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "backon",
  "bytes",
  "combine",
+ "futures",
  "futures-util",
  "itertools 0.13.0",
  "itoa",

--- a/services/server/Cargo.toml
+++ b/services/server/Cargo.toml
@@ -79,7 +79,7 @@ futures = "0.3"
 async-trait = "0.1"
 
 # Rate limiting (Redis-backed)
-redis = { version = "0.27", features = ["tokio-comp"] }
+redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 
 # Utils
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/services/server/src/engine/walrus_seal.rs
+++ b/services/server/src/engine/walrus_seal.rs
@@ -50,7 +50,7 @@ pub struct WalrusSealEngine {
     http_client: reqwest::Client,
     key_pool: Arc<KeyPool>,
     config: Arc<Config>,
-    redis: redis::aio::MultiplexedConnection,
+    redis: redis::aio::ConnectionManager,
     /// Blob ciphertext cache TTL. Zero disables write-back.
     blob_cache_ttl: Duration,
     /// Max ciphertext size kept in the Redis cache. Reads ignore
@@ -66,7 +66,7 @@ impl WalrusSealEngine {
         http_client: reqwest::Client,
         key_pool: Arc<KeyPool>,
         config: Arc<Config>,
-        redis: redis::aio::MultiplexedConnection,
+        redis: redis::aio::ConnectionManager,
         blob_cache_ttl: Duration,
         blob_cache_max_bytes: usize,
     ) -> Self {

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -170,14 +170,20 @@ fn endpoint_weight(path: &str) -> i64 {
 // Redis Client
 // ============================================================
 
-/// Create a Redis client that reconnects after a dropped connection.
-/// A one-shot multiplexed connection never recovers, which fail-closes
-/// unauthenticated sponsor/accounts traffic for the process lifetime.
+/// Reconnect so a dropped Redis connection does not fail-close
+/// unauthenticated limiters for the process lifetime.
 pub async fn create_redis_client(redis_url: &str) -> Result<redis::aio::ConnectionManager, String> {
     let client = redis::Client::open(redis_url)
         .map_err(|e| format!("Failed to create Redis client: {}", e))?;
 
-    redis::aio::ConnectionManager::new(client)
+    // Bound reconnect so a dead Redis still 503s promptly instead of
+    // stalling fail-closed routes.
+    let config = redis::aio::ConnectionManagerConfig::new()
+        .set_connection_timeout(Duration::from_secs(2))
+        .set_response_timeout(Duration::from_secs(2))
+        .set_max_delay(2_000)
+        .set_number_of_retries(3);
+    redis::aio::ConnectionManager::new_with_config(client, config)
         .await
         .map_err(|e| format!("Failed to connect to Redis: {}", e))
 }
@@ -1167,8 +1173,7 @@ pub async fn sponsor_rate_limit_middleware(
 
     // XFF is ignored by default. Only walk back through the explicitly
     // configured number of trusted proxy hops, using the same resolver as
-    // the MCP proxy path. Missing ConnectInfo is a shared 0.0.0.0 bucket,
-    // not a 503 — see `rate_limit_peer_addr`.
+    // the MCP proxy path.
     let ip = rate_limit_peer_addr(&request, state.config.trusted_proxy_hops).to_string();
 
     let config = &state.config.sponsor_rate_limit;
@@ -1381,8 +1386,7 @@ pub async fn accounts_rate_limit_middleware(
 
     // XFF is ignored by default. Only walk back through the explicitly
     // configured number of trusted proxy hops, using the same resolver as
-    // the sponsor and MCP proxy paths. Missing ConnectInfo is a shared
-    // 0.0.0.0 bucket, not a 503 — see `rate_limit_peer_addr`.
+    // the sponsor and MCP proxy paths.
     let ip = rate_limit_peer_addr(&request, state.config.trusted_proxy_hops).to_string();
 
     let config = &state.config.accounts_rate_limit;

--- a/services/server/src/rate_limit.rs
+++ b/services/server/src/rate_limit.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use crate::{
-    client_ip::canonical_client_ip,
     storage::db::{StorageAdmission, StorageReservationRequest},
     types::{AppError, AppState, AuthInfo},
 };
@@ -171,19 +170,16 @@ fn endpoint_weight(path: &str) -> i64 {
 // Redis Client
 // ============================================================
 
-/// Create a Redis multiplexed connection for shared use across the app.
-pub async fn create_redis_client(
-    redis_url: &str,
-) -> Result<redis::aio::MultiplexedConnection, String> {
+/// Create a Redis client that reconnects after a dropped connection.
+/// A one-shot multiplexed connection never recovers, which fail-closes
+/// unauthenticated sponsor/accounts traffic for the process lifetime.
+pub async fn create_redis_client(redis_url: &str) -> Result<redis::aio::ConnectionManager, String> {
     let client = redis::Client::open(redis_url)
         .map_err(|e| format!("Failed to create Redis client: {}", e))?;
 
-    let conn = client
-        .get_multiplexed_async_connection()
+    redis::aio::ConnectionManager::new(client)
         .await
-        .map_err(|e| format!("Failed to connect to Redis: {}", e))?;
-
-    Ok(conn)
+        .map_err(|e| format!("Failed to connect to Redis: {}", e))
 }
 
 // ============================================================
@@ -247,15 +243,18 @@ enum WindowCheckResult {
 /// The Lua script executes as a single atomic Redis operation, preventing the
 /// TOCTOU race where two concurrent requests could both pass the check before
 /// either records, then both record and collectively exceed the limit.
-async fn check_and_record_window(
-    redis: &mut redis::aio::MultiplexedConnection,
+async fn check_and_record_window<C>(
+    redis: &mut C,
     key: &str,
     window_start: f64,
     now: f64,
     limit: i64,
     weight: i64,
     ttl_seconds: i64,
-) -> Result<WindowCheckResult, redis::RedisError> {
+) -> Result<WindowCheckResult, redis::RedisError>
+where
+    C: redis::aio::ConnectionLike,
+{
     // The UUID keeps members distinct across concurrent requests, processes,
     // and replicas even when they share an identical millisecond timestamp.
     let request_id = Uuid::new_v4().to_string();
@@ -891,8 +890,8 @@ fn stable_hash_i64(s: &str) -> i64 {
 /// check/log/fail-open boilerplate that already exists inline in
 /// `rate_limit_middleware`'s per-account layer and in the global
 /// sponsor/account limiters below.
-async fn check_owner_window_limit(
-    redis: &mut redis::aio::MultiplexedConnection,
+async fn check_owner_window_limit<C>(
+    redis: &mut C,
     scope: &str,
     key: &str,
     window_start: f64,
@@ -902,7 +901,10 @@ async fn check_owner_window_limit(
     ttl_seconds: i64,
     owner: &str,
     deny_message: impl FnOnce() -> String,
-) -> Result<(), AppError> {
+) -> Result<(), AppError>
+where
+    C: redis::aio::ConnectionLike,
+{
     match check_and_record_window(redis, key, window_start, now, limit, weight, ttl_seconds).await {
         Ok(WindowCheckResult::Denied) => {
             crate::observability::record_rate_limit_denial(scope);
@@ -1127,6 +1129,21 @@ pub async fn charge_explicit_weight(
 }
 
 // ============================================================
+// Client IP for unauthenticated IP limiters
+// ============================================================
+
+/// Resolve the rate-limit client IP. Missing `ConnectInfo` uses `0.0.0.0`
+/// so hops=0 still shares one unknown bucket and hops>0 still read XFF.
+fn rate_limit_peer_addr(request: &Request, trusted_proxy_hops: usize) -> std::net::IpAddr {
+    let peer = request
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0)
+        .unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 0)));
+    crate::client_ip::canonical_client_ip(request.headers(), peer, trusted_proxy_hops)
+}
+
+// ============================================================
 // Sponsor Rate Limit Middleware (IP-based, unauthenticated)
 // ============================================================
 
@@ -1150,19 +1167,9 @@ pub async fn sponsor_rate_limit_middleware(
 
     // XFF is ignored by default. Only walk back through the explicitly
     // configured number of trusted proxy hops, using the same resolver as
-    // the MCP proxy path.
-    let ip = match request
-        .extensions()
-        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-        .map(|ci| canonical_client_ip(request.headers(), ci.0, state.config.trusted_proxy_hops))
-    {
-        Some(ip) => ip.to_string(),
-        None => {
-            // Cannot determine IP — fail-closed: deny rather than allow unknown callers.
-            tracing::warn!("sponsor_rate_limit_middleware: cannot determine client IP, denying");
-            return rate_limiter_unavailable_response();
-        }
-    };
+    // the MCP proxy path. Missing ConnectInfo is a shared 0.0.0.0 bucket,
+    // not a 503 — see `rate_limit_peer_addr`.
+    let ip = rate_limit_peer_addr(&request, state.config.trusted_proxy_hops).to_string();
 
     let config = &state.config.sponsor_rate_limit;
     let mut redis = state.redis.clone();
@@ -1374,19 +1381,9 @@ pub async fn accounts_rate_limit_middleware(
 
     // XFF is ignored by default. Only walk back through the explicitly
     // configured number of trusted proxy hops, using the same resolver as
-    // the sponsor and MCP proxy paths.
-    let ip = match request
-        .extensions()
-        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-        .map(|ci| canonical_client_ip(request.headers(), ci.0, state.config.trusted_proxy_hops))
-    {
-        Some(ip) => ip.to_string(),
-        None => {
-            // Cannot determine IP — fail-closed: deny rather than allow unknown callers.
-            tracing::warn!("accounts_rate_limit_middleware: cannot determine client IP, denying");
-            return rate_limiter_unavailable_response();
-        }
-    };
+    // the sponsor and MCP proxy paths. Missing ConnectInfo is a shared
+    // 0.0.0.0 bucket, not a 503 — see `rate_limit_peer_addr`.
+    let ip = rate_limit_peer_addr(&request, state.config.trusted_proxy_hops).to_string();
 
     let config = &state.config.accounts_rate_limit;
     let mut redis = state.redis.clone();
@@ -1535,19 +1532,7 @@ pub async fn owner_token_ip_rate_limit_middleware(
         return next.run(request).await;
     }
 
-    let ip = match request
-        .extensions()
-        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-        .map(|ci| canonical_client_ip(request.headers(), ci.0, state.config.trusted_proxy_hops))
-    {
-        Some(ip) => ip.to_string(),
-        None => {
-            tracing::warn!(
-                "owner_token_ip_rate_limit_middleware: cannot determine client IP, denying"
-            );
-            return rate_limiter_unavailable_response();
-        }
-    };
+    let ip = rate_limit_peer_addr(&request, state.config.trusted_proxy_hops).to_string();
 
     let config = &state.config.owner_token_rate_limit;
     let mut redis = state.redis.clone();
@@ -1915,6 +1900,64 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         // Verify Retry-After header is present
         assert!(resp.headers().contains_key("retry-after"));
+    }
+
+    // ---- Missing ConnectInfo must still be rate-limited (WALM-626) ----
+
+    fn rate_limit_request(peer: Option<std::net::SocketAddr>, xff: Option<&str>) -> Request {
+        let mut builder = axum::http::Request::builder().uri("/");
+        if let Some(xff) = xff {
+            builder = builder.header("x-forwarded-for", xff);
+        }
+        let mut request = builder.body(axum::body::Body::empty()).unwrap();
+        if let Some(peer) = peer {
+            request
+                .extensions_mut()
+                .insert(axum::extract::ConnectInfo(peer));
+        }
+        request
+    }
+
+    #[test]
+    fn missing_connect_info_with_zero_hops_uses_unspecified_peer() {
+        let request = rate_limit_request(None, Some("198.51.100.7"));
+        assert_eq!(
+            rate_limit_peer_addr(&request, 0),
+            "0.0.0.0".parse::<std::net::IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn connect_info_present_with_zero_hops_ignores_xff() {
+        let peer = "203.0.113.9:443".parse().unwrap();
+        let request = rate_limit_request(Some(peer), Some("198.51.100.7"));
+        assert_eq!(
+            rate_limit_peer_addr(&request, 0),
+            "203.0.113.9".parse::<std::net::IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn missing_connect_info_with_trusted_hop_uses_xff() {
+        let request = rate_limit_request(None, Some("198.51.100.7"));
+        assert_eq!(
+            rate_limit_peer_addr(&request, 1),
+            "198.51.100.7".parse::<std::net::IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn missing_connect_info_with_trusted_hop_falls_back_without_xff() {
+        let no_xff = rate_limit_request(None, None);
+        let malformed = rate_limit_request(None, Some("not-an-ip"));
+        assert_eq!(
+            rate_limit_peer_addr(&no_xff, 1),
+            "0.0.0.0".parse::<std::net::IpAddr>().unwrap()
+        );
+        assert_eq!(
+            rate_limit_peer_addr(&malformed, 1),
+            "0.0.0.0".parse::<std::net::IpAddr>().unwrap()
+        );
     }
 
     // ---- Read API rate limit config + response shape ----

--- a/services/server/src/security_delete_auth.rs
+++ b/services/server/src/security_delete_auth.rs
@@ -8,7 +8,7 @@ use axum::Json;
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use hmac::{Hmac, Mac};
-use redis::aio::MultiplexedConnection;
+use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use sui_crypto::{simple::SimpleVerifier, SuiVerifier};
@@ -168,11 +168,11 @@ pub trait NonceStore: Send + Sync {
 }
 
 pub struct RedisNonceStore {
-    connection: MultiplexedConnection,
+    connection: ConnectionManager,
 }
 
 impl RedisNonceStore {
-    pub fn new(connection: MultiplexedConnection) -> Self {
+    pub fn new(connection: ConnectionManager) -> Self {
         Self { connection }
     }
 }
@@ -405,7 +405,7 @@ mod tests {
             return;
         };
         let client = redis::Client::open(url).unwrap();
-        let connection = client.get_multiplexed_async_connection().await.unwrap();
+        let connection = redis::aio::ConnectionManager::new(client).await.unwrap();
         let store = RedisNonceStore::new(connection);
         let id = Uuid::new_v4().to_string();
         store.issue(&id, r#"{"ok":true}"#, 30).await.unwrap();

--- a/services/server/src/types.rs
+++ b/services/server/src/types.rs
@@ -233,8 +233,8 @@ pub struct AppState {
     /// when the request body sets `scoring_weights`; default weights
     /// preserve the pgvector cosine order exactly.
     pub ranker: Arc<dyn Ranker>,
-    /// Redis multiplexed connection for rate limiting
-    pub redis: redis::aio::MultiplexedConnection,
+    /// Redis connection manager for rate limiting (reconnects after a drop)
+    pub redis: redis::aio::ConnectionManager,
     /// In-memory token bucket fallback for when Redis is unavailable
     pub fallback_rate_limit: tokio::sync::Mutex<crate::rate_limit::InMemoryFallback>,
     /// Bounds concurrent AccountRegistry fallback scans (auth Strategy 3).


### PR DESCRIPTION
## Ticket

WALM-626 — https://linear.app/mysten-labs/issue/WALM-626/bug-account-setup-blocked-by-persistent-sponsor-503-rate-limiter
GH #905 — https://github.com/MystenLabs/MemWal/issues/905

## What changed?

- Relayer Redis is now `ConnectionManager` (feature `connection-manager`) so a dropped connection reconnects instead of 503-ing `/sponsor` for the process lifetime.
- Reconnect is bounded (2s connect/response timeout, 2s max delay, 3 retries) so a dead Redis still fail-closes promptly.
- Missing `ConnectInfo` on the IP limiters (`/sponsor`, `/api/accounts/{owner}/exists`, owner-token IP) no longer returns the same 503. It uses `canonical_client_ip` with a `0.0.0.0` peer: hops=0 shares one unknown bucket and still ignores XFF; hops>0 still reads XFF.

## Why is this needed?

Mainnet `POST /sponsor` was returning HTTP 503 `Rate limiter temporarily unavailable`. The dashboard maps that to “Sponsor service is temporarily unavailable”, which blocks account setup / `memwal_login`. `/health` stayed ok because authenticated write-path limiters fail open.

Reproduced 2026-09-13: replica metrics `POST /sponsor` 200=205 vs 503=254, dominated by `rate_limiter_unavailable`. Same 503 on `/api/accounts/:owner/exists`.

## Scope

Stop recoverable Redis/ConnectInfo failures from hard-blocking gasless account setup.

### Out of scope

- Fail-opening the sponsor gas budget onto the in-memory token bucket
- Trusting XFF when `TRUSTED_PROXY_HOPS=0`
- Health-schema / dashboard copy changes
- Version dump (relayer is unversioned)

## How was this tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not applicable

Commands:
- `cargo test -p memwal-server rate_limit --offline` (39 passed, 2 ignored Redis integration)
- `cargo test -p memwal-server client_ip --offline` (7 lib + 11 bin passed)

## How can the reviewer verify it?

1. `git diff origin/dev...HEAD` — Redis type is `ConnectionManager` in `AppState`, `RedisNonceStore`, and `WalrusSealEngine`.
2. Missing-ConnectInfo tests in `rate_limit.rs`: hops=0 ignores XFF / uses `0.0.0.0`; hops=1 reads XFF.
3. Confirm sponsor/accounts/owner-token IP limiters still return 503 on Redis error (no in-memory fallback).

## Risks and dependencies

A live Redis outage still 503s `/sponsor` (intentional fail-closed). The first command after a drop can still 503 once; later requests use the reconnected client. Deploying this to mainnet is what unblocks GH #905; the code change does not fix production until it ships.

## Author checklist

- [x] This pull request maps to one ticket and one logical outcome.
- [x] I reviewed the complete diff myself.
- [x] I removed unrelated, debug, and temporary changes.
- [x] I ran the relevant tests.
- [ ] CI is green.
- [x] The branch is up to date with its target branch.
- [x] I added or updated tests where appropriate.
- [x] I documented any important risk, dependency, rollout, or follow-up.
- [x] I provided clear verification steps.
- [x] The pull request is ready for review and is no longer a Draft.
